### PR TITLE
docs(plans): top-5 leverage work items, ranked (PLAN-1..PLAN-5)

### DIFF
--- a/PLAN-1-fix-red-ci.md
+++ b/PLAN-1-fix-red-ci.md
@@ -1,0 +1,218 @@
+# PLAN 1 — Fix the red CI gate + merge the live synthetic smoke test
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Rank: 1 of 5 — do this FIRST.**
+Why first: GitHub Actions is enabled and running, but the per-commit gate (`ci.yml`) fails at the ruff lint step on every recent push to `main`. A red gate means every merge (including plans 2–5) lands unverified, and nobody notices new breakage because red is the normal color. This plan makes the gate trustworthy again and merges an already-written live-production smoke test that is sitting unmerged on a branch.
+
+**Goal:** `ci.yml` green on `main`; `ci-offline.yml` either green or retired; `synthetic-live.yml` (from branch `worktree-feat-live-smoke`) merged and running.
+
+**Architecture:** No production code changes expected — this is lint fixes, workflow YAML fixes, and one clean branch merge.
+
+**Tech Stack:** GitHub Actions, ruff, pytest, Playwright (already-written script).
+
+---
+
+## Verified facts (do not re-derive; checked 2026-07-07)
+
+- Repo: `Ranjith36963/job360`. Actions IS enabled (`gh api repos/Ranjith36963/job360/actions/permissions` → `"enabled":true`).
+- 4 workflows on `main`: `ci.yml` (push/PR — backend job with Postgres 16 + Redis 7 service containers, runs `ruff check` then pytest then non-blocking mypy; frontend job passes), `ci-offline.yml` (push/PR/daily — runs full pytest WITHOUT a Postgres service container), `live-e2e.yml` (nightly `pytest -m live`), `uptime.yml` (10-min ping — the only green one).
+- `ci.yml` backend job currently fails at step "Lint (ruff)", exit 1, before tests run. Frontend job passes.
+- `ci-offline.yml` was written BEFORE the SQLite→Postgres migration. The backend test suite now requires a real Postgres (`backend/src/repositories/pg.py`, default DSN `postgresql://job360:job360dev@localhost:5433/job360`). Its two backend jobs (`offline-suite`, `loop2-e2e-spotlight`) have no Postgres service container — that is almost certainly why its scheduled runs fail. Its third job (`frontend-e2e`, Playwright UI specs) is unique — `ci.yml` does NOT run Playwright.
+- Branch `worktree-feat-live-smoke` is exactly 1 commit ahead of `main` (`0338864`), adds 3 files (`.github/workflows/synthetic-live.yml`, `frontend/tests/synthetic/live-smoke.mjs`, `frontend/tests/synthetic/sample-cv.pdf`), **0 conflicts** — branch point equals current main tip `fc8ce20`.
+- The smoke script's defaults: `SMOKE_BASE_URL` → `https://frontend-production-c608f.up.railway.app`, `SMOKE_API_URL` → `https://backend-production-80e8e.up.railway.app`. Public corners (landing/login/register/privacy/terms/contact) run with no secrets. Authed corners need repo secret `SMOKE_SESSION` (a valid `job360_session` cookie value from a verified synthetic account) — that part is a human step.
+
+## Files to touch
+
+- Modify: whatever `backend/` files ruff flags (unknown until run — likely `backend/src/**/*.py`, `backend/tests/**/*.py`)
+- Modify: `.github/workflows/ci-offline.yml`
+- Merge in (no edits): `.github/workflows/synthetic-live.yml`, `frontend/tests/synthetic/live-smoke.mjs`, `frontend/tests/synthetic/sample-cv.pdf`
+- Possibly modify: `.github/workflows/live-e2e.yml` (triage outcome dependent)
+
+## Environment prerequisites (all commands from repo root unless stated)
+
+- Local Postgres for the test suite must be reachable at `postgresql://job360:job360dev@localhost:5433/job360` (or set `DATABASE_URL`). If `python -m pytest` errors with connection-refused, start the dev Postgres first (check `docker ps`; the project's dev DB runs on port 5433).
+- Windows quirk: running the FULL backend suite twice back-to-back in one shell can crash psycopg natively (exit 139). This is environmental, not a real failure. Run the full suite ONCE per shell; if you see exit 139 on a second run, open a fresh shell and re-run once.
+
+---
+
+### Task 0: Preflight
+
+- [ ] **Step 0.1: Branch + clean tree**
+
+```bash
+git fetch origin main
+git checkout -b fix/ci-red-gate origin/main
+git status --porcelain   # must be empty
+```
+
+Expected: new branch from origin/main, empty status. If status is not empty or origin/main has diverged from what you expect, STOP and report — do not stash or rebase silently.
+
+### Task 1: Reproduce and fix the ruff failure
+
+- [ ] **Step 1.1: See exactly what CI runs.** Open `.github/workflows/ci.yml`, find the backend job's "Lint (ruff)" step, and copy its exact command and working directory. (Expected shape: `ruff check .` or `ruff check src/ tests/` with `working-directory: backend`.)
+
+- [ ] **Step 1.2: Reproduce locally with the same command:**
+
+```bash
+cd backend
+python -m ruff check .    # substitute the exact command from Step 1.1
+```
+
+Expected: FAILS with a list of violations. Copy the full list into your notes. If it passes locally, your ruff version differs from CI — run `python -m ruff --version`, compare against the version CI installs (it comes from `pip install -e ".[dev]"`, so check the `ruff` pin in `backend/pyproject.toml` dev extras), and `pip install -e ".[dev]"` to sync before proceeding.
+
+- [ ] **Step 1.3: Auto-fix the safe ones:**
+
+```bash
+python -m ruff check . --fix
+git diff
+```
+
+**Review EVERY change `--fix` made before accepting it.** See the edge cases section — two ruff auto-fixes are dangerous in this repo.
+
+- [ ] **Step 1.4: Fix the remaining violations by hand.** Decision rules, in order of preference:
+  1. Fix the code (rename unused variable to `_`, remove dead code, split long line).
+  2. If a violation is a deliberate pattern (e.g., an import inside a function — see edge cases), add a targeted `# noqa: <RULE>` on that one line with a short trailing comment saying why.
+  3. NEVER blanket-disable a rule in `pyproject.toml` and NEVER add file-level `# ruff: noqa`. If you believe a rule itself is wrong for this repo, STOP and report instead.
+
+- [ ] **Step 1.5: Verify lint is clean and tests still pass:**
+
+```bash
+python -m ruff check .        # expected: "All checks passed!"
+python -m pytest -q -p no:randomly
+```
+
+Expected: 0 ruff violations; pytest ~1,600+ passed, 0 failed (exact count varies; 3 skips on Windows are normal).
+
+- [ ] **Step 1.6: Commit**
+
+```bash
+git add -A
+git commit -m "fix(ci): clear ruff violations blocking the backend lint gate"
+```
+
+### Task 2: Fix or retire `ci-offline.yml`
+
+- [ ] **Step 2.1: Confirm the diagnosis.** Fetch the log of the latest failed run:
+
+```bash
+gh run list --workflow ci-offline.yml --limit 3
+gh run view <latest-failed-run-id> --log-failed | head -80
+```
+
+Expected finding: backend jobs fail with a Postgres connection error (connection refused / could not translate host). If instead the failure is something else entirely (e.g., a dependency install error), fix THAT and skip Step 2.2.
+
+- [ ] **Step 2.2: Give the two backend jobs a database.** Open `.github/workflows/ci.yml` and copy — verbatim — the backend job's `services:` block AND any `env:` entries that set `DATABASE_URL`/`REDIS_URL` for the test steps. Paste both into `.github/workflows/ci-offline.yml`, into BOTH the `offline-suite` job and the `loop2-e2e-spotlight` job (the `frontend-e2e` job needs no database). Do not invent your own service config — `ci.yml`'s is known-good for this suite.
+
+- [ ] **Step 2.3: Reduce redundancy.** `ci.yml` already runs the full backend suite on every push/PR. Edit `ci-offline.yml`'s `on:` block to remove `push:` and `pull_request:`, keeping only:
+
+```yaml
+on:
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch: {}
+```
+
+This keeps the daily deep signal (including Playwright UI specs, which ci.yml lacks) without running the same pytest suite twice on every push.
+
+- [ ] **Step 2.4: Commit**
+
+```bash
+git add .github/workflows/ci-offline.yml
+git commit -m "fix(ci): give ci-offline backend jobs a Postgres service; run on schedule only"
+```
+
+### Task 3: Triage `live-e2e.yml` (bounded — max 30 minutes)
+
+- [ ] **Step 3.1: Read the failure:**
+
+```bash
+gh run list --workflow live-e2e.yml --limit 3
+gh run view <latest-failed-run-id> --log-failed | head -100
+```
+
+Decision rules:
+- **Import/collection error or infra error** (module not found, DB connection, fixture error): fix it — it's a real regression.
+- **Individual live-source assertion failures** (a job board changed its HTML/API): do NOT chase them in this plan. These tests hit real external sites and are flaky by design. Leave the workflow as-is and note the failing sources in the PR description.
+- If unsure which case you're in, treat it as the second case and note it.
+
+- [ ] **Step 3.2: Commit if you changed anything**
+
+```bash
+git add -A && git commit -m "fix(ci): repair live-e2e collection error"   # only if applicable
+```
+
+### Task 4: Merge the live synthetic smoke test
+
+- [ ] **Step 4.1: Merge the branch (verified 0 conflicts):**
+
+```bash
+git merge worktree-feat-live-smoke --no-edit
+```
+
+Expected: clean merge adding exactly 3 files: `.github/workflows/synthetic-live.yml`, `frontend/tests/synthetic/live-smoke.mjs`, `frontend/tests/synthetic/sample-cv.pdf`. If there ARE conflicts (main moved since this plan was written), STOP and report — do not resolve blind.
+
+- [ ] **Step 4.2: Set the repo variables the workflow reads** (public corners work without secrets):
+
+```bash
+gh variable set SMOKE_BASE_URL --body "https://frontend-production-c608f.up.railway.app"
+gh variable set SMOKE_API_URL --body "https://backend-production-80e8e.up.railway.app"
+```
+
+- [ ] **Step 4.3: HUMAN STEP (note in PR, do not block on it):** the `SMOKE_SESSION` secret needs a `job360_session` cookie from a verified synthetic prod account (log in on prod, copy the cookie from browser devtools, then `gh secret set SMOKE_SESSION`). Until set, authed corners are skipped by design — public corners still run.
+
+### Task 5: Ship and verify green
+
+- [ ] **Step 5.1: Push and open the PR:**
+
+```bash
+git push -u origin fix/ci-red-gate
+gh pr create --title "fix(ci): green gate — ruff clean, ci-offline Postgres service, merge synthetic-live smoke" --body "Fixes the red ci.yml lint gate, repairs ci-offline's missing Postgres service, merges worktree-feat-live-smoke. live-e2e triage notes: <fill in from Task 3>."
+```
+
+- [ ] **Step 5.2: Watch the PR checks:**
+
+```bash
+gh pr checks --watch
+```
+
+Expected: `ci.yml` backend AND frontend jobs green on this PR.
+
+- [ ] **Step 5.3: After merge, manually fire the new/repaired scheduled workflows once:**
+
+```bash
+gh workflow run synthetic-live.yml
+gh workflow run ci-offline.yml
+# wait a few minutes, then:
+gh run list --limit 5
+```
+
+Expected: synthetic-live green (public corners), ci-offline green.
+
+---
+
+## Edge cases a weaker model would miss
+
+1. **ruff `--fix` can delete "unused" imports that are load-bearing.** This repo lazy-imports heavy deps (`apprise`, `sentence_transformers`, `chromadb`, `rapidfuzz`, `sklearn`) INSIDE functions on purpose (CLAUDE.md rules #11/#16). Never "fix" an import-related violation by moving an import to module top level, and never let `--fix` remove an import that a conditional/lazy path uses. Review the `git diff` after `--fix` line by line.
+2. **ruff version drift**: CI installs ruff via `backend/pyproject.toml` dev extras. If your local ruff is newer/older, you'll fix a different violation set than CI sees. Sync versions before fixing (Step 1.2).
+3. **`ci-offline.yml` is not "offline" anymore.** The name predates the Postgres migration. Don't try to make the suite pass without a database (e.g., by skipping tests) — the correct fix is adding the service container. Do not rename the file either (workflow history/badges reference it); a comment in the YAML noting the name is historical is fine.
+4. **Two different `main.py` files exist**: `backend/src/api/main.py` (FastAPI app) and `backend/src/main.py` (pipeline orchestrator). If ruff flags either, make sure you're editing the file it actually pointed at.
+5. **Don't fix live-e2e by deleting/skipping live tests.** They're deselected from the offline suite already (`-m live` marker). Their nightly red is a signal for the owner about real upstream breakage, not noise to silence.
+6. **The smoke workflow only schedules from the default branch.** Merging the PR is what activates `synthetic-live.yml`'s cron — testing it on the feature branch requires `workflow_dispatch` AFTER merge, not before.
+7. **Windows double-run psycopg crash** (exit 139 on the second consecutive full-suite run in one shell) is environmental. Don't debug it; fresh shell, run once.
+
+## Acceptance criteria (verify each)
+
+- [ ] `cd backend && python -m ruff check .` → "All checks passed!" locally.
+- [ ] `cd backend && python -m pytest -q -p no:randomly` → 0 failures locally (one run).
+- [ ] PR checks: `ci.yml` fully green on the PR (`gh pr checks`).
+- [ ] After merge: `gh run list --workflow ci.yml --limit 1` on main → success.
+- [ ] After merge: `gh workflow run ci-offline.yml` → green run.
+- [ ] After merge: `gh api repos/Ranjith36963/job360/actions/workflows` lists `synthetic-live.yml`; `gh workflow run synthetic-live.yml` → green (public corners).
+- [ ] `ci-offline.yml` no longer triggers on push/PR (check its `on:` block on main).
+
+## STOP conditions (report instead of proceeding)
+
+- origin/main has moved such that `worktree-feat-live-smoke` no longer merges clean.
+- A ruff violation can only be fixed by restructuring scoring/search-engine code under `backend/src/services/` (Pillar 2 is owner-reserved — report, don't touch `skill_matcher.py`, `scoring_dimensions.py`, `retrieval.py`, `embeddings.py`, `vector_index.py`, `llm_matcher.py`, `job_enrichment.py` beyond mechanical one-line lint fixes).
+- The pytest suite has real (non-environmental) failures unrelated to your changes.

--- a/PLAN-2-unblock-real-signups.md
+++ b/PLAN-2-unblock-real-signups.md
@@ -1,0 +1,252 @@
+# PLAN 2 — Unblock real sign-ups: production email delivery
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Rank: 2 of 5.**
+Why: Job360 is LIVE on Railway (since 2026-07-02) with passwordless magic-link login — but Resend is in sandbox mode, which only delivers to the account owner's email (`rahulranjith369@gmail.com`). **No other human can log in to the live product.** Everything else (plans 3–5) matters less while the product has a maximum user count of one.
+
+**Goal:** Any email address can receive a magic-link and log in on production; email-send failures are visible instead of silent; the undocumented email env vars are documented and tested.
+
+**Architecture:** The code path is already correct and well-tested (token minting, single-use consume, no-enumeration 204s). The blocker is provider configuration plus three small code gaps: undocumented env vars, zero tests on the send-failure path, and a silent-failure UX. Most of Task 1 is a HUMAN step (DNS); everything after is code.
+
+**Tech Stack:** Resend HTTP API (primary), smtplib fallback, httpx, FastAPI, pytest, Vitest.
+
+---
+
+## Verified facts (checked 2026-07-07 — trust these over docs)
+
+- Sender: `backend/src/services/auth/email_sender.py`, function `send_system_email(...) -> bool` (never raises; returns False and logs a WARNING on failure).
+- From-address logic (line ~53): `os.environ.get("SMTP_FROM") or os.environ.get("SMTP_EMAIL") or "onboarding@resend.dev"` — the fallback is Resend's shared sandbox sender.
+- Resend key logic (lines ~60-62): reads `RESEND_API_KEY`; if unset, falls back to `SMTP_PASSWORD` **if it starts with `re_`**. Neither `RESEND_API_KEY` nor `SMTP_FROM` is declared in `backend/src/core/settings.py` or documented in `.env.example` — they are read ad hoc from `os.environ` only inside `email_sender.py`.
+- SMTP fallback (lines ~88-125): used only when no Resend key is found; host from `os.environ.get("SMTP_HOST", "smtp.gmail.com")` — NOTE: `settings.py:60-62` also defines `SMTP_HOST`/`SMTP_PORT` constants but they are **dead code**, `email_sender.py` never reads them.
+- Magic-link flow: `POST /api/auth/magic-link/request` (always 204; rate-limit 3/5min per email) → email link `{FRONTEND_ORIGIN}/auth/magic?token=...` → `POST /api/auth/magic-link/consume` (400 generic on invalid/expired/used; on success creates/reactivates user, sets `email_verified_at`, sets session cookie). Routes in `backend/src/api/routes/auth.py:502-573`; logic in `backend/src/services/auth/magic_link.py`; tokens table from migration `0022_magic_link_tokens`.
+- `REQUIRE_EMAIL_VERIFICATION` env (default `"true"`, read in `backend/src/api/auth_deps.py:105-128`) gates `require_verified_user` routes; the code comment says it exists as an escape hatch "while Resend is in sandbox mode." It may currently be `false` on Railway.
+- Existing tests: `backend/tests/test_magic_link.py` (8 tests, all monkeypatch `send_system_email` to return True — the failure path and the real provider path have ZERO coverage). Frontend: no test exists for `frontend/src/app/auth/magic/page.tsx`.
+- Frontend magic pages: `frontend/src/app/(auth)/login/page.tsx` (MagicLinkForm shows "Check your email (and Spam)…" on 204 — even if the send actually failed) and `frontend/src/app/auth/magic/page.tsx` (consumes `?token=`, redirects to `/dashboard`).
+
+## Files to touch
+
+- Modify: `.env.example` (root)
+- Modify: `backend/src/core/settings.py` (document + declare email vars; remove dead constants)
+- Modify: `backend/src/services/auth/email_sender.py` (read settings-declared names consistently; error-level log on failure)
+- Create: `backend/tests/test_email_sender.py`
+- Modify: `backend/tests/test_magic_link.py` (add send-failure test)
+- Create: `frontend/src/app/auth/magic/__tests__/magic-consume.test.tsx`
+- HUMAN: Resend dashboard + DNS records + Railway env vars
+
+---
+
+### Task 1: Provider unblock — HUMAN STEP (do first; code tasks don't depend on it)
+
+This cannot be done by an agent. Present it to the owner exactly like this:
+
+**Option A (recommended, permanent): verify a domain in Resend.**
+1. In the Resend dashboard → Domains → Add Domain (e.g. `job360.example` — any domain you own; if you own none, buy one first, ~£10/yr).
+2. Add the DKIM/SPF DNS records Resend shows you at your DNS provider. Wait for "Verified".
+3. On Railway (backend service) set:
+   - `SMTP_FROM=Job360 <login@yourdomain>` ← must be on the verified domain, otherwise Resend rejects with 403
+   - `RESEND_API_KEY=re_...` (a production key, not the sandbox one)
+4. Redeploy the backend service.
+
+**Option B (stopgap, works today, no domain needed): Gmail SMTP fallback.**
+1. Create a Gmail app password (https://myaccount.google.com/apppasswords).
+2. On Railway set: `SMTP_EMAIL=<your gmail>`, `SMTP_PASSWORD=<app password>`, `SMTP_FROM=<your gmail>`, and **REMOVE any `re_`-prefixed value from `SMTP_PASSWORD` and remove/blank `RESEND_API_KEY`** — if a `re_` key is visible anywhere, the code takes the Resend path and Gmail is never used (see Verified facts).
+3. Redeploy. Deliverability is worse than Option A (may land in spam) but any address can receive links.
+
+**Either way, afterwards:** if `REQUIRE_EMAIL_VERIFICATION=false` was set on Railway as the sandbox escape hatch, set it back to `true` once delivery works.
+
+### Task 2: Document + declare the email env vars
+
+- [ ] **Step 2.1: Read the whole sender first** (`backend/src/services/auth/email_sender.py`) — the exact env names and fallback order in "Verified facts" must match what you see; if the file has changed, adapt.
+
+- [ ] **Step 2.2: Add the missing entries to `.env.example`** in the existing "Email notifications" section (keep the existing SMTP_* lines):
+
+```
+# === Transactional email (magic-link login, verification, password reset) ===
+# Preferred: Resend (https://resend.com). Key must be a production key and
+# SMTP_FROM must be an address on a domain verified in Resend.
+RESEND_API_KEY=
+SMTP_FROM=
+```
+
+- [ ] **Step 2.3: Declare them in `backend/src/core/settings.py`** next to the existing SMTP block, and delete the two dead constants:
+
+```python
+# Transactional email (magic-link / verification). email_sender.py prefers
+# Resend when RESEND_API_KEY is set; otherwise falls back to SMTP.
+RESEND_API_KEY = os.getenv("RESEND_API_KEY", "")
+SMTP_FROM = os.getenv("SMTP_FROM", "")
+```
+
+Remove `SMTP_HOST = "smtp.gmail.com"` and `SMTP_PORT = 587` ONLY IF a repo-wide grep proves nothing imports them:
+
+```bash
+cd backend && grep -rn "SMTP_HOST\|SMTP_PORT" src/ tests/ | grep -v email_sender
+```
+
+If anything else imports them, leave them and add a comment `# NOTE: email_sender.py reads SMTP_HOST/SMTP_PORT from os.environ directly; these constants are not used by it.`
+
+- [ ] **Step 2.4: Keep `email_sender.py` behavior identical** but make it read the same names (it already does — this step is verification only). Do NOT refactor it to import from settings (settings is loaded at import time; tests monkeypatch `os.environ` — changing the read location breaks the monkeypatch pattern).
+
+- [ ] **Step 2.5: Run the env-example parity gate + commit:**
+
+```bash
+cd backend && python scripts/check_env_example.py
+git add -A && git commit -m "docs(email): declare RESEND_API_KEY + SMTP_FROM; remove dead SMTP constants"
+```
+
+Expected: gate passes. If it complains about other undocumented vars, fix only the ones this plan added; report the rest.
+
+### Task 3: Make send failures loud (log level + tests)
+
+- [ ] **Step 3.1: Failing test first.** Create `backend/tests/test_email_sender.py`:
+
+```python
+"""Send-failure paths of send_system_email — previously untested."""
+import pytest
+
+from src.services.auth import email_sender
+
+
+class _FakeResponse:
+    status_code = 500
+    text = "internal error from resend"
+
+
+class _FakeAsyncClient:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def post(self, *args, **kwargs):
+        return _FakeResponse()
+
+
+@pytest.mark.asyncio
+async def test_resend_5xx_returns_false_and_logs_error(monkeypatch, caplog):
+    monkeypatch.setenv("RESEND_API_KEY", "re_test_key")
+    monkeypatch.delenv("SMTP_EMAIL", raising=False)
+    monkeypatch.setattr(email_sender.httpx, "AsyncClient", _FakeAsyncClient)
+    ok = await email_sender.send_system_email(
+        to_email="someone@example.com", subject="s", body_text="b"
+    )
+    assert ok is False
+    assert any(r.levelname == "ERROR" for r in caplog.records), (
+        "delivery failure must be logged at ERROR so it is visible in Sentry/Railway logs"
+    )
+
+
+@pytest.mark.asyncio
+async def test_no_provider_configured_returns_false(monkeypatch):
+    for var in ("RESEND_API_KEY", "SMTP_PASSWORD", "SMTP_EMAIL"):
+        monkeypatch.delenv(var, raising=False)
+    ok = await email_sender.send_system_email(
+        to_email="someone@example.com", subject="s", body_text="b"
+    )
+    assert ok is False
+```
+
+Before running: READ `email_sender.py` and adjust the patch target if httpx is imported differently (e.g., `from httpx import AsyncClient` would need `monkeypatch.setattr(email_sender, "AsyncClient", ...)`). Also check what the current no-provider behavior is — if it currently attempts SMTP to smtp.gmail.com with empty creds, the second test may need `monkeypatch.setattr` on the SMTP helper instead; the assertion `ok is False` is the contract.
+
+```bash
+cd backend && python -m pytest tests/test_email_sender.py -v -p no:randomly
+```
+
+Expected: the ERROR-level assertion FAILS (current code logs WARNING).
+
+- [ ] **Step 3.2: Minimal fix.** In `email_sender.py`, change the failure logs (Resend non-2xx, Resend exception, SMTP exception) from `logger.warning(...)` to `logger.error(...)`. Do not change return values or add raises — callers rely on the never-raises contract.
+
+- [ ] **Step 3.3: Add the magic-link-specific failure test** to `backend/tests/test_magic_link.py` (follow the file's existing fixture style — it has a `_no_real_email` autouse-style fixture; this test overrides the send to fail):
+
+```python
+async def test_request_returns_204_even_when_send_fails(client, monkeypatch):
+    """Delivery failure must not leak email-existence (204 always) but the
+    token row is still minted, so a re-send after fixing the provider works."""
+    async def _failing_send(**kwargs):
+        return False
+
+    monkeypatch.setattr(
+        "src.services.auth.magic_link.send_system_email", _failing_send
+    )
+    resp = await client.post(
+        "/api/auth/magic-link/request", json={"email": "fail@example.com"}
+    )
+    assert resp.status_code == 204
+```
+
+Adapt the client fixture name/signature to match the existing tests in that file (READ the file first — it may use a sync TestClient; copy the shape of `test_request_mints_token_and_returns_204`).
+
+- [ ] **Step 3.4: Run + commit:**
+
+```bash
+cd backend && python -m pytest tests/test_email_sender.py tests/test_magic_link.py -v -p no:randomly
+git add -A && git commit -m "test(email): cover send-failure paths; log delivery failures at ERROR"
+```
+
+### Task 4: Frontend test for the consume page
+
+- [ ] **Step 4.1:** READ `frontend/src/app/auth/magic/page.tsx` fully, then create `frontend/src/app/auth/magic/__tests__/magic-consume.test.tsx` following the pattern of the existing `frontend/src/app/(auth)/login/__tests__/login-redirect.test.tsx` (same mocking style for `next/navigation` and `@/lib/api`). Cover three cases:
+  1. No `?token=` param → error state shown, `consumeMagicLink` NOT called.
+  2. `consumeMagicLink` resolves → `router.replace("/dashboard")` called.
+  3. `consumeMagicLink` rejects → error message + link back to `/login` rendered.
+
+Use the login test's exact mock setup for `useSearchParams`/`useRouter` — do not invent a new mocking approach.
+
+- [ ] **Step 4.2: Run + commit:**
+
+```bash
+cd frontend && npm run test:unit
+git add -A && git commit -m "test(frontend): cover magic-link consume page states"
+```
+
+### Task 5: Live verification + ship
+
+- [ ] **Step 5.1: Local end-to-end sanity** (backend running locally, `python main.py` from `backend/`): POST a magic-link request and confirm a token row appears:
+
+```bash
+curl -s -X POST http://localhost:8000/api/auth/magic-link/request -H "Content-Type: application/json" -d "{\"email\":\"local-test@example.com\"}" -i | head -1
+```
+
+Expected: `HTTP/1.1 204 No Content`. Check backend logs — with no local provider configured you should now see an ERROR-level delivery-failure line (that's the new visibility working).
+
+- [ ] **Step 5.2: Push + PR:**
+
+```bash
+git push -u origin feat/unblock-real-signups
+gh pr create --title "feat(email): production email readiness — env docs, failure visibility, tests" --body "Code half of the sign-up unblock. HUMAN half (Resend domain verify or Gmail stopgap + Railway vars) documented in PLAN-2-unblock-real-signups.md Task 1. After Railway vars are set: send a magic link to a NON-owner address on prod and confirm receipt + login."
+```
+
+- [ ] **Step 5.3: HUMAN verification on prod (after Task 1 done):** request a magic link for an address that is NOT the Resend account owner's, receive it, click it, land on `/dashboard`. Then confirm `REQUIRE_EMAIL_VERIFICATION` is back to `true` on Railway.
+
+---
+
+## Edge cases a weaker model would miss
+
+1. **The `re_` smuggling quirk:** a Resend key can arrive via `SMTP_PASSWORD` (if it starts with `re_`). If the owner picks Option B (Gmail), leaving the old `re_` value in `SMTP_PASSWORD` silently keeps routing through sandbox Resend. The stopgap instructions must explicitly remove it.
+2. **`SMTP_FROM` must match the verified domain.** With Resend, a from-address outside the verified domain gets a 403 — and because `send_system_email` never raises, the user sees "Check your email" while nothing was sent. This is why Task 3's ERROR-level logging matters.
+3. **`settings.SMTP_HOST`/`SMTP_PORT` are decoys.** They exist in `settings.py` but `email_sender.py` reads `os.environ` directly. Editing settings.py to "configure SMTP" does nothing.
+4. **Don't refactor `email_sender.py` to import from settings.** Settings values freeze at import time; the existing tests (and this plan's tests) monkeypatch `os.environ` at call time. Keep the ad hoc reads.
+5. **No-enumeration is a security property, not sloppiness.** The request endpoint must return 204 on unknown emails, rate-limited requests AND send failures alike. Do not "improve" it to return an error when the send fails — that leaks provider state and invites email-existence probing. Failure visibility belongs in logs/Sentry, not in the HTTP response.
+6. **`REQUIRE_EMAIL_VERIFICATION` re-enable:** if it stays `false` after email works, every route guarded by `require_verified_user` is open to unverified accounts. The flag flip is part of DONE for this plan.
+7. **Rate limit in manual testing:** 3 requests per 5 minutes per email. If prod testing "stops working" after 3 tries, that's the limiter (still 204, silently no token) — wait 5 minutes, don't debug.
+8. **Magic-link URL uses `FRONTEND_ORIGIN`'s first entry.** If Railway's `FRONTEND_ORIGIN` has multiple comma-separated origins, the link is built from the first — make sure the production frontend URL is first, or links point at localhost.
+
+## Acceptance criteria
+
+- [ ] `python scripts/check_env_example.py` passes; `.env.example` documents `RESEND_API_KEY` + `SMTP_FROM`.
+- [ ] `python -m pytest tests/test_email_sender.py tests/test_magic_link.py -p no:randomly` → all pass, including the new failure-path tests.
+- [ ] Full backend suite green: `python -m pytest -q -p no:randomly` (one run).
+- [ ] `npm run test:unit` green including the new magic-consume tests.
+- [ ] A delivery failure produces an ERROR-level log line (verify in Step 5.1).
+- [ ] PROD: a non-owner email receives a magic link and can log in end-to-end (human-verified).
+- [ ] PROD: `REQUIRE_EMAIL_VERIFICATION=true` on Railway.
+
+## STOP conditions
+
+- `email_sender.py` on main no longer matches the "Verified facts" shape (someone changed the provider logic) — re-map before editing.
+- The owner has no domain and rejects both options in Task 1 — code tasks still land, but say clearly the product remains single-user until Task 1 happens.

--- a/PLAN-3-db-backups-and-prod-safety.md
+++ b/PLAN-3-db-backups-and-prod-safety.md
@@ -1,0 +1,332 @@
+# PLAN 3 — Wire database backups + close the remaining prod-safety gaps
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Rank: 3 of 5.**
+Why: the app is live on Railway with a real Postgres database and **no scheduled backup anywhere** — a working `pg_dump` script exists (`backend/scripts/backup_db.py`) but a repo-wide grep confirms nothing references it: no cron, no Railway job, no CI schedule, no docs. One bad migration or fat-fingered delete and the data is gone. This plan wires the existing script to a nightly scheduler, proves restore actually works (a backup you've never restored is a hope, not a backup), and closes three verified smaller gaps.
+
+**Goal:** nightly automated Postgres backups with retention + a documented, rehearsed restore procedure + correct container healthchecks + an inbound request-timeout middleware.
+
+**Architecture:** GitHub Actions nightly job runs the existing `backup_db.py` against prod `DATABASE_URL` (secret) and stores the gzipped dump as a private artifact. Healthcheck paths corrected to the probes that already exist. One new middleware (the only genuinely new code).
+
+**Tech Stack:** GitHub Actions, pg_dump/psql, FastAPI/Starlette middleware, pytest.
+
+---
+
+## Verified facts (checked 2026-07-07 — several "Step 4" items already exist; do NOT rebuild them)
+
+- `backend/scripts/backup_db.py` EXISTS and works: reads `DATABASE_URL` (errors if unset), streams `pg_dump --no-owner --no-privileges` into gzip, names files `job360-{UTC}.sql.gz`, output dir `./backups` or `$BACKUP_DIR`, retention via `--keep`/`$BACKUP_KEEP` (default 14). Restore is documented in its docstring: `gunzip -c file.sql.gz | psql "$DATABASE_URL"`. It is referenced by NOTHING else in the repo.
+- `/api/livez` and `/api/readyz` ALREADY EXIST and are tested (`backend/src/api/routes/health.py:35-98`, `backend/tests/test_health_probes.py`). readyz checks Postgres (`SELECT 1`) and Redis (skipped when `REDIS_URL` unset). Do not build probes.
+- `SecurityHeadersMiddleware` ALREADY EXISTS (`backend/src/api/middleware.py:109-133`, registered in `backend/src/api/main.py:106`): nosniff, X-Frame-Options DENY, Referrer-Policy, CSP, HSTS in prod. Do not build it.
+- Healthcheck path bugs: `backend/Dockerfile:40-41` HEALTHCHECK hits `/api/health` (works, but it's the trivial no-dependency endpoint); `docker-compose.prod.yml` backend healthcheck hits `/health` (NO `/api` prefix — that path does not exist, so the compose healthcheck can never pass).
+- Inbound request timeout: DOES NOT EXIST. `REQUEST_TIMEOUT`/`SOURCE_FETCH_TIMEOUT*` in `backend/src/core/settings.py` are OUTBOUND (job-source fetch) timeouts only. The FastAPI middleware stack (`backend/src/api/main.py:94-113`) is CORS → SecurityHeaders → AccessLog → RequestId; no timeout middleware.
+- `.env.example` does NOT document `DATABASE_URL`, `SENTRY_DSN`, `BACKUP_DIR`, `BACKUP_KEEP`. `backend/scripts/check_env_example.py` is the parity gate.
+- Deploy shape: no railway.json/Procfile — Railway builds `backend/Dockerfile` (API) and `backend/Dockerfile.worker` (ARQ worker via `RAILWAY_DOCKERFILE_PATH`). Prod DB is Railway Postgres; its `DATABASE_URL` lives in the Railway dashboard.
+- App runs Postgres-only through the `pg.py` psycopg3 shim; connections are autocommit, no pool.
+
+## Files to touch
+
+- Create: `.github/workflows/db-backup.yml`
+- Create: `docs/RUNBOOK-backups.md`
+- Modify: `backend/Dockerfile` (healthcheck path), `docker-compose.prod.yml` (healthcheck path)
+- Modify: `backend/src/api/middleware.py` (new `RequestTimeoutMiddleware`), `backend/src/api/main.py` (register it), `backend/src/core/settings.py` (timeout setting)
+- Create: `backend/tests/test_request_timeout.py`
+- Modify: `.env.example`
+
+---
+
+### Task 0: Preflight
+
+- [ ] **Step 0.1:**
+
+```bash
+git fetch origin main
+git checkout -b feat/prod-safety-net origin/main
+git status --porcelain   # must be empty
+```
+
+- [ ] **Step 0.2: Privacy gate for artifact backups.** Database dumps contain user emails and CVs — they must never land in a public repo's artifacts:
+
+```bash
+gh repo view --json visibility
+```
+
+If visibility is not `PRIVATE`: STOP the backup-workflow task (Tasks 1–2), report, and do only Tasks 3–5. (Fallback for a public repo would be Railway's own backup add-on or an encrypted-at-rest bucket — owner decision.)
+
+### Task 1: Nightly backup workflow
+
+- [ ] **Step 1.1: Read the script first** (`backend/scripts/backup_db.py`) and confirm: env names (`DATABASE_URL`, `BACKUP_DIR`, `BACKUP_KEEP`), CLI flags, and that it shells out to `pg_dump` (so the runner needs the Postgres client installed).
+
+- [ ] **Step 1.2: Create `.github/workflows/db-backup.yml`:**
+
+```yaml
+# Nightly Postgres backup of the live Railway database.
+# Dump lands as a workflow artifact (repo is private; artifacts inherit repo ACL).
+# Restore procedure: docs/RUNBOOK-backups.md
+name: db-backup
+on:
+  schedule:
+    - cron: "17 2 * * *" # 02:17 UTC nightly (odd minute avoids top-of-hour load spikes)
+  workflow_dispatch: {}
+
+jobs:
+  backup:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Postgres client
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y -q postgresql-client
+          pg_dump --version
+      - name: Dump database
+        env:
+          DATABASE_URL: ${{ secrets.PROD_DATABASE_URL }}
+          BACKUP_DIR: ./backups
+          BACKUP_KEEP: "2"
+        run: python backend/scripts/backup_db.py
+      - name: Sanity-check the dump is non-trivial
+        run: |
+          ls -l backups/
+          FILE=$(ls backups/*.sql.gz | head -1)
+          SIZE=$(stat -c%s "$FILE")
+          echo "dump size: $SIZE bytes"
+          test "$SIZE" -gt 10000   # a real dump of a live DB is far bigger than 10 KB
+          gunzip -t "$FILE"        # gzip integrity
+      - name: Upload backup artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: db-backup-${{ github.run_id }}
+          path: backups/
+          retention-days: 14
+          if-no-files-found: error
+```
+
+- [ ] **Step 1.3: HUMAN STEP — set the secret.** The prod `DATABASE_URL` lives in the Railway dashboard (Postgres service → Variables → the PUBLIC/external connection URL, not the `.railway.internal` one — GitHub runners are outside Railway's network). Owner runs:
+
+```bash
+gh secret set PROD_DATABASE_URL
+```
+
+- [ ] **Step 1.4: Commit.** Note in the PR that the workflow only activates after merge to main + secret set, then fire once with `gh workflow run db-backup.yml` and confirm green + artifact present.
+
+```bash
+git add .github/workflows/db-backup.yml
+git commit -m "feat(ops): nightly pg_dump backup workflow wiring the existing backup_db.py"
+```
+
+### Task 2: Restore drill + runbook
+
+- [ ] **Step 2.1: Do a real restore locally** against the dev Postgres (default DSN `postgresql://job360:job360dev@localhost:5433/job360`). Use a LOCAL dump for the drill (run the script against your local DB) so no prod secret is needed on the workstation:
+
+```bash
+cd backend
+set DATABASE_URL=postgresql://job360:job360dev@localhost:5433/job360   # PowerShell: $env:DATABASE_URL="..."
+python scripts/backup_db.py
+# restore into a fresh database, NEVER the live one:
+psql "postgresql://job360:job360dev@localhost:5433/postgres" -c "DROP DATABASE IF EXISTS job360_restore_drill;"
+psql "postgresql://job360:job360dev@localhost:5433/postgres" -c "CREATE DATABASE job360_restore_drill;"
+# Windows has no gunzip -c by default; python does it portably:
+python -c "import gzip,sys,glob; f=sorted(glob.glob('backups/*.sql.gz'))[-1]; sys.stdout.buffer.write(gzip.open(f,'rb').read())" | psql "postgresql://job360:job360dev@localhost:5433/job360_restore_drill"
+# verify shape:
+psql "postgresql://job360:job360dev@localhost:5433/job360_restore_drill" -c "SELECT count(*) FROM users; SELECT count(*) FROM jobs; SELECT max(id) FROM _schema_migrations;"
+```
+
+Expected: counts match the source DB; `_schema_migrations` max id equals the highest migration number applied. Record the actual numbers.
+
+- [ ] **Step 2.2: Write `docs/RUNBOOK-backups.md`** containing, concretely: where backups live (Actions → db-backup → artifacts, 14-day retention), how to download one (`gh run download <run-id>`), the exact restore commands from Step 2.1 adapted for prod (restore into a NEW Railway database service, repoint `DATABASE_URL`, never in-place), the drill log (date + counts from Step 2.1), and a "test the restore quarterly" note.
+
+- [ ] **Step 2.3: Commit:**
+
+```bash
+git add docs/RUNBOOK-backups.md
+git commit -m "docs(ops): backup restore runbook + first restore drill log"
+```
+
+### Task 3: Fix the healthcheck paths
+
+- [ ] **Step 3.1:** In `backend/Dockerfile` HEALTHCHECK line, change `/api/health` → `/api/livez` (liveness is the correct semantic for a container healthcheck — see edge cases for why NOT readyz).
+- [ ] **Step 3.2:** In `docker-compose.prod.yml` backend healthcheck, change `http://localhost:8000/health` → `http://localhost:8000/api/livez` (the current path lacks the `/api` prefix and 404s forever).
+- [ ] **Step 3.3: Verify + commit:**
+
+```bash
+docker build -t job360-hc-test backend/   # optional if docker available; else skip build, the path change is textual
+git add backend/Dockerfile docker-compose.prod.yml
+git commit -m "fix(ops): container healthchecks hit /api/livez (compose path was 404ing)"
+```
+
+### Task 4: Inbound request-timeout middleware (the one genuinely new piece)
+
+- [ ] **Step 4.1: Failing test first.** Create `backend/tests/test_request_timeout.py`:
+
+```python
+"""Inbound request-timeout middleware — slow handlers must 504, fast ones pass."""
+import asyncio
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from src.api.middleware import RequestTimeoutMiddleware
+
+
+def _app_with_timeout(timeout: float, exempt=()) -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(
+        RequestTimeoutMiddleware, timeout_seconds=timeout, exempt_prefixes=exempt
+    )
+
+    @app.get("/fast")
+    async def fast():
+        return {"ok": True}
+
+    @app.get("/slow")
+    async def slow():
+        await asyncio.sleep(0.5)
+        return {"ok": True}
+
+    @app.get("/exempt/slow")
+    async def exempt_slow():
+        await asyncio.sleep(0.5)
+        return {"ok": True}
+
+    return app
+
+
+@pytest.mark.asyncio
+async def test_fast_request_passes():
+    app = _app_with_timeout(0.2)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        resp = await c.get("/fast")
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_slow_request_gets_504():
+    app = _app_with_timeout(0.2)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        resp = await c.get("/slow")
+    assert resp.status_code == 504
+    assert resp.json()["detail"] == "request timed out"
+
+
+@pytest.mark.asyncio
+async def test_exempt_prefix_is_not_timed_out():
+    app = _app_with_timeout(0.2, exempt=("/exempt",))
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        resp = await c.get("/exempt/slow")
+    assert resp.status_code == 200
+```
+
+Run: `cd backend && python -m pytest tests/test_request_timeout.py -v -p no:randomly` — expected: ImportError (middleware doesn't exist yet).
+
+- [ ] **Step 4.2: Implement** in `backend/src/api/middleware.py` (append; match the file's existing style — it already has BaseHTTPMiddleware subclasses to copy the shape from):
+
+```python
+class RequestTimeoutMiddleware(BaseHTTPMiddleware):
+    """Cap inbound request duration. LLM-heavy routes are exempted by prefix —
+    tailoring/extraction legitimately run longer than an API roundtrip should."""
+
+    def __init__(self, app, timeout_seconds: float = 60.0, exempt_prefixes: tuple = ()):
+        super().__init__(app)
+        self.timeout_seconds = timeout_seconds
+        self.exempt_prefixes = tuple(exempt_prefixes)
+
+    async def dispatch(self, request: Request, call_next) -> Response:
+        path = request.url.path
+        if any(path.startswith(p) for p in self.exempt_prefixes):
+            return await call_next(request)
+        try:
+            return await asyncio.wait_for(
+                call_next(request), timeout=self.timeout_seconds
+            )
+        except asyncio.TimeoutError:
+            return JSONResponse(
+                status_code=504, content={"detail": "request timed out"}
+            )
+```
+
+Add the needed imports at the top of `middleware.py` if missing (`asyncio`, `JSONResponse` from `fastapi.responses`). Keep Python 3.9-compatible typing (no `tuple[str, ...]` in signatures unless the file already uses `from __future__ import annotations`).
+
+- [ ] **Step 4.3: Find the routes that legitimately run long BEFORE choosing exemptions.** These call LLMs or parse files inline:
+
+```bash
+cd backend && grep -rn "async def" src/api/routes/tailor.py src/api/routes/profile.py | head -20
+```
+
+Starting exemption list (verify each actually does inline slow work by reading the route bodies): `("/api/tailor", "/api/profile")`. If a route only ENQUEUES background work (returns fast), it does NOT need exemption.
+
+- [ ] **Step 4.4: Register in `backend/src/api/main.py`** next to the existing middleware registrations (order note: Starlette runs `add_middleware` calls LIFO — add it AFTER the CORS registration so CORS headers still apply to 504 responses; concretely, place the `add_middleware(RequestTimeoutMiddleware, ...)` line BEFORE `app.add_middleware(CORSMiddleware, ...)` in source order… **verify empirically**: run the app, hit a route, confirm 504s carry `Access-Control-Allow-Origin` when sent with an Origin header):
+
+```python
+app.add_middleware(
+    RequestTimeoutMiddleware,
+    timeout_seconds=float(os.getenv("API_REQUEST_TIMEOUT_SECONDS", "60")),
+    exempt_prefixes=("/api/tailor", "/api/profile"),
+)
+```
+
+- [ ] **Step 4.5: Declare the setting + env doc:** add to `backend/src/core/settings.py`:
+
+```python
+# Inbound API request ceiling (seconds). Outbound source-fetch ceilings are
+# SOURCE_FETCH_TIMEOUT / SOURCE_FETCH_TIMEOUT_ATS — different knob, do not merge.
+API_REQUEST_TIMEOUT_SECONDS = float(os.getenv("API_REQUEST_TIMEOUT_SECONDS", "60"))
+```
+
+(and import/use it in `main.py` instead of the inline `os.getenv` if `main.py` conventionally imports from settings — READ `main.py` and match its style). Add `API_REQUEST_TIMEOUT_SECONDS=` to `.env.example`.
+
+- [ ] **Step 4.6: Run everything + commit:**
+
+```bash
+cd backend
+python -m pytest tests/test_request_timeout.py -v -p no:randomly
+python -m pytest -q -p no:randomly
+python scripts/check_env_example.py
+git add -A && git commit -m "feat(ops): inbound request-timeout middleware (504), LLM routes exempt"
+```
+
+Expected: new tests pass; full suite green (one run — Windows double-run crash is environmental).
+
+### Task 5: Document the missing env vars
+
+- [ ] **Step 5.1:** Add to `.env.example` (with one-line comments each): `DATABASE_URL=`, `SENTRY_DSN=`, `BACKUP_DIR=`, `BACKUP_KEEP=`. Run `python backend/scripts/check_env_example.py` — if the gate flags direction mismatches, fix per its output.
+
+- [ ] **Step 5.2: Commit, push, PR:**
+
+```bash
+git add .env.example
+git commit -m "docs(env): document DATABASE_URL, SENTRY_DSN, backup vars"
+git push -u origin feat/prod-safety-net
+gh pr create --title "feat(ops): nightly DB backups + restore drill + healthcheck fixes + request timeouts" --body "Wires the existing (orphaned) backup_db.py to a nightly Actions job with artifact retention; documents + rehearses restore; fixes compose healthcheck 404; adds inbound 504 timeout middleware with LLM-route exemptions. HUMAN steps: set PROD_DATABASE_URL secret (Task 1.3), fire db-backup once after merge."
+```
+
+---
+
+## Edge cases a weaker model would miss
+
+1. **Don't rebuild what exists.** livez/readyz, security headers, and the backup script are DONE. The work is wiring and correcting, not creating. If you find yourself writing a new probe or a new pg_dump wrapper, re-read the Verified facts.
+2. **Container healthcheck must be livez, not readyz.** readyz fails when Redis blips; a failing container healthcheck makes Docker/Railway restart the API — turning a Redis hiccup into an API outage. Liveness for the container, readiness for deploy gating/load balancing (Railway's dashboard healthcheck can use `/api/readyz` — note that as a human option in the PR, it's dashboard config, not repo config).
+3. **Internal vs public Railway DSN.** The `DATABASE_URL` inside Railway services is often `postgres.railway.internal` — unreachable from GitHub runners. The secret must be the EXTERNAL connection string, or the workflow fails with DNS errors that look like auth problems.
+4. **pg_dump client vs server version.** `pg_dump` refuses to dump a server NEWER than itself. ubuntu-latest ships a recent client; if the workflow fails with "server version mismatch," install the matching `postgresql-client-NN` (add the PGDG apt repo). Put this in the runbook.
+5. **`asyncio.wait_for` + BaseHTTPMiddleware caveat:** cancelling `call_next` abandons the handler mid-flight; DB writes in this codebase are autocommit single statements (per `pg.py`), so a cancelled handler cannot leave an open transaction — but a cancelled route that was mid-way through a multi-statement sequence may leave partial state. That's acceptable for a timeout backstop; do NOT try to "fix" it with transactions here (that's a bigger change; out of scope).
+6. **Exemptions by prefix, not exact path** — `/api/tailor` must also cover `/api/tailor/{id}/...` subroutes. But keep the prefixes tight: exempting `/api` would neuter the whole middleware.
+7. **Backup file size check matters.** `pg_dump` against a wrong-but-reachable DSN (e.g., an empty default DB) exits 0 and produces a tiny valid dump. The `test "$SIZE" -gt 10000` step is what catches "backing up the wrong database for six months."
+8. **Windows shell for the restore drill:** `gunzip -c` doesn't exist in PowerShell; the plan's python one-liner is the portable path. Also `set VAR=` vs `$env:VAR=` differ — both shown in Step 2.1.
+9. **Artifacts inherit repo visibility.** The Step 0.2 gate is not optional; a dump artifact in a public repo is a data breach.
+
+## Acceptance criteria
+
+- [ ] After merge + secret set: one green `db-backup` run with a `.sql.gz` artifact > 10 KB (`gh run list --workflow db-backup.yml`).
+- [ ] `docs/RUNBOOK-backups.md` exists with a logged restore drill (real row counts from Step 2.1).
+- [ ] `docker-compose.prod.yml` and `backend/Dockerfile` healthchecks point at `/api/livez`.
+- [ ] `python -m pytest tests/test_request_timeout.py -p no:randomly` → 3 passed.
+- [ ] Full backend suite green (one run); `check_env_example.py` passes.
+- [ ] `curl -i` against a locally-running API on a normal route shows no behavior change; an artificially slow route (temporarily add `await asyncio.sleep(70)` to a test route, or trust the unit tests) → 504.
+
+## STOP conditions
+
+- Repo is public (Step 0.2) — skip Tasks 1–2, do the rest, report.
+- `backup_db.py` has materially changed from the Verified-facts description.
+- Adding the middleware breaks existing tests in a way that isn't a simple ordering/import fix — report rather than reshuffling the whole middleware stack.

--- a/PLAN-4-rescue-profile-extraction-fixes.md
+++ b/PLAN-4-rescue-profile-extraction-fixes.md
@@ -1,0 +1,178 @@
+# PLAN 4 — Rescue the stranded profile-extraction quality fixes (worktree-tp-final)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Rank: 4 of 5.**
+Why: ~2,300 lines of finished, tested profile-extraction quality work (fuzzy dedup of certs/education/skills, LLM-provider hardening with timeouts + smart 429 backoff, prompt-steered CV extraction, GitHub dependency-noise removal) sit unmerged on `worktree-tp-final`. Profile extraction quality is the core of the product — every score depends on it. The branch decays: main moved 91 commits past its fork point already. The catch: **a plain `git merge` conflicts (9 markers, 5 files)** because main independently re-implemented four of the branch's own commits. The rescue is a selective cherry-pick, not a merge.
+
+**Goal:** the ~11 genuinely novel commits from `worktree-tp-final` land on main; the 4 commits main already re-implemented are skipped; full suite green.
+
+**Architecture:** Cherry-pick oldest-first onto a fresh branch from main, with explicit skip list, per-pick targeted tests, and a fallback to manual porting when a pick conflicts too widely.
+
+**Tech Stack:** git cherry-pick, pytest.
+
+---
+
+## Verified facts (checked 2026-07-07 — the commit analysis below is the heart of this plan)
+
+- `worktree-tp-final` is 18 commits ahead of main; merge-base is `61d1971`; main has 91 commits since, INCLUDING the SQLite→Postgres migration (`8d240f8`) and — critically — **independent re-implementations of four of the branch's commits**:
+
+| Branch commit (SKIP — already on main as…) | Main's twin |
+|---|---|
+| `467d27d` symmetric two-pass extraction | `62f1505` |
+| `041857a` merge Stage 1 + Stage 2 | `e7dbe67` |
+| `ff5b5d5` 4 dedicated input routes | `db2c518` |
+| `a0d3767` remove dead reextract_and_rescore | `e7d4f52` |
+
+Also skip `ae6ada0` (test patch for the Stage-1/2 merge) and `e5432d7` (import cleanup after that patch) — they only make sense on top of the skipped refactor; main's twins carry their own test updates.
+
+- **PICK list, in this exact order (oldest first):**
+
+| # | SHA | Subject |
+|---|---|---|
+| 1 | `aae8b53` | docs(pillar1): extraction blockers + quality audit with live evidence |
+| 2 | `752a604` | feat(llm): harden provider layer - timeouts, smart 429 backoff, rate-limit taxonomy |
+| 3 | `e31febc` | feat(cv): robust deterministic skill-heading detection for prose/non-standard CVs |
+| 4 | `2e1b23a` | feat(github): runtime-only manifest deps - drop dev-tooling noise (rule #28 safe) |
+| 5 | `e517703` | test: update review-fix test for runtime-only manifest deps |
+| 6 | `44b976f` | feat(cv): prompt-steer LLM extraction — categories/acronyms + skip vague duties |
+| 7 | `dec740b` | feat(llm): OpenAI gpt-4o-mini as deterministic PRIMARY provider — ⚠ see edge case #1 |
+| 8 | `58e0345` | docs(pillar1): deep honest extraction diagnosis (OpenAI primary, 5 CVs) |
+| 9 | `c3ecb8e` | fix(pillar1): close 3 extraction gaps TDD — CV prose, GitHub language, LinkedIn leak |
+| 10 | `0e6e1c2` | fix(pillar1): skills were polluted with prose/dates/headers + empty skill tiers |
+| 11 | `6081bfc` | fix(pillar1): profile-page trust audit — GitHub noise, wiped username, polluted roles, fake education count |
+| 12 | `37a330d` | fix(pillar1): de-fragment + dedup certifications/education + collapse spacing-variant skills |
+| 13 | `9355f86` | fix(pillar1): general fuzzy + acronym dedup for certs/education/skills (all profiles) |
+
+- Safety copies: tag `tp-final-safe` == branch tip `9355f86` == external worktree `D:\dev\job360-tprun`. Nothing can be lost as long as nobody deletes the tag. NEVER force-delete the tag or branch during this work.
+- Conflicting files in a naive merge (expect the same hotspots during picks): `backend/src/api/routes/profile.py`, `backend/src/services/profile/{github_enricher,linkedin_parser,llm_provider,two_pass}.py`.
+- Branch's test surface: `test_cv_prompt_steering.py` (NEW file), plus edits to `conftest.py`, `test_cv_schema.py`, `test_github_deps.py`, `test_linkedin_github.py`, `test_llm_provider.py`, `test_profile.py`, `test_profile_upload.py`, `test_profile_versions_endpoint.py`, `test_review_fixes.py`, `test_skill_tiering.py`, `test_two_pass.py`.
+- Main-side churn to respect during conflict resolution: `e1cbb30` set **Cerebras-first LLM order for the ENGINES (E2/E3/E4)** and fixed Chroma/HF writable dirs; `b359a20` added profile-extraction summary logging.
+- Hard rule #28 (CLAUDE.md) applies to every pick: ZERO hardcoded skill/keyword lists in `src/services/profile/` — extraction is ESCO-data + LLM only. Commit `2e1b23a` was explicitly written to be rule-#28-safe; verify the others don't reintroduce lists.
+
+## Files that will change
+
+All under `backend/`: `src/api/routes/profile.py`, `src/core/settings.py`, `src/services/profile/{cv_parser,dep_file_parser,github_enricher,linkedin_parser,llm_provider,preferences,schemas,skill_tiering,two_pass}.py`, the 11 test files listed above + new `tests/test_cv_prompt_steering.py`, plus `docs/PILLAR1_DEEP_DIAGNOSIS.md` and `docs/PILLAR1_EXTRACTION_AUDIT.md`.
+
+---
+
+### Task 0: Preflight
+
+- [ ] **Step 0.1:**
+
+```bash
+git fetch origin main
+git checkout -b rescue/pillar1-extraction origin/main
+git status --porcelain          # must be empty
+git tag -l "tp*"                # must show tp-final-safe — the recovery anchor
+git log --oneline -1 tp-final-safe   # must be 9355f86
+```
+
+- [ ] **Step 0.2: Baseline green.** Run the suite ONCE before touching anything so you can distinguish inherited failures from ones you cause:
+
+```bash
+cd backend && python -m pytest -q -p no:randomly
+```
+
+Record the pass/fail/skip counts. (Windows note: a SECOND full-suite run in the same shell can crash psycopg with exit 139 — environmental, use a fresh shell per full run.)
+
+### Task 1: Cherry-pick loop (repeat for each of the 13 PICK commits, in table order)
+
+For commit N:
+
+- [ ] **Step 1.N.a: Pick it:**
+
+```bash
+git cherry-pick <SHA>
+```
+
+- [ ] **Step 1.N.b: If it conflicts**, count the conflicted files (`git status --porcelain | grep -c "^UU"`):
+  - **≤ 3 conflicted files:** resolve using these decision rules:
+    1. **Structure from main, semantics from the branch.** Main's shape (Postgres shim imports, the 4-input route layout from `db2c518`, the merged Stage-1/2 extraction flow from `e7dbe67`) WINS on structure. The branch's ADDITIONS (new functions like fuzzy/acronym dedup helpers, new prompt text, new timeout/backoff logic, new schema fields) get carried into that shape.
+    2. If the branch side edits a function that no longer exists on main (renamed/moved by the refactor), find where its responsibility lives now (`git log -S "<function name>" main -- backend/src/services/profile/` helps) and apply the change there.
+    3. Never resolve by deleting a test — port it.
+  - **> 3 conflicted files:** `git cherry-pick --abort`, then port MANUALLY: `git show <SHA>` to read the full diff, re-apply its intent file-by-file onto the current tree, commit with the original subject plus suffix ` (ported)`. This is expected mainly for #9–#13 (the pillar1 fixes) if they touch the refactored files heavily.
+
+- [ ] **Step 1.N.c: Targeted tests after EVERY pick** (fast feedback beats one big bang at the end):
+
+```bash
+cd backend && python -m pytest tests/test_profile.py tests/test_two_pass.py tests/test_llm_provider.py tests/test_skill_tiering.py tests/test_profile_upload.py -q -p no:randomly
+```
+
+Expected: green after each pick. If red: fix before the next pick — a broken intermediate state makes later conflicts unreadable.
+
+- [ ] **Step 1.N.d (picks #4, #6, #9–#13 only): rule #28 scan** — the pick must not (re)introduce hardcoded skill lists:
+
+```bash
+cd backend && grep -rn "_SKILL_TERMS\|_TO_SKILL\|SKILL_MAP\|_DENYLIST" src/services/profile/ || echo CLEAN
+```
+
+Expected: `CLEAN` (or only hits that existed at Step 0.2 baseline — compare).
+
+### Task 2: Reconcile the provider-order question (after pick #7, before continuing)
+
+Commit `dec740b` makes OpenAI `gpt-4o-mini` the PRIMARY provider **for CV/profile extraction**. Main's `e1cbb30` made Cerebras first **for the engines (E2/E3/E4 enrichment/semantic/judge)**. These are different call chains and BOTH should survive:
+
+- [ ] **Step 2.1:** Open `backend/src/services/profile/llm_provider.py` after pick #7 and confirm the provider order it changes is the PROFILE-extraction chain.
+- [ ] **Step 2.2:** Grep for where engines pick providers (`cd backend && grep -rn "cerebras" src/services/ --include=*.py -il`) and confirm engine-side ordering still matches main's `e1cbb30` behavior (Cerebras first). If pick #7 clobbered engine ordering, restore main's engine ordering while keeping OpenAI-primary for extraction.
+- [ ] **Step 2.3:** `python -m pytest tests/test_llm_provider.py -v -p no:randomly` — the branch updated this file (+122 lines) to match the new order; after reconciliation it must pass.
+- [ ] **Step 2.4: OPENAI_API_KEY handling:** pick #7 likely reads an `OPENAI_API_KEY`. Check `.env.example` documents it and `backend/scripts/check_env_example.py` passes; the provider must SKIP gracefully (fall through the chain) when the key is empty — verify a test covers that; if not, add one modeled on the existing empty-key tests in `test_llm_provider.py`.
+
+### Task 3: Full verification
+
+- [ ] **Step 3.1: Full suite, fresh shell, one run:**
+
+```bash
+cd backend && python -m pytest -q -p no:randomly
+```
+
+Expected: pass count ≥ Step 0.2 baseline + new tests (the branch adds ~37 tests in `test_cv_prompt_steering.py` alone); 0 failures.
+
+- [ ] **Step 3.2: Live behavior check (this is extraction — tests can't prove quality).** Start the backend (`cd backend && python main.py`) + frontend (`cd frontend && npm run dev`), log in, upload a CV (a real one from `backend/data/` fixtures or `frontend/tests/synthetic/sample-cv.pdf` if present), and verify on the profile page:
+  - skills contain NO prose fragments, dates, or section headers;
+  - certifications/education lists have NO near-duplicate entries (e.g. "AWS Certified Solutions Architect" vs "AWS certified solutions architect – associate" collapsed);
+  - GitHub-derived skills (if a GitHub username is set) contain no dev-tooling noise (eslint/prettier-type entries).
+  Screenshot or note what you saw — this is the acceptance evidence.
+
+- [ ] **Step 3.3: Frontend sanity:** `cd frontend && npm run type-check && npm run lint` (extraction changes are backend-only; this guards against accidental API-shape drift).
+
+### Task 4: Ship
+
+- [ ] **Step 4.1:**
+
+```bash
+git push -u origin rescue/pillar1-extraction
+gh pr create --title "fix(pillar1): land the stranded extraction-quality work from worktree-tp-final" --body "Selective cherry-pick of the 13 novel commits from worktree-tp-final (tag tp-final-safe). Skipped 467d27d/041857a/ae6ada0/e5432d7/ff5b5d5/a0d3767 — main re-implemented those as 62f1505/e7dbe67/db2c518/e7d4f52. Provider-order reconciliation: OpenAI-primary for extraction, Cerebras-first preserved for engines. Live profile-page verification: <paste Step 3.2 evidence>."
+```
+
+- [ ] **Step 4.2: AFTER the PR merges (not before):** clean up the stranded copies — `git branch -d worktree-tp-final` (will refuse if unmerged — that refusal is a safety check, investigate before forcing), remove the external worktree (`git worktree remove D:/dev/job360-tprun`), KEEP the tag `tp-final-safe` permanently as the historical anchor.
+
+---
+
+## Edge cases a weaker model would miss
+
+1. **The provider-order collision (Task 2) is the subtlest trap.** Two "make X the first LLM provider" decisions exist for two DIFFERENT call chains (extraction vs engines). Blindly taking either side of a conflict in `llm_provider.py` silently breaks the other chain — and tests may not catch engine-side ordering because engine flags default OFF.
+2. **Don't `git merge worktree-tp-final`.** It conflicts on 9 hunks AND would re-apply refactors main already has, producing duplicate logic. The skip list is not optional.
+3. **Cherry-picking pre-Postgres commits onto post-Postgres main:** the branch forked before `8d240f8`. If a pick's diff context mentions `aiosqlite` or sqlite paths, the resolution is main's Postgres-shim form (`from src.repositories import pg as aiosqlite` is the established alias pattern — code that imports `aiosqlite` via that alias is CORRECT, don't "fix" it).
+4. **Rule #28 is a hard rule, not a preference.** If any pick reintroduces a hand-typed skill map (grep in Step 1.N.d), strip that part and route through ESCO/LLM — even if it makes a branch test fail; adapt the test to the data-driven path.
+5. **Order matters within the pick list.** #5 (`e517703`) is the test for #4; #8 documents #7. Picking out of order creates avoidable conflicts.
+6. **Docs picks (#1, #8) may conflict on nothing but still matter** — they contain the measured evidence (5-CV diagnosis) that justifies the code. Don't drop them as "just docs."
+7. **`conftest.py` edits from the branch** (+18 lines) may collide with Postgres-era conftest changes (per-test schemas, sqlite3 shim registration). Resolution rule: keep ALL of main's Postgres fixtures; add the branch's new fixtures alongside.
+8. **Pillar 2 is owner-reserved.** These picks touch `services/profile/` (Pillar 1 — allowed). If any resolution tempts you into `skill_matcher.py`, `scoring_dimensions.py`, `llm_matcher.py`, `retrieval.py`, `embeddings.py`, `vector_index.py`, or `job_enrichment.py` — STOP, that's out of bounds.
+9. **Windows full-suite double-run crash (exit 139)** — environmental psycopg issue; fresh shell per full run; don't chase it.
+
+## Acceptance criteria
+
+- [ ] `git log --oneline origin/main..rescue/pillar1-extraction` shows ~13 commits matching the PICK table (subjects may carry "(ported)").
+- [ ] Full backend suite: 0 failures; pass count strictly greater than the Step 0.2 baseline (new tests landed).
+- [ ] `tests/test_cv_prompt_steering.py` exists and passes.
+- [ ] rule-#28 grep (Step 1.N.d) reports CLEAN.
+- [ ] Cerebras-first engine ordering verified intact (Task 2.2) AND extraction chain is OpenAI-primary (Task 2.1).
+- [ ] Live check (Step 3.2): profile page shows deduped certs/education and prose-free skills — evidence pasted in the PR.
+- [ ] Tag `tp-final-safe` still exists after all cleanup.
+
+## STOP conditions
+
+- More than 3 consecutive picks need full manual porting — the branch has drifted further than analyzed; stop and report with the list of what landed and what remains (partial rescue is still valuable — ship what's green).
+- Any resolution would require changing Pillar-2 files beyond mechanical import fixes.
+- The Step 0.2 baseline suite is NOT green before you start — fix or report that first; never rescue onto a broken base.

--- a/PLAN-5-free-premium-gating.md
+++ b/PLAN-5-free-premium-gating.md
@@ -1,0 +1,282 @@
+# PLAN 5 — Free/Premium plan gating, Phase 1 (no payments)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Rank: 5 of 5.**
+Why: monetization needs a plan system before it needs a payment system — the `users.plan` column, the `require_premium` dependency, and the plan-aware UI are the foundation Stripe later plugs into. It ranks last only because plans 1–4 protect what already exists; this one builds new surface. It is deliberately Phase-1-only: **no Stripe, no billing, no trial clock** — a text column, a dependency, one real gated feature (CV tailoring), and visible plan state in the UI. The richer Free/Pro/Max + 7-day-taste model (decided in the PR #22 pricing docs) layers on top later; the `plan` column being TEXT means `'pro'`/`'max'` fit without another migration.
+
+**Goal:** every user has a `plan` (`free` default); premium users bypass the tailor monthly cap; `/api/auth/me` and the account page show the plan; free users hitting a premium wall get a clean 402 the frontend explains.
+
+**Architecture:** Migration 0025 adds the column → `CurrentUser` carries it → `require_premium` dependency (mirrors `require_verified_user`) → wire into the existing tailor 402 quota gate → expose via `UserResponse` → frontend `User` type + account-page plan card.
+
+**Tech Stack:** SQL migration (SQLite-dialect, auto-translated to Postgres), FastAPI dependencies, pytest, React/Next.js 16, Vitest.
+
+---
+
+## Verified facts (checked 2026-07-07)
+
+- `users` columns today: `id, email, password_hash, created_at, deleted_at, timezone, email_verified_at`. No plan/premium/tier concept exists ANYWHERE in backend or frontend code (grepped — only forward-looking comments).
+- Highest migration: `0024_tailored_flagged_terms` → this plan creates **0025**. Naming: `NNNN_name.up.sql` + `NNNN_name.down.sql`, discovered by glob, tracked in `_schema_migrations`, auto-applied on API boot (`backend/src/api/dependencies.py:11-22`).
+- **Migrations are written in SQLite dialect but ONLY ever run against Postgres** — `backend/src/repositories/pg.py:translate()` rewrites them (`ADD COLUMN` → `ADD COLUMN IF NOT EXISTS`, `?` → `%s`, etc.). Copy the style of `0024_tailored_flagged_terms.up.sql`. Do NOT write Postgres-native SQL.
+- `CurrentUser` is a FROZEN dataclass in `backend/src/api/auth_deps.py:45-49` (`id`, `email`, `email_verified`), built in `_current_user_from_cookie` (`auth_deps.py:52-76`) from `SELECT id, email, email_verified_at FROM users WHERE id = ? AND deleted_at IS NULL`.
+- The dependency to mirror: `require_verified_user` (`auth_deps.py:105-128`) — it takes `user: CurrentUser = Depends(require_user)` and raises on a missing property. Follow that exact shape.
+- The first real premium feature already has a seam: `backend/src/api/routes/tailor.py:105-125` enforces a monthly cap (`TAILOR_FREE_PER_MONTH`, default 10, from `backend/src/core/settings.py:141`) returning **402** — with a comment saying a real premium tier will bypass it later. Phase 1 = premium bypasses the cap. (Do NOT convert tailor to `require_premium`-only — free users keep their 10/month.)
+- `GET /api/auth/me` → `backend/src/api/routes/auth.py:226-228`, returns `UserResponse` (`auth.py:85-87`: `id`, `email`). `UserResponse` is ALSO returned by register/login/magic-consume — adding a field touches all their code paths; give it a safe default.
+- Frontend: `User` type is HAND-WRITTEN at `frontend/src/lib/api.ts:340` (`{ id: string; email: string }`) — not generated; `me()` at `api.ts:362-368`. Account page: `frontend/src/app/settings/account/page.tsx` (composes cards; add a PlanCard). `frontend/src/middleware.ts:42` also fetches `/api/auth/me` — additive field is safe there.
+- Test pattern to copy for gating tests: `backend/tests/test_email_enforcement.py` (free vs gated route, per the original plan doc `docs/plans/2026-06-21-free-premium-plans.md`).
+- Rule #12/#25 (CLAUDE.md): plan must derive from the session user server-side. NEVER accept a plan value from a request body/URL — no self-upgrade endpoint in Phase 1.
+
+## Files to touch
+
+- Create: `backend/migrations/0025_user_plan.up.sql`, `backend/migrations/0025_user_plan.down.sql`
+- Modify: `backend/src/api/auth_deps.py` (CurrentUser + SELECT + `require_premium`)
+- Modify: `backend/src/api/routes/auth.py` (`UserResponse.plan` + constructor sites)
+- Modify: `backend/src/api/routes/tailor.py` (premium bypasses the monthly cap)
+- Create: `backend/tests/test_plan_gating.py`
+- Create: `backend/scripts/set_plan.py` (owner backfill tool)
+- Modify: `frontend/src/lib/api.ts` (User type), `frontend/src/app/settings/account/page.tsx` (PlanCard)
+- Create: PlanCard test alongside existing account-page tests
+
+---
+
+### Task 0: Preflight
+
+- [ ] **Step 0.1:**
+
+```bash
+git fetch origin main
+git checkout -b feat/plan-gating-phase1 origin/main
+git status --porcelain   # must be empty
+```
+
+### Task 1: Migration 0025
+
+- [ ] **Step 1.1: Create `backend/migrations/0025_user_plan.up.sql`:**
+
+```sql
+-- 0025 — subscription plan, Phase 1 (no payments yet).
+-- TEXT so future tiers ('pro', 'max') need no further migration.
+-- Every existing and new user defaults to 'free'; upgrades happen server-side
+-- only (scripts/set_plan.py today, Stripe webhook later).
+-- IF NOT EXISTS keeps the runner idempotent (pg.py translate guarantees it anyway).
+ALTER TABLE users ADD COLUMN IF NOT EXISTS plan TEXT NOT NULL DEFAULT 'free';
+```
+
+- [ ] **Step 1.2: Create `backend/migrations/0025_user_plan.down.sql`:**
+
+```sql
+-- Reverse 0025
+ALTER TABLE users DROP COLUMN IF EXISTS plan;
+```
+
+- [ ] **Step 1.3: Apply + verify round-trip:**
+
+```bash
+cd backend
+python -m migrations.runner up
+python -m migrations.runner status    # 0025 listed as applied
+python -m migrations.runner down      # reverses 0025
+python -m migrations.runner up        # re-applies
+```
+
+Expected: no errors; status shows 0025 applied at the end.
+
+- [ ] **Step 1.4: Commit:** `git add backend/migrations && git commit -m "feat(plans): migration 0025 — users.plan column, default free"`
+
+### Task 2: Backend — CurrentUser + require_premium (TDD)
+
+- [ ] **Step 2.1: Failing tests first.** Create `backend/tests/test_plan_gating.py`. READ `backend/tests/test_email_enforcement.py` FIRST and copy its fixture/client/user-creation style exactly (do not invent a new setup). The tests to write:
+
+```python
+"""Phase-1 plan gating: free vs premium behavior. Fixture style follows
+test_email_enforcement.py — copy its client/user setup verbatim."""
+
+# 1. test_me_includes_plan_free_by_default
+#    Register/login a fresh user → GET /api/auth/me → body["plan"] == "free".
+
+# 2. test_require_premium_returns_402_for_free_user
+#    Add a throwaway premium-only route to the test app (or use the dependency
+#    directly with FastAPI's dependency_overrides testing pattern):
+#    free user → 402, body detail mentions upgrading, body["code"] == "premium_required".
+
+# 3. test_require_premium_passes_for_premium_user
+#    Same route; UPDATE users SET plan='premium' WHERE id=? via the test db
+#    fixture → 200.
+
+# 4. test_tailor_cap_bypassed_for_premium
+#    Copy the existing tailor-quota test from tests (grep: TAILOR_FREE_PER_MONTH
+#    or "402" in backend/tests/test_tailor*.py), set the user premium, exhaust
+#    past the cap → still 200/201, never 402.
+
+# 5. test_plan_cannot_be_set_from_request
+#    POST /api/auth/register with an extra "plan": "premium" field in the JSON
+#    → user's row in DB still has plan='free' (extra fields ignored, never honored).
+```
+
+Write them as real tests (the comments above are the spec, not placeholders to leave in). Run: `cd backend && python -m pytest tests/test_plan_gating.py -v -p no:randomly` — expected: all FAIL (plan field doesn't exist yet).
+
+- [ ] **Step 2.2: Extend `CurrentUser` + the SELECT** in `backend/src/api/auth_deps.py`:
+
+```python
+@dataclass(frozen=True)
+class CurrentUser:
+    id: str
+    email: str
+    email_verified: bool = False
+    plan: str = "free"
+```
+
+In `_current_user_from_cookie`, change the query to `SELECT id, email, email_verified_at, plan FROM users WHERE id = ? AND deleted_at IS NULL` and pass `plan=row["plan"]` to the constructor. **Then grep for every other `CurrentUser(` constructor call** (`cd backend && grep -rn "CurrentUser(" src/ tests/`) — the default `plan="free"` keeps them compiling, but any test that builds a premium user must pass `plan="premium"` explicitly.
+
+- [ ] **Step 2.3: Add `require_premium`** in `auth_deps.py`, directly below `require_verified_user`, mirroring its exact shape:
+
+```python
+async def require_premium(
+    user: CurrentUser = Depends(require_user),
+) -> CurrentUser:
+    """Gate for premium-only routes. Free users get 402 Payment Required.
+
+    Phase 1: plan is a plain column ('free'/'premium'), set server-side only.
+    """
+    if user.plan != "premium":
+        raise HTTPException(
+            status_code=status.HTTP_402_PAYMENT_REQUIRED,
+            detail="This feature needs a premium plan. Upgrade to unlock it.",
+        )
+    return user
+```
+
+If `require_verified_user` attaches a machine-readable `code` to its error body (READ it — it may use a custom exception or headers), replicate that mechanism with `code="premium_required"` so the frontend can branch on it.
+
+- [ ] **Step 2.4: Wire the tailor cap bypass** in `backend/src/api/routes/tailor.py` — find the monthly-cap check (~line 105-125) and short-circuit it:
+
+```python
+if user.plan != "premium":
+    # existing monthly-cap logic stays exactly as-is, one indent deeper
+    ...
+```
+
+Keep the route's existing `require_verified_user` dependency untouched. Update the code comment that said premium would bypass "later" — it's now.
+
+- [ ] **Step 2.5: Expose the plan** in `backend/src/api/routes/auth.py`: add `plan: str = "free"` to `UserResponse`, then update EVERY place that constructs `UserResponse(...)` (grep `UserResponse(` in the file — register, login, me, magic-consume) to pass `plan=user.plan` where a `CurrentUser` is in hand; for freshly-created users pass `"free"` literally (or re-read the row).
+
+- [ ] **Step 2.6: Run the new tests, then the full suite:**
+
+```bash
+cd backend
+python -m pytest tests/test_plan_gating.py -v -p no:randomly
+python -m pytest -q -p no:randomly     # one run; fresh shell if you already ran a full suite
+git add -A && git commit -m "feat(plans): users.plan on CurrentUser, require_premium (402), premium bypasses tailor cap"
+```
+
+### Task 3: Owner backfill tool
+
+- [ ] **Step 3.1: Create `backend/scripts/set_plan.py`** (mirrors the style of other scripts in that folder — plain argparse + the pg-backed DB):
+
+```python
+"""Set a user's plan by email. Phase-1 admin tool (no billing yet).
+
+Usage (from backend/):
+    python scripts/set_plan.py user@example.com premium
+    python scripts/set_plan.py user@example.com free
+"""
+import argparse
+import asyncio
+import sys
+
+from src.repositories import pg as aiosqlite  # established Postgres-shim alias
+from src.core.settings import DB_PATH
+
+VALID_PLANS = ("free", "premium")
+
+
+async def set_plan(email: str, plan: str) -> int:
+    if plan not in VALID_PLANS:
+        print(f"invalid plan {plan!r}; choose from {VALID_PLANS}")
+        return 2
+    db = await aiosqlite.connect(str(DB_PATH))
+    try:
+        cur = await db.execute(
+            "UPDATE users SET plan = ? WHERE email = ? AND deleted_at IS NULL",
+            (plan, email.lower()),
+        )
+        if getattr(cur, "rowcount", 0) == 0:
+            print(f"no active user with email {email!r}")
+            return 1
+        print(f"{email} -> {plan}")
+        return 0
+    finally:
+        await db.close()
+
+
+if __name__ == "__main__":
+    p = argparse.ArgumentParser()
+    p.add_argument("email")
+    p.add_argument("plan", choices=VALID_PLANS)
+    a = p.parse_args()
+    sys.exit(asyncio.run(set_plan(a.email, a.plan)))
+```
+
+Before committing: READ one existing script that opens the DB (e.g. `backend/scripts/dump_db.py`) and match ITS connect/close idiom exactly — the snippet above is the intent; the local idiom (row factory, connect signature, `DB_PATH` usage) wins on any mismatch. Test it locally: set your dev user premium, hit `/api/auth/me`, see `"plan":"premium"`, set back to free.
+
+- [ ] **Step 3.2: Commit:** `git add backend/scripts/set_plan.py && git commit -m "feat(plans): set_plan.py owner tool"`
+
+### Task 4: Frontend — show the plan
+
+- [ ] **Step 4.1: Type + API:** in `frontend/src/lib/api.ts` change line ~340 to `export type User = { id: string; email: string; plan: "free" | "premium" };`. Run `npm run type-check` — fix any site that constructs a `User` literal (tests/mocks) by adding `plan: "free"`.
+
+- [ ] **Step 4.2: PlanCard on the account page.** In `frontend/src/app/settings/account/page.tsx`, add a `PlanCard` component ABOVE the existing cards, following the exact card/styling pattern of `VerifyEmailCard` in the same file (READ it first; reuse its shadcn Card primitives and data-fetch approach — it already has access to the current user via the page's existing `me()`/query usage):
+  - Shows "Your plan: Free" or "Your plan: Premium" (badge style consistent with existing badges).
+  - Free state: one line on what Premium unlocks today ("Unlimited CV tailoring — free plan includes 10/month") + a disabled/`mailto:` "Upgrade" button labeled "Upgrade (coming soon)". NO fake checkout.
+  - Premium state: "Premium — thanks for supporting Job360."
+
+- [ ] **Step 4.3: 402 UX check:** `frontend/src/components/tailor/TailorPanel.tsx:143` already renders the 402 quota message. Verify its message still reads correctly now that 402 can mean "cap reached (free plan)" — if the backend detail string changed in Task 2.4, align this copy.
+
+- [ ] **Step 4.4: Component test** for PlanCard (both states) following the test style of the existing account-page tests (find them: `cd frontend && ls src/app/settings/account/__tests__ 2>/dev/null || grep -rl "VerifyEmailCard" src --include=*.test.tsx`).
+
+- [ ] **Step 4.5: Verify + commit:**
+
+```bash
+cd frontend
+npm run type-check && npm run lint && npm run test:unit
+git add -A && git commit -m "feat(plans): plan display on account page + User.plan type"
+```
+
+### Task 5: End-to-end verification + ship
+
+- [ ] **Step 5.1:** Backend + frontend running locally: fresh user → account page shows "Free"; `python scripts/set_plan.py <email> premium` → refresh → shows "Premium"; tailor a CV more than `TAILOR_FREE_PER_MONTH` times as premium (set the env to `1` locally to make this cheap: `TAILOR_FREE_PER_MONTH=1`) → no 402.
+- [ ] **Step 5.2:**
+
+```bash
+git push -u origin feat/plan-gating-phase1
+gh pr create --title "feat(plans): Phase 1 free/premium gating — users.plan, require_premium, tailor-cap bypass, account-page plan card" --body "Phase 1 of docs/plans/2026-06-21-free-premium-plans.md. No payments; plan set server-side via scripts/set_plan.py. Premium currently unlocks: unlimited tailoring. TEXT column leaves room for the Free/Pro/Max model (PR #22 docs) without another migration. Prod migration 0025 auto-applies on deploy boot."
+```
+
+---
+
+## Edge cases a weaker model would miss
+
+1. **Write the migration in SQLite dialect.** It LOOKS wrong (`IF NOT EXISTS` on ADD COLUMN isn't SQLite syntax) but the pg.py translator is the only thing that ever executes it, and 0024 sets the precedent. Postgres-native syntax elsewhere in the file (e.g. `::text` casts) would break the translator's assumptions.
+2. **`CurrentUser` is frozen.** You can't mutate `user.plan` in a test — construct a new instance or update the DB row. Tests that try `user.plan = "premium"` fail with `FrozenInstanceError`.
+3. **`UserResponse` is shared by four flows** (register/login/me/magic-consume). Adding the field with a default keeps old constructor calls compiling — but then `/me` silently returns `"free"` for premium users if you forget to thread `user.plan` through. Test #1 catches me; grep catches the rest. This is exactly rule #21 (value-presence over schema-presence): assert the VALUE flips after `set_plan.py`, not just that the key exists.
+4. **402 vs 403 semantics:** the codebase already chose 402 for the tailor quota; `require_premium` must also use 402 so `frontend/src/lib/api-error.ts` and TailorPanel treat both walls the same way. Don't "correct" it to 403.
+5. **No self-service upgrade in Phase 1** — an endpoint that lets the client set its own plan is a self-upgrade IDOR (rules #12/#25). Upgrades happen via `scripts/set_plan.py` only. Test #5 pins this.
+6. **Migration auto-applies on prod boot.** Merging this PR migrates the LIVE database on next deploy. `ADD COLUMN ... DEFAULT 'free'` on Postgres 11+ is metadata-only (no table rewrite, no lock pain) — safe — but mention it in the PR body so the deploy isn't a surprise.
+7. **`middleware.ts` fetches `/me` too** (`frontend/src/middleware.ts:42`) — it only checks auth, so the extra field is harmless, but if type-check complains there, the fix is the `User` type, not a second type.
+8. **The tailor bypass must keep the LEDGER working**: if the cap code also RECORDS usage (read the block carefully), premium users should still record usage (for future analytics/limits) — only the REJECTION is bypassed. Don't skip the whole block unless it's purely a check.
+9. **Frontend `User` mocks:** vitest mocks constructing `{ id, email }` will fail type-check after Step 4.1 — that's the point; fix each mock with `plan: "free"` rather than loosening the type.
+
+## Acceptance criteria
+
+- [ ] `python -m migrations.runner status` shows 0025 applied; down/up round-trip works (Step 1.3).
+- [ ] `python -m pytest tests/test_plan_gating.py -p no:randomly` → 5 passed.
+- [ ] Full backend suite green (one run, fresh shell).
+- [ ] `GET /api/auth/me` returns `"plan": "free"` for a fresh user and `"plan": "premium"` after `scripts/set_plan.py` (value-presence, rule #21).
+- [ ] Free user over the tailor cap → 402; premium user over the cap → success.
+- [ ] Register with `"plan": "premium"` injected in the body → DB row still `free`.
+- [ ] Account page renders the correct plan in both states; `npm run type-check`, `lint`, `test:unit` all green.
+
+## STOP conditions
+
+- `auth_deps.py` or the tailor quota block no longer matches the Verified facts (someone landed plan work first — check `git log --oneline origin/main -- backend/src/api/auth_deps.py` before assuming).
+- You find yourself designing trial clocks, Stripe hooks, or per-tier source gating — that's Phase 2 / the PR #22 model; Phase 1 ends at the acceptance criteria above.


### PR DESCRIPTION
Five self-contained, executable plans at repo root, written so a less capable model can run each one without asking questions. Each carries verified facts (checked 2026-07-07), exact files, ordered steps with commands + expected output, edge cases, acceptance criteria, and STOP conditions.

## Ranking — do them in this order

1. **PLAN-1-fix-red-ci.md** — ci.yml fails at ruff on every push; ci-offline.yml lost its database when the suite went Postgres; worktree-feat-live-smoke (a finished live prod smoke test) merges clean. A red gate means every merge lands unverified — fix this before landing anything else.
2. **PLAN-2-unblock-real-signups.md** — Resend sandbox only delivers magic links to the owner's email, so the live product has a max user count of one. Human half: verify a domain (or Gmail SMTP stopgap). Code half: document RESEND_API_KEY/SMTP_FROM, ERROR-level failure logging, failure-path tests.
3. **PLAN-3-db-backups-and-prod-safety.md** — backend/scripts/backup_db.py exists but NOTHING runs it: the live Postgres has no scheduled backup. Wire it to a nightly Actions job, rehearse a restore, fix the compose healthcheck that 404s, add inbound request-timeout middleware.
4. **PLAN-4-rescue-profile-extraction-fixes.md** — ~2,300 lines of finished extraction-quality work stranded on worktree-tp-final. Plain merge conflicts (main re-implemented 4 of its commits); the plan is a selective 13-commit cherry-pick with an explicit skip list and a provider-order reconciliation step.
5. **PLAN-5-free-premium-gating.md** — Phase 1 monetization foundation: migration 0025 (users.plan), require_premium (402), premium bypasses the existing tailor cap, plan shown on the account page. No Stripe.

## Not in the top 5 (cheap follow-ups)
- worktree-docs-docsync (5 doc-sync commits, 0 conflicts) and worktree-feat-universal-design (PageHeader unification, 0 conflicts) both merge clean — quick wins whenever convenient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)