### PR TITLE
feat(profile): two-pass extraction (deterministic + LLM) for all 4 inputs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -429,6 +429,10 @@ UserProfile
   |     +-- github_languages: dict[str, int]     # From GitHub API
   |     +-- github_topics: list[str]             # From GitHub API
   |     +-- github_skills_inferred: list[str]    # From GitHub API
+  |     +-- linkedin_raw_text: str               # Two-pass: stored for offline LLM re-run
+  |     +-- github_repos_brief: list[dict]       # Two-pass: name/description/topics for LLM re-run
+  |     +-- github_llm_skills: list[str]         # Two-pass: LLM read repo prose
+  |     +-- about_me_inferred_skills: list[str]  # Two-pass: LLM mined preferences.about_me
   +-- preferences: UserPreferences
         +-- target_job_titles: list[str]
         +-- additional_skills: list[str]
@@ -504,6 +508,29 @@ PDF/DOCX -> extract_text() -> raw text
   |     Returns: skills[], job_titles[], education[], certifications[], summary
   |     The regex KNOWN_SKILLS / KNOWN_TITLE_PATTERNS approach was removed in commit 804725c
 ```
+
+### Two-Pass Extraction (`services/profile/two_pass.py`)
+
+Every input gets a **deterministic pass** (plain code) AND an **LLM enhance pass**,
+both merged into one `CVData`:
+
+```
+run_two_pass_extraction(profile)        # in place, never raises, no network
+  CV         : deterministic_cv_fields(raw_text)      + llm_cv_fields_from_text(raw_text)
+  LinkedIn   : header/skills split (deterministic)    + parse_linkedin_from_text(linkedin_raw_text)
+  GitHub     : LANGUAGE/TOPIC lookup (deterministic)  + llm_infer_github_skills(github_repos_brief)
+  Preferences: form parse (deterministic)             + llm_infer_from_about_me(about_me)
+
+reextract_and_rescore(user_id)          # change trigger (background)
+  load_profile -> run_two_pass_extraction -> save_profile("two_pass_reextract")
+               -> new profile version id -> rescore_user_feed
+```
+
+Re-runs use only **stored** inputs (`raw_text`, `linkedin_raw_text`,
+`github_repos_brief`, `about_me`) — no re-upload, no GitHub re-fetch. Each pass
+no-ops when its input or LLM key is missing. Skill provenance is preserved: the
+new sources `about_me_llm` (weight 2.0) and `github_llm` (1.5) feed
+`skill_tiering` alongside the existing ones.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -320,6 +320,18 @@ Adds engine #4 — the LLM judge: `services/llm_matcher.py` (`MatchVerdict`, `ma
 - **Ordinary search** → only newly-fetched jobs are scored; existing rows keep their scores and verdicts untouched.
 A job's score changes only when the profile changes — never just because time passed.
 
