### PR TITLE
docs: auto-sync (Loop 3)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,4 +1,5 @@
 # Job360 Architecture
+<!-- doc: LIVING | last-verified: 2026-07-17 by /sync -->
 
 > **Current state lives in `docs/pillars/`** — three code-verified pillar docs (User, Search & Match Engine, Job Providers) plus a glossary and runbook are the *authoritative* architecture reference today. This file is preserved for historical continuity and gives a higher-level system overview; for any specific claim about the codebase, cross-check `docs/pillars/` first.
 
@@ -39,7 +40,7 @@ job360/
 │   ├── main.py                       # FastAPI uvicorn entry (thin; imports src/api/main.py)
 │   ├── pyproject.toml                # Deps + dev + indeed extras, ruff/mypy/pytest config
 │   ├── data/                         # Runtime (gitignored): jobs.db, user_profile.json, chroma/, exports/, reports/, logs/
-│   ├── migrations/                   # 22 forward/reverse SQL migrations (0000 → 0021) + runner.py
+│   ├── migrations/                   # 25 forward/reverse SQL migrations (0000 → 0024) + runner.py
 │   ├── src/
 │   │   ├── main.py                   # Orchestrator: run_search(), SOURCE_REGISTRY (47 keys → 46 instances), _build_sources()
 │   │   ├── cli.py                    # Click CLI: run, api, status, sources, view, setup-profile
@@ -77,7 +78,7 @@ job360/
 │   │   │   ├── notifications/        # email / slack / discord / report_generator (legacy CLI summaries)
 │   │   │   └── profile/              # cv_parser, llm_provider, linkedin_parser, github_enricher, models, preferences, storage, keyword_generator
 │   │   ├── repositories/             # (post-Phase-4 rename from storage/)
-│   │   │   ├── database.py           # Async SQLite + 22-migration forward-compat schema
+│   │   │   ├── database.py           # Postgres via psycopg3 (`pg.py` aiosqlite-shaped shim) + 25-migration forward-compat schema
 │   │   │   └── csv_export.py
 │   │   ├── sources/                  # (post-Phase-2 split into 6 category subfolders)
 │   │   │   ├── base.py               # BaseJobSource ABC: retry, rate limit, conditional fetch, _is_uk_or_remote
