### PR TITLE
Tailored CV/cover-letter feature + skill analysis + 6 design docs (merges Pillar-1 main)

### DIFF
--- a/backend/src/services/profile/storage.py
+++ b/backend/src/services/profile/storage.py
@@ -34,6 +34,19 @@ from src.services.profile.models import CVData, UserPreferences, UserProfile
 
 logger = logging.getLogger("job360.profile.storage")
 
+
+def _is_missing_table(exc: Exception) -> bool:
+    """True when a DB error means the table/relation is absent.
+
+    Tolerant of BOTH backends' wording: SQLite says ``no such table`` while
+    Postgres says ``relation "..." does not exist``. The profile-version helpers
+    below degrade gracefully on a pre-migration schema — but only if they
+    recognise the error. The old check matched SQLite wording only, so on
+    Postgres the "tolerated" error re-raised instead (crashing run_search).
+    """
+    msg = str(exc).lower()
+    return "no such table" in msg or "does not exist" in msg
+
 LEGACY_PROFILE_PATH: Path = DATA_DIR / "user_profile.json"
 """Pre-Batch-3.5.2 single-file store. Hydrated into the DB on first load
 of ``DEFAULT_TENANT_ID`` then deleted. Monkey-patchable in tests."""
@@ -91,7 +104,7 @@ def save_profile(
             )
             _prune_old_versions(conn, user_id)
         except sqlite3.OperationalError as e:
