### PR TITLE
feat(ops): prod safety net (PLAN-3) — request timeouts + healthcheck fixes + backup runbook

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -153,3 +153,18 @@ MAX_CONCURRENT_SEARCHES_PER_USER=3
 # Only override if the public keys rotate upstream.
 EIGHTYKHOURS_ALGOLIA_APP_ID=
 EIGHTYKHOURS_ALGOLIA_API_KEY=
+
+# === Ops / infrastructure ===
+# Postgres connection string. Defaults to the local dev DB on port 5433; set in
+# prod (Railway injects it). The whole app runs on Postgres via the pg.py shim.
+DATABASE_URL=postgresql://job360:job360dev@localhost:5433/job360
+# Sentry error tracking (optional). Empty disables Sentry.
+SENTRY_DSN=
+# Inbound API request ceiling in seconds (RequestTimeoutMiddleware returns 504).
+# LLM-heavy routes (/api/tailor, /api/profile) are exempt. Default 60.
+API_REQUEST_TIMEOUT_SECONDS=60
+# Manual DB backup script (scripts/backup_db.py): output dir + how many dumps to
+# keep. See docs/RUNBOOK-backups.md. Automated CI-artifact backups are NOT wired
+# up because this repo is public (a dump artifact would leak user data).
+BACKUP_DIR=./backups
+BACKUP_KEEP=14

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -35,10 +35,12 @@ USER job360
 
 EXPOSE 8000
 
-# Hit the /api/health endpoint. $PORT is injected by Railway (dynamic); fall
+# Hit the /api/livez liveness probe (always 200 if the process is up, zero
+# dependency checks — a failing container healthcheck should mean "process is
+# wedged", not "Redis blipped"). $PORT is injected by Railway (dynamic); fall
 # back to 8000 for local `docker run`. Shell-form so ${PORT} expands.
 HEALTHCHECK --interval=30s --timeout=10s --start-period=20s --retries=3 \
-  CMD curl -fsS http://localhost:${PORT:-8000}/api/health || exit 1
+  CMD curl -fsS http://localhost:${PORT:-8000}/api/livez || exit 1
 
 # Shell form (not exec) so ${PORT} is expanded by the shell. Railway assigns a
 # dynamic port and routes to it; the app MUST listen on $PORT or it's unreachable.

--- a/backend/src/api/main.py
+++ b/backend/src/api/main.py
@@ -19,7 +19,12 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from src.api.dependencies import close_db, init_db
 from src.api.errors import register_exception_logging
