### PR TITLE
docs(pricing): Free/Pro/Max model + drug-dealer trial + paid-API feature map

### DIFF
--- a/docs/plans/2026-06-21-free-premium-plans.md
+++ b/docs/plans/2026-06-21-free-premium-plans.md
@@ -6,35 +6,57 @@ no admin role model. Access is split by **subscription plan**, like a normal Saa
 
 ## The idea (plain words)
 
-Every user has a **plan**: `free` or `premium`.
-- **Free** = a taste of the product (limited).
-- **Premium** = everything unlocked.
+Every user has a **plan**. Moved to a **3-tier model** (like ChatGPT Free/Pro/Max),
+updated 2026-06-25:
+- **Free** = the 46 free job boards only. Still real jobs, just limited.
+- **Pro** = free boards + **paid real-time data** (Fantastic Jobs: LinkedIn/Indeed/ATS,
+  hourly) + AI judge + notifications.
+- **Max** = everything + **minute-fresh premium data** (TheirStack, 344k sources) +
+  unlimited + priority.
 
 Same mechanism that "admin RBAC" would have used (a field on the user + a check on
 routes), but the *meaning* is subscription tier, not admin.
 
+### Why the paid data is the wedge (the key economic point)
+The paid providers (TheirStack / Fantastic Jobs — researched in memory
+`reference_paid_job_aggregator_apis`) charge **per job fetched**. So live
+LinkedIn/Indeed CANNOT be in Free — every free signup would cost money at zero
+revenue. Free = the 46 free sources = **$0 marginal cost**. Pro/Max = paid data,
+capped per plan to protect margin. That gating IS the business model.
+
 ## Why it's cheap to build
 
-The codebase already has the on/off levers. Premium = flip them on; Free = keep
+The codebase already has the on/off levers. Higher tier = flip them on; Free = keep
 them limited. We are **gating features that already exist**, not building new ones:
 - `ENGINE1..4_ENABLED` — keyword / dimensions / semantic / LLM-judge engines.
 - `MAX_CONCURRENT_SEARCHES_PER_USER` + (future) a daily search cap.
 - Notification rules + dispatcher (email / Slack / Discord).
 - CSV export (`/api/jobs/export`).
 
-## Proposed Free vs Premium split (decide before building)
+**The one genuinely new lever:** `_build_sources()` in `src/main.py` must become
+**plan-aware** — today it filters sources by *domain*; it also needs to filter by
+*plan* so Free users skip the paid `ActiveJobsDBSource` / `TheirStackSource`. Small,
+clean addition to the existing domain filter. This is what keeps Free at $0 cost.
 
-| Feature | Free | Premium |
-|---|---|---|
-| Searches | few per day (cap) | unlimited |
-| Job sources | a subset | all 47 |
-| Scoring | keyword only (Engine 1) | all 4 engines + AI judge verdicts |
-| Notifications (email/Slack/Discord) | ❌ | ✅ |
-| CSV export | ❌ | ✅ |
-| Jobs shown | top N | all |
+## Proposed Free / Pro / Max split (decide before building)
 
-> ⚠️ Open product question: confirm these lines. (e.g. AI verdicts free but
-> notifications premium? a 7-day premium trial?)
+| Feature | 🆓 Free | 💷 Pro | 👑 Max |
+|---|---|---|---|
+| Job sources | 46 free boards only | Free + Fantastic Jobs (LinkedIn/Indeed/ATS) | Free + TheirStack (344k sources) |
+| Freshness | free-board cadence (60s ATS, daily rest) | hourly LinkedIn/Indeed | minute-level real-time |
+| Scoring | keyword only (Engine 1) | + enrichment + semantic (E2/E3) | all 4 + AI judge verdicts (E4) |
+| Searches/day | few (cap) | higher cap | unlimited |
+| Jobs shown | top N | all | all + priority ranking |
+| Notifications (email/Slack/Discord) | ❌ | ✅ | ✅ + instant |
+| CSV export | ❌ | ✅ | ✅ |
+| AI CV tailoring | 3/month | unlimited | unlimited |
+
+**What Free deliberately loses (so upgrade feels worth it):** no live LinkedIn/Indeed,
+no AI judge "why it fits you", no push notifications, capped searches + top-N only.
+Free still delivers real jobs from 46 sources — a taste, not useless.
+
+> ⚠️ Open product questions: exact daily caps per tier; per-tier paid-data job
+> budget (protects margin); Pro vs Max price points; 7-day Pro trial?
 
 ## Build pieces
 

--- a/docs/plans/PRICING_FEATURE_MAP.md
+++ b/docs/plans/PRICING_FEATURE_MAP.md
@@ -18,9 +18,15 @@ Pro and Max**.
 ## Verified corrections (be honest about these)
 - **AI CV tailoring is NOT built** (backend audit confirmed — no route exists). Do not
   list it as a real tier feature until built.