-            if "no such table" in str(e).lower():
+            if _is_missing_table(e):
                 logger.info(
                     "user_profile_versions table absent — skipping snapshot "
                     "(run ``python -m migrations.runner up``). Tip still saved."
@@ -236,7 +249,7 @@ def current_profile_version_id(user_id: str) -> Optional[int]:
             return None
         return int(row[0])
     except sqlite3.OperationalError as e:
-        if "no such table" in str(e).lower():
+        if _is_missing_table(e):
             return None
         raise
 
@@ -251,7 +264,8 @@ def profile_content_changed_since_previous(user_id: str) -> bool:
     - 1 row   → True  (first-ever save is always "changed")
     - 2+ rows → True if the two most-recent rows differ, else False
 
-    Tolerates missing table (returns False on OperationalError "no such table").
+    Tolerates a missing table (returns False) via _is_missing_table — recognising
+    both SQLite ("no such table") and Postgres ("does not exist") wording.
     """
     try:
         with sqlite3.connect(str(DB_PATH)) as conn:
@@ -267,7 +281,7 @@ def profile_content_changed_since_previous(user_id: str) -> bool:
             )
             rows = cur.fetchall()
     except sqlite3.OperationalError as e:
-        if "no such table" in str(e).lower():
+        if _is_missing_table(e):
             return False
         raise
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,6 +35,7 @@ Start here to find the right doc fast.
 | Doc | What it is |
 |---|---|
 | [`STACK.md`](STACK.md) | Tech stack layer-by-layer: what we have vs what to add (Postgres, Docker, Stripe, etc.) + costs. |
+| [`llm_prod.md`](llm_prod.md) | Production LLM provider choice (researched 2026-07-08): why the 429s, provider comparison, GDPR split, recommended chain. TL;DR: Gemini 2.5 Flash single / +DeepSeek for cheap batch. |
 | [`STACK_checklist.md`](STACK_checklist.md) | Code-audited checklist: 27 built ✅ (with file proof) vs 21 to build ❌. |
 | [`UPGRADE_PLAN.md`](UPGRADE_PLAN.md) | Phase 1–3 execution plan (Postgres → deploy → monitoring): TDD + multi-agent, money + keys per phase. |
 | [`../CLAUDE.md`](../CLAUDE.md) | Load-bearing architecture doc: data flow, module map, **28 hard rules**, scoring, env vars. |

--- a/docs/llm_prod.md
+++ b/docs/llm_prod.md
@@ -1,0 +1,98 @@
+# Production LLM — provider choice for Job360
+
+> **One-line answer:** For a *single* provider → **Gemini 2.5 Flash** (GDPR-safe for CV data, does all 4 workloads, reliable). For *cost-optimal* → **Gemini (free, PII/CV work) + DeepSeek (cheap, batch of public job-text)**. The root problem to fix first: **stop running production on free tiers** — their per-minute walls are what cause the 429s.
+
+Researched + cross-checked against official provider docs, 2026-07-08. Every price is vendor self-report — treat as directional; **no independent benchmark exists.**
+
+---
+
+## 1. Why we get 429s (the actual cause)
+
+The whole chain (Cerebras → Groq → Gemini) runs on **free tiers**, and every free tier has a brutal **per-minute wall**:
+
+- **Cerebras free = 5 requests/min, 30K tokens/min.** The **5 RPM** is the killer — inference is sub-second, so a batch of 30 fit-judge calls blows past 5/min in the first second. **This is the direct cause of the batch 429s.**
+- **Groq free = 30 RPM, 6–12K TPM.** 30 RPM exactly equals a 30-job batch → zero retry headroom.
+
+> The fix is **not** "add backoff." It's **move batch work off per-minute-token providers** and **use paid Developer tiers** (free to unlock with a card, ~10× the limits). Running production on a free tier is the root problem, not the specific provider.
+
+---
+
+## 2. The app's 4 LLM workloads
+
+| # | Workload | Shape | Sensitivity |
+|---|---|---|---|
+| 1 | **CV / LinkedIn / GitHub extraction** → strict JSON | ~5–10k in, JSON out | **PII + quality** (personal data — GDPR) |
+| 2 | **Per-job enrichment** → 18-field JSON | BATCH (dozens/run), concurrency ~10 | throughput; public job text (no PII) |
+| 3 | **Fit judge** → 0–100 score + reason | BATCH (≤30/user/run), concurrency ~3 | throughput + light reasoning; **where the 429 bites** |
+| 4 | **CV + cover-letter generation** | ~2–4k tokens out | **quality + PII**, user-facing (must not sound robotic) |
+
+Key split: **#1 and #4 touch personal data (GDPR); #2 and #3 are public job text.**
+
+---
+
+## 3. The key finding: DeepSeek has no per-minute wall
+
+**DeepSeek limits by concurrent connections (~2,500), NOT tokens-per-minute** (official: `api-docs.deepseek.com`). A batch of 30 at concurrency 3–10 is nowhere near 2,500 → **structurally removes the exact 429 pain**. And it's the cheapest quality option: **$0.14 in / $0.28 out per 1M** (V4-Flash).
+
+⚠️ **Caveat — DeepSeek is China-hosted.** For UK/GDPR personal data (CVs, LinkedIn), **do NOT** route PII extraction (#1) or CV generation (#4) through it. Use it only for **public job text** (#2 enrichment, #3 judge) and non-PII cover-letter drafting.
+
+---
+
+## 4. Comparison (per 1M tokens, verified 2026-07-08)
+
+| Provider | Cheap model in/out | Free tier | Batch-friendly? | JSON | Reliability |
+|---|---|---|---|---|---|
+| **DeepSeek** V4-Flash | **$0.14 / $0.28** | ~5M tok/30d (unconfirmed) | ✅ concurrency-based, **no TPM wall** | `json_object` best-effort | occasional load throttle; no big outages |
+| **Gemini** 2.5 Flash-Lite | $0.10 / $0.40 | **1M TPM / ~15–30 RPM** | ✅ huge free TPM; RPM is the gate | **native `responseSchema`** | Google uptime |
+| **Gemini** 2.5 Flash | $0.30 / $2.50 | same tier | ✅ | native, strong | same |
+| **Groq** gpt-oss-20b | $0.075 / $0.30 | 30 RPM / 8K TPM (tight) | ❌ free / ✅ paid | token-level constrained (gpt-oss only) | rate-limit friction, not outages |
+| **Cerebras** gpt-oss-120b | $0.35 / $0.75 | **5 RPM / 30K TPM ← the bug** | ❌ free / ✅ paid (1M TPM) | constrained (gpt-oss only) | frequent incidents logged |
+| **Novita** llama-3.1-8b | **$0.02 / $0.05** | unclear | tiers unpublished | unconfirmed | thin track record |
+| **Fireworks** | ~$0.20 / ~$0.90 | $1 credit, 10 RPM | ✅ paid (6,000 RPM) | **constrained decoding** (strong) | 99.8% claimed |
+| **Together** | 8B $0.14 / 70B $1.04 | unclear | ⚠️ dynamic limits, risky new-acct | schema + regex | no public status page |
+| **Mistral** small-4 | $0.15 / $0.60 | strict eval tier | ⚠️ hidden numbers | schema + tools | 99.58% 90d |
+| **Grok** cheapest | $1.00 / $2.00 | $25 credit | ✅ 37 RPS / 10M TPM | schema + tools | 48h+ 429 lockout Apr 2026 |
+| **Cloudflare** llama-8b | $0.282 / $0.827 | 10K neurons/day | ✅ 300 RPM | **best-effort only** | tied to CF-wide June 2026 outage |
+| **Bedrock** Nova Micro | $0.035 / $0.14 | none | ⚠️ hidden quotas | Converse tools | recurring 429 complaints |
+
+**JSON note:** only Cerebras / Groq / Fireworks offer true token-level constrained decoding (schema *cannot* be violated) — but on Groq/Cerebras only for gpt-oss models. Gemini/DeepSeek are "usually valid JSON," fine in practice.
+
+---
+
+## 5. The picks
+
+- **Best FREE + reliable → Gemini 2.5 Flash-Lite.** The only free tier whose token budget (1M TPM) won't wall a batch; the gate is RPM (~15–30), which you control by pacing concurrency. Google uptime. *(Verify your key's live limit at `aistudio.google.com/rate-limit` — Google stopped publishing free limits and cut quotas in late 2025.)*
+- **Best CHEAP + rock-solid paid → DeepSeek V4-Flash** ($0.14/$0.28). Concurrency-based limiting is the structural cure for the batch 429, at the lowest quality-grade price. *(Keep PII off it — see §3.)*
+- **Best SINGLE provider (if you pick just one) → Gemini 2.5 Flash.** The only one-choice that is **GDPR-safe for the CV data AND competent at all 4 workloads AND reliable.** Not the absolute cheapest, but for "just one," safety + does-everything beats cheapest. DeepSeek is disqualified as *sole* provider because it can't legally hold the personal-data path.
+
+---
+
+## 6. Recommended chain (mapped to workloads)
+
+| Workload | Primary → fallback |
+|---|---|
+| **Batch** — enrichment (#2) + judge (#3), *public text* | **DeepSeek V4-Flash** → Gemini 2.5 Flash-Lite → Groq gpt-oss-20b (paid dev tier) |
+| **Quality + PII** — CV extraction (#1) + generation (#4) | **Gemini 2.5 Flash** (GDPR-safe) → Groq gpt-oss-120b → *(DeepSeek only for non-PII cover-letter drafting)* |
+
+**If you insist on one model everywhere:** Gemini 2.5 Flash for all four.
+
+---
+
+## 7. Two concrete moves
+
+1. **Drop Cerebras from the batch path** — its 5 RPM free cap *is* the 429. Keep it (if at all) only as a paid last-resort speed fallback.
+2. **Use the *paid* Developer tier** of whatever fast provider you keep — Groq/Cerebras dev tiers unlock ~10× limits, free-with-a-card. **Free tiers ≠ production.**
+
+---
+
+## 8. Implementation notes
+
+- **All the above are OpenAI-compatible** — point the existing SDK at their `base_url` + change the model name. They slot into the current `services/profile/llm_provider.py` fallback chain with minimal change.
+- **GDPR split is code-level:** route the *extraction* + *CV-generation* calls to the Gemini branch; route *enrichment* + *judge* to DeepSeek. Don't let PII reach the China-hosted path.
+- **Adapter trap:** proxy layers (e.g. LiteLLM) can silently downgrade `json_schema strict:true` → loose `json_object` while `finish_reason` still says "stop". If you use an adapter, **test that strict mode survives the hop.**
+- **Verify prod first:** before changing anything, confirm what LLM keys are actually set on Railway and whether prod generation currently works — earlier failures were *assumed* from the batch 429s, not verified on the live tailor path.
+
+---
+
+## 9. One-line summary
+> **Gemini 2.5 Flash if you pick one (GDPR-safe, does everything). DeepSeek for cheap batch of public job-text + Gemini for the PII/CV work if you split for cost. Either way: get off free tiers and drop Cerebras from batching — that per-minute wall is the 429.**

--- a/scripts/gate-fresh-db.sh
+++ b/scripts/gate-fresh-db.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# gate-fresh-db.sh — run the commit gate against a FRESH, throwaway Postgres
+# database, the way CI does. The shared dev DB carries data + partial migration
+# state that breaks empty-DB-assuming tests; a clean per-run DB avoids that.
+#
+# Usage:  bash scripts/gate-fresh-db.sh
+# Result: on success, writes the same .claude/gate-stamp scripts/agent-gate.sh
+#         does, so the commit hook is satisfied.
+set -uo pipefail
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+
+PGADMIN="${PGADMIN_URL:-postgresql://job360:job360dev@localhost:5433/postgres}"
+DB="job360_gate_$$"                       # unique per run
+GATE_URL="postgresql://job360:job360dev@localhost:5433/${DB}"
+
+_psql_admin() { python -c "import psycopg,sys;psycopg.connect('${PGADMIN}',autocommit=True,connect_timeout=10).execute(sys.argv[1])" "$1"; }
+
+cleanup() { _psql_admin "DROP DATABASE IF EXISTS ${DB} WITH (FORCE)" 2>/dev/null || true; }
+trap cleanup EXIT
+
+echo "[fresh-gate] creating throwaway DB ${DB}"
+_psql_admin "DROP DATABASE IF EXISTS ${DB} WITH (FORCE)"
+_psql_admin "CREATE DATABASE ${DB} OWNER job360"
+
+echo "[fresh-gate] running the gate against the fresh DB..."
+DATABASE_URL="${GATE_URL}" bash "${ROOT}/scripts/agent-gate.sh"
+rc=$?
+
+if [ "$rc" -eq 0 ]; then
+  echo "[fresh-gate] PASS — stamp written; safe to commit."
+else
+  echo "[fresh-gate] FAIL — gate did not pass (rc=${rc})." >&2
+fi
+exit "$rc"


### PR DESCRIPTION
Brings this session's work to main, with origin/main (Pillar-1 extraction overhaul, PR #25) merged in cleanly.

## What this adds on top of main
- **Per-User AI CV + Cover Letter** — tailored generation, PDF+DOCX download, fact-provenance highlighting, per-user learning layer, edit/keep (docs/peruser_cv_coverletter.md)
- **Skill Analysis** panel populated (skill-gap: matched/missing/transferable)
- **Guardrail #2 enforcement** — proper-noun repair (Monzo->Monox) + don't-flag-credentials fix (found via live verify)
- Matcher telemetry -> run_log; scheduler scraper->scrapers fix
- **6 design docs**: raw_feedback_loop, peruser_cv_coverletter, post_application, feedback_loops_map, loop1_safe_reenable, llm_prod

## Verified
- Merge-validation suite (both branches): 156 passed
- Tailor feature: 18+7+6+6 TDD tests, live HTTP end-to-end, **browser-verified with screenshots**
- Deployed + live-route-gated on prod

Merge is clean (0 conflicts); llm_provider.py resolved to the Pillar-1 OpenAI-primary chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)