-from src.api.middleware import AccessLogMiddleware, RequestIdMiddleware, SecurityHeadersMiddleware
+from src.api.middleware import (
+    AccessLogMiddleware,
+    RequestIdMiddleware,
+    RequestTimeoutMiddleware,
+    SecurityHeadersMiddleware,
+)
 from src.api.routes import (
     actions,
     auth,
@@ -90,6 +95,17 @@ app = FastAPI(title="Job360 API", version="1.0.0", lifespan=lifespan)
 
 # Gap E — log every unhandled exception (traceback + request_id) into data/logs/.
 register_exception_logging(app)
+
+# RequestTimeoutMiddleware is added FIRST so it is INNERMOST (Starlette LIFO):
+# it wraps only the route handler, so a hung route returns a 504 that the outer
+# middleware still post-process — CORS + security headers + a logged access line
+# + a request id. LLM-heavy routes (tailoring, profile extraction) legitimately
+# run longer than a normal round-trip, so they are exempted by prefix.
+app.add_middleware(
+    RequestTimeoutMiddleware,
+    timeout_seconds=float(os.environ.get("API_REQUEST_TIMEOUT_SECONDS", "60")),
+    exempt_prefixes=("/api/tailor", "/api/profile"),
+)
 
 # CORS — env-driven so dev / staging / prod can differ without a rebuild.
 # Default keeps Batch 1 behaviour (localhost:3000) so existing dev flows work.

--- a/backend/src/api/middleware.py
+++ b/backend/src/api/middleware.py
@@ -1,13 +1,14 @@
 """HTTP middleware for Job360 FastAPI app."""
 from __future__ import annotations
 
+import asyncio
 import os
 import time
 import uuid
 
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
-from starlette.responses import Response
+from starlette.responses import JSONResponse, Response
 
 from src.utils.logger import _request_id_var, get_logger, get_request_id, set_request_id
 
@@ -131,3 +132,31 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
         if _is_production():
             response.headers["Strict-Transport-Security"] = _HSTS
         return response
+
+
+class RequestTimeoutMiddleware(BaseHTTPMiddleware):
+    """Cap inbound request duration so a hung handler can't tie up a worker.
+
+    A backstop, not a scheduler: outbound source-fetch ceilings
+    (``SOURCE_FETCH_TIMEOUT*``) are a different knob. LLM-heavy routes (CV
+    tailoring, profile extraction) legitimately run longer than a normal API
+    round-trip, so they are exempted by path prefix. Everything else that
+    exceeds ``timeout_seconds`` gets a ``504`` instead of hanging.
+
+    Note: cancelling ``call_next`` abandons the handler mid-flight. DB writes in
+    this app are autocommit single statements (``repositories/pg.py``), so a
+    cancelled request cannot leave an open transaction.
+    """
+
+    def __init__(self, app, timeout_seconds: float = 60.0, exempt_prefixes: tuple = ()):
+        super().__init__(app)
+        self.timeout_seconds = timeout_seconds
+        self.exempt_prefixes = tuple(exempt_prefixes)
+
+    async def dispatch(self, request: Request, call_next) -> Response:
+        if any(request.url.path.startswith(p) for p in self.exempt_prefixes):
+            return await call_next(request)
+        try:
+            return await asyncio.wait_for(call_next(request), timeout=self.timeout_seconds)
+        except asyncio.TimeoutError:
+            return JSONResponse(status_code=504, content={"detail": "request timed out"})

--- a/backend/tests/test_request_timeout.py
+++ b/backend/tests/test_request_timeout.py
@@ -1,0 +1,59 @@
+"""RequestTimeoutMiddleware — slow handlers 504, fast/exempt ones pass.
+
+The slow-route tests use @pytest.mark.real_sleep because conftest mocks
+asyncio.sleep to instant by default (which would make a "slow" route finish
+immediately and never trip the timeout).
+"""
+import asyncio
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from src.api.middleware import RequestTimeoutMiddleware
+
+
+def _app(timeout: float, exempt: tuple = ()) -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(
+        RequestTimeoutMiddleware, timeout_seconds=timeout, exempt_prefixes=exempt
+    )
+
+    @app.get("/fast")
+    async def fast():
+        return {"ok": True}
+
+    @app.get("/slow")
+    async def slow():
+        await asyncio.sleep(0.3)
+        return {"ok": True}
+
+    @app.get("/exempt/slow")
+    async def exempt_slow():
+        await asyncio.sleep(0.3)
+        return {"ok": True}
+
+    return app
+
+
+async def _get(app: FastAPI, path: str):
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        return await c.get(path)
+
+
+async def test_fast_request_passes():
+    resp = await _get(_app(1.0), "/fast")
+    assert resp.status_code == 200
+
+
+@pytest.mark.real_sleep
+async def test_slow_request_times_out_504():
+    resp = await _get(_app(0.1), "/slow")
+    assert resp.status_code == 504
+    assert resp.json()["detail"] == "request timed out"
+
+
+@pytest.mark.real_sleep
+async def test_exempt_prefix_is_not_timed_out():
+    resp = await _get(_app(0.1, exempt=("/exempt",)), "/exempt/slow")
+    assert resp.status_code == 200

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -82,7 +82,7 @@ services:
       redis:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "curl -fsS http://localhost:8000/health || exit 1"]
