### PR TITLE
ci: stop every workflow double-firing; cancel superseded runs

### DIFF
--- a/.github/workflows/ci-offline.yml
+++ b/.github/workflows/ci-offline.yml
@@ -9,12 +9,23 @@ name: CI — offline suite (automated Loop 2 + full backend)
 # To enable: just turn on GitHub Actions for the repo (Settings → Actions). No
 # secrets needed — tests inject SESSION_SECRET / channel key themselves.
 
+# Unfiltered `push` + `pull_request` double-fires: a push to a branch with an open
+# PR runs the same commit twice. Filtering push to main gives branches exactly one
+# run (via the PR) and main exactly one run (via the push).
 on:
   push:
+    branches: [main]
   pull_request:
   schedule:
     - cron: "0 6 * * *" # 06:00 UTC daily
   workflow_dispatch: {}
+
+# A newer push supersedes the run it replaces; don't pay for the stale one.
+# run_id keeps each scheduled/dispatched run in its own group so a push to main
+# can never cancel the nightly suite.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'schedule' && github.run_id || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   offline-suite:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,18 @@ name: CI
 # Replaces ci-offline.yml as the canonical per-commit gate.
 # ci-offline.yml (automated Loop-2 + Playwright) continues to run independently.
 
+# Unfiltered `push` + `pull_request` double-fires: a push to a branch with an open
+# PR runs the same commit twice. Filtering push to main gives branches exactly one
+# run (via the PR) and main exactly one run (via the push).
 on:
   push:
+    branches: [main]
   pull_request:
+
+# A newer push supersedes the run it replaces; don't pay for the stale one.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
 


### PR DESCRIPTION
## The bug

`ci.yml` and `ci-offline.yml` both declared unfiltered `on: push` **and** `on: pull_request`. When a branch has an open PR, the same commit fires both events — so every workflow runs **twice**.

Proof: PR #46 (a 7-file docs change) burned **13 check-runs** — 2× `Backend (Python 3.12)`, 2× `offline-suite`, 2× `frontend-e2e`, 2× `loop2-e2e-spotlight`, each pair with different run IDs.

Separately, **no** workflow declared a `concurrency:` group, so pushing again never superseded the in-flight run — stale runs ran to completion next to their replacement.

## The fix

```yaml
on:
  push:
    branches: [main]   # branches get their one run via the PR
  pull_request:

concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```

Branch work = 1 run. Merge to main = 1 run. Never both.

`ci-offline.yml` keys its group on `run_id` for `schedule` events, so a push to main can **not** cancel the nightly suite.

## Scope

- `security.yml` has the identical bug but is modified by **#47** — deferred to avoid a merge conflict. Follow-up once #47 lands.
- Cron-only workflows (`db-backup`, `uptime`, `live-e2e`, `synthetic-live`) deliberately untouched — cancelling a backup mid-run is not wanted.

## Verification

Both files parse via `yaml.safe_load`; triggers and job lists intact (`backend`/`frontend`; `offline-suite`/`frontend-e2e`/`loop2-e2e-spotlight`). No conflict with #47 or #48 — neither touches these two files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpxEMPz2ZWG9Qed5BsFHvg