### PR TITLE
feat(email): production email readiness (PLAN-2) — visible failures + documented vars + tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,6 +57,14 @@ SMTP_EMAIL=
 SMTP_PASSWORD=
 NOTIFY_EMAIL=
 
+# === Transactional email (magic-link login + verification) ===
+# Preferred path: Resend (https://resend.com). RESEND_API_KEY must be a
+# production key, and SMTP_FROM must be an address on a domain you've verified
+# in Resend — otherwise Resend rejects the send (and the user silently gets no
+# email). Leave blank to fall back to the SMTP_* Gmail path above.
+RESEND_API_KEY=
+SMTP_FROM=
+
 # === Slack / Discord webhooks ===
 # Slack incoming webhook — https://api.slack.com/messaging/webhooks
 SLACK_WEBHOOK_URL=

--- a/.env.example
+++ b/.env.example
@@ -153,3 +153,18 @@ MAX_CONCURRENT_SEARCHES_PER_USER=3
 # Only override if the public keys rotate upstream.
 EIGHTYKHOURS_ALGOLIA_APP_ID=
 EIGHTYKHOURS_ALGOLIA_API_KEY=
+
+# === Ops / infrastructure ===
+# Postgres connection string. Defaults to the local dev DB on port 5433; set in
+# prod (Railway injects it). The whole app runs on Postgres via the pg.py shim.
+DATABASE_URL=postgresql://job360:job360dev@localhost:5433/job360
+# Sentry error tracking (optional). Empty disables Sentry.
+SENTRY_DSN=
+# Inbound API request ceiling in seconds (RequestTimeoutMiddleware returns 504).
+# LLM-heavy routes (/api/tailor, /api/profile) are exempt. Default 60.
+API_REQUEST_TIMEOUT_SECONDS=60
+# Manual DB backup script (scripts/backup_db.py): output dir + how many dumps to
+# keep. See docs/RUNBOOK-backups.md. Automated CI-artifact backups are NOT wired
+# up because this repo is public (a dump artifact would leak user data).
+BACKUP_DIR=./backups
+BACKUP_KEEP=14

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -35,10 +35,12 @@ USER job360
 
 EXPOSE 8000
 
-# Hit the /api/health endpoint. $PORT is injected by Railway (dynamic); fall
+# Hit the /api/livez liveness probe (always 200 if the process is up, zero
+# dependency checks — a failing container healthcheck should mean "process is
+# wedged", not "Redis blipped"). $PORT is injected by Railway (dynamic); fall
 # back to 8000 for local `docker run`. Shell-form so ${PORT} expands.
 HEALTHCHECK --interval=30s --timeout=10s --start-period=20s --retries=3 \
-  CMD curl -fsS http://localhost:${PORT:-8000}/api/health || exit 1
+  CMD curl -fsS http://localhost:${PORT:-8000}/api/livez || exit 1
 
 # Shell form (not exec) so ${PORT} is expanded by the shell. Railway assigns a
 # dynamic port and routes to it; the app MUST listen on $PORT or it's unreachable.

--- a/backend/src/api/main.py
+++ b/backend/src/api/main.py
@@ -19,7 +19,12 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from src.api.dependencies import close_db, init_db
 from src.api.errors import register_exception_logging