+      test: ["CMD-SHELL", "curl -fsS http://localhost:8000/api/livez || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/docs/RUNBOOK-backups.md
+++ b/docs/RUNBOOK-backups.md
@@ -1,0 +1,94 @@
+# Runbook — Database backups & restore
+
+Job360's production data lives in a single Postgres database (Railway). This
+runbook covers how to back it up and — the part people skip — how to actually
+restore it.
+
+## ⚠️ Why automated CI-artifact backups are NOT wired up
+
+The obvious approach (a nightly GitHub Action that runs `pg_dump` and uploads the
+dump as a workflow artifact) is **unsafe for this repo because the repo is
+public**. A dump contains every user's email and CV; a workflow artifact in a
+public repo is downloadable by anyone. So we deliberately did **not** add that
+workflow. Pick one of the safe options below instead.
+
+### Option A (recommended): Railway managed backups
+Railway's Postgres plugin offers automated daily backups + point-in-time
+restore on its paid tiers. Enable it in the Railway dashboard → Postgres service
+→ Backups. Zero code, encrypted at rest, never touches the repo. This is the
+right answer for a live product.
+
+### Option B: make the repo private, then enable the artifact workflow
+If the repo is made private, a nightly `pg_dump → upload-artifact` job becomes
+safe (artifacts inherit the private repo's access control). The script
+(`backend/scripts/backup_db.py`) already exists; wiring is a ~40-line workflow.
+Do NOT do this while the repo is public.
+
+## Manual backup (any time, from a machine with the Postgres client)
+
+`backend/scripts/backup_db.py` streams `pg_dump` straight into a gzip file with
+retention pruning. It needs `pg_dump` on PATH and `DATABASE_URL` set.
+
+```bash
+cd backend
+export DATABASE_URL="postgresql://…"      # the EXTERNAL Railway connection string
+export BACKUP_DIR=./backups               # optional (default ./backups)
+export BACKUP_KEEP=14                      # optional (keep newest 14, default 14)
+python -m scripts.backup_db
+# → backups/job360-2026-07-09T0200Z.sql.gz
+```
+
+If you don't have the Postgres client locally, run `pg_dump` through any Postgres
+container instead (see the drill below).
+
+## Restore
+
+A dump is only useful if restore works. **Always restore into a NEW database,
+never in-place over live data**, then repoint the app.
+
+```bash
+# 1. Create a fresh target database
+psql "$ADMIN_DATABASE_URL" -c "CREATE DATABASE job360_restored;"
+
+# 2. Load the dump
+gunzip -c job360-2026-07-09T0200Z.sql.gz | psql "postgresql://…/job360_restored"
+
+# 3. Sanity-check row counts and the migration head
+psql "postgresql://…/job360_restored" -c \
+  "SELECT count(*) FROM users; SELECT count(*) FROM jobs; SELECT max(id) FROM _schema_migrations;"
+
+# 4. Only once verified: repoint the app's DATABASE_URL at the restored DB.
+```
+
+## Restore drill — logged evidence
+
+Run a restore drill at least quarterly so you find problems before you need the
+backup. Most recent drill:
+
+**2026-07-09** — dumped the dev Postgres (`job360-dev-postgres` container), restored
+into a scratch `drill` database, and compared row counts. Commands (client run
+inside the container, which ships `pg_dump`/`psql`):
+
+```bash
+docker exec job360-dev-postgres bash -c \
+  "pg_dump --no-owner --no-privileges -U job360 job360 > /tmp/drill.sql && \
+   psql -U job360 -d postgres -c 'CREATE DATABASE drill;' && \
+   psql -U job360 -d drill -f /tmp/drill.sql"
+```
+
+Result — counts matched exactly, restore verified:
+
+| Table | Source | Restored |
+|-------|-------:|---------:|
+| users |      7 |        7 |
+| jobs  |     19 |       19 |
+
+## Gotchas
+
+- **Use the EXTERNAL Railway connection string**, not the `*.railway.internal`
+  host — internal hostnames only resolve inside Railway's network.
+- **`pg_dump` version ≥ server version.** `pg_dump` refuses to dump a newer
+  server. If you hit "server version mismatch", install the matching
+  `postgresql-client-NN`.
+- The dump includes real user PII (emails, CV text). Treat `.sql.gz` files as
+  secret — never commit them, never attach to a public issue/PR/artifact.


### PR DESCRIPTION
## PLAN-3 — prod safety, scoped for a PUBLIC repo

### 🔴 Backup automation deliberately SKIPPED
The plan's Step 0.2 privacy gate: **the repo is public**, so a nightly `pg_dump → upload-artifact` job would publish every user's email + CV to a downloadable URL — a data breach. Skipped it. Do ONE of:
- **Enable Railway managed backups** (dashboard → Postgres → Backups) — recommended, encrypted, zero code.
- **Make the repo private**, then the artifact workflow becomes safe to add (`backend/scripts/backup_db.py` already exists).

### What shipped
- **Request-timeout middleware** — a hung request returns `504` instead of tying up a worker. `API_REQUEST_TIMEOUT_SECONDS` (default 60). Registered **innermost** so 504s still get CORS + security headers + an access-log line. LLM routes (`/api/tailor`, `/api/profile`) exempt. 3 tests.
- **Healthcheck fixes** — Dockerfile `/api/health`→`/api/livez`; `docker-compose.prod.yml` `/health`→`/api/livez` (that path 404'd — the compose healthcheck **never passed**). Liveness (not readiness) is correct for a container check so a Redis blip doesn't trigger restarts.
- **`docs/RUNBOOK-backups.md`** with a **logged restore drill**: dumped the dev DB, restored into a scratch DB, row counts matched exactly (users 7/7, jobs 19/19). Documented `DATABASE_URL`/`SENTRY_DSN`/timeout/backup vars in `.env.example`.

### Evidence
Gate: **1680 passed**, api-types no drift. livez/readyz + security headers already existed and are unchanged.

### Stacking
Based on `feat/unblock-real-signups` (PLAN-2 → PLAN-1). Merge #27 then #29 then this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)