### PR TITLE
chore(security): add CodeQL scanning + SECURITY.md

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,47 @@
+name: CodeQL
+
+# CodeQL — GitHub's static security scanner. Reads YOUR source (not just deps)
+# for real vulnerability patterns: injection, auth bypass, unsafe deserialization,
+# path traversal, etc. Complements the CI's bandit (python-only, lighter) and
+# gitleaks (secrets-only) with cross-language dataflow analysis.
+#
+# Runs on push to main, on every PR, and weekly (catches new query-pack rules
+# even when code is quiet). Findings appear under Security → Code scanning alerts.
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  schedule:
+    - cron: "0 5 * * 1" # 05:00 UTC Monday
+
+permissions:
+  contents: read
+  security-events: write # required so CodeQL can upload alerts
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # python = backend, javascript-typescript = frontend
+        language: ["python", "javascript-typescript"]
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          language: ${{ matrix.language }}
+          queries: security-and-quality # broader than the default security pack
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,40 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+**Please do not open a public issue for security problems.**
+
+Report privately through GitHub's **[Private vulnerability reporting](https://github.com/Ranjith36963/job360/security/advisories/new)**
+(Security tab → "Report a vulnerability"). This keeps the details hidden until a
+fix is out.
+
+We aim to acknowledge a report within **3 business days** and to ship a fix or a
+mitigation plan within **30 days**, depending on severity.
+
+Please include, where possible:
+
+- what the vulnerability is and the impact,
+- steps to reproduce (a minimal proof-of-concept helps),
+- affected area (backend API, frontend, auth, notifications, …) and any
+  relevant version / commit.
+
+## Supported versions
+
+Job360 is a continuously deployed service — the **live `main` branch** is the
+only supported version. Fixes land on `main` and deploy to production; there are
+no back-ported release branches.
+
+## What we already run
+
+- **Dependabot alerts + automated security fixes** — CVEs in dependencies are
+  flagged and patched out-of-band.
+- **CodeQL** — static analysis of backend + frontend source on every push/PR.
+- **Secret scanning** — blocks committed credentials.
+- **CI security gates** — `bandit` (Python), `gitleaks` (secrets),
+  `pip-audit` + `npm audit` (dependency CVEs) on every pull request.
+
+## Scope
+
+In scope: the Job360 application code in this repository (backend API, frontend,
+auth, data handling). Out of scope: third-party platforms we build on (GitHub,
+Railway, Resend, etc.) — report those to the respective vendor.


### PR DESCRIPTION
Closes the last 2 gaps on the repo Security overview.

## CodeQL (`.github/workflows/codeql.yml`)
Static security analysis of **your** source — backend (python) + frontend (javascript-typescript), `security-and-quality` query pack. Runs on push to main, every PR, and weekly. Deeper than the existing `bandit`+`gitleaks` CI gates (cross-language dataflow: injection, auth bypass, unsafe deserialization…). Findings appear under **Security → Code scanning alerts**.

## SECURITY.md
Private-disclosure policy → points reporters at GitHub private vulnerability reporting (enabled today), with response SLAs and a supported-version note.

## Also enabled today (repo settings, via API)
- ✅ Dependabot **alerts** (was OFF — the actual CVE guard)
- ✅ Automated security fixes (auto-PR on CVE, out-of-band)
- ✅ Private vulnerability reporting

After this merges, the Security overview is fully green except optional items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)