-from src.api.middleware import AccessLogMiddleware, RequestIdMiddleware, SecurityHeadersMiddleware
+from src.api.middleware import (
+    AccessLogMiddleware,
+    RequestIdMiddleware,
+    RequestTimeoutMiddleware,
+    SecurityHeadersMiddleware,
+)
 from src.api.routes import (
     actions,
     auth,
@@ -90,6 +95,17 @@ app = FastAPI(title="Job360 API", version="1.0.0", lifespan=lifespan)
 
 # Gap E — log every unhandled exception (traceback + request_id) into data/logs/.
 register_exception_logging(app)
+
+# RequestTimeoutMiddleware is added FIRST so it is INNERMOST (Starlette LIFO):
+# it wraps only the route handler, so a hung route returns a 504 that the outer
+# middleware still post-process — CORS + security headers + a logged access line
+# + a request id. LLM-heavy routes (tailoring, profile extraction) legitimately
+# run longer than a normal round-trip, so they are exempted by prefix.
+app.add_middleware(
+    RequestTimeoutMiddleware,
+    timeout_seconds=float(os.environ.get("API_REQUEST_TIMEOUT_SECONDS", "60")),
+    exempt_prefixes=("/api/tailor", "/api/profile"),
+)
 
 # CORS — env-driven so dev / staging / prod can differ without a rebuild.
 # Default keeps Batch 1 behaviour (localhost:3000) so existing dev flows work.

--- a/backend/src/api/middleware.py
+++ b/backend/src/api/middleware.py
@@ -1,13 +1,14 @@
 """HTTP middleware for Job360 FastAPI app."""
 from __future__ import annotations
 
+import asyncio
 import os
 import time
 import uuid
 
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
-from starlette.responses import Response
+from starlette.responses import JSONResponse, Response
 
 from src.utils.logger import _request_id_var, get_logger, get_request_id, set_request_id
 
@@ -131,3 +132,31 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
         if _is_production():
             response.headers["Strict-Transport-Security"] = _HSTS
         return response
+
+
+class RequestTimeoutMiddleware(BaseHTTPMiddleware):
+    """Cap inbound request duration so a hung handler can't tie up a worker.
+
+    A backstop, not a scheduler: outbound source-fetch ceilings
+    (``SOURCE_FETCH_TIMEOUT*``) are a different knob. LLM-heavy routes (CV
+    tailoring, profile extraction) legitimately run longer than a normal API
+    round-trip, so they are exempted by path prefix. Everything else that
+    exceeds ``timeout_seconds`` gets a ``504`` instead of hanging.
+
+    Note: cancelling ``call_next`` abandons the handler mid-flight. DB writes in
+    this app are autocommit single statements (``repositories/pg.py``), so a
+    cancelled request cannot leave an open transaction.
+    """
+
+    def __init__(self, app, timeout_seconds: float = 60.0, exempt_prefixes: tuple = ()):
+        super().__init__(app)
+        self.timeout_seconds = timeout_seconds
+        self.exempt_prefixes = tuple(exempt_prefixes)
+
+    async def dispatch(self, request: Request, call_next) -> Response:
+        if any(request.url.path.startswith(p) for p in self.exempt_prefixes):
+            return await call_next(request)
+        try:
+            return await asyncio.wait_for(call_next(request), timeout=self.timeout_seconds)
+        except asyncio.TimeoutError:
+            return JSONResponse(status_code=504, content={"detail": "request timed out"})

--- a/backend/src/core/settings.py
+++ b/backend/src/core/settings.py
@@ -58,11 +58,16 @@ GROQ_API_KEY = os.getenv("GROQ_API_KEY", "")
 CEREBRAS_API_KEY = os.getenv("CEREBRAS_API_KEY", "")
 
 # Email
-SMTP_HOST = "smtp.gmail.com"
-SMTP_PORT = 587
 SMTP_EMAIL = os.getenv("SMTP_EMAIL", "")
 SMTP_PASSWORD = os.getenv("SMTP_PASSWORD", "")
 NOTIFY_EMAIL = os.getenv("NOTIFY_EMAIL", "")
+# Transactional email (magic-link login + verification). email_sender.py prefers
+# Resend when RESEND_API_KEY is set, else falls back to SMTP. Declared here for
+# discoverability + .env.example parity; email_sender.py reads them (and
+# SMTP_HOST/SMTP_PORT) from os.environ directly, so the old hardcoded
+# SMTP_HOST/SMTP_PORT constants here were dead and have been removed.
+RESEND_API_KEY = os.getenv("RESEND_API_KEY", "")
+SMTP_FROM = os.getenv("SMTP_FROM", "")
 
 # Slack / Discord webhooks
 SLACK_WEBHOOK_URL = os.getenv("SLACK_WEBHOOK_URL", "")

--- a/backend/src/services/auth/email_sender.py
+++ b/backend/src/services/auth/email_sender.py
@@ -12,7 +12,7 @@ existing Gmail App Password setup is enough to verify the flow.
 
 Failure model:
 - If ``SMTP_EMAIL`` / ``SMTP_PASSWORD`` are unset, ``send_system_email``
-  logs at WARNING and *returns False* — never raises. Callers can either
+  logs at ERROR and *returns False* — never raises. Callers can either
   treat that as a soft failure (don't 5xx the password-reset request — see
   Phase −2 plan note about no-enumeration) or surface it in dev console.
 - Network or auth failures during send are caught, logged, and produce
@@ -47,7 +47,7 @@ async def send_system_email(
     """Send a single transactional email. Returns True on success, False on failure.
 
     Never raises — the auth flows that call this must remain robust to SMTP
-    outages. A False return surfaces in logs at WARNING with the underlying
+    outages. A False return surfaces in logs at ERROR with the underlying
     cause so an operator can diagnose post-hoc.
     """
     from_addr = os.environ.get("SMTP_FROM") or os.environ.get("SMTP_EMAIL") or "onboarding@resend.dev"
@@ -74,7 +74,7 @@ async def send_system_email(
                     json=payload,
                 )
             if resp.status_code >= 400:
-                logger.warning(
+                logger.error(
                     "send_system_email (resend) failed: to=%s subject=%s status=%s body=%s",
                     to_email, subject, resp.status_code, resp.text[:300],
                 )
@@ -82,14 +82,14 @@ async def send_system_email(
             logger.info("send_system_email (resend) ok: to=%s subject=%s", to_email, subject)
             return True
         except Exception as exc:  # noqa: BLE001 — never raise to the auth flow
-            logger.warning("send_system_email (resend) error: to=%s subject=%s err=%s", to_email, subject, exc)
+            logger.error("send_system_email (resend) error: to=%s subject=%s err=%s", to_email, subject, exc)
             return False
 
     # Fallback: real SMTP. Run BLOCKING smtplib in a worker thread so a slow or
     # blocked SMTP server can never stall the async event loop again.
     cfg = _smtp_config()
     if cfg is None:
-        logger.warning(
+        logger.error(
             "send_system_email skipped: no RESEND_API_KEY and SMTP_EMAIL/SMTP_PASSWORD not set. to=%s subject=%s",
             to_email, subject,
         )
@@ -119,7 +119,7 @@ async def send_system_email(
 
         await asyncio.to_thread(_send_blocking)
     except Exception as exc:  # noqa: BLE001 — intentionally broad
-        logger.warning("send_system_email failed: to=%s subject=%s err=%s", to_email, subject, exc)
+        logger.error("send_system_email failed: to=%s subject=%s err=%s", to_email, subject, exc)
         return False
     logger.info("send_system_email ok: to=%s subject=%s", to_email, subject)
     return True

--- a/backend/tests/test_email_sender.py
+++ b/backend/tests/test_email_sender.py
@@ -1,0 +1,66 @@
+"""Failure-path coverage for send_system_email.
+
+The magic-link/verification suites only ever exercised the happy path (they
+monkeypatch the sender to succeed). These tests pin the *failure* contract:
+a broken provider must return False (never raise) AND log at ERROR so a silent
+prod outage is visible in logs — the whole point of PLAN-2's log-level bump.
+"""
+import logging
+
+import httpx
+
+from src.services.auth import email_sender
+
+
+class _Resp:
+    """Minimal stand-in for an httpx.Response."""
+
+    def __init__(self, status_code: int) -> None:
+        self.status_code = status_code
+        self.text = "error body from provider"
+
+
+class _FakeAsyncClient:
+    """Drop-in for httpx.AsyncClient whose POST always 500s."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def post(self, *args, **kwargs):
+        return _Resp(500)
+
+
+async def test_resend_5xx_returns_false_and_logs_error(monkeypatch, caplog):
+    """A Resend 5xx must not raise, must return False, and must log at ERROR."""
+    monkeypatch.setenv("RESEND_API_KEY", "re_test_key")
+    monkeypatch.setattr(httpx, "AsyncClient", _FakeAsyncClient)
+
+    with caplog.at_level(logging.ERROR, logger="job360.auth.email_sender"):
+        ok = await email_sender.send_system_email(
+            to_email="someone@example.com", subject="s", body_text="b"
+        )
+
+    assert ok is False
+    assert any(
+        r.levelno == logging.ERROR for r in caplog.records
+    ), "delivery failure must log at ERROR so it is visible in prod logs"
+
+
+async def test_no_provider_configured_returns_false_and_logs_error(monkeypatch, caplog):
+    """No Resend key and no SMTP creds -> False + ERROR (silent-config guard)."""
+    for var in ("RESEND_API_KEY", "SMTP_PASSWORD", "SMTP_EMAIL", "SMTP_FROM"):
+        monkeypatch.delenv(var, raising=False)
+
+    with caplog.at_level(logging.ERROR, logger="job360.auth.email_sender"):
+        ok = await email_sender.send_system_email(
+            to_email="someone@example.com", subject="s", body_text="b"
+        )
+
+    assert ok is False
+    assert any(r.levelno == logging.ERROR for r in caplog.records)

--- a/backend/tests/test_magic_link.py
+++ b/backend/tests/test_magic_link.py
@@ -167,6 +167,19 @@ def test_request_mints_token_and_returns_204(client, monkeypatch, temp_db):
     assert row["used_at"] is None
 
 
+def test_request_returns_204_and_mints_token_when_send_fails(client, monkeypatch, temp_db):
+    """Delivery failure must not leak email existence (still 204) and must still
+    mint the token row, so a resend after the provider is fixed works."""
+    async def _failing_send(**_kwargs):
+        return False
+
+    monkeypatch.setattr("src.services.auth.magic_link.send_system_email", _failing_send)
+    raw = _request_capture_token(client, monkeypatch, "bob@example.com")
+    row = asyncio.run(_latest_token_row(temp_db, "bob@example.com"))
+    assert row is not None
+    assert row["token_hash"] == tokens.hash_token(raw)
+
+
 def test_request_rate_limited_after_cap(client, temp_db):
     email = "spammer@example.com"
     # Cap is 3 per 5 min. First three allowed, fourth suppressed.

--- a/backend/tests/test_request_timeout.py
+++ b/backend/tests/test_request_timeout.py
@@ -1,0 +1,59 @@
+"""RequestTimeoutMiddleware — slow handlers 504, fast/exempt ones pass.
+
+The slow-route tests use @pytest.mark.real_sleep because conftest mocks
+asyncio.sleep to instant by default (which would make a "slow" route finish
+immediately and never trip the timeout).
+"""
+import asyncio
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from src.api.middleware import RequestTimeoutMiddleware
+
+
+def _app(timeout: float, exempt: tuple = ()) -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(
+        RequestTimeoutMiddleware, timeout_seconds=timeout, exempt_prefixes=exempt
+    )
+
+    @app.get("/fast")
+    async def fast():
+        return {"ok": True}
+
+    @app.get("/slow")
+    async def slow():
+        await asyncio.sleep(0.3)
+        return {"ok": True}
+
+    @app.get("/exempt/slow")
+    async def exempt_slow():
+        await asyncio.sleep(0.3)
+        return {"ok": True}
+
+    return app
+
+
+async def _get(app: FastAPI, path: str):
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        return await c.get(path)
+
+
+async def test_fast_request_passes():
+    resp = await _get(_app(1.0), "/fast")
+    assert resp.status_code == 200
+
+
+@pytest.mark.real_sleep
+async def test_slow_request_times_out_504():
+    resp = await _get(_app(0.1), "/slow")
+    assert resp.status_code == 504
+    assert resp.json()["detail"] == "request timed out"
+
+
+@pytest.mark.real_sleep
+async def test_exempt_prefix_is_not_timed_out():
+    resp = await _get(_app(0.1, exempt=("/exempt",)), "/exempt/slow")
+    assert resp.status_code == 200

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -82,7 +82,7 @@ services:
       redis:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "curl -fsS http://localhost:8000/health || exit 1"]
+      test: ["CMD-SHELL", "curl -fsS http://localhost:8000/api/livez || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/docs/RUNBOOK-backups.md
+++ b/docs/RUNBOOK-backups.md
@@ -1,0 +1,94 @@
+# Runbook — Database backups & restore
+
+Job360's production data lives in a single Postgres database (Railway). This
+runbook covers how to back it up and — the part people skip — how to actually
+restore it.
+
+## ⚠️ Why automated CI-artifact backups are NOT wired up
+
+The obvious approach (a nightly GitHub Action that runs `pg_dump` and uploads the
+dump as a workflow artifact) is **unsafe for this repo because the repo is
+public**. A dump contains every user's email and CV; a workflow artifact in a
+public repo is downloadable by anyone. So we deliberately did **not** add that
+workflow. Pick one of the safe options below instead.
+
+### Option A (recommended): Railway managed backups
+Railway's Postgres plugin offers automated daily backups + point-in-time
+restore on its paid tiers. Enable it in the Railway dashboard → Postgres service
+→ Backups. Zero code, encrypted at rest, never touches the repo. This is the
+right answer for a live product.
+
+### Option B: make the repo private, then enable the artifact workflow
+If the repo is made private, a nightly `pg_dump → upload-artifact` job becomes
+safe (artifacts inherit the private repo's access control). The script
+(`backend/scripts/backup_db.py`) already exists; wiring is a ~40-line workflow.
+Do NOT do this while the repo is public.
+
+## Manual backup (any time, from a machine with the Postgres client)
+
+`backend/scripts/backup_db.py` streams `pg_dump` straight into a gzip file with
+retention pruning. It needs `pg_dump` on PATH and `DATABASE_URL` set.
+
+```bash
+cd backend
+export DATABASE_URL="postgresql://…"      # the EXTERNAL Railway connection string
+export BACKUP_DIR=./backups               # optional (default ./backups)
+export BACKUP_KEEP=14                      # optional (keep newest 14, default 14)
+python -m scripts.backup_db
+# → backups/job360-2026-07-09T0200Z.sql.gz
+```
+
+If you don't have the Postgres client locally, run `pg_dump` through any Postgres
+container instead (see the drill below).
+
+## Restore
+
+A dump is only useful if restore works. **Always restore into a NEW database,
+never in-place over live data**, then repoint the app.
+
+```bash
+# 1. Create a fresh target database
+psql "$ADMIN_DATABASE_URL" -c "CREATE DATABASE job360_restored;"
+
+# 2. Load the dump
+gunzip -c job360-2026-07-09T0200Z.sql.gz | psql "postgresql://…/job360_restored"
+
+# 3. Sanity-check row counts and the migration head
+psql "postgresql://…/job360_restored" -c \
+  "SELECT count(*) FROM users; SELECT count(*) FROM jobs; SELECT max(id) FROM _schema_migrations;"
+
+# 4. Only once verified: repoint the app's DATABASE_URL at the restored DB.
+```
+
+## Restore drill — logged evidence
+
+Run a restore drill at least quarterly so you find problems before you need the
+backup. Most recent drill:
+
+**2026-07-09** — dumped the dev Postgres (`job360-dev-postgres` container), restored
+into a scratch `drill` database, and compared row counts. Commands (client run
+inside the container, which ships `pg_dump`/`psql`):
+
+```bash
+docker exec job360-dev-postgres bash -c \
+  "pg_dump --no-owner --no-privileges -U job360 job360 > /tmp/drill.sql && \
+   psql -U job360 -d postgres -c 'CREATE DATABASE drill;' && \
+   psql -U job360 -d drill -f /tmp/drill.sql"
+```
+
+Result — counts matched exactly, restore verified:
+
+| Table | Source | Restored |
+|-------|-------:|---------:|
+| users |      7 |        7 |
+| jobs  |     19 |       19 |
+
+## Gotchas
+
+- **Use the EXTERNAL Railway connection string**, not the `*.railway.internal`
+  host — internal hostnames only resolve inside Railway's network.
+- **`pg_dump` version ≥ server version.** `pg_dump` refuses to dump a newer
+  server. If you hit "server version mismatch", install the matching
+  `postgresql-client-NN`.
+- The dump includes real user PII (emails, CV text). Treat `.sql.gz` files as
+  secret — never commit them, never attach to a public issue/PR/artifact.

--- a/frontend/src/app/auth/magic/__tests__/magic-consume.test.tsx
+++ b/frontend/src/app/auth/magic/__tests__/magic-consume.test.tsx
@@ -1,0 +1,57 @@
+/**
+ * Magic-link consume page — token handling states.
+ *
+ * Verifies:
+ * 1. Missing ?token → error shown, API never called (no pointless request).
+ * 2. Successful consume → router.replace("/dashboard").
+ * 3. Failed consume → error message + "Back to login" escape hatch.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import MagicLinkPage from "../page";
+
+const mockReplace = vi.fn();
+const mockGet = vi.fn<(key: string) => string | null>();
+const mockConsume = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: mockReplace }),
+  useSearchParams: () => ({ get: mockGet }),
+}));
+
+vi.mock("@/lib/api", () => ({
+  consumeMagicLink: (...args: unknown[]) => mockConsume(...args),
+}));
+
+describe("MagicLinkPage — token consume", () => {
+  beforeEach(() => {
+    mockReplace.mockClear();
+    mockGet.mockReset();
+    mockConsume.mockReset();
+  });
+
+  it("shows an error and never calls the API when the token is missing", async () => {
+    mockGet.mockReturnValue(null);
+    render(<MagicLinkPage />);
+    expect(await screen.findByText(/token missing/i)).toBeTruthy();
+    expect(mockConsume).not.toHaveBeenCalled();
+  });
+
+  it("redirects to /dashboard on a successful consume", async () => {
+    mockGet.mockReturnValue("good-token");
+    mockConsume.mockResolvedValue({});
+    render(<MagicLinkPage />);
+    await waitFor(() => expect(mockReplace).toHaveBeenCalledWith("/dashboard"));
+    expect(mockConsume).toHaveBeenCalledWith("good-token");
+  });
+
+  it("shows the error message and a back-to-login link when consume fails", async () => {
+    mockGet.mockReturnValue("bad-token");
+    mockConsume.mockRejectedValue(new Error("invalid or expired link"));
+    render(<MagicLinkPage />);
+    expect(await screen.findByText(/invalid or expired link/i)).toBeTruthy();
+    expect(screen.getByText(/back to login/i)).toBeTruthy();
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## PLAN-2 — unblock real sign-ups (code half)

Job360 is live, but Resend is in **sandbox mode**, which only delivers magic-link login emails to the account owner. So no other human can log in. This PR is the code half; the actual unblock is a **human step** (below).

### Code changes
- **Failures are now visible.** The 4 delivery-failure logs in `email_sender.py` are `ERROR` (were `WARNING`). A broken provider (e.g. wrong `SMTP_FROM` domain → Resend 403) previously ate every login email silently while the user saw "check your email".
- **Documented the hidden env vars.** `RESEND_API_KEY` + `SMTP_FROM` were read only via `os.environ`, undocumented. Now declared in `settings.py` and `.env.example`. Removed the dead `SMTP_HOST`/`SMTP_PORT` constants (nothing imported them).
- **Tests for the untested failure paths:** `test_email_sender.py` (Resend 5xx + no-provider → returns False + logs ERROR), a magic-link send-failure test (still returns 204 — no email enumeration — and still mints the token so a resend works), and 3 frontend consume-page tests.

### 🔴 HUMAN STEP required to actually unblock sign-ups (I can't do this)
**Option A (recommended):** In Resend, verify a domain you own (add its DKIM/SPF DNS records). Then on Railway set `RESEND_API_KEY` (production key) and `SMTP_FROM=login@yourdomain`. Redeploy.
**Option B (stopgap, no domain):** Gmail app password → set `SMTP_EMAIL`/`SMTP_PASSWORD`/`SMTP_FROM`, and remove any `re_`-prefixed value from `SMTP_PASSWORD` (or the code takes the Resend path).
After either: if `REQUIRE_EMAIL_VERIFICATION=false` was set as a sandbox escape hatch, set it back to `true`. Then send a magic link to a NON-owner address and confirm login.

### Evidence
Gate: backend **1677 passed**, frontend **155 passed**, api-types no drift.

### Stacking
Based on `fix/ci-red-gate` (PLAN-1, PR #27). Merge #27 first, then this retargets to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)