+### Two-pass profile extraction (branch `feat/two-pass-profile-extraction`, 2026-06-17)
+
+Every profile input now runs a **deterministic pass** (plain code) AND an **LLM enhance pass**, merged into one `CVData`. The two passes per input:
+- **CV** — `cv_parser.deterministic_cv_fields(raw_text)` (no-LLM skills/summary) + `cv_parser.llm_cv_fields_from_text(raw_text)` (LLM).
+- **LinkedIn** — deterministic header/skills split + `linkedin_parser.parse_linkedin_from_text` (LLM prose). Now stores `cv.linkedin_raw_text`.
+- **GitHub** — deterministic lookup tables + NEW `github_enricher.llm_infer_github_skills(repos_brief)` (LLM reads repo prose). Stores `cv.github_repos_brief`.
+- **Preferences** — plain form parse + NEW `preferences.llm_infer_from_about_me(about_me)` (LLM mines free text).
+
+`services/profile/two_pass.py` orchestrates: `run_two_pass_extraction(profile)` re-runs both passes for all four inputs **from stored data only** (no re-upload, no GitHub re-fetch); each pass no-ops when its input/keys are absent and never raises. `reextract_and_rescore(user_id)` = load → re-extract → `save_profile(..., "two_pass_reextract")` (new version id) → `rescore_user_feed`. The `profile.py` change trigger now schedules `reextract_and_rescore` instead of bare `rescore_user_feed`.
+
+**Rule analog (same spirit as #18):** new `CVData` fields (`linkedin_raw_text`, `github_repos_brief`, `github_llm_skills`, `about_me_inferred_skills`) need **no migration** — profiles store as a JSON blob and `storage._filter_fields` drops unknown keys, so old rows load with defaults. New skill-tiering sources: `about_me_llm` (2.0) and `github_llm` (1.5) in `skill_tiering._SOURCE_WEIGHTS`. **Cost note:** any input change re-runs all LLM passes in the background (faithful to design); gate behind a flag later if it proves expensive. M2 / the LLM judge is untouched.
+
 ## Related documentation
 
 - **`STATUS.md`** — Current phase, what's complete/next, known issues, fragile-source table.

--- a/STATUS.md
+++ b/STATUS.md
@@ -2,7 +2,16 @@
 
 ## Current State: Post-Step-3 matcher batch merged; Step 4 (ops hardening) is next; autonomous maintenance loop running
 
-**Last updated:** 2026-06-11
+> **In flight (branch `feat/two-pass-profile-extraction`, 2026-06-17):** two-pass
+> profile extraction. Every input (CV / LinkedIn / GitHub / preferences) now gets a
+> deterministic pass **and** an LLM enhance pass, merged into one `CVData`. New
+> `CVData` fields (`linkedin_raw_text`, `github_repos_brief`, `github_llm_skills`,
+> `about_me_inferred_skills`) store raw inputs so both passes re-run from storage on
+> any profile change (`two_pass.reextract_and_rescore`) → new profile version → feed
+> re-score. No DB migration (JSON-blob storage). M2 / LLM judge untouched. See
+> `docs/IMPLEMENTATION_LOG.md` for the full entry.
+
+**Last updated:** 2026-06-17
 **Total tests:** 1,285 passing / 0 failing / 3 skipped (1,288 collected as of `a4fe829` — defer to the runtime collected count, not this figure)
 **Source files:** 45 source files in `backend/src/sources/` (excluding `__init__.py` and `base.py`) split into 6 category subfolders | **Test files:** 60+ test modules
 **Job sources:** 46 registered in `SOURCE_REGISTRY` post-M6 rotation (Batch 3 added teaching_vacancies, gov_apprenticeships, nhs_jobs_xml, rippling, comeet, dropped yc_companies/nomis/findajob; M6 2026-06 dropped jobtensor, comeet, gov_apprenticeships, aijobs_global — all upstream-dead). See CLAUDE.md rule #13 for the five load-bearing surfaces that move together on a registry change.

--- a/backend/src/api/routes/profile.py
+++ b/backend/src/api/routes/profile.py
@@ -66,12 +66,16 @@ async def _maybe_trigger_rescore(user_id: str) -> None:
             return
 
         import asyncio  # noqa: PLC0415
-        from src.services.rescore import rescore_user_feed  # noqa: PLC0415
 
-        task = asyncio.create_task(rescore_user_feed(user_id))
+        # Two-pass: a profile change re-runs the deterministic + LLM passes over
+        # ALL inputs from stored data, saves a new profile version (new id),
+        # THEN re-scores the feed against the refreshed profile.
+        from src.services.profile.two_pass import reextract_and_rescore  # noqa: PLC0415
+
+        task = asyncio.create_task(reextract_and_rescore(user_id))
         _rescore_bg_tasks.add(task)
         task.add_done_callback(_rescore_bg_tasks.discard)
-        logger.info("rescore: background re-score scheduled for user %s", user_id)
+        logger.info("two_pass: background re-extract + re-score scheduled for user %s", user_id)
     except Exception as exc:  # noqa: BLE001
         logger.warning(
             "rescore: failed to schedule background re-score for user %s: %s",

--- a/backend/src/api/routes/profile.py
+++ b/backend/src/api/routes/profile.py
@@ -22,7 +22,11 @@ from src.api.models import (
     ProfileVersionSummary,
 )
 from src.services.profile.cv_parser import parse_cv_async
-from src.services.profile.github_enricher import enrich_cv_from_github, fetch_github_profile
+from src.services.profile.github_enricher import (
+    enrich_cv_from_github,
+    fetch_github_profile,
+    normalize_github_username,
+)
 from src.services.profile.linkedin_parser import enrich_cv_from_linkedin, parse_linkedin_pdf
 from src.services.profile.models import UserPreferences, UserProfile
 from src.services.profile.preferences import merge_cv_and_preferences
@@ -325,11 +329,16 @@ async def upload_github(
     username: str = Form(...),  # noqa: B008 — FastAPI dependency-injection idiom
     user: CurrentUser = Depends(require_user),  # noqa: B008 — FastAPI dependency-injection idiom
 ):
-    """Enrich the caller's profile with GitHub public data."""
-    github_data = await fetch_github_profile(username)
+    """Enrich the caller's profile with GitHub public data.
+
+    Accepts a full profile URL or @handle, not just a bare username —
+    ``normalize_github_username`` reduces it to the handle before lookup.
+    """
+    clean_username = normalize_github_username(username)
+    github_data = await fetch_github_profile(clean_username)
     profile = load_profile(user.id) or UserProfile()
     profile.cv_data = enrich_cv_from_github(profile.cv_data, github_data)
-    profile.preferences.github_username = username
+    profile.preferences.github_username = clean_username
     save_profile(profile, user.id)
     await _maybe_trigger_rescore(user.id)
     return GitHubResponse(ok=True, merged=True)

--- a/backend/src/services/profile/cv_parser.py
+++ b/backend/src/services/profile/cv_parser.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import re
 from pathlib import Path
 
 from src.services.profile.models import CVData
@@ -219,6 +220,87 @@ def _build_section_hint(file_path: str) -> str:
     )
 
 
+# ── CV deterministic pass (Pass 1) — no LLM, plain text heuristics ──
+
+_DET_SKILL_HEADINGS = {
+    "skills", "technical skills", "core skills", "key skills",
+    "competencies", "technical competencies", "areas of expertise",
+}
+_DET_SUMMARY_HEADINGS = {
+    "summary", "profile", "professional summary", "about", "about me",
+    "objective", "personal statement",
+}
+# Any heading that ends a section body. Broad on purpose so a skills block
+# stops at the next section even when that section isn't one we extract.
+_DET_OTHER_HEADINGS = {
+    "experience", "work experience", "employment", "education", "projects",
+    "certifications", "licenses & certifications", "achievements", "awards",
+    "publications", "references", "interests", "languages", "contact",
+    "volunteer experience", "courses",
+}
+_DET_ALL_HEADINGS = _DET_SKILL_HEADINGS | _DET_SUMMARY_HEADINGS | _DET_OTHER_HEADINGS
+
+# Split a skills line on commas, pipes, slashes, bullets, semicolons.
+_DET_SKILL_SPLIT = re.compile(r"[,•·|;/]+")
+
+
+def _det_heading_key(line: str) -> str:
+    """Normalise a line for heading comparison: lowercase, strip, drop a
+    trailing colon. Returns '' for lines too long to be a heading."""
+    t = line.strip().rstrip(":").strip().lower()
+    # Real headings are short. Guards against a sentence that happens to
+    # start with 'Summary of my work ...' being treated as a heading.
+    if len(t) > 30:
+        return ""
+    return t
+
+
+def _det_collect_section(lines: list[str], heading_set: set) -> list[str]:
+    """Return the body lines under the first heading in ``heading_set``,
+    stopping at the next recognised heading. Empty list when absent."""
+    out: list[str] = []
+    capturing = False
+    for line in lines:
+        key = _det_heading_key(line)
+        if not capturing:
+            if key in heading_set:
+                capturing = True
+            continue
+        # capturing
+        if key and key in _DET_ALL_HEADINGS:
+            break  # next section starts
+        if line.strip():
+            out.append(line.strip())
+    return out
+
+
+def deterministic_cv_fields(raw_text: str) -> dict:
+    """Pass 1 for the CV — pull base fields from text with NO LLM.
+
+    Conservative by design: only the clearly-delimited "Skills" and
+    "Summary" sections are read. Returns ``{"skills": [...], "summary": str}``.
+    The LLM pass later enhances this; this pass guarantees *something* lands
+    even when no LLM key is configured, and lets the orchestrator re-run on a
+    later change from the stored ``raw_text``.
+    """
+    if not raw_text or not raw_text.strip():
+        return {"skills": [], "summary": ""}
+    lines = raw_text.splitlines()
+
+    skill_lines = _det_collect_section(lines, _DET_SKILL_HEADINGS)
+    skills: list[str] = []
+    seen: set[str] = set()
+    for line in skill_lines:
+        for token in _DET_SKILL_SPLIT.split(line):
+            tok = token.strip()
+            if tok and tok.lower() not in seen:
+                skills.append(tok)
+                seen.add(tok.lower())
+
+    summary = " ".join(_det_collect_section(lines, _DET_SUMMARY_HEADINGS)).strip()
+    return {"skills": skills, "summary": summary}
+
+
 async def parse_cv_async(file_path: str) -> CVData:
     """Parse a CV file using LLM analysis. Works for ANY professional domain.
 
@@ -244,10 +326,23 @@ async def parse_cv_async(file_path: str) -> CVData:
             "Only PDF and DOCX files are supported."
         )
 
+    # PDF-only font-size section hint (needs the file). The LLM extraction
+    # itself works purely off text — see ``llm_cv_fields_from_text``.
+    section_hint = _build_section_hint(file_path)
+    return await llm_cv_fields_from_text(raw_text, section_hint=section_hint)
+
+
+async def llm_cv_fields_from_text(raw_text: str, section_hint: str = "") -> CVData:
+    """Pass 2 for the CV — LLM extraction from raw text only (no file needed).
+
+    Factored out of ``parse_cv_async`` so the two-pass orchestrator can re-run
+    the CV LLM pass on a later profile change from the stored ``cv.raw_text``,
+    without the original upload. Same validation + graceful-degradation
+    contract as the file path (Batch 1.1 / review fix #3).
+    """
     from src.services.profile.llm_provider import llm_extract, llm_extract_validated
     from src.services.profile.schemas import CVSchema, cv_schema_to_cvdata
 
-    section_hint = _build_section_hint(file_path)
     prompt = _CV_PROMPT.format(cv_text=raw_text) + section_hint
 
     try:

--- a/backend/src/services/profile/github_enricher.py
+++ b/backend/src/services/profile/github_enricher.py
@@ -29,6 +29,40 @@ import aiohttp
 
 _GITHUB_USERNAME_RE = re.compile(r'^[a-zA-Z0-9]([a-zA-Z0-9-]{0,37}[a-zA-Z0-9])?$')
 
+
+def normalize_github_username(raw: str) -> str:
+    """Reduce any GitHub input to a bare username.
+
+    Accepts what users actually paste — a full profile URL
+    (``https://github.com/torvalds``), an ``@handle``, or the plain
+    username — and returns just the username. The caller still runs
+    ``_GITHUB_USERNAME_RE`` on the result, so junk input that doesn't
+    reduce to a valid handle is rejected downstream (returns "").
+
+    Examples:
+      ``https://github.com/torvalds``       -> ``torvalds``
+      ``github.com/torvalds/repo``          -> ``torvalds``
+      ``www.github.com/torvalds?tab=repos`` -> ``torvalds``
+      ``@torvalds``                         -> ``torvalds``
+      ``torvalds``                          -> ``torvalds``
+    """
+    if not isinstance(raw, str):
+        return ""
+    s = raw.strip()
+    if not s:
+        return ""
+    # Drop a leading @ that users copy from social handles.
+    s = s.lstrip("@").strip()
+    # If it mentions github.com, take the first path segment after it.
+    # Tolerates http(s)://, www., a trailing path, query string, or fragment.
+    match = re.search(r"github\.com/+([^/?#\s]+)", s, re.IGNORECASE)
+    if match:
+        return match.group(1)
+    # Otherwise treat the whole thing as a handle, but still strip any
+    # stray path/query so "torvalds/repo" -> "torvalds".
+    return re.split(r"[/?#\s]", s, maxsplit=1)[0]
+
+
 from src.core.settings import GITHUB_TOKEN
 from src.services.profile.dep_file_parser import MANIFEST_FILES, parse_manifest
 from src.services.profile.dependency_map import lookup_skill
@@ -268,6 +302,8 @@ async def fetch_github_profile(
         "frameworks_inferred": [],
         "repos_brief": [],
     }
+    # Accept a full profile URL or @handle, not just a bare username.
+    username = normalize_github_username(username)
     if not _GITHUB_USERNAME_RE.match(username):
         logger.warning("Invalid GitHub username format: %s", username)
         return empty

--- a/backend/src/services/profile/github_enricher.py
+++ b/backend/src/services/profile/github_enricher.py
@@ -266,6 +266,7 @@ async def fetch_github_profile(
         "topics": [],
         "skills_inferred": [],
         "frameworks_inferred": [],
+        "repos_brief": [],
     }
     if not _GITHUB_USERNAME_RE.match(username):
         logger.warning("Invalid GitHub username format: %s", username)
@@ -338,12 +339,26 @@ async def fetch_github_profile(
 
         skills_inferred = _infer_skills(weighted_languages, all_topics)
 
+        # Two-pass — compact repo briefs (name/description/topics) for the
+        # LLM pass. Only repos with prose worth reading (a description or
+        # topics) are kept, capped so the prompt stays small.
+        repos_brief = [
+            {
+                "name": r["name"],
+                "description": r.get("description", ""),
+                "topics": list(r.get("topics", []) or []),
+            }
+            for r in repositories
+            if r.get("description") or r.get("topics")
+        ][:MAX_REPOS]
+
         return {
             "repositories": repositories,
             "languages": weighted_languages,
             "topics": sorted(all_topics),
             "skills_inferred": skills_inferred,
             "frameworks_inferred": frameworks_inferred,
+            "repos_brief": repos_brief,
         }
     finally:
         if own_session:
@@ -370,6 +385,77 @@ def _infer_skills(languages: dict[str, int], topics: set[str]) -> list[str]:
     return skills
 
 
+# ── GitHub LLM pass (Pass 2) — read repo prose for extra skills ─────
+
+_GITHUB_LLM_SYSTEM = (
+    "You are an expert at reading a developer's GitHub repositories and naming "
+    "the concrete technologies, frameworks, and domains they demonstrate. You "
+    "return JSON only and never invent skills the text does not support."
+)
+
+_GITHUB_LLM_PROMPT = """Below is a list of a developer's public GitHub repositories — each with
+a name, description, and topic tags.
+
+Infer the concrete technical SKILLS this developer demonstrates: frameworks,
+libraries, tools, platforms, and technical domains. Focus on things a
+hard-coded language/topic table would MISS — e.g. "LangChain", "RAG",
+"Stripe API", "Computer Vision", "Kubernetes Operators".
+
+Return JSON: {{"skills": ["Skill One", "Skill Two", ...]}}
+
+Rules:
+- Only skills the repo text actually supports. Do not guess from nothing.
+- Individual items, not categories ("PyTorch", not "ML frameworks").
+- Skip bare programming languages (Python/Java/etc.) — those are covered elsewhere.
+
+REPOSITORIES:
+---
+{repos}
+---"""
+
+
+async def llm_infer_github_skills(repos_brief: list[dict]) -> list[str]:
+    """Pass 2 for GitHub — ask the LLM to read repo prose and name skills the
+    hard-coded ``LANGUAGE_TO_SKILL`` / ``TOPIC_TO_SKILL`` tables can't know.
+
+    Returns ``[]`` (never raises) when there are no repos worth reading or the
+    provider chain fails — graceful no-op, mirroring the deterministic path.
+    The empty-input branch never calls the LLM (cost guard).
+    """
+    if not repos_brief:
+        return []
+
+    lines: list[str] = []
+    for r in repos_brief:
+        name = (r.get("name") or "").strip()
+        desc = (r.get("description") or "").strip()
+        topics = ", ".join(t for t in (r.get("topics") or []) if t)
+        if not (name or desc or topics):
+            continue
+        lines.append(f"- {name}: {desc} [topics: {topics}]")
+    if not lines:
+        return []
+
+    prompt = _GITHUB_LLM_PROMPT.format(repos="\n".join(lines))
+    try:
+        from src.services.profile.llm_provider import llm_extract  # noqa: PLC0415
+        result = await llm_extract(prompt, system=_GITHUB_LLM_SYSTEM)
+    except Exception as e:  # noqa: BLE001 — never crash the pass
+        logger.warning("GitHub LLM skill inference failed: %s", e)
+        return []
+
+    raw = result.get("skills") if isinstance(result, dict) else None
+    if not isinstance(raw, list):
+        return []
+    out: list[str] = []
+    seen: set[str] = set()
+    for s in raw:
+        if isinstance(s, str) and s.strip() and s.strip().lower() not in seen:
+            out.append(s.strip())
+            seen.add(s.strip().lower())
+    return out
+
+
 def enrich_cv_from_github(cv: CVData, github_data: dict) -> CVData:
     """Merge GitHub-inferred skills into CVData, deduplicating.
 
@@ -377,6 +463,9 @@ def enrich_cv_from_github(cv: CVData, github_data: dict) -> CVData:
     ``frameworks_inferred`` with dedup against existing CV skills AND
     the language/topic-derived skills, so the same framework never
     appears twice in a downstream SearchConfig.
+
+    Two-pass — also stores ``github_repos_brief`` so the LLM pass can re-run
+    offline on a later profile change.
     """
     seen_skills = {s.lower() for s in cv.skills}
 
@@ -396,5 +485,9 @@ def enrich_cv_from_github(cv: CVData, github_data: dict) -> CVData:
     cv.github_topics = github_data.get("topics", [])
     cv.github_skills_inferred = new_github_skills
     cv.github_frameworks = new_frameworks
+    # Two-pass — keep repo briefs for offline LLM re-runs. Only overwrite when
+    # a non-empty value arrives, so a partial re-enrich never wipes them.
+    if github_data.get("repos_brief"):
+        cv.github_repos_brief = github_data["repos_brief"]
 
     return cv

--- a/backend/src/services/profile/linkedin_parser.py
+++ b/backend/src/services/profile/linkedin_parser.py
@@ -437,6 +437,8 @@ def _empty_linkedin_data() -> dict:
         "projects": [],
         "volunteer": [],
         "courses": [],
+        # Two-pass — raw text kept for offline LLM re-runs (empty here).
+        "raw_text": "",
     }
 
 
@@ -452,6 +454,20 @@ async def parse_linkedin_pdf_async(file_path: str) -> dict:
     if not text or not _looks_like_linkedin(text):
         if text:
             logger.info("PDF at %s does not look like a LinkedIn export; skipping", file_path)
+        return _empty_linkedin_data()
+
+    return await parse_linkedin_from_text(text)
+
+
+async def parse_linkedin_from_text(text: str) -> dict:
+    """Parse already-extracted LinkedIn text into the canonical dict schema.
+
+    Factored out of ``parse_linkedin_pdf_async`` so the two-pass orchestrator
+    can re-run the LinkedIn LLM pass from the stored ``cv.linkedin_raw_text``
+    on a later profile change — no re-upload needed. Returns the empty-data
+    dict when the text doesn't look like a LinkedIn export.
+    """
+    if not text or not _looks_like_linkedin(text):
         return _empty_linkedin_data()
 
     sections = _split_sections(text)
@@ -510,6 +526,9 @@ async def parse_linkedin_pdf_async(file_path: str) -> dict:
         "projects": _coerce_projects(_get(proj_raw, "projects")),
         "volunteer": _coerce_volunteer(_get(vol_raw, "volunteer")),
         "courses": _coerce_courses(_get(course_raw, "courses")),
+        # Two-pass — keep the extracted text so the LLM pass can re-run on a
+        # later profile change without the user re-uploading the PDF.
+        "raw_text": text,
     }
 
 
@@ -571,6 +590,11 @@ def enrich_cv_from_linkedin(cv: CVData, linkedin_data: dict) -> CVData:
     cv.linkedin_positions = linkedin_data.get("positions", [])
     cv.linkedin_skills = new_linkedin_skills
     cv.linkedin_industry = linkedin_data.get("industry", "")
+    # Two-pass — keep the raw text (if the parser supplied it) so the LLM
+    # pass can re-run offline. Only overwrite when a non-empty value arrives,
+    # so a partial re-enrich never wipes a previously-stored transcript.
+    if linkedin_data.get("raw_text"):
+        cv.linkedin_raw_text = linkedin_data["raw_text"]
 
     # Batch 1.5 — expanded sections. Overwrite rather than merge: LinkedIn
     # is the canonical source for these, and re-parsing a profile should

--- a/backend/src/services/profile/models.py
+++ b/backend/src/services/profile/models.py
@@ -26,6 +26,11 @@ class CVData:
     linkedin_positions: list[dict] = field(default_factory=list)
     linkedin_skills: list[str] = field(default_factory=list)
     linkedin_industry: str = ""
+    # Two-pass extraction — the raw text pdfplumber pulled from the LinkedIn
+    # "Save to PDF" export. Stored so the LLM pass can re-run on any profile
+    # change WITHOUT the user re-uploading the file (the temp file is deleted
+    # after the first parse). Empty when no LinkedIn PDF was ever uploaded.
+    linkedin_raw_text: str = ""
     # Batch 1.5 — expanded LinkedIn sections (Languages, Projects,
     # Volunteer Experience, Courses). All are LinkedIn-sourced display
     # fields: they inform the CV viewer and feed relevance keywords
@@ -44,6 +49,15 @@ class CVData:
     # separate from github_skills_inferred so downstream can audit
     # where a skill came from (language signal vs declared dependency).
     github_frameworks: list[str] = field(default_factory=list)
+    # Two-pass extraction — a compact list of {name, description, topics}
+    # for the user's public repos. Stored so the GitHub LLM pass can re-run
+    # offline (no re-fetch) on a later profile change.
+    github_repos_brief: list[dict] = field(default_factory=list)
+    # Two-pass extraction — skills the LLM inferred by reading repo prose
+    # (names/descriptions/topics) that the hard-coded language/topic lookup
+    # tables can't recognise (e.g. "LangChain", "RAG"). Separate field so
+    # skill-tiering can weight this signal independently.
+    github_llm_skills: list[str] = field(default_factory=list)
     # Batch 1.1 — archetype classification (CareerDomain enum value).
     # Optional; None means "LLM did not classify". Consumed by
     # archetype-aware scoring (Pillar 1 #10 / Pillar 2).
@@ -63,6 +77,11 @@ class CVData:
     # behaviour. ProfileResponse expansion surfaces this as
     # ``skill_provenance``.
     cv_skills_esco: dict[str, str] = field(default_factory=dict)
+    # Two-pass extraction — skills the LLM mined from the user's free-text
+    # ``preferences.about_me``. Stored on CVData (the skill container) so
+    # skill-tiering can weight this "user's own words" signal. Empty when
+    # about_me is blank or the LLM pass is unavailable.
+    about_me_inferred_skills: list[str] = field(default_factory=list)
 
     @classmethod
     def from_json_resume(cls, data: dict) -> CVData:

--- a/backend/src/services/profile/preferences.py
+++ b/backend/src/services/profile/preferences.py
@@ -2,7 +2,64 @@
 
 from __future__ import annotations
 
+import logging
+
 from src.services.profile.models import UserPreferences
+
+logger = logging.getLogger("job360.profile.preferences")
+
+
+# ── Preferences LLM pass (Pass 2) — mine free-text about_me ─────────
+
+_ABOUT_ME_SYSTEM = (
+    "You read a job-seeker's free-text 'about me' blurb and name the concrete "
+    "professional skills it implies. You return JSON only and never invent "
+    "skills the text does not support."
+)
+
+_ABOUT_ME_PROMPT = """Read this job-seeker's free-text "about me" and extract the concrete
+professional SKILLS it implies — tools, methods, domains, specialities.
+
+Return JSON: {{"skills": ["Skill One", "Skill Two", ...]}}
+
+Rules:
+- Only skills the text actually supports. Do not invent.
+- Individual items, not categories.
+- Domain-agnostic: technical OR non-technical (e.g. "Stakeholder Management", "HIPAA Compliance", "Welding").
+
+ABOUT ME:
+---
+{about_me}
+---"""
+
+
+async def llm_infer_from_about_me(about_me: str) -> list[str]:
+    """Pass 2 for preferences — mine the free-text ``about_me`` for skills the
+    structured form never captured.
+
+    Returns ``[]`` (never raises) on blank input or provider failure. Blank
+    input never calls the LLM (cost guard).
+    """
+    if not about_me or not about_me.strip():
+        return []
+    prompt = _ABOUT_ME_PROMPT.format(about_me=about_me.strip())
+    try:
+        from src.services.profile.llm_provider import llm_extract  # noqa: PLC0415
+        result = await llm_extract(prompt, system=_ABOUT_ME_SYSTEM)
+    except Exception as e:  # noqa: BLE001 — never crash the pass
+        logger.warning("about_me LLM skill inference failed: %s", e)
+        return []
+
+    raw = result.get("skills") if isinstance(result, dict) else None
+    if not isinstance(raw, list):
+        return []
+    out: list[str] = []
+    seen: set[str] = set()
+    for s in raw:
+        if isinstance(s, str) and s.strip() and s.strip().lower() not in seen:
+            out.append(s.strip())
+            seen.add(s.strip().lower())
+    return out
 
 
 def _split_and_clean(value: str) -> list[str]:

--- a/backend/src/services/profile/skill_tiering.py
+++ b/backend/src/services/profile/skill_tiering.py
@@ -49,7 +49,14 @@ _SOURCE_WEIGHTS: dict[SourceName, float] = {
     "user_declared": 3.0,
     "cv_explicit": 2.0,
     "linkedin": 2.0,
+    # Two-pass LLM enhance sources. ``about_me_llm`` = skills the LLM mined
+    # from the user's own free-text blurb (the user's own words → trust on a
+    # par with an explicit CV mention). ``github_llm`` = skills the LLM read
+    # off repo prose (demonstrated usage but inferred → same trust as a
+    # declared dependency).
+    "about_me_llm": 2.0,
     "github_dep": 1.5,
+    "github_llm": 1.5,
     "github_lang": 1.0,
 }
 
@@ -144,5 +151,10 @@ def collect_evidence_from_profile(profile) -> list[SkillEvidence]:
             _add(s, "github_dep")
         for s in getattr(cv, "github_skills_inferred", []) or []:
             _add(s, "github_lang")
+        # Two-pass LLM enhance sources.
+        for s in getattr(cv, "github_llm_skills", []) or []:
+            _add(s, "github_llm")
+        for s in getattr(cv, "about_me_inferred_skills", []) or []:
+            _add(s, "about_me_llm")
 
     return list(evidence.values())

--- a/backend/src/services/profile/two_pass.py
+++ b/backend/src/services/profile/two_pass.py
@@ -1,0 +1,151 @@
+"""Two-pass profile extraction orchestrator.
+
+Goal: every profile input (CV, LinkedIn, GitHub, preferences) goes through a
+deterministic pass (plain code) AND an LLM enhance pass, both merged into one
+``CVData``. When the user later changes ANY input, both passes re-run from the
+STORED raw inputs (``cv.raw_text``, ``cv.linkedin_raw_text``,
+``cv.github_repos_brief``, ``preferences.about_me``) — no re-upload, no network
+re-fetch — producing a refreshed CVData and a new profile-version id.
+
+Each pass gracefully no-ops when its input is missing or the LLM provider chain
+is unavailable, so this is safe to call with partial profiles and offline.
+
+Heavy/LLM imports stay module-local-friendly; the four enhance helpers are
+imported at module top so tests can monkeypatch them by name.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from src.services.profile.cv_parser import (
+    deterministic_cv_fields,
+    llm_cv_fields_from_text,
+)
+from src.services.profile.github_enricher import llm_infer_github_skills
+from src.services.profile.linkedin_parser import (
+    enrich_cv_from_linkedin,
+    parse_linkedin_from_text,
+)
+from src.services.profile.models import CVData, UserProfile
+from src.services.profile.preferences import llm_infer_from_about_me
+
+logger = logging.getLogger("job360.profile.two_pass")
+
+
+def _merge_str_list(dst: list[str], src: list[str]) -> None:
+    """Append items from ``src`` not already in ``dst`` (case-insensitive),
+    preserving ``dst`` order then ``src`` order. Mutates ``dst`` in place."""
+    seen = {s.lower() for s in dst}
+    for s in src or []:
+        if isinstance(s, str) and s.strip() and s.lower() not in seen:
+            dst.append(s)
+            seen.add(s.lower())
+
+
+def _merge_cv_llm_into(cv: CVData, llm_cv: CVData) -> None:
+    """Merge the CV-OWNED fields of an LLM result into the live ``cv``.
+
+    Unions the list fields and fills empty scalars. Deliberately does NOT touch
+    ``linkedin_*`` / ``github_*`` / ``about_me_inferred_skills`` — those belong
+    to the other passes and must survive a CV re-parse.
+    """
+    _merge_str_list(cv.skills, llm_cv.skills)
+    _merge_str_list(cv.job_titles, llm_cv.job_titles)
+    _merge_str_list(cv.companies, llm_cv.companies)
+    _merge_str_list(cv.education, llm_cv.education)
+    _merge_str_list(cv.certifications, llm_cv.certifications)
+    _merge_str_list(cv.achievements, llm_cv.achievements)
+    _merge_str_list(cv.industries, llm_cv.industries)
+    _merge_str_list(cv.cv_languages, llm_cv.cv_languages)
+    # Fill empty scalars only — never overwrite a value the user already has.
+    if not cv.name and llm_cv.name:
+        cv.name = llm_cv.name
+    if not cv.headline and llm_cv.headline:
+        cv.headline = llm_cv.headline
+    if not cv.location and llm_cv.location:
+        cv.location = llm_cv.location
+    if not cv.summary and llm_cv.summary:
+        cv.summary = llm_cv.summary
+    if not cv.experience_text and llm_cv.experience_text:
+        cv.experience_text = llm_cv.experience_text
+
+
+async def run_two_pass_extraction(profile: UserProfile) -> UserProfile:
+    """Run deterministic + LLM enhance passes over all four inputs, in place.
+
+    Re-runs entirely from data already stored on the profile — never re-reads a
+    file or re-hits the GitHub API. Returns the same ``profile`` object for
+    convenience. Never raises: a failing LLM pass is logged and skipped.
+    """
+    cv = profile.cv_data
+    prefs = profile.preferences
+
+    # ── CV: deterministic pass first, then LLM enhance ──
+    if cv.raw_text:
+        det = deterministic_cv_fields(cv.raw_text)
+        _merge_str_list(cv.skills, det.get("skills", []))
+        if not cv.summary and det.get("summary"):
+            cv.summary = det["summary"]
+        try:
+            llm_cv = await llm_cv_fields_from_text(cv.raw_text)
+            _merge_cv_llm_into(cv, llm_cv)
+        except Exception as e:  # noqa: BLE001 — deterministic result still stands
+            logger.warning("two_pass: CV LLM pass skipped: %s", e)
+
+    # ── LinkedIn: re-run the (hybrid) parse from stored text ──
+    if cv.linkedin_raw_text:
+        try:
+            ld = await parse_linkedin_from_text(cv.linkedin_raw_text)
+            enrich_cv_from_linkedin(cv, ld)
+        except Exception as e:  # noqa: BLE001
+            logger.warning("two_pass: LinkedIn pass skipped: %s", e)
+
+    # ── GitHub: LLM pass over stored repo briefs (deterministic skills kept) ──
+    if cv.github_repos_brief:
+        try:
+            cv.github_llm_skills = await llm_infer_github_skills(cv.github_repos_brief)
+        except Exception as e:  # noqa: BLE001
+            logger.warning("two_pass: GitHub LLM pass skipped: %s", e)
+
+    # ── Preferences: LLM mine of the free-text about_me ──
+    if prefs.about_me:
+        try:
+            cv.about_me_inferred_skills = await llm_infer_from_about_me(prefs.about_me)
+        except Exception as e:  # noqa: BLE001
+            logger.warning("two_pass: about_me LLM pass skipped: %s", e)
+
+    return profile
+
+
+async def reextract_and_rescore(user_id: str, db_path: str | None = None) -> dict:
+    """Background entry point fired when a user changes any profile input.
+
+    Loads the profile, re-runs both extraction passes over all inputs, saves a
+    new profile version (the new id the change produces), then re-scores the
+    user's feed against the refreshed profile. Never raises — returns a small
+    status dict. Storage/rescore imports are local to keep this import-cheap.
+    """
+    from src.services.profile.storage import load_profile, save_profile  # noqa: PLC0415
+
+    profile = load_profile(user_id)
+    if profile is None:
+        return {"reextracted": False, "reason": "no_profile"}
+
+    try:
+        await run_two_pass_extraction(profile)
+        save_profile(profile, user_id, source_action="two_pass_reextract")
+    except Exception as e:  # noqa: BLE001 — must never break the change flow
+        logger.warning("two_pass: reextract failed for user %s: %s", user_id, e)
+        return {"reextracted": False, "reason": "error"}
+
+    # Re-score the feed against the freshly enhanced profile.
+    try:
+        from src.services.rescore import rescore_user_feed  # noqa: PLC0415
+
+        result = await rescore_user_feed(user_id, db_path=db_path)
+    except Exception as e:  # noqa: BLE001
+        logger.warning("two_pass: rescore after reextract failed for %s: %s", user_id, e)
+        result = {"rescored": 0, "reason": "rescore_error"}
+
+    return {"reextracted": True, "rescore": result}

--- a/backend/tests/test_github_deps.py
+++ b/backend/tests/test_github_deps.py
@@ -320,6 +320,99 @@ async def test_fetch_github_profile_aggregates_frameworks():
     assert set(frameworks) == {"FastAPI", "Pydantic", "React", "Next.js"}
 
 
+# ── GitHub LLM pass (Pass 2) — infer skills from repo prose ─────────
+
+
+@pytest.mark.asyncio
+async def test_llm_infer_github_skills_parses_skills():
+    """The LLM reads repo name/description/topics and returns extra skills
+    the hard-coded lookup table can't know (e.g. 'LangChain', 'RAG')."""
+    seen = {}
+
+    async def fake_llm(prompt, system=""):
+        seen["prompt"] = prompt
+        return {"skills": ["LangChain", "RAG", "Vector Search"]}
+
+    repos_brief = [
+        {"name": "rag-bot", "description": "A retrieval bot built with langchain", "topics": ["llm"]},
+    ]
+    with patch("src.services.profile.llm_provider.llm_extract", new=fake_llm):
+        skills = await github_enricher.llm_infer_github_skills(repos_brief)
+
+    assert "rag-bot" in seen["prompt"]  # repo data reached the prompt
+    assert "LangChain" in skills and "RAG" in skills
+
+
+@pytest.mark.asyncio
+async def test_llm_infer_github_skills_empty_input_skips_llm():
+    """No repos → return [] without ever calling the LLM (cost guard)."""
+    called = False
+
+    async def fake_llm(prompt, system=""):
+        nonlocal called
+        called = True
+        return {"skills": ["should-not-happen"]}
+
+    with patch("src.services.profile.llm_provider.llm_extract", new=fake_llm):
+        skills = await github_enricher.llm_infer_github_skills([])
+
+    assert skills == []
+    assert called is False
+
+
+@pytest.mark.asyncio
+async def test_llm_infer_github_skills_llm_failure_returns_empty():
+    """Provider error must not crash the pass — returns [] (never raises)."""
+    async def boom(prompt, system=""):
+        raise RuntimeError("no LLM key configured")
+
+    repos_brief = [{"name": "r", "description": "d", "topics": []}]
+    with patch("src.services.profile.llm_provider.llm_extract", new=boom):
+        skills = await github_enricher.llm_infer_github_skills(repos_brief)
+
+    assert skills == []
+
+
+@pytest.mark.asyncio
+async def test_fetch_github_profile_includes_repos_brief():
+    """fetch_github_profile exposes repos_brief (name/description/topics) so the
+    LLM pass can re-run offline on a later profile change."""
+    now_iso = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    repos = [
+        {"name": "rag-bot", "language": "Python", "description": "RAG with langchain",
+         "stargazers_count": 3, "topics": ["llm", "rag"], "pushed_at": now_iso, "fork": False},
+    ]
+
+    async def fake_get_json(session, url):
+        if url.endswith("/repos?per_page=30&sort=pushed"):
+            return repos
+        if "/languages" in url:
+            return {"Python": 1}
+        return None
+
+    fake_session = _make_async_session()
+    with patch("src.services.profile.github_enricher._get_json", side_effect=fake_get_json), \
+         patch("src.services.profile.github_enricher._fetch_repo_frameworks",
+               new=AsyncMock(return_value=[])), \
+         patch("src.services.profile.github_enricher.aiohttp.ClientSession", return_value=fake_session):
+        result = await github_enricher.fetch_github_profile("alice")
+
+    brief = result["repos_brief"]
+    assert brief and brief[0]["name"] == "rag-bot"
+    assert brief[0]["description"] == "RAG with langchain"
+    assert "rag" in brief[0]["topics"]
+
+
+def test_enrich_cv_from_github_stores_repos_brief():
+    cv = CVData()
+    github_data = {
+        "languages": {}, "topics": [], "skills_inferred": [], "frameworks_inferred": [],
+        "repos_brief": [{"name": "x", "description": "y", "topics": ["z"]}],
+    }
+    out = github_enricher.enrich_cv_from_github(cv, github_data)
+    assert out.github_repos_brief == [{"name": "x", "description": "y", "topics": ["z"]}]
+
+
 @pytest.mark.asyncio
 async def test_fetch_repo_frameworks_parses_real_manifest_content():
     """Smoke test: given a real requirements.txt payload the helper yields mapped skills."""

--- a/backend/tests/test_github_deps.py
+++ b/backend/tests/test_github_deps.py
@@ -240,6 +240,53 @@ def _make_async_session():
     return AsyncMock()
 
 
+# ── github_enricher — username normalisation (URL / @handle / bare) ─
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("https://github.com/torvalds", "torvalds"),
+        ("http://github.com/torvalds", "torvalds"),
+        ("github.com/torvalds", "torvalds"),
+        ("www.github.com/torvalds", "torvalds"),
+        ("github.com/torvalds/linux", "torvalds"),
+        ("https://github.com/torvalds/?tab=repositories", "torvalds"),
+        ("https://github.com/torvalds/", "torvalds"),
+        ("@torvalds", "torvalds"),
+        ("torvalds", "torvalds"),
+        ("torvalds/linux", "torvalds"),
+        ("  torvalds  ", "torvalds"),
+        ("https://github.com/foo-bar", "foo-bar"),
+        ("", ""),
+    ],
+)
+def test_normalize_github_username(raw, expected):
+    assert github_enricher.normalize_github_username(raw) == expected
+
+
+def test_normalize_github_username_non_string():
+    assert github_enricher.normalize_github_username(None) == ""
+
+
+@pytest.mark.asyncio
+async def test_fetch_github_profile_accepts_full_url():
+    """A pasted profile URL is normalised to the username before the API call."""
+    captured: dict = {}
+
+    async def fake_get_json(session, url):
+        captured["url"] = url
+        return []  # empty repo list → early return with empty payload
+
+    with patch.object(github_enricher, "_get_json", side_effect=fake_get_json):
+        result = await github_enricher.fetch_github_profile(
+            "https://github.com/torvalds", session=_make_async_session()
+        )
+
+    assert "users/torvalds/repos" in captured["url"]
+    assert result["repositories"] == []
+
+
 def _passthrough_cm(resp_status: int, resp_json: dict | list | None):
     """Build a MagicMock behaving like aiohttp's async context manager on ``session.get``."""
     response = MagicMock()

--- a/backend/tests/test_linkedin_github.py
+++ b/backend/tests/test_linkedin_github.py
@@ -319,6 +319,7 @@ class TestParseLinkedInPdfEndToEnd:
             "positions", "skills", "education", "certifications",
             "summary", "industry", "headline",
             "languages", "projects", "volunteer", "courses",
+            "raw_text",
         }
         assert data["skills"] == ["Python"]
 
