### PR TITLE
fix(security): close CodeQL findings + drop duplicate quality noise

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,7 +36,12 @@ jobs:
         uses: github/codeql-action/init@v3
         with:
           language: ${{ matrix.language }}
-          queries: security-and-quality # broader than the default security pack
+          # security-extended, NOT security-and-quality: the quality half
+          # duplicates ruff (which already governs style/dead-code and documents
+          # deliberate suppressions like S110 empty-except). Running both meant
+          # 97 "note" alerts re-flagging patterns ruff sanctions — noise that
+          # trains you to ignore the tool. One tool per job.
+          queries: security-extended
 
       - name: Autobuild
         uses: github/codeql-action/autobuild@v3

--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -9,6 +9,10 @@ on:
     - cron: "*/10 * * * *" # every ~10 minutes
   workflow_dispatch: {} # allow manual runs from the Actions tab
 
+# Least-privilege token: this workflow only curls a public URL, it never reads
+# repo contents or writes anything (CodeQL actions/missing-workflow-permissions).
+permissions: {}
+
 jobs:
   ping:
     runs-on: ubuntu-latest

--- a/backend/tests/test_auth_routes.py
+++ b/backend/tests/test_auth_routes.py
@@ -46,7 +46,7 @@ def temp_db(monkeypatch, tmp_path):
             await db.commit()
         await runner.up(db_path)
 
-    asyncio.get_event_loop().run_until_complete(_bootstrap()) if False else asyncio.run(_bootstrap())
+    asyncio.run(_bootstrap())
 
     # Patch every module that has already imported DB_PATH.
     from pathlib import Path


### PR DESCRIPTION
CodeQL's first scan returned **100 alerts — 3 real**.

## Fixed (2)
| Finding | Fix |
|---|---|
| `uptime.yml` missing `permissions:` (medium) | `permissions: {}` — it only curls a public URL, needs zero token privileges |
| `test_auth_routes.py:49` dead code | `X if False else Y` → the first branch could never run; cleaned. 8 tests pass |

## Dismissed (1 — false positive)
`pg.py Row(dict)` *"__eq__ not overridden"* — dict equality is the **intended** aiosqlite.Row parity behaviour. Overriding `__eq__` would break the shim CodeQL is asking to "fix". Dismissed with reason.

## Noise removed (97)
All `note`-level **quality** findings duplicating ruff — 37 were `py/empty-except`, which `pyproject.toml` explicitly sanctions (S110, deliberate graceful degradation). Query pack switched `security-and-quality` → `security-extended`.

**Ruff owns quality, CodeQL owns security.** A scanner reporting 100 things where 2 matter trains you to ignore it — and the day a real critical lands, it drowns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)