-- **Fantastic Jobs boards = LinkedIn / Wellfound / Y Combinator — Indeed NOT confirmed
-  in it.** TheirStack is the one carrying Indeed + Glassdoor. So Pro gets LinkedIn;
-  Max adds Indeed/Glassdoor. [verify FJ Indeed coverage before marketing it]
+- **VERIFIED 2026-07-05: Fantastic Jobs does NOT have Indeed.** Confirmed from
+  fantastic.jobs/about + its RapidAPI listing. Its job boards are ONLY **LinkedIn,
+  Wellfound, Y Combinator** (+ 200k ATS career sites across 54 platforms). Indeed,
+  Glassdoor, ZipRecruiter are absent. **Indeed/Glassdoor come only from TheirStack
+  (Max).** ⇒ Pro promise must say "live LinkedIn + company career sites", NOT "Indeed".
+- **Overlap caveat (Fable):** FJ's ATS list (Greenhouse, Lever, Ashby, Workable,
+  SmartRecruiters, Personio, Recruitee, Rippling…) overlaps Job360's existing 47 free
+  sources. FJ's UNIQUE add = LinkedIn + Wellfound + YC + a bigger company list on the
+  same ATS. Run a dedup trial before buying — true cost is per-UNIQUE-job, not $1/1k.
 - **Direct/easy apply exists in BOTH APIs** (FJ `direct_apply`, TS `easy_apply` +
   resolved apply URL) — it is not a unique FJ moat.
 

--- a/docs/plans/PRICING_FEATURE_MAP.md
+++ b/docs/plans/PRICING_FEATURE_MAP.md
@@ -9,6 +9,36 @@ fields of the two paid providers to concrete Pro/Max features. Companion to
 - **TheirStack enriches the COMPANY** (tech stack, funding, size, hiring manager) → **Max**.
 - Story: Pro = *smarter jobs*; Max = *smarter about the companies behind them*.
 
+## CUMULATIVE RULE (important — 2026-06-25 correction)
+Tiers stack: **Max = Free + Pro + TheirStack**, NOT "TheirStack instead of Fantastic
+Jobs." Max users still get all Fantastic Jobs data + features (incl. one-click direct
+apply). Nobody loses a feature by paying more. Direct-apply therefore lives in **both
+Pro and Max**.
+
+## Verified corrections (be honest about these)
+- **AI CV tailoring is NOT built** (backend audit confirmed — no route exists). Do not
+  list it as a real tier feature until built.
+- **Fantastic Jobs boards = LinkedIn / Wellfound / Y Combinator — Indeed NOT confirmed
+  in it.** TheirStack is the one carrying Indeed + Glassdoor. So Pro gets LinkedIn;
+  Max adds Indeed/Glassdoor. [verify FJ Indeed coverage before marketing it]
+- **Direct/easy apply exists in BOTH APIs** (FJ `direct_apply`, TS `easy_apply` +
+  resolved apply URL) — it is not a unique FJ moat.
+
+## Full Free/Pro/Max feature allocation (code-audited)
+See the two tables in this session's summary; canonical allocation:
+- **Free (all $0-cost):** 47 free boards, keyword score (E1), CV upload+parse+prefs,
+  like/apply, capped feed (top-20/day), basic tracker (≤50 jobs), duplicates view,
+  ghost filter, 1 weekly digest email, full account mgmt.
+- **Pro (+ Fantastic Jobs):** live LinkedIn + 200k career sites, all AI scoring
+  (E2/E3/E4 verdicts), 8-D radar, one-click direct apply, smart filters (salary/
+  seniority/remote/visa), hide agencies, AI summary + skill-match %, LinkedIn+GitHub
+  profile enrichment, version history/diff/restore, full Kanban tracker (unlimited),
+  all notification channels + rules + digests, CSV/JSON-Resume export.
+- **Max (+ TheirStack, cumulative):** Indeed+Glassdoor+344k sources, minute-fresh
+  instant alerts, company tech-stack match, funding/size/revenue/industry filters,
+  hiring-manager contact card, "company scaling" alerts, tech-stack explorer,
+  direct-employer-only, unlimited + priority ranking.
+
 ## FREE (no paid data)
 46 free boards, keyword scoring, capped daily matches, no notifications. $0 cost.
 