@@ -337,6 +338,38 @@ class TestParseLinkedInPdfEndToEnd:
         assert data["skills"] == ["Python", "Rust"]
         assert data["positions"] == []
         assert data["education"] == []
+
+
+# ---------------------------------------------------------------------------
+# Two-pass: LinkedIn raw text storage (re-run extraction without re-upload)
+# ---------------------------------------------------------------------------
+
+class TestLinkedInRawTextStorage:
+    @pytest.mark.asyncio
+    async def test_parse_returns_raw_text(self, tmp_path):
+        """parse_linkedin_pdf_async exposes the extracted text under 'raw_text'
+        so the two-pass orchestrator can re-run the LLM pass without the file."""
+        path = _make_linkedin_pdf(
+            tmp_path,
+            summary="",
+            experience=None, education=None,
+            skills=["Python", "Rust"], certifications=None,
+        )
+        data = await parse_linkedin_pdf_async(str(path))
+        assert "raw_text" in data
+        assert "Python" in data["raw_text"]
+
+    def test_enrich_stores_linkedin_raw_text(self):
+        cv = CVData()
+        data = {"skills": ["Python"], "positions": [], "raw_text": "RAW LINKEDIN TEXT"}
+        out = enrich_cv_from_linkedin(cv, data)
+        assert out.linkedin_raw_text == "RAW LINKEDIN TEXT"
+
+    def test_enrich_missing_raw_text_leaves_empty(self):
+        """Older callers that don't pass raw_text don't crash; field stays ''."""
+        cv = CVData()
+        out = enrich_cv_from_linkedin(cv, {"skills": [], "positions": []})
+        assert out.linkedin_raw_text == ""
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_two_pass.py
+++ b/backend/tests/test_two_pass.py
@@ -1,0 +1,290 @@
+"""Two-pass profile extraction — deterministic pass + LLM enhance pass.
+
+Covers the NEW pieces added for the user-side profile improvement goal:
+  * preferences LLM pass — mine free-text ``about_me`` for skills
+  * CV deterministic pass — no-LLM field grab from CV text
+  * the orchestrator that re-runs both passes for all inputs from stored data
+
+All LLM calls are mocked (rule #4 — suite runs offline).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from src.services.profile.models import CVData, UserPreferences, UserProfile
+
+# ── Preferences LLM pass (Pass 2) — mine about_me ───────────────────
+
+
+class TestPreferencesLlmPass:
+    @pytest.mark.asyncio
+    async def test_infers_skills_from_about_me(self):
+        from src.services.profile.preferences import llm_infer_from_about_me
+
+        captured = {}
+
+        async def fake_llm(prompt, system=""):
+            captured["prompt"] = prompt
+            return {"skills": ["Stakeholder Management", "Roadmapping"]}
+
+        text = "I'm a product lead who loves stakeholder management and roadmapping."
+        with patch("src.services.profile.llm_provider.llm_extract", new=fake_llm):
+            skills = await llm_infer_from_about_me(text)
+
+        assert "stakeholder" in captured["prompt"].lower()
+        assert "Stakeholder Management" in skills
+
+    @pytest.mark.asyncio
+    async def test_blank_about_me_skips_llm(self):
+        from src.services.profile.preferences import llm_infer_from_about_me
+
+        called = False
+
+        async def fake_llm(prompt, system=""):
+            nonlocal called
+            called = True
+            return {"skills": ["nope"]}
+
+        with patch("src.services.profile.llm_provider.llm_extract", new=fake_llm):
+            skills = await llm_infer_from_about_me("   ")
+
+        assert skills == []
+        assert called is False
+
+    @pytest.mark.asyncio
+    async def test_llm_failure_returns_empty(self):
+        from src.services.profile.preferences import llm_infer_from_about_me
+
+        async def boom(prompt, system=""):
+            raise RuntimeError("no provider")
+
+        with patch("src.services.profile.llm_provider.llm_extract", new=boom):
+            skills = await llm_infer_from_about_me("some real text here")
+
+        assert skills == []
+
+
+# ── CV deterministic pass (Pass 1) — no-LLM field grab ──────────────
+
+
+class TestCvDeterministicPass:
+    def test_extracts_skills_section_lines(self):
+        from src.services.profile.cv_parser import deterministic_cv_fields
+
+        text = (
+            "John Doe\nSenior Engineer\n\n"
+            "Skills\nPython\nDjango\nAWS\n\n"
+            "Experience\nDid things at a company\n"
+        )
+        out = deterministic_cv_fields(text)
+        assert "Python" in out["skills"]
+        assert "Django" in out["skills"]
+        assert "AWS" in out["skills"]
+        # The 'Experience' body must NOT leak into skills.
+        assert "Did things at a company" not in out["skills"]
+
+    def test_splits_comma_separated_skills(self):
+        from src.services.profile.cv_parser import deterministic_cv_fields
+
+        text = "Skills:\nPython, Django, AWS, Docker\n\nEducation\nBSc\n"
+        out = deterministic_cv_fields(text)
+        assert {"Python", "Django", "AWS", "Docker"}.issubset(set(out["skills"]))
+
+    def test_no_skills_section_returns_empty(self):
+        from src.services.profile.cv_parser import deterministic_cv_fields
+
+        out = deterministic_cv_fields("John Doe\nSome prose, no skills header.\n")
+        assert out["skills"] == []
+
+    def test_captures_summary_section(self):
+        from src.services.profile.cv_parser import deterministic_cv_fields
+
+        text = "Summary\nExperienced ML engineer with 5 years.\n\nSkills\nPython\n"
+        out = deterministic_cv_fields(text)
+        assert "Experienced ML engineer" in out["summary"]
+
+    def test_empty_text_returns_empty_fields(self):
+        from src.services.profile.cv_parser import deterministic_cv_fields
+
+        out = deterministic_cv_fields("")
+        assert out["skills"] == []
+        assert out["summary"] == ""
+
+
+# ── Skill tiering — new two-pass sources contribute evidence ────────
+
+
+class TestSkillTieringNewSources:
+    def test_github_llm_skill_becomes_evidence(self):
+        from src.services.profile.skill_tiering import collect_evidence_from_profile
+
+        prof = UserProfile(cv_data=CVData(github_llm_skills=["LangChain"]))
+        ev = {e.name: e.sources for e in collect_evidence_from_profile(prof)}
+        assert "github_llm" in ev["LangChain"]
+
+    def test_about_me_skill_becomes_evidence(self):
+        from src.services.profile.skill_tiering import collect_evidence_from_profile
+
+        prof = UserProfile(cv_data=CVData(about_me_inferred_skills=["Stakeholder Management"]))
+        ev = {e.name: e.sources for e in collect_evidence_from_profile(prof)}
+        assert "about_me_llm" in ev["Stakeholder Management"]
+
+    def test_new_sources_have_positive_weights(self):
+        from src.services.profile.skill_tiering import _SOURCE_WEIGHTS
+
+        assert _SOURCE_WEIGHTS.get("github_llm", 0) > 0
+        assert _SOURCE_WEIGHTS.get("about_me_llm", 0) > 0
+
+
+# ── Orchestrator — run both passes over all four inputs ─────────────
+
+
+def _linkedin_text():
+    """Minimal text that passes _looks_like_linkedin (URL + 3 headings)."""
+    return (
+        "Jane Dev\nSenior Engineer\n"
+        "linkedin.com/in/janedev\n"
+        "Summary\nI build things.\n"
+        "Experience\nSenior Engineer at Acme\n"
+        "Skills\nKubernetes\n"
+    )
+
+
+class TestTwoPassOrchestrator:
+    @pytest.mark.asyncio
+    async def test_enhances_all_four_sources(self, monkeypatch):
+        from src.services.profile import two_pass
+
+        cv = CVData(
+            raw_text="Skills\nPython\nDjango\n\nExperience\nWorked somewhere\n",
+            linkedin_raw_text=_linkedin_text(),
+            github_repos_brief=[{"name": "rag", "description": "rag app", "topics": ["llm"]}],
+        )
+        prefs = UserPreferences(about_me="I lead product and love stakeholder management")
+        prof = UserProfile(cv_data=cv, preferences=prefs)
+
+        async def fake_cv(text, section_hint=""):
+            return CVData(raw_text=text, skills=["FastAPI"], job_titles=["Engineer"])
+
+        async def fake_linkedin(text):
+            return {"skills": ["Kubernetes"], "positions": [{"title": "SRE"}], "raw_text": text}
+
+        async def fake_gh(brief):
+            return ["LangChain"]
+
+        async def fake_about(text):
+            return ["Stakeholder Management"]
+
+        monkeypatch.setattr(two_pass, "llm_cv_fields_from_text", fake_cv)
+        monkeypatch.setattr(two_pass, "parse_linkedin_from_text", fake_linkedin)
+        monkeypatch.setattr(two_pass, "llm_infer_github_skills", fake_gh)
+        monkeypatch.setattr(two_pass, "llm_infer_from_about_me", fake_about)
+
+        out = await two_pass.run_two_pass_extraction(prof)
+        c = out.cv_data
+
+        # Deterministic CV pass landed.
+        assert "Python" in c.skills and "Django" in c.skills
+        # LLM CV pass enhanced.
+        assert "FastAPI" in c.skills
+        assert "Engineer" in c.job_titles
+        # LinkedIn pass merged.
+        assert "Kubernetes" in c.linkedin_skills
+        # GitHub LLM pass.
+        assert c.github_llm_skills == ["LangChain"]
+        # Preferences LLM pass.
+        assert c.about_me_inferred_skills == ["Stakeholder Management"]
+
+    @pytest.mark.asyncio
+    async def test_cv_llm_failure_keeps_deterministic_skills(self, monkeypatch):
+        from src.services.profile import two_pass
+
+        prof = UserProfile(cv_data=CVData(raw_text="Skills\nPython\nRust\n\nEducation\nBSc\n"))
+
+        async def boom(text, section_hint=""):
+            raise RuntimeError("no LLM key")
+
+        monkeypatch.setattr(two_pass, "llm_cv_fields_from_text", boom)
+        out = await two_pass.run_two_pass_extraction(prof)
+        # Deterministic skills survive even though the LLM pass blew up.
+        assert "Python" in out.cv_data.skills
+        assert "Rust" in out.cv_data.skills
+
+    @pytest.mark.asyncio
+    async def test_empty_profile_is_noop(self):
+        from src.services.profile import two_pass
+
+        prof = UserProfile()
+        out = await two_pass.run_two_pass_extraction(prof)
+        assert out.cv_data.skills == []
+        assert out.cv_data.github_llm_skills == []
+        assert out.cv_data.about_me_inferred_skills == []
+
+    @pytest.mark.asyncio
+    async def test_cv_llm_does_not_wipe_github_and_linkedin(self, monkeypatch):
+        """A CV re-parse must preserve LinkedIn/GitHub fields set by other passes."""
+        from src.services.profile import two_pass
+
+        cv = CVData(
+            raw_text="Skills\nPython\n",
+            linkedin_skills=["Existing LI Skill"],
+            github_skills_inferred=["Existing GH Skill"],
+        )
+        prof = UserProfile(cv_data=cv)
+
+        async def fake_cv(text, section_hint=""):
+            return CVData(raw_text=text, skills=["NewSkill"])
+
+        monkeypatch.setattr(two_pass, "llm_cv_fields_from_text", fake_cv)
+        out = await two_pass.run_two_pass_extraction(prof)
+        assert "Existing LI Skill" in out.cv_data.linkedin_skills
+        assert "Existing GH Skill" in out.cv_data.github_skills_inferred
+
+
+class TestReextractAndRescore:
+    @pytest.mark.asyncio
+    async def test_runs_extract_then_save_then_rescore(self, monkeypatch):
+        import src.services.rescore as rescore_mod
+        from src.services.profile import storage, two_pass
+
+        calls = []
+        prof = UserProfile(cv_data=CVData(raw_text="x"))
+
+        monkeypatch.setattr(storage, "load_profile", lambda uid: prof)
+
+        def fake_save(p, uid, source_action="user_edit"):
+            calls.append(("save", source_action))
+
+        monkeypatch.setattr(storage, "save_profile", fake_save)
+
+        async def fake_run(p):
+            calls.append(("extract", None))
+            return p
+
+        monkeypatch.setattr(two_pass, "run_two_pass_extraction", fake_run)
+
+        async def fake_rescore(uid, db_path=None):
+            calls.append(("rescore", uid))
+            return {"rescored": 3}
+
+        monkeypatch.setattr(rescore_mod, "rescore_user_feed", fake_rescore)
+
+        result = await two_pass.reextract_and_rescore("user-1")
+
+        assert [c[0] for c in calls] == ["extract", "save", "rescore"]
+        # The new profile version is stamped with the two-pass audit label.
+        assert ("save", "two_pass_reextract") in calls
+        assert result["reextracted"] is True
+        assert result["rescore"] == {"rescored": 3}
+
+    @pytest.mark.asyncio
+    async def test_no_profile_is_noop(self, monkeypatch):
+        from src.services.profile import storage, two_pass
+
+        monkeypatch.setattr(storage, "load_profile", lambda uid: None)
+        result = await two_pass.reextract_and_rescore("ghost")
+        assert result["reextracted"] is False
+        assert result["reason"] == "no_profile"

--- a/docs/IMPLEMENTATION_LOG.md
+++ b/docs/IMPLEMENTATION_LOG.md
@@ -1394,3 +1394,54 @@ Initial commit `eb5c030` claimed `frontend/.env.local.example` was added, but th
 
 - **Step 1 (Batch S1 — Engine→API seam):** date-model fields, 7-dim score breakdown, `enrich_job()` invocation, `mode=hybrid` wiring. See `docs/ExecutionOrder.md` for the full 6-step roadmap.
 - **Tag candidate:** `step-0-done-2026-04-24` for quick-reference.
+
+---
+
+## Two-pass profile extraction (2026-06-17, branch `feat/two-pass-profile-extraction`)
+
+**Goal (user-side profile improvement):** every profile input runs through a
+**deterministic pass** (plain code) AND an **LLM enhance pass**, merged into one
+`CVData`. When the user changes ANY input later, both passes re-run from STORED
+raw inputs (no re-upload, no network re-fetch), producing a refreshed CVData and
+a new profile-version id, then the feed re-scores. (M2 / the LLM judge was left
+untouched per scope.)
+
+**What existed before:** CV = LLM-only; LinkedIn = hybrid (deterministic headers
++ LLM prose); GitHub = deterministic lookup-table only; preferences = plain form
+parse. New-id-per-save + change→rescore already existed (`storage.py`,
+`profile.py::_maybe_trigger_rescore`).
+
+**New code (all TDD, offline, LLM mocked):**
+- `models.py` — `CVData` gains `linkedin_raw_text`, `github_repos_brief`,
+  `github_llm_skills`, `about_me_inferred_skills`. **No migration** — profiles
+  store as a JSON blob and `storage._filter_fields` drops unknown keys, so old
+  rows load with defaults.
+- `linkedin_parser.py` — `parse_*` now returns `raw_text`; `enrich_cv_from_linkedin`
+  stores it on `cv.linkedin_raw_text`. Factored `parse_linkedin_from_text(text)`
+  so the LLM pass can re-run offline.
+- `github_enricher.py` — `fetch_github_profile` now returns `repos_brief`
+  (name/description/topics); new `llm_infer_github_skills(repos_brief)` reads repo
+  prose for skills the lookup tables miss (e.g. "LangChain", "RAG").
+- `preferences.py` — new `llm_infer_from_about_me(about_me)` mines the free-text
+  blurb for skills.
+- `cv_parser.py` — new `deterministic_cv_fields(raw_text)` (no-LLM skills/summary
+  grab); factored `llm_cv_fields_from_text(raw_text)` so the CV LLM pass re-runs
+  from stored text.
+- `skill_tiering.py` — two new evidence sources + weights: `about_me_llm` (2.0,
+  user's own words) and `github_llm` (1.5, inferred-but-demonstrated).
+- `two_pass.py` (NEW) — `run_two_pass_extraction(profile)` runs both passes over
+  all four inputs in place (never raises; each pass no-ops when its input/keys are
+  absent); `reextract_and_rescore(user_id)` = load → re-extract → save (new
+  version, `source_action="two_pass_reextract"`) → rescore.
+- `api/routes/profile.py` — the change trigger now schedules
+  `reextract_and_rescore` instead of bare `rescore_user_feed`.
+
+**Tests:** `tests/test_two_pass.py` (17) + new cases in `test_linkedin_github.py`
+and `test_github_deps.py`. Full suite **1540 passed, 3 skipped**. Lint: no new
+ruff findings vs baseline.
+
+**Known cost tradeoff (no flag added):** a change to ANY input re-runs all LLM
+passes in the background (faithful to the ask). On a CV upload this re-runs the
+CV LLM once more than strictly needed. If this proves expensive, gate
+`reextract_and_rescore`'s LLM passes behind a flag later — the deterministic
+passes are free and always safe.


### PR DESCRIPTION
Two-pass profile extraction: every input (CV / LinkedIn / GitHub / preferences) runs a deterministic pass AND an LLM enhance pass, merged into one CVData. On any input change, both passes re-run from stored data → new profile version → rescore. Plus: GitHub input accepts a full URL or @handle.

Built on current main (cherry-picked clean, no conflicts). Full suite green (gate-passed).

- new CVData fields (linkedin_raw_text, github_repos_brief, github_llm_skills, about_me_inferred_skills) — no migration (JSON-blob storage)
- new module services/profile/two_pass.py (run_two_pass_extraction + reextract_and_rescore)
- GitHub + about_me LLM passes; CV deterministic pass; skill-tiering sources about_me_llm/github_llm
- normalize_github_username() accepts URL/@handle
- tests/test_two_pass.py (17) + new linkedin/github cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)