### PR TITLE
feat(loop3): doc-type headers + dead-link sweep — 10/10 problem types…

### DIFF
--- a/.claude/skills/doc-audit/SKILL.md
+++ b/.claude/skills/doc-audit/SKILL.md
@@ -12,7 +12,12 @@ contract. The code is the only truth.
   RECOMMENDED action (archive / banner / fix / park / write-doc / delete).
   Then STOP and wait for the user's decisions.
 - **Phase B — APPLY (only what the user approved).** Execute exactly the
-  approved items, nothing more, on a `docs/audit-<YYYYMMDD>-<HHMM>` branch
+  approved items, nothing more. When the user approves the classification,
+  also write each doc's type header on line 2 (spec in DOC-MAINTENANCE.md):
+  `<!-- doc: PLAN | status: ACTIVE -->`, `<!-- doc: LOG | append-only -->`,
+  `<!-- doc: REFERENCE -->` (LIVING headers are owned by /sync — skip them;
+  an untouchable AHEAD doc gets NO header unless the user approves that
+  specific doc). Work on a `docs/audit-<YYYYMMDD>-<HHMM>` branch
   (time suffix — parallel sessions must not collide), ending in ONE docs-only
   PR — never commit to main. Rebase on freshly-fetched `origin/main` right
   before pushing. **Only one doc-writing session (sync or audit) at a time** —

--- a/.claude/skills/sync/SKILL.md
+++ b/.claude/skills/sync/SKILL.md
@@ -54,10 +54,11 @@ For each mismatch found in Step 2:
 - Keep the same structure and tone of the existing document
 
 **Then stamp every LIVING doc you verified** (even ones needing no fix):
-add or update `<!-- last-verified: YYYY-MM-DD by /sync -->` on line 2 of
-CLAUDE.md, README.md, ARCHITECTURE.md, STATUS.md, backend/CLAUDE.md,
+add or update `<!-- doc: LIVING | last-verified: YYYY-MM-DD by /sync -->` on
+line 2 of CLAUDE.md, README.md, ARCHITECTURE.md, STATUS.md, backend/CLAUDE.md,
 frontend/README.md. The daily Loop-3 tripwire (`scripts/doc_sync_check.py`)
