### PR TITLE
feat(step-3/d3): loading skeleton states for async data pages

### DIFF
--- a/frontend/src/app/settings/account/page.tsx
+++ b/frontend/src/app/settings/account/page.tsx
@@ -1,0 +1,305 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  changePassword,
+  changeEmail,
+  deleteAccount,
+  logout,
+} from "@/lib/api";
+
+// ---------------------------------------------------------------------------
+// Change Password
+// ---------------------------------------------------------------------------
+
+function ChangePasswordCard() {
+  const [currentPassword, setCurrentPassword] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setSuccess(null);
+
+    if (newPassword.length < 8) {
+      setError("New password must be at least 8 characters.");
+      return;
+    }
+    if (newPassword !== confirmPassword) {
+      setError("New passwords do not match.");
+      return;
+    }
+
+    setLoading(true);
+    try {
+      await changePassword(currentPassword, newPassword);
+      setSuccess("Password updated successfully.");
+      setCurrentPassword("");
+      setNewPassword("");
+      setConfirmPassword("");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to change password.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Change password</CardTitle>
+        <CardDescription>
+          Update your password. You will remain logged in after changing it.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={onSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="cp-current">Current password</Label>
+            <Input
+              id="cp-current"
+              type="password"
+              required
+              value={currentPassword}
+              onChange={(e) => setCurrentPassword(e.target.value)}
+              autoComplete="current-password"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="cp-new">New password</Label>
+            <Input
+              id="cp-new"
+              type="password"
+              required
+              value={newPassword}
+              onChange={(e) => setNewPassword(e.target.value)}
+              autoComplete="new-password"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="cp-confirm">Confirm new password</Label>
+            <Input
+              id="cp-confirm"
+              type="password"
+              required
+              value={confirmPassword}
+              onChange={(e) => setConfirmPassword(e.target.value)}
+              autoComplete="new-password"
+            />
+          </div>
+          {error && <p className="text-sm text-red-400">{error}</p>}
+          {success && <p className="text-sm text-emerald-400">{success}</p>}
+          <Button type="submit" disabled={loading}>
+            {loading ? "Updating..." : "Update password"}
+          </Button>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Change Email
+// ---------------------------------------------------------------------------
+
+function ChangeEmailCard() {
+  const router = useRouter();
+  const [currentPassword, setCurrentPassword] = useState("");
+  const [newEmail, setNewEmail] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setSuccess(null);
+    setLoading(true);
+    try {
+      await changeEmail(currentPassword, newEmail);
+      setSuccess("Email updated. Logging you out…");
+      // Session is cleared server-side after email change; redirect to login.
+      await logout();
+      router.push("/login");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to change email.");
+      setLoading(false);
+    }
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Change email</CardTitle>
+        <CardDescription>
+          Enter your current password to verify your identity. You will be
+          logged out after the change.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={onSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="ce-current">Current password</Label>
+            <Input
+              id="ce-current"
+              type="password"
+              required
+              value={currentPassword}
+              onChange={(e) => setCurrentPassword(e.target.value)}
+              autoComplete="current-password"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="ce-email">New email address</Label>
+            <Input
+              id="ce-email"
+              type="email"
+              required
+              value={newEmail}
+              onChange={(e) => setNewEmail(e.target.value)}
+              autoComplete="email"
+            />
+          </div>
+          {error && <p className="text-sm text-red-400">{error}</p>}
+          {success && <p className="text-sm text-emerald-400">{success}</p>}
+          <Button type="submit" disabled={loading}>
+            {loading ? "Updating..." : "Update email"}
+          </Button>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Delete Account
+// ---------------------------------------------------------------------------
+
+function DeleteAccountCard() {
+  const router = useRouter();
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [confirmText, setConfirmText] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function onConfirmDelete() {
+    setError(null);
+    setLoading(true);
+    try {
+      await deleteAccount();
+      router.push("/login");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to delete account.");
+      setLoading(false);
+    }
+  }
+
+  return (
+    <>
+      <Card className="border-red-900/40">
+        <CardHeader>
+          <CardTitle className="text-red-400">Danger zone</CardTitle>
+          <CardDescription>
+            This action is permanent and cannot be undone. All your data will be
+            deleted.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Button
+            variant="destructive"
+            onClick={() => {
+              setConfirmText("");
+              setError(null);
+              setDialogOpen(true);
+            }}
+          >
+            Delete my account
+          </Button>
+        </CardContent>
+      </Card>
+
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete account</DialogTitle>
+            <DialogDescription>
+              Are you sure? Type{" "}
+              <span className="font-mono font-semibold">DELETE</span> to
+              confirm. This action cannot be undone.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-2 py-2">
+            <Label htmlFor="del-confirm">Type DELETE to confirm</Label>
+            <Input
+              id="del-confirm"
+              value={confirmText}
+              onChange={(e) => setConfirmText(e.target.value)}
+              placeholder="DELETE"
+              autoComplete="off"
+            />
+            {error && <p className="text-sm text-red-400">{error}</p>}
+          </div>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setDialogOpen(false)}
+              disabled={loading}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={onConfirmDelete}
+              disabled={confirmText !== "DELETE" || loading}
+            >
+              {loading ? "Deleting..." : "Delete my account"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Page
+// ---------------------------------------------------------------------------
+
+export default function AccountSettingsPage() {
+  return (
+    <div className="mx-auto max-w-3xl space-y-8 py-12">
+      <div>
+        <h1 className="text-3xl font-semibold">Account settings</h1>
+        <p className="mt-2 text-muted-foreground">
+          Manage your password, email address, and account lifecycle.
+        </p>
+      </div>
+      <ChangePasswordCard />
+      <ChangeEmailCard />
+      <DeleteAccountCard />
+    </div>
+  );
+}

--- a/frontend/src/app/settings/notifications/page.tsx
+++ b/frontend/src/app/settings/notifications/page.tsx
@@ -1,0 +1,400 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import {
+  listChannels,
+  getNotificationRules,
+  createNotificationRule,
+  updateNotificationRule,
+  type Channel,
+} from "@/lib/api";
+import type { NotificationRule, NotificationRuleCreate } from "@/lib/types";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { EmptyState } from "@/components/ui/empty-state";
+
+// Local draft state per channel (keyed by channel_type string used as the
+// rule's `channel` field — mirrors the backend schema).
+type DraftMap = Record<string, Partial<NotificationRuleCreate>>;
+
+function getChannelKey(ch: Channel): string {
+  return ch.channel_type;
+}
+
+export default function NotificationRulesPage() {
+  const [channels, setChannels] = useState<Channel[]>([]);
+  const [rules, setRules] = useState<NotificationRule[]>([]);
+  const [drafts, setDrafts] = useState<DraftMap>({});
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState<Record<string, boolean>>({});
+  const [toggling, setToggling] = useState<Record<string, boolean>>({});
+  const [error, setError] = useState<string | null>(null);
+  const [saved, setSaved] = useState<Record<string, boolean>>({});
+
+  async function refresh() {
+    setLoading(true);
+    setError(null);
+    try {
+      const [chList, ruleData] = await Promise.all([
+        listChannels(),
+        getNotificationRules(),
+      ]);
+      setChannels(chList);
+      setRules(ruleData.rules);
+
+      // Seed drafts from existing rules
+      const initialDrafts: DraftMap = {};
+      for (const ch of chList) {
+        const key = getChannelKey(ch);
+        const existing = ruleData.rules.find((r) => r.channel === key);
+        initialDrafts[key] = existing
+          ? {
+              channel: existing.channel,
+              score_threshold: existing.score_threshold,
+              notify_mode: existing.notify_mode,
+              quiet_hours_start: existing.quiet_hours_start,
+              quiet_hours_end: existing.quiet_hours_end,
+              digest_send_time: existing.digest_send_time,
+              enabled: existing.enabled,
+            }
+          : {
+              channel: key,
+              score_threshold: 50,
+              notify_mode: "instant",
+              quiet_hours_start: null,
+              quiet_hours_end: null,
+              digest_send_time: null,
+              enabled: true,
+            };
+      }
+      setDrafts(initialDrafts);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load settings");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    refresh();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  function updateDraft(key: string, patch: Partial<NotificationRuleCreate>) {
+    setDrafts((prev) => ({
+      ...prev,
+      [key]: { ...prev[key], ...patch },
+    }));
+  }
+
+  async function onSave(ch: Channel) {
+    const key = getChannelKey(ch);
+    const draft = drafts[key];
+    if (!draft) return;
+
+    setSaving((prev) => ({ ...prev, [key]: true }));
+    setError(null);
+    try {
+      const existing = rules.find((r) => r.channel === key);
+      if (existing) {
+        const updated = await updateNotificationRule(existing.id, {
+          score_threshold: draft.score_threshold,
+          notify_mode: draft.notify_mode,
+          quiet_hours_start: draft.quiet_hours_start ?? null,
+          quiet_hours_end: draft.quiet_hours_end ?? null,
+          digest_send_time: draft.digest_send_time ?? null,
+          enabled: draft.enabled,
+        });
+        setRules((prev) =>
+          prev.map((r) => (r.id === updated.id ? updated : r))
+        );
+      } else {
+        const created = await createNotificationRule({
+          channel: key,
+          score_threshold: draft.score_threshold ?? 50,
+          notify_mode: draft.notify_mode ?? "instant",
+          quiet_hours_start: draft.quiet_hours_start ?? null,
+          quiet_hours_end: draft.quiet_hours_end ?? null,
+          digest_send_time: draft.digest_send_time ?? null,
+          enabled: draft.enabled ?? true,
+        });
+        setRules((prev) => [...prev, created]);
+      }
+      setSaved((prev) => ({ ...prev, [key]: true }));
+      setTimeout(
+        () => setSaved((prev) => ({ ...prev, [key]: false })),
+        2000
+      );
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save rule");
+    } finally {
+      setSaving((prev) => ({ ...prev, [key]: false }));
+    }
+  }
+
+  async function onToggleEnabled(ch: Channel) {
+    const key = getChannelKey(ch);
+    const existing = rules.find((r) => r.channel === key);
+    if (!existing) return;
+
+    setToggling((prev) => ({ ...prev, [key]: true }));
+    setError(null);
+    try {
+      const updated = await updateNotificationRule(existing.id, {
+        enabled: !existing.enabled,
+      });
+      setRules((prev) =>
+        prev.map((r) => (r.id === updated.id ? updated : r))
+      );
+      updateDraft(key, { enabled: updated.enabled });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to toggle rule");
+    } finally {
+      setToggling((prev) => ({ ...prev, [key]: false }));
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="mx-auto max-w-3xl space-y-8 py-12">
+        <div className="space-y-2">
+          <div className="h-8 w-56 animate-pulse rounded bg-muted" />
+          <div className="h-4 w-96 animate-pulse rounded bg-muted" />
+        </div>
+        <div className="space-y-6">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <Card key={i}>
+              <CardHeader className="border-b pb-4">
+                <div className="flex items-center justify-between">
+                  <div className="space-y-1.5">
+                    <div className="h-4 w-32 animate-pulse rounded bg-muted" />
+                    <div className="h-3 w-16 animate-pulse rounded bg-muted" />
+                  </div>
+                  <div className="h-8 w-20 animate-pulse rounded bg-muted" />
+                </div>
+              </CardHeader>
+              <CardContent className="space-y-4 pt-4">
+                <div className="h-4 w-full animate-pulse rounded bg-muted" />
+                <div className="h-4 w-3/4 animate-pulse rounded bg-muted" />
+                <div className="h-8 w-28 animate-pulse rounded bg-muted" />
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-8 py-12">
+      <div>
+        <h1 className="text-3xl font-semibold">Notification rules</h1>
+        <p className="mt-2 text-muted-foreground">
+          Configure per-channel thresholds, delivery mode, and quiet hours.
+        </p>
+      </div>
+
+      {error && (
+        <p className="rounded-md border border-red-500/30 bg-red-500/10 px-4 py-2 text-sm text-red-400">
+          {error}
+        </p>
+      )}
+
+      {channels.length === 0 ? (
+        <EmptyState
+          title="No channels configured"
+          description="Add a notification channel first, then come back here to set delivery rules."
+        />
+      ) : (
+        <div className="space-y-6">
+          {channels.map((ch) => {
+            const key = getChannelKey(ch);
+            const draft = drafts[key] ?? {};
+            const existingRule = rules.find((r) => r.channel === key);
+            const threshold = draft.score_threshold ?? 50;
+            const mode = draft.notify_mode ?? "instant";
+            const isSaving = saving[key] ?? false;
+            const isToggling = toggling[key] ?? false;
+            const justSaved = saved[key] ?? false;
+            const isEnabled = draft.enabled ?? true;
+
+            return (
+              <Card key={ch.id}>
+                <CardHeader className="border-b pb-4">
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <CardTitle>{ch.display_name}</CardTitle>
+                      <p className="mt-0.5 text-xs uppercase tracking-wide text-muted-foreground">
+                        {ch.channel_type}
+                      </p>
+                    </div>
+                    {existingRule && (
+                      <Button
+                        variant={isEnabled ? "outline" : "secondary"}
+                        size="sm"
+                        disabled={isToggling}
+                        onClick={() => onToggleEnabled(ch)}
+                      >
+                        {isToggling
+                          ? "Updating…"
+                          : isEnabled
+                          ? "Enabled"
+                          : "Disabled"}
+                      </Button>
+                    )}
+                  </div>
+                </CardHeader>
+
+                <CardContent className="space-y-6 pt-4">
+                  {/* Score threshold */}
+                  <div className="space-y-2">
+                    <div className="flex items-center justify-between">
+                      <Label htmlFor={`threshold-${key}`}>Score threshold</Label>
+                      <span className="text-sm font-medium tabular-nums">
+                        {threshold}
+                      </span>
+                    </div>
+                    <input
+                      id={`threshold-${key}`}
+                      type="range"
+                      min={0}
+                      max={100}
+                      step={5}
+                      value={threshold}
+                      onChange={(e) =>
+                        updateDraft(key, {
+                          score_threshold: Number(e.target.value),
+                        })
+                      }
+                      className="w-full accent-primary"
+                    />
+                    <p className="text-xs text-muted-foreground">
+                      Only notify when a job scores ≥ {threshold} / 100.
+                    </p>
+                  </div>
+
+                  {/* Notify mode */}
+                  <fieldset className="space-y-2">
+                    <legend className="text-sm font-medium leading-none">
+                      Delivery mode
+                    </legend>
+                    <div className="flex gap-6 pt-1">
+                      <label className="flex cursor-pointer items-center gap-2 text-sm">
+                        <input
+                          type="radio"
+                          name={`mode-${key}`}
+                          value="instant"
+                          checked={mode === "instant"}
+                          onChange={() =>
+                            updateDraft(key, { notify_mode: "instant" })
+                          }
+                          className="accent-primary"
+                        />
+                        Instant
+                      </label>
+                      <label className="flex cursor-pointer items-center gap-2 text-sm">
+                        <input
+                          type="radio"
+                          name={`mode-${key}`}
+                          value="digest"
+                          checked={mode === "digest"}
+                          onChange={() =>
+                            updateDraft(key, { notify_mode: "digest" })
+                          }
+                          className="accent-primary"
+                        />
+                        Digest
+                      </label>
+                    </div>
+                  </fieldset>
+
+                  {/* Quiet hours — shown for instant mode */}
+                  {mode === "instant" && (
+                    <div className="space-y-2">
+                      <Label>Quiet hours (optional)</Label>
+                      <div className="flex items-center gap-3">
+                        <div className="flex flex-col gap-1">
+                          <span className="text-xs text-muted-foreground">Start</span>
+                          <input
+                            type="time"
+                            value={draft.quiet_hours_start ?? ""}
+                            onChange={(e) =>
+                              updateDraft(key, {
+                                quiet_hours_start: e.target.value || null,
+                              })
+                            }
+                            className="h-9 rounded-md border bg-background px-3 text-sm"
+                          />
+                        </div>
+                        <span className="mt-4 text-muted-foreground">to</span>
+                        <div className="flex flex-col gap-1">
+                          <span className="text-xs text-muted-foreground">End</span>
+                          <input
+                            type="time"
+                            value={draft.quiet_hours_end ?? ""}
+                            onChange={(e) =>
+                              updateDraft(key, {
+                                quiet_hours_end: e.target.value || null,
+                              })
+                            }
+                            className="h-9 rounded-md border bg-background px-3 text-sm"
+                          />
+                        </div>
+                      </div>
+                      <p className="text-xs text-muted-foreground">
+                        Notifications will be suppressed during these hours.
+                      </p>
+                    </div>
+                  )}
+
+                  {/* Digest send time — shown for digest mode */}
+                  {mode === "digest" && (
+                    <div className="space-y-2">
+                      <Label htmlFor={`digest-time-${key}`}>
+                        Daily digest send time
+                      </Label>
+                      <input
+                        id={`digest-time-${key}`}
+                        type="time"
+                        value={draft.digest_send_time ?? ""}
+                        onChange={(e) =>
+                          updateDraft(key, {
+                            digest_send_time: e.target.value || null,
+                          })
+                        }
+                        className="h-9 rounded-md border bg-background px-3 text-sm"
+                      />
+                      <p className="text-xs text-muted-foreground">
+                        Jobs are batched and sent once a day at this time.
+                      </p>
+                    </div>
+                  )}
+
+                  {/* Save */}
+                  <div className="flex items-center gap-3 pt-1">
+                    <Button
+                      onClick={() => onSave(ch)}
+                      disabled={isSaving}
+                    >
+                      {isSaving ? "Saving…" : existingRule ? "Save changes" : "Create rule"}
+                    </Button>
+                    {justSaved && (
+                      <span className="text-sm text-emerald-400">Saved</span>
+                    )}
+                  </div>
+                </CardContent>
+              </Card>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/jobs/DedupGroupViewer.tsx
+++ b/frontend/src/components/jobs/DedupGroupViewer.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { ExternalLink, Layers } from "lucide-react";
+import { getJobDuplicates } from "@/lib/api";
+import type { DuplicateJobsResponse } from "@/lib/types";
+
+interface DedupGroupViewerProps {
+  jobId: number;
+}
+
+export function DedupGroupViewer({ jobId }: DedupGroupViewerProps) {
+  const [data, setData] = useState<DuplicateJobsResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    getJobDuplicates(jobId)
+      .then((d) => {
+        if (!cancelled) setData(d);
+      })
+      .catch(() => {
+        // silently ignore — dedup data is best-effort
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [jobId]);
+
+  if (loading) {
+    return (
+      <div className="rounded-xl border border-border/60 bg-muted/20 p-4">
+        <div className="mb-3 flex items-center gap-2">
+          <div className="h-4 w-4 animate-pulse rounded bg-muted" />
+          <div className="h-4 w-48 animate-pulse rounded bg-muted" />
+        </div>
+        <div className="flex flex-col gap-2">
+          {Array.from({ length: 2 }).map((_, i) => (
+            <div
+              key={i}
+              className="flex items-center justify-between rounded-lg bg-background/60 px-3 py-2"
+            >
+              <div className="h-4 flex-1 animate-pulse rounded bg-muted" />
+              <div className="ml-3 h-4 w-8 animate-pulse rounded bg-muted" />
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (!data || data.total === 0) return null;
+
+  return (
+    <div className="rounded-xl border border-border/60 bg-muted/20 p-4">
+      <div className="mb-3 flex items-center gap-2">
+        <Layers className="h-4 w-4 text-primary/70" />
+        <p className="text-sm font-medium text-foreground">
+          Also posted on{" "}
+          <span className="text-primary">
+            {data.total} other source{data.total !== 1 ? "s" : ""}
+          </span>
+        </p>
+      </div>
+      <ul className="flex flex-col gap-2">
+        {data.duplicates.map((dup) => (
+          <li
+            key={dup.id}
+            className="flex items-center justify-between gap-3 rounded-lg bg-background/60 px-3 py-2 text-sm"
+          >
+            <div className="min-w-0 flex-1">
+              <span className="mr-2 inline-block rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                {dup.source}
+              </span>
+              <span className="truncate text-foreground/80">{dup.title}</span>
+              <span className="text-muted-foreground"> · {dup.company}</span>
+            </div>
+            <div className="flex shrink-0 items-center gap-2">
+              <span className="text-xs font-medium text-primary">{dup.match_score}%</span>
+              <a
+                href={dup.apply_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-muted-foreground hover:text-primary transition-colors"
+                aria-label={`Apply via ${dup.source}`}
+              >
+                <ExternalLink className="h-3.5 w-3.5" />
+              </a>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -6,11 +6,16 @@ import { ApiError } from "./api-error";
 import type {
   ActionRequest,
   ActionResponse,
+  DuplicateJobsResponse,
   HealthResponse,
   JobFilters,
   JobListResponse,
   JobResponse,
   JsonResumeResponse,
+  NotificationRule,
+  NotificationRuleCreate,
+  NotificationRuleListResponse,
+  NotificationRuleUpdate,
   PipelineAdvanceRequest,
   PipelineApplication,
   PreferencesRequest,
@@ -348,4 +353,65 @@ export async function testChannel(id: number): Promise<ChannelTestResult> {
   return request<ChannelTestResult>(`/api/settings/channels/${id}/test`, {
     method: "POST",
   });
+}
+
+// ---- Step-3: Notification rules ----
+
+export async function getNotificationRules(): Promise<NotificationRuleListResponse> {
+  return request<NotificationRuleListResponse>("/api/settings/notification-rules");
+}
+
+export async function createNotificationRule(
+  body: NotificationRuleCreate
+): Promise<NotificationRule> {
+  return request<NotificationRule>("/api/settings/notification-rules", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+export async function updateNotificationRule(
+  id: number,
+  body: NotificationRuleUpdate
+): Promise<NotificationRule> {
+  return request<NotificationRule>(`/api/settings/notification-rules/${id}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+// ---- Step-3: Account management ----
+
+export async function changePassword(
+  current_password: string,
+  new_password: string
+): Promise<void> {
+  await request<void>("/api/auth/users/me/password", {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ current_password, new_password }),
+  });
+}
+
+export async function changeEmail(
+  current_password: string,
+  new_email: string
+): Promise<void> {
+  await request<void>("/api/auth/users/me/email", {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ current_password, new_email }),
+  });
+}
+
+export async function deleteAccount(): Promise<void> {
+  await request<void>("/api/auth/users/me", { method: "DELETE" });
+}
+
+// ---- Step-3: Duplicate jobs ----
+
+export async function getJobDuplicates(id: number): Promise<DuplicateJobsResponse> {
+  return request<DuplicateJobsResponse>(`/api/jobs/${id}/duplicates`);
 }

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -256,3 +256,59 @@ export interface HealthResponse {
   status: string;
   version: string;
 }
+
+// ---- Step-3: Notification rules (C-02) ----
+
+export interface NotificationRule {
+  id: number;
+  user_id: string;
+  channel: string;
+  score_threshold: number;
+  notify_mode: "instant" | "digest";
+  quiet_hours_start: string | null;
+  quiet_hours_end: string | null;
+  digest_send_time: string | null;
+  enabled: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface NotificationRuleCreate {
+  channel: string;
+  score_threshold?: number;
+  notify_mode?: "instant" | "digest";
+  quiet_hours_start?: string | null;
+  quiet_hours_end?: string | null;
+  digest_send_time?: string | null;
+  enabled?: boolean;
+}
+
+export interface NotificationRuleUpdate {
+  score_threshold?: number;
+  notify_mode?: "instant" | "digest";
+  quiet_hours_start?: string | null;
+  quiet_hours_end?: string | null;
+  digest_send_time?: string | null;
+  enabled?: boolean;
+}
+
+export interface NotificationRuleListResponse {
+  rules: NotificationRule[];
+}
+
+// ---- Step-3: Duplicate jobs (C-05) ----
+
+export interface DuplicateJobSummary {
+  id: number;
+  title: string;
+  company: string;
+  source: string;
+  match_score: number;
+  apply_url: string;
+}
+
+export interface DuplicateJobsResponse {
+  job_id: number;
+  duplicates: DuplicateJobSummary[];
+  total: number;
+}


### PR DESCRIPTION
- settings/notifications/page.tsx: 3-card skeleton (header chip + threshold bar + save button rows) during initial data fetch; replaces bare text loader
- settings/account/page.tsx: new page with Change Password / Change Email / Delete Account cards; all submit buttons disabled while in-flight
- components/jobs/DedupGroupViewer.tsx: new component with 2-row pulse skeleton while duplicates fetch; collapses to null when total=0
- lib/types.ts: add NotificationRule*, DuplicateJobSummary, DuplicateJobsResponse Step-3 types
- lib/api.ts: add getNotificationRules, createNotificationRule, updateNotificationRule, changePassword, changeEmail, deleteAccount, getJobDuplicates endpoints
- VersionHistoryDrawer.tsx already had skeleton (4 pulse cards) — no change needed