### PR TITLE
fix(ops): PG18 client via official PGDG script (CI-safe key import)

### DIFF
--- a/.github/workflows/db-backup.yml
+++ b/.github/workflows/db-backup.yml
@@ -36,21 +36,16 @@ jobs:
       - name: Install tools (Postgres client 18)
         run: |
           # Railway's Postgres is 18.x; pg_dump refuses to dump a server newer
-          # than itself, and Ubuntu 24.04's default client is 16 — so pull the
-          # matching client from the official PostgreSQL (PGDG) apt repo.
-          # aws CLI v2 + gpg are already on the runner image.
+          # than itself, and Ubuntu 24.04's default client is 16. Use PostgreSQL's
+          # OFFICIAL repo-setup script (postgresql-common) — it installs the PGDG
+          # apt key/repo correctly, avoiding the `sudo gpg --dearmor` /dev/tty
+          # failure that a manual key import hits in CI. aws CLI v2 is pre-installed.
           sudo apt-get update -q
-          sudo apt-get install -y -q curl ca-certificates lsb-release
-          sudo install -d /usr/share/postgresql-common/pgdg
-          curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc \
-            | sudo gpg --dearmor -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.gpg
-          echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.gpg] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" \
-            | sudo tee /etc/apt/sources.list.d/pgdg.list
-          sudo apt-get update -q
+          sudo apt-get install -y -q postgresql-common
+          sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y
           sudo apt-get install -y -q postgresql-client-18
           pg_dump --version
           aws --version
-          gpg --version
 
       - name: Dump prod database
         env:


### PR DESCRIPTION
Third backup fix. The manual gpg key import hit `gpg: cannot open '/dev/tty'` in CI. Switch to PostgreSQL's official `apt.postgresql.org.sh -y` helper (via postgresql-common) — the documented, non-interactive way. Workflow-only.