-reads these stamps and flags any doc not verified within 45 days.
+reads both the type tag and the date, and flags any doc not verified within
+45 days.
 
 **If a doc claims something the code does NOT do** (code is behind the doc —
 an "AHEAD" doc): **leave that doc completely untouched** (user's rule —

--- a/.github/workflows/doc-sync.yml
+++ b/.github/workflows/doc-sync.yml
@@ -141,7 +141,7 @@ jobs:
             .claude/skills/sync/SKILL.md exactly, with these constraints:
             - Run `python scripts/doc_sync_check.py` first; fix EVERY drift
               row it reports (numbers, stale phrases) in the LIVING docs.
-            - Add/update the `<!-- last-verified: YYYY-MM-DD by /sync -->`
+            - Add/update the `<!-- doc: LIVING | last-verified: YYYY-MM-DD by /sync -->`
               stamp on line 2 of all six LIVING docs.
             - If a doc claims something the code does not do, add it to
               docs/maintenance/PARKED.md — never describe missing code as real.

--- a/docs/maintenance/DOC-MAINTENANCE.md
+++ b/docs/maintenance/DOC-MAINTENANCE.md
@@ -14,6 +14,23 @@
 | **LOG** | `docs/IMPLEMENTATION_LOG.md`, `docs/maintenance/JOURNAL.md` | Append-only. Never rewritten, so never stale by definition. |
 | **REFERENCE** | decision records (`docs/plans/batch-2-decisions.md`), research notes | Updated only when the decision itself changes; superseded ones get a banner pointing to the successor, content stays. |
 
+### Every doc carries its type on line 2 (machine + human readable)
+
+One HTML comment — invisible when the doc renders, parseable by the tripwire:
+
+```markdown
+<!-- doc: LIVING | last-verified: 2026-07-15 by /sync -->   ← written by /sync
+<!-- doc: PLAN | status: ACTIVE -->                          ← written by /doc-audit
+<!-- doc: LOG | append-only -->
+<!-- doc: REFERENCE -->
+```
+
+LIVING headers (tag + freshness date) are owned by the `/sync` auto-fixer.
+All other headers are applied by `/doc-audit` Phase B after the user approves
+the classification. The daily tripwire verifies LIVING docs carry the right
+tag and a fresh date; untagged non-living docs surface in the next audit, not
+as daily alarms.
+
 ## 2. Plan lifecycle (fixes the "implemented docs still lying around" problem)
 
 ```

--- a/scripts/doc_sync_check.py
+++ b/scripts/doc_sync_check.py
@@ -51,7 +51,17 @@ FORBIDDEN_PHRASES = [
     ("async SQLite", "the DB is Postgres via psycopg3 since 2026-07-02 (pg.py shim)"),
 ]
 
-_STAMP_RE = re.compile(r"<!--\s*last-verified:\s*(\d{4}-\d{2}-\d{2})")
+# Header spec (DOC-MAINTENANCE.md): one HTML comment near the top of a doc,
+# e.g.  <!-- doc: LIVING | last-verified: 2026-07-15 by /sync -->
+#       <!-- doc: PLAN | status: ACTIVE -->
+_STAMP_RE = re.compile(r"last-verified:\s*(\d{4}-\d{2}-\d{2})")
+_TYPE_RE = re.compile(r"<!--\s*doc:\s*(LIVING|PLAN|LOG|REFERENCE)\b")
+
+# Relative markdown links to check for dead targets: [text](path.md) style.
+_LINK_RE = re.compile(r"\]\(([^)#\s]+?\.md)(?:#[^)]*)?\)")
+
+# Dirs holding docs whose links we sweep (node_modules etc. excluded).
+LINK_SWEEP_DIRS = [".", "docs", "backend", "frontend"]
 
 
 def registry_counts() -> tuple[int, int]:
@@ -94,6 +104,26 @@ def migration_head() -> int:
     if not nums:
         raise RuntimeError("no NNNN_*.sql migrations found")
     return max(nums)
+
+
+def dead_links() -> list[tuple[str, str]]:
+    """(doc, broken target) for every relative .md link pointing at a missing file."""
+    files: list[Path] = []
+    for d in LINK_SWEEP_DIRS:
+        base = ROOT / d
+        if not base.is_dir():
+            continue
+        files.extend(base.rglob("*.md") if d == "docs" else base.glob("*.md"))
+    broken = []
+    for f in files:
+        text = f.read_text(encoding="utf-8", errors="replace")
+        for m in _LINK_RE.finditer(text):
+            target = m.group(1)
+            if "://" in target or target.startswith("mailto:"):
+                continue
+            if not (f.parent / target).exists():
+                broken.append((str(f.relative_to(ROOT)).replace("\\", "/"), target))
+    return broken
 
 
 def main() -> int:
@@ -145,6 +175,16 @@ def main() -> int:
             age = (today - _dt.date.fromisoformat(stamp.group(1))).days
             if age > STALE_DAYS:
                 drift.append((rel, "-", "freshness", f"verified {age} days ago", f"max {STALE_DAYS} — run /sync"))
+
+        type_tag = _TYPE_RE.search(text)
+        if not type_tag:
+            drift.append((rel, "-", "doc-type", "no doc-type header", "needs <!-- doc: LIVING ... -->"))
+        elif type_tag.group(1) != "LIVING":
+            drift.append((rel, "-", "doc-type", f"tagged {type_tag.group(1)}", "this file is a LIVING doc"))
+
+    # Dead relative links anywhere in the doc tree (archive moves, renames).
+    for doc, target in dead_links():
+        drift.append((doc, "-", "dead-link", f"→ {target}", "target file does not exist"))
 
     # A fact nobody claims anymore = the claim was reworded/deleted and this
     # checker just went blind to it. That is drift, not success.


### PR DESCRIPTION
… covered

User-approved final upgrades:
- Header spec: every doc carries '<!-- doc: TYPE | ... -->' on line 2. LIVING headers (+ last-verified date) written by the /sync auto-fixer; PLAN/LOG/REFERENCE headers applied by /doc-audit Phase B after the user approves the classification. AHEAD docs get no header unless the user approves that specific doc (untouchable rule holds).
- Tripwire now verifies LIVING docs carry the right type tag + fresh date.
- Dead-link sweep: every relative .md link in root/docs/backend/frontend must point at an existing file — broken link = drift. Negative-tested (synthetic ghost link detected, exit 1); real repo currently clean.

Live run on the recovered tree: 20 findings (3 numbers, 6 stale phrases, 6 missing stamps, 6 missing type headers wait 5 - counts per report), 0 dead links.