@@ -706,7 +707,8 @@ Each source has configured `concurrent` (max parallel requests) and `delay` (sec
 | Package | Purpose |
 |---------|---------|
 | aiohttp >=3.9.0 | Async HTTP client for source fetching |
-| aiosqlite >=0.19.0 | Async SQLite for job storage |
+| psycopg[binary] >=3.2 | Postgres driver — actual job storage backend since 2026-07-02 |
+| aiosqlite >=0.19.0 | Legacy driver-shaped API only; `pg.py` shims it over Postgres (real storage is not SQLite) |
 | python-dotenv >=1.0.0 | .env file loading |
 | jinja2 >=3.1.0 | HTML report templates |
 | click >=8.1.0 | CLI framework |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,5 @@
 # CLAUDE.md
+<!-- doc: LIVING | last-verified: 2026-07-17 by /sync -->
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
@@ -99,7 +100,8 @@ Job360 is an automated UK job search system supporting **any professional domain
 | Package | Version | Purpose |
 |---------|---------|---------|
 | aiohttp | >=3.9.0 | Async HTTP client for source fetching |
-| aiosqlite | >=0.19.0 | Async SQLite for job storage |
+| psycopg[binary] | >=3.2 | Postgres driver — actual job storage backend since 2026-07-02 |
+| aiosqlite | >=0.19.0 | Legacy driver-shaped API only; `pg.py` shims it over Postgres (real storage is not SQLite) |
 | python-dotenv | >=1.0.0 | .env file loading |
 | jinja2 | >=3.1.0 | HTML report templates |
 | click | >=8.1.0 | CLI framework |

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Job360
+<!-- doc: LIVING | last-verified: 2026-07-17 by /sync -->
 
 Automated UK job search system supporting **any professional domain**. Aggregates jobs from **46 source instances** (47 keys in `SOURCE_REGISTRY`; `indeed`/`glassdoor` share `JobSpySource`), scores them 0–100 against your profile (CV, LinkedIn, GitHub, and manual preferences), deduplicates via a four-layer cascade, and delivers results via CLI, email/Slack/Discord/Telegram/webhook (per-user via Apprise), CSV, Rich terminal table, and a Next.js dashboard backed by FastAPI.
 
@@ -345,7 +346,7 @@ job360/
 │   ├── main.py                  # FastAPI uvicorn entry (thin)
 │   ├── pyproject.toml           # Deps + [dev] extras; ruff/mypy/pytest config
 │   ├── data/                    # Runtime (gitignored): jobs.db, user_profile.json, chroma/, exports/, reports/, logs/
-│   ├── migrations/              # 22 forward+reverse SQL migration pairs (0000 → 0021) + runner.py
+│   ├── migrations/              # 25 forward+reverse SQL migration pairs (0000 → 0024) + runner.py
 │   └── src/
 │       ├── main.py              # Orchestrator: run_search(), SOURCE_REGISTRY (47), _build_sources()
 │       ├── cli.py               # Click CLI: run, api, status, sources, view, setup-profile

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,4 +1,5 @@
 # Job360 Project Status
+<!-- doc: LIVING | last-verified: 2026-07-17 by /sync -->
 
 ## Current State: Post-Step-3 matcher batch merged; Step 4 (ops hardening) is next; autonomous maintenance loop running
 
@@ -29,7 +30,7 @@
 **Last updated:** 2026-06-20
 **Total tests:** defer to the runtime collected count (~1,409 collected offline, 2 live deselected; 0 failing, 3 skipped on Windows)
 **Source files:** 46 source files in `backend/src/sources/` (excluding `__init__.py` and `base.py`) split into 6 category subfolders | **Test files:** 60+ test modules
-**Job sources:** 47 entries in `SOURCE_REGISTRY` (46 live instances — `indeed` + `glassdoor` share `JobSpySource`); gov_apprenticeships restored 2026-06-16 on DfE Display Advert API v2 (M6 2026-06 had dropped jobtensor, comeet, gov_apprenticeships, aijobs_global — only jobtensor, comeet, aijobs_global remain removed). See CLAUDE.md rule #13 for the five load-bearing surfaces that move together on a registry change.
+**Job sources:** 47 entries in `SOURCE_REGISTRY`; 46 live instances since `indeed` + `glassdoor` share `JobSpySource`; gov_apprenticeships restored 2026-06-16 on DfE Display Advert API v2 (M6 2026-06 had dropped jobtensor, comeet, gov_apprenticeships, aijobs_global — only jobtensor, comeet, aijobs_global remain removed). See CLAUDE.md rule #13 for the five load-bearing surfaces that move together on a registry change.
 **Latest merged head:** `225040e` on `origin/main` — docs audit + cleanup (2026-06-21); all worktree/feature branches merged and deleted.
 **Sentinel:** `.claude/step-3-verified.txt` → `337fbda19b5ae30d55dba061bc6658a49bcd208d` (post-reviewer-fix SHA).
 

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -1,4 +1,5 @@
 # backend/ — Claude Code pointer
+<!-- doc: LIVING | last-verified: 2026-07-17 by /sync -->
 
 > **This is a thin pointer, not the source of truth.** The load-bearing guidance
 > (the 26 hard rules, `SOURCE_REGISTRY`/five-surfaces, lazy-import rules, scoring
@@ -14,7 +15,7 @@ means in one short line). No walls of text — say what happened, what I did, wh
 
 ## What this is
 
-The Job360 backend: Python 3.9+, FastAPI, async SQLite (aiosqlite), ARQ worker.
+The Job360 backend: Python 3.9+, FastAPI, Postgres via psycopg3 (`pg.py` — an aiosqlite-shaped shim), ARQ worker.
 Entry points: `main.py` (uvicorn) and `python -m src.cli`. Runtime data (gitignored)
 lives in `data/` (`jobs.db`, `user_profile.json`, `exports/`, `reports/`, `logs/`, `chroma/`).
 
@@ -52,7 +53,7 @@ fully offline (~8 s, 14 tests). Do NOT add `--ignore=tests/test_main.py` back.
 
 - `src/main.py` — orchestrator + `SOURCE_REGISTRY` (47) + `_build_sources()`
 - `src/cli.py` — Click CLI · `src/api/` — FastAPI app + routes · `src/services/` — engine
-- `src/repositories/database.py` — async SQLite · `migrations/` — forward/reverse SQL pairs
+- `src/repositories/database.py` — Postgres via psycopg3 (aiosqlite-shaped shim) · `migrations/` — forward/reverse SQL pairs
 - `scripts/` — backend Python helpers (run `python scripts/X.py`); see root `CONTRIBUTING.md`
 
 See root [`../ARCHITECTURE.md`](../ARCHITECTURE.md) for the deep technical reference.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,4 +1,5 @@
 # Job360 Frontend
+<!-- doc: LIVING | last-verified: 2026-07-17 by /sync -->
 
 Next.js 16 + React 19 dashboard for Job360. Talks to the FastAPI backend for
 job listings, profile, pipeline, and search.


### PR DESCRIPTION
Docs drift fixed by the CI auto-fixer (run 29589428999): 6 files, numbers corrected, stale phrases removed, living docs stamped. Shipped manually this once because the repo blocked Actions from creating PRs (setting now flipped — future runs ship themselves).

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)