### PR TITLE
fix(loop3): fixer was silently denied its tools — unquote allowedTools + fail loud

### DIFF
--- a/.github/workflows/doc-sync.yml
+++ b/.github/workflows/doc-sync.yml
@@ -151,7 +151,10 @@ jobs:
               before/after drift report. Do NOT merge it.
             - Re-run scripts/doc_sync_check.py at the end; include its output
               in the PR body as proof (should report freshness-only or clean).
-          claude_args: "--allowedTools 'Bash,Edit,Write,Read,Glob,Grep'"
+          # No inner quotes — the action passes this string verbatim; quoted
+          # tool names never match and every call gets DENIED (learned from
+          # run 29584302854: 3 denials, $1.94 spent, nothing shipped, job green).
+          claude_args: --allowedTools Bash,Edit,Write,Read,Glob,Grep
 
       - name: Enable auto-merge only if the PR is 100% markdown
         if: steps.token.outputs.have == 'true'
@@ -159,7 +162,9 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           pr=$(gh pr list --head "docs/sync-auto-${{ github.run_id }}" --json number -q '.[0].number')
-          [ -n "$pr" ] && [ "$pr" != "null" ] || { echo "no PR created — nothing to merge"; exit 0; }
+          # The fixer ran because drift EXISTS — no PR means it silently failed
+          # (e.g. tool permissions). Fail LOUD so a broken fixer is never green.
+          [ -n "$pr" ] && [ "$pr" != "null" ] || { echo "::error::auto-fixer produced no PR despite drift — check the Claude step log"; exit 1; }
           nonmd=$(gh pr view "$pr" --json files -q '.files[].path' | grep -vc '\.md$' || true)
           if [ "$nonmd" -eq 0 ]; then
             gh pr merge "$pr" --auto --squash \


### PR DESCRIPTION
First live run of the auto-fixer (run 29584302854) revealed two bugs:

1. **Quoted `--allowedTools 'Bash,...'` passed the quotes literally** → no tool matched → 3 permission denials → Claude couldn't push or open the PR → $1.94 spent, nothing shipped.
2. **The job still went green** — the no-PR path exited 0. Exactly the silent-green failure mode the design review warned about, now in the harness itself.

Both fixed: unquoted tool list; missing-PR-despite-drift now fails the job with `::error`.

After merge: re-run the `doc-sync` workflow and the fixer should ship its first real docs PR (issue #51 is still open, drift is still there — perfect test case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)