--- a/docs/plans/PRICING_FEATURE_MAP.md
+++ b/docs/plans/PRICING_FEATURE_MAP.md
@@ -1,0 +1,65 @@
+# Pricing — Feature Map (what each paid API unlocks)
+
+**Researched 2026-06-25** (verified against each API's live docs). Maps the real data
+fields of the two paid providers to concrete Pro/Max features. Companion to
+`PRICING_FINAL_DECISION.md`. Sources at end.
+
+## The clean split
+- **Fantastic Jobs enriches the JOB** (salary, visa, seniority, skills, apply link) → **Pro**.
+- **TheirStack enriches the COMPANY** (tech stack, funding, size, hiring manager) → **Max**.
+- Story: Pro = *smarter jobs*; Max = *smarter about the companies behind them*.
+
+## FREE (no paid data)
+46 free boards, keyword scoring, capped daily matches, no notifications. $0 cost.
+
+## PRO — Fantastic Jobs (~£14.99/mo, hourly LinkedIn/Indeed/ATS)
+
+| Feature | API field | Note |
+|---|---|---|
+| One-click direct apply | `direct_apply` | apply without leaving the product |
+| Salary floor filter | `ai_salary_min/max_value`, `ai_salary_currency` | LLM-recovers salary from free text |
+| Visa-sponsorship-only mode | `ai_visa_sponsorship` | **feeds existing `VISA_WEIGHT` dim** |
+| "Matches your level" search | `ai_experience_level` (0-2/2-5/5-10/10+) | maps to CV seniority |
+| Remote precision filter | `ai_work_arrangement` + office-days | Remote Solely / OK / Hybrid |
+| Hide recruitment agencies | `removeAgency` / `org_linkedin_recruitment_agency_derived` | strips agency reposts |
+| AI 2-line job summary | `ai_core_responsibilities` + `ai_requirements_summary` | instant TL;DR per card |
+| "3 of 5 skills matched" | `ai_key_skills` vs CV skills | **set-diff, respects rule #28** |
+| Company basic card | `org_linkedin_headcount`, `industry`, `founded` | "know the company" panel |
+| Notifications + higher caps | (Job360 existing levers) | email/Slack/Discord |
+
+**Cheap-to-build note:** `ai_visa_sponsorship`, `ai_salary`, `ai_experience_level`,
+`ai_key_skills` map directly onto Job360's existing scoring dims + ESCO CV extraction —
+read a richer field, no new logic.
+
+## MAX — TheirStack (~£29-39/mo, minute-fresh, 344k sources) — the anchor
+
+Features the cheaper API **cannot** provide (no technographics, funding, or hiring-team):
+
+| Feature | API capability | Note |
+|---|---|---|
+| **Jobs at companies using YOUR tech stack** | `company_technology_slug_or/and/not` | killer feature — ties to ESCO CV skills |
+| Well-funded startup filter | `funding_stage_or`, `min_funding_usd`, `company_investors_or` | "Series A/B, YC-backed" |
+| Company size/stage targeting | `min/max_employee_count` | "50-500 person companies" |
+| Direct-employer-only mode | `company_type=direct_employer` | hard agency strip |
+| Hiring-manager contact card | `hiring_team[]` (name, role, LinkedIn) | cold-message vs blind-apply |
+| "Company is scaling" alert | `num_jobs_last_30_days` + Hiring Signals | apply before the rush |
+| Revenue/industry precision | `industry_id_or` + `min_revenue_usd` | "fintech, $50M+ revenue" |
+| Tech-stack explorer per company | Technographics API (confidence-scored) | skills-gap prep before applying |
+| Minute-fresh instant alerts | ~10-min ATS polling cadence | speed = top-tier flex |
+| All engines + priority ranking | (Job360 existing) | + unlimited searches |
+
+## Cost sanity (per the pricing research)
+- Fantastic Jobs: ~$1/1,000 jobs (self-serve, RapidAPI — clones existing JSearch wiring).
+- TheirStack: Starter $59 (1.5k credits) → Pro $169 (10k credits, $0.0169/job). 1 credit/job,
+  3/company-or-technographics lookup. Cheap enough to gate behind Max, not Free.
+
+## Build notes
+- Both need the **plan-aware `_build_sources()`** lever (Free skips paid sources).
+- New source classes: `ActiveJobsDBSource` (Fantastic, clones `JSearchSource`) and
+  `TheirStackSource`. Each touches the 5 load-bearing surfaces (CLAUDE.md rule #8).
+- Enrichment fields flow into existing scoring dims — don't rebuild, just read.
+
+## Sources
+**Fantastic Jobs:** developer.fantastic.jobs/api/~schemas · fantastic.jobs/api · fantastic.jobs/about · apify.com/fantastic-jobs/career-site-job-listing-api
+**TheirStack:** theirstack.com/en/docs/api-reference/jobs/search_jobs_v1 · theirstack.com/en/docs/datasets/options/job · theirstack.com/en/docs/api-reference/companies/technographics_v1 · theirstack.com/en/pricing · theirstack.com/en/hiring-signals
+**Flagged unverified:** exact RapidAPI tier names/rate-limits for Fantastic Jobs (JS-rendered); Glassdoor fields (marketing copy, not in schema); TheirStack "every minute" is monitoring-loop language, real cadence is tiered (10min/hourly/daily).

--- a/docs/plans/PRICING_FINAL_DECISION.md
+++ b/docs/plans/PRICING_FINAL_DECISION.md
@@ -1,0 +1,45 @@
+# Pricing — Final Decision (Job360)
+
+**Decided 2026-06-25, research-verified.** This is the chosen model. Detail + sources
+live in `PRICING_METHOD_3TIER.md` and `PRICING_METHOD_DRUG_DEALER.md`.
+
+## The model: Hybrid (3 tiers + reverse-trial taste)
+This is the 2026 SaaS default for a product with a clear free/premium split — not an
+invention. Verified: ~65% of product-led SaaS use the hybrid; it's called the safest
+default for a new product.
+
+| Piece | Decision |
+|---|---|
+| Model | 3 tiers + reverse-trial taste on top |
+| Taste (new user) | First **7 days OR 5 searches** = full **Max**, **no card** |
+| After taste | Drop to **Free** — data kept, premium greyed + visible |
+| Card | Asked **only at upgrade**, never at the taste |
+| Annual | 2 months free (~17% off) |
+
+## The three tiers
+
+| | Free | Pro (push, "Most Popular") | Max (anchor) |
+|---|---|---|---|
+| Price | £0 | **~£14.99/mo** | ~£29-39/mo (decide) |
+| Sources | 46 free boards | + Fantastic Jobs (LinkedIn/Indeed/ATS) | + TheirStack (344k, minute-fresh) |
+| Scoring | keyword only | + AI judge verdicts | all engines + priority rank |
+| Freshness | free-board cadence | hourly | minute-level |
+| Notifications | ❌ | ✅ | ✅ instant |
+| Searches/day | few (cap) | higher | unlimited |
+
+## Rules that make it work (verified levers)
+- **Taste stays short (5 searches)** — it hits paid APIs = real money.
+- **No card at taste** — protects the cheap free-funnel edge (biggest advantage).
+- **Card at upgrade** — ~2.7-5x conversion lift without killing signups.
+- **One aha-moment = "first strong match"** — onboarding beats method choice.
+- **Meter paid-data per user** — or heavy users bleed margin (plan-aware `_build_sources()`).
+- **At drop: grey-out, don't delete** — seeing the loss is the conversion trigger.
+
+## Verified honesty flags (don't repeat as fact)
+- Reverse-trial's edge over freemium is **small/contested**, not a proven 2x.
+- Card lift is **~2.7-5x**, and it **reduces signup volume** — hence card-at-upgrade only.
+- Free-to-paid realistic target: **3-6%**.
+
+## Still your call (research settled everything else)
+1. Taste size: 5 searches vs 7 days (or whichever comes first).
+2. Max tier price point.

--- a/docs/plans/PRICING_FINAL_DECISION.md
+++ b/docs/plans/PRICING_FINAL_DECISION.md
@@ -1,12 +1,37 @@
 # Pricing — Final Decision (Job360)
 
-**Decided 2026-06-25, research-verified.** This is the chosen model. Detail + sources
-live in `PRICING_METHOD_3TIER.md` and `PRICING_METHOD_DRUG_DEALER.md`.
+**Decided 2026-06-25, research-verified. UPDATED 2026-07-05 (two advisers, incl. Fable):
+LAUNCH WITH 2 TIERS, not 3.** Detail + sources live in `PRICING_METHOD_3TIER.md` and
+`PRICING_METHOD_DRUG_DEALER.md`.
 
-## The model: Hybrid (3 tiers + reverse-trial taste)
+## LAUNCH DECISION: 2 tiers (Free + Pro). Max is DEFERRED.
+Both advisers (Opus + Fable) independently chose 2 tiers for this stage. Why:
+- **Direct competitors (Teal, Huntr, Jobscan) are all 2-tier.** AI giants' 3-tier was
+  earned *after millions of users* revealed a power segment — we have zero users.
+- **Max is the most expensive tier to build AND run** (TheirStack 17-40x pricier + a
+  whole new company-intel UI) aimed at the *least-proven* demand, while Free still has
+  known issues. Wrong place to spend hours pre-launch.
+- **One paid tier = one clean signal:** "is live LinkedIn worth £X/mo?" 3 tiers = muddy
+  signals + choice paralysis on an unproven product.
+
+### Build so Max drops in later with near-zero rework
+- `users.plan` = **string** (`'free'|'pro'|'max'`), NOT a boolean `is_paid`.
+- Single **entitlements map** `PLAN_ENTITLEMENTS = {plan: {sources, company_intel, ...}}` —
+  never `if plan == 'pro'` scattered in routes. Adding Max = one dict entry.
+- Add **`min_plan`** attribute per source (alongside existing `.category`); registry/
+  scheduler filters per user. TheirStack later = one source file + one flag.
+- Pricing page: leave room for a 3rd column (optionally "Max — coming soon" to test demand).
+
+### Price risk (no anchor)
+Without a Max anchor Pro can look expensive standalone → **price Pro at the TOP of the
+competitor band (~£20-25/mo), not the bottom.** Discounting later is easy; raising is hard.
+
+---
+## (DEFERRED) The full 3-tier model — build toward this, sell 2 for now
 This is the 2026 SaaS default for a product with a clear free/premium split — not an
 invention. Verified: ~65% of product-led SaaS use the hybrid; it's called the safest
-default for a new product.
+default for a new product. **Keep as the eventual target once Free is solid + Pro has
+paying users.**
 
 | Piece | Decision |
 |---|---|
@@ -21,7 +46,7 @@ default for a new product.
 | | Free | Pro (push, "Most Popular") | Max (anchor) |
 |---|---|---|---|
 | Price | £0 | **~£14.99/mo** | ~£29-39/mo (decide) |
-| Sources | 46 free boards | + Fantastic Jobs (LinkedIn/Indeed/ATS) | + TheirStack (344k, minute-fresh) |
+| Sources | 46 free boards | + Fantastic Jobs (LinkedIn + career sites; **no Indeed**) | + TheirStack (Indeed/Glassdoor/344k, minute-fresh) |
 | Scoring | keyword only | + AI judge verdicts | all engines + priority rank |
 | Freshness | free-board cadence | hourly | minute-level |
 | Notifications | ❌ | ✅ | ✅ instant |

--- a/docs/plans/PRICING_METHOD_3TIER.md
+++ b/docs/plans/PRICING_METHOD_3TIER.md
@@ -1,0 +1,179 @@
+# Pricing Method — 3-Tier Freemium (Free / Pro / Max)
+
+**Captured 2026-06-25. Research-backed. Status: design captured, not built.**
+
+The pricing *structure*: three permanent tiers you subscribe to, like Anthropic
+(Free / Pro / Max) or ChatGPT (Free / Plus / Pro). Sibling doc:
+`PRICING_METHOD_DRUG_DEALER.md` (the conversion *mechanic* that runs on top).
+Paid-data research: memory `reference_paid_job_aggregator_apis`.
+
+> Stats that could not be traced to a primary source are flagged **[unverified]** /
+> **[approximate]** / **[industry-reported]**. Full sources at the end.
+
+---
+
+## TL;DR (the playbook)
+
+- **Use 3 tiers, not 2 or 4+.** Enough to segment casual vs power vs heavy users,
+  few enough to avoid choice paralysis. 3 is the industry sweet spot.
+- **Design the middle (Pro) tier to win.** ~60-70% of buyers pick the middle in a
+  3-tier layout **[industry-reported]**. Badge it "Most Popular."
+- **Free must be genuinely useful but capped where a *daily power user* feels pain** —
+  cap by usage volume + time-decay, never by removing the core action.
+- **Anchor with an expensive Max tier** so Pro looks reasonable (decoy/anchoring).
+- **Realistic free-to-paid target: 3-6%** (median freemium ~2.6-8%).
+- **Charm pricing (£14.99) has real field-experiment backing.** Annual discount
+  ≈ 16-20% ("2 months free").
+
+---
+
+## 1. Tier structure ("Good / Better / Best")
+
+**How to split features:**
+- **Free** = enough to *prove value* (the hook). Exposes ~20-40% of core capability.
+- **Pro (middle)** = the plan built for the **majority** — full core product,
+  moderate caps. This is the designed winner.
+- **Max (top)** = power/heavy users — higher limits, priority, exclusive top-end
+  features. Doubles as the price **anchor**.
+
+**Middle-tier-as-target:** the "center-stage effect" / Goldilocks option — with 3
+options, people disproportionately pick the middle. Price it to look 50-70% cheaper
+than the top anchor. Nudge with a "Most Popular" badge, contrasting colour, larger
+card, default-selected CTA.
+
+**Decoy/anchoring — the classic Economist experiment** (Ariely, *Predictably
+Irrational*): Web-only $59 / Print-only $125 / Print+Web $125. With all three shown,
+**84% chose the $125 bundle**; remove the "useless" print-only decoy and **68% flip
+to Web-only**. An intentionally-inferior option reframes the expensive one as value.
+
+**Why 3, not 2 or 4+:** 2 leaves segmentation on the table; 4+ risks choice overload
+(Hick's Law; the Iyengar & Lepper 2000 "jam study" — 6 jams outsold 24 by 10x, but
+this is **contested**, a 2010 meta-analysis found no reliable overall effect — cite
+as influential, not gospel). A 4th tier should only exist as an anchor/decoy.
+
+---
+
+## 2. What Free should contain — "useful but capped where it hurts"
+
+| Product | Free cap | Paid unlocks |
+|---|---|---|
+| **Spotify** | lower bitrate, ads, skip limits | ad-free, 320 kbps, offline |
+| **Notion** | **1,000-block cap once 2+ members**, 7-day history | unlimited, 30-90d history |
+| **Slack** | **90-day** message history, 10 apps | unlimited history + apps |
+| **Canva** | 5 GB, ~2% of library [approx] | full library, AI, bg-remover |
+| **Dropbox** | **2 GB**, 3 devices | 2 TB, unlimited devices |
+| **ChatGPT** | flagship for ~10-15 msgs then mini model [approx] | more flagship, unlimited images |
+| **Claude** | ~15-40 msgs/5h [approx], **no Opus** | ~5x usage, Opus |
+| **LinkedIn** | 0 InMail, last 5 viewers, capped search | InMail, full history |
+
+**The shared principles (the important part):**
+1. **Cap by usage volume, not core-feature removal.** You can always do the core
+   thing; the wall is *quantity/frequency*.
+2. **Free reaches the "aha" repeatedly, then bites at habit formation.** Caps sit
+   where a *daily-active* user lives.
+3. **Time-decay + collaboration are the sharpest knives** (Slack 90-day history;
+   Notion's cap triggers only when you add teammates).
+4. **Quality/convenience downgrade, not denial** (Spotify bitrate; ChatGPT smaller
+   model) — never blocked, just nudged.
+5. **Caps are often deliberately fuzzy/dynamic** (ChatGPT/Claude/LinkedIn don't
+   publish exact numbers — flexibility + anti-gaming).
+
+---
+
+## 3. How AI companies tier (real prices, ~mid-2026 — verify at checkout)
+
+| Company | Free | Pro (~$20) | Max/top |
+|---|---|---|---|
+| **Claude** | Sonnet+Haiku, no Opus | **$20**, adds Claude Code | **Max 5x $100** (unlocks Opus) / **20x $200** |
+| **ChatGPT** | GPT-5 few msgs then downgrade | **Plus $20** (UK ~£20) | **Pro $100** (5x, added Apr 2026) / **$200** (20x) |
+| **Perplexity** | ~3 Pro Searches/day | **Pro $20**, model choice | **Max $200** |
+| **Cursor** | limited completions | **Pro $20** credit pool | **Pro+ $60** (3x) / **Ultra $200** (20x) |
+
+**The universal AI shape:** Free (capped, weaker/no top model) → Pro ~$20/mo (full
+model, moderate cap) → Max/Ultra $100-200/mo (**5x-20x usage multiplier** + a few
+exclusives like top model, bigger context, priority). Price = **usage multiplier +
+model gate**.
+
+---
+
+## 4. Conversion benchmarks
+
+- **Freemium → paid: median ~2.6% (OpenView); 3-5% "good", 8-12% "great".** First
+  Page Sage avg **3.7%** (category matters). Tunguz: **2-4%**.
+- **Free trials convert ~2x higher** (~14-25%) but freemium wins absolute volume.
+- **Named numbers (flagged):** Dropbox ~4% (credible); Slack "30%" **disputed**;
+  LinkedIn "39%" **likely wrong**; Spotify ~35-40% **not analogous** (ad→paid).
+- **What drives it — the activation "aha moment":** Facebook "7 friends in 10 days",
+  Slack "2,000 messages", Twitter "~30 follows". Paywalls at **natural usage limits**
+  convert ~25% better [Chargebee]; **engagement-triggered paywalls** 2-3x better than
+  time-based [Elena Verna]; users who activate before any sales touch convert ~5x.
+
+---
+
+## 5. Pricing psychology
+
+- **Anchoring:** a high Max tier resets the reference point so Pro *feels* reasonable
+  (its price didn't change).
+- **Charm pricing (£14.99) — real research:** Anderson & Simester (2003) catalog
+  field experiments — a jacket sold **better at $39 than at $34**. (Soft "24% lift"
+  pop claims **[unverified]**.)
+- **Annual discount — real numbers:** Notion ~20% off, Slack ~17% off; standard "2
+  months free" = **16.7%** off.
+- **"Most Popular" badge:** social proof + decision simplification, paired with the
+  center-stage/anchoring effect on the middle tier.
+
+---
+
+## 6. Common mistakes (with real examples)
+
+**A) Free too generous → no reason to pay:** Baremetrics killed its free plan after
+11 weeks (1,000 signups, 53 conversions, **lost ~60 paying customers**); Docebo
+7,000 free signups, **zero** converted; Evernote's 2016 2-device clampdown. *Lesson
+(a16z): gate the feature that delivers meaningful value, not just volume.*
+
+**B) Free too stingy → no hook, kills virality:** Trello's "1 Power-Up per board"
+forced tool-switching; PLG rule (Lenny) — paywalling collaboration/seats kills the
+viral loop. *Tell: low adoption at the free tier itself = too restrictive.*
+
+**C) Too many tiers → choice paralysis.** Good/Better/Best 3-tier is the default;
+add a 4th only as a deliberate anchor.
+
+**D) Framing:** freemium is an **acquisition model, not a revenue model** (Paddle) —
+sub-5% free→paid means the tier design needs fixing (a16z).
+
+---
+
+## 7. Applying this to Job360
+
+- **Free** = 46 free boards, keyword scoring, capped daily matches + limited saved
+  alerts. Must reach the "this found me a good job" moment for a *casual* seeker,
+  then bite at *daily power use* (match volume, alert count/frequency, tracker
+  history) — **not** at first use.
+- **Pro (the designed winner, badge it)** = + paid real-time data (Fantastic Jobs:
+  LinkedIn/Indeed/ATS), AI judge verdicts, notifications, higher caps. Target
+  ~**£14.99/mo**, annual ~£119 (2 months free).
+- **Max (the anchor)** = + TheirStack (minute-fresh, 344k sources), unlimited,
+  priority ranking. Its main job on the pricing page is to make Pro look cheap.
+- **One activation event to design onboarding around** — e.g. "user gets their first
+  strong matched job." Put the paywall *after* activation, at habitual daily use.
+- **The economic guardrail:** paid data + LLM judge cost per use, so those are the
+  Pro/Max gates; Free stays on $0-cost free boards. (See the drug-dealer doc for the
+  taste-then-drop mechanic that feeds this ladder.)
+
+---
+
+## Sources
+
+**Structure & psychology:** getmonetizely.com (good-better-best; anchoring) ·
+thestrategystory.com (Economist decoy) · lawsofux.com/choice-overload ·
+kellogg.northwestern.edu (Anderson & Simester 9-price-endings PDF) · notion.com/pricing ·
+slack.com/pricing
+**Free-tier caps:** spotify support · notion.com/help/understanding-block-usage ·
+slack.com/help/articles/115002422943 · help.dropbox.com/plans/dropbox-basic-faq ·
+help.openai.com/.../chatgpt-free-tier-faq · support.claude.com/.../choose-a-claude-plan
+**AI pricing:** claude.com/pricing · chatgpt.com/pricing · techcrunch.com (ChatGPT Pro $100, Apr 2026) ·
+perplexity.ai/pro · cursor.com/blog/june-2025-pricing
+**Conversion:** openviewpartners.com/blog/freemium-pricing-guide · chartmogul.com/reports/saas-conversion-report ·
+userpilot.com/blog/freemium-conversion-rate · mode.com/blog/facebook-aha-moment · productled.com/blog/aha-moment
+**Mistakes:** a16z.com/how-to-optimize-your-free-tier-freemium · lennysnewsletter.com/p/why-saas-freemium-playbooks-dont ·
+getmonetizely.com free-tier-trap · paddle.com/blog/state-of-freemium

--- a/docs/plans/PRICING_METHOD_DRUG_DEALER.md
+++ b/docs/plans/PRICING_METHOD_DRUG_DEALER.md
@@ -1,0 +1,174 @@
+# Pricing Method — The "Drug Dealer" Method (Reverse Trial)
+
+**Captured 2026-06-25. Research-backed. Status: design captured, not built.**
+
+The industry name for the "drug dealer method" is the **Reverse Trial**:
+*give every new user the full premium experience first, then drop them to a
+limited-but-working free tier* — with the premium features left visible and locked.
+
+This is the sibling doc to `PRICING_METHOD_3TIER.md` (the pricing *structure*).
+This doc is the *conversion mechanic* that runs on top of it. Related paid-data
+research: memory `reference_paid_job_aggregator_apis`.
+
+---
+
+## 1. What it is (plain words)
+
+Give the best for free for a short while, then take it away.
+
+- **Day 1:** new user gets **full Max** — live LinkedIn/Indeed jobs, all engines,
+  AI judge verdicts, instant notifications. No card needed (decide later, see §6).
+- **After N searches / N days:** they **drop to Free** — keyword scoring, 46 free
+  boards, daily digest. The account and their saved data stay intact.
+- **The locked premium features stay visible**, greyed out: "🔒 47 live LinkedIn
+  roles matched you — upgrade to view."
+
+It's **freemium in reverse**: paid-first, free-forever-second.
+
+**How it differs from its two neighbours:**
+
+| Model | Day 1 | At the drop |
+|---|---|---|
+| Classic free trial | Full access, card often required | **Access ENDS** — hard paywall |
+| Plain freemium | Free tier only, never tastes premium | Nothing changes — pay to ever taste |
+| **Reverse trial (this)** | **Full premium, no card** | **Drops to a free tier that still works** + upgrade nudge |
+
+Exactly the **ChatGPT/Claude pattern**: best model for a few messages → "you've hit
+your limit, wait or upgrade." We meter *searches* instead of *messages*, and
+*live-data quality* instead of *model quality*.
+
+---
+
+## 2. Why it works — the psychology (sourced)
+
+- **Loss aversion is the engine.** Kahneman & Tversky, *Prospect Theory* (1979):
+  losses feel ~**2x** as intense as equal gains. Once a user has *had* the live
+  LinkedIn feed, losing it hurts more than never having had it. That ache converts.
+- **Endowment effect.** Thaler: people value things more once they *own* them. A
+  user who built saved searches + saw AI verdicts on their real jobs is attached.
+- **Faster "aha" moment.** Zero feature-gating on day 1 = they hit the magic
+  (live matches + "why this fits you") immediately, before they'd churn.
+- **Honest caveat:** these are behavioural-economics + practitioner framings. There
+  is **no peer-reviewed proof** a reverse trial *causally* beats plain freemium.
+
+---
+
+## 3. How real companies do "taste then drop"
+
+**Usage-capped (the model that fits us best):**
+- **Slack** — free hides message history past 90 days; data isn't deleted, it
+  *reappears on upgrade*. Cleanest "cap forces upgrade" example.
+- **Zoom** — 40-minute cap on group calls.
+- **Notion AI** — **20 lifetime AI responses**, no reset, then locked.
+- **ChatGPT** — when free users exhaust the frontier model, it **silently falls back
+  to a cheaper model (GPT-4o-mini)** instead of blocking. *Confirmed by OpenAI's
+  help center.* This is the closest real analog to what we should do.
+- **Claude.ai** — rolling 5-hour usage window; on cap → upgrade prompt / wait. (No
+  numeric caps published by design.)
+- **Cursor** — throttles **speed** not quality ("never downgraded in quality"). A
+  useful contrast: you can meter availability instead of quality.
+
+**Time-capped:**
+- **Canva Pro** 30 days · **LinkedIn Premium** 1 month · **Duolingo Super** ~14 days /
+  **Max** 7 days · **Grammarly** 7 days.
+- **Superhuman** — the textbook "reverse trial" name, but has **no free tier**; it
+  starts self-serve users on the *higher* Business tier.
+
+**Anti-farming lever worth copying:** LinkedIn — **no repeat premium trial for 12
+months** per account.
+
+---
+
+## 4. The AI rate-limit variant — why it's the strongest fit
+
+A **usage cap creates a recurring upgrade moment** — every time the user hits the
+wall on a high-intent day, not a single day-14 decision. They keep walking back to
+the paywall themselves.
+
+For Job360 that means: **meter the expensive thing** (LLM judge calls + paid data
+sources like Fantastic Jobs/TheirStack). When a free user runs out, **fall back to
+the cheap engine** (keyword scoring on the 46 free boards) — like ChatGPT dropping
+to GPT-4o-mini — so Free stays useful *and* cheap to serve. Never a hard block.
+
+---
+
+## 5. Does it "double conversion"? — the honest answer
+
+**No verified data supports "reverse trials double conversion." Do not claim 2x.**
+
+- Best controlled data (**ChartMogul + ProductLed, Jan 2026, n=200 B2B SaaS**):
+  reverse trial ≈ **4–6% good / 8–12% great** — essentially **the same as
+  freemium** (3–5% / 8–12%). The gap is **not statistically significant**.
+- The "15–30%" figures floating around blogs have **no cited primary study** —
+  treat as folklore.
+- **The evidenced levers are elsewhere:** credit-card-on-file trials convert
+  **~5x higher** than no-card; onboarding/activation quality beats trial length.
+
+**Defensible internal framing:** "Reverse trial *can* modestly beat freemium
+because everyone tastes premium, but the proven gap is small. The real levers are
+card-on-file and a great first-run experience."
+
+---
+
+## 6. Risks & how not to lose money
+
+- **The free taste has real cost.** Those first Max searches hit the paid providers
+  + LLM judge — the free sample is a **marketing spend**. Meter it by
+  tokens/searches per user; keep N small (**3–5 searches or 7–14 days**).
+- **Anti-farming (layer them — none holds alone):** block disposable emails +
+  require verification (baseline); signup-velocity / IP checks; LinkedIn's
+  "no repeat trial per 12 months" rule; consider **card-on-file** (raises abuse
+  cost *and* lifts conversion ~5x).
+- **At the drop:** keep account + data intact, disable premium **gracefully**
+  (grey out, don't delete), leave locked features **visible**. Seeing what you lost
+  is the whole point. Avoid a silent feature cliff — tell them what changed.
+- **Trial length:** 14 days is the common B2B sweet spot, but **most conversions
+  happen in week 1** — for us, "first N searches" works as well as a day count.
+
+---
+
+## 7. Applying it to Job360 (the concrete shape)
+
+1. New user → **first 5 searches (or 7 days) run on full Max**: live LinkedIn/Indeed,
+   all 4 engines, AI verdicts, instant notifications.
+2. At the drop → **Free tier that still works**: keyword scoring on 46 free boards,
+   daily digest, top-N jobs. Premium features **visible but locked**.
+3. Meter the expensive calls; **fall back to the cheap engine** (ChatGPT-style), never
+   hard-block.
+4. Gate farming: email verification + "no repeat premium taste per account/12mo";
+   consider card-on-file for the taste (the ~5x lever).
+5. Surface the upgrade at the **drop moment** and on every later wall-hit.
+
+### Open questions
+- Taste size: 5 searches? 7 days? Both (whichever first)?
+- Give **Max** quality or only **Pro** quality in the taste? (Max converts harder,
+  costs more per free user.)
+- Card-on-file for the taste — worth the signup friction for the ~5x lift?
+
+---
+
+## 8. Corrections the research surfaced (so we cite honestly)
+
+- The term is best attributed to **Elena Verna** (secondary sources); the clearest
+  primary write-up is **OpenView, "Your Guide to Reverse Trials."** The
+  "Bhavik Patel" origin could **not** be verified — don't cite it.
+- Lenny's Newsletter's freemium post does **not** use the term "reverse trial."
+- "Doubles conversion" = **folklore**, not data (see §5).
+
+---
+
+## Sources
+
+- OpenView — Guide to Reverse Trials: https://openviewpartners.com/blog/your-guide-to-reverse-trials/
+- GTM Strategist — reverse trial best practices: https://knowledge.gtmstrategist.com/p/reverse-trials-best-practices-for-saas-companies
+- Prospect Theory (Kahneman & Tversky 1979): https://en.wikipedia.org/wiki/Prospect_theory · https://www.nngroup.com/articles/prospect-theory/
+- Endowment effect: https://www.getmonetizely.com/articles/how-does-the-endowment-effect-make-free-trials-so-powerful
+- ChatGPT free-tier fallback (OpenAI): https://help.openai.com/en/articles/9275245-chatgpt-free-tier-faq
+- Claude usage limits: https://support.claude.com/en/articles/11647753-how-do-usage-and-length-limits-work
+- Cursor pricing (throttles speed not quality): https://cursor.com/docs/models-and-pricing
+- Slack free usage limits: https://slack.com/help/articles/115002422943-Usage-limits-for-free-workspaces
+- Canva pricing: https://www.canva.com/en/pricing/ · Notion pricing: https://www.notion.com/pricing
+- LinkedIn Premium trial rules: https://www.linkedin.com/help/linkedin/answer/a1355837
+- Superhuman pricing: https://newsletter.pricingsaas.com/p/inside-superhumans-pricing-evolution
+- Free-to-paid conversion report (ChartMogul + ProductLed, n=200): https://www.growthunhinged.com/p/free-to-paid-conversion-report
+- Free-trial abuse prevention: https://fingerprint.com/blog/free-trial-abuse/ · https://clearout.io/blog/saas-free-trial-abuse-prevention/


### PR DESCRIPTION
## What
Research-backed pricing strategy for Job360, from this session's discussion.

### New docs (docs/plans/)
- **PRICING_FINAL_DECISION.md** — the chosen model: hybrid 3-tier + short no-card reverse-trial taste, card-at-upgrade.
- **PRICING_METHOD_3TIER.md** — Free/Pro/Max structure research (good/better/best, anchoring/decoy, conversion benchmarks).
- **PRICING_METHOD_DRUG_DEALER.md** — reverse-trial (taste-then-drop) research + loss-aversion psychology.
- **PRICING_FEATURE_MAP.md** — maps Fantastic Jobs (Pro) + TheirStack (Max) real API fields to concrete features.
- **2026-06-21-free-premium-plans.md** — updated 2-tier → 3-tier.

## Key decisions
- **Free** = 46 free boards ($0 marginal cost). **Pro (~£14.99)** = Fantastic Jobs live LinkedIn/Indeed + AI verdicts. **Max** = TheirStack minute-fresh + company intel.
- Paid data charges per job → gating it behind Pro/Max IS the business model.
- Verified levers: card-at-upgrade (~2.7-5x, not at the taste), one aha-moment, meter paid-data per user.

## Notes
- Docs only — no code changes. Every soft stat flagged `[unverified]`; sources in each file.
- Design captured, **not built** — build plan lives in the free-premium-plans doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)