### PR TITLE
fix(security): least-privilege permissions on 5 workflows (CodeQL medium ×8)

### DIFF
--- a/.github/workflows/ci-offline.yml
+++ b/.github/workflows/ci-offline.yml
@@ -27,6 +27,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'schedule' && github.run_id || github.ref }}
   cancel-in-progress: true
 
+# Least-privilege token (CodeQL actions/missing-workflow-permissions):
+# these jobs only check out code and run tests/uploads — no repo writes.
+permissions:
+  contents: read
+
 jobs:
   offline-suite:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Least-privilege token (CodeQL actions/missing-workflow-permissions):
+# these jobs only check out code and run tests/uploads — no repo writes.
+permissions:
+  contents: read
+
 jobs:
 
   # ─── Backend ───────────────────────────────────────────────────────────────

--- a/.github/workflows/db-backup.yml
+++ b/.github/workflows/db-backup.yml
@@ -15,6 +15,11 @@ on:
     - cron: "17 2 * * *" # 02:17 UTC nightly
   workflow_dispatch: {} # fire on demand from the Actions tab
 
+# Least-privilege token (CodeQL actions/missing-workflow-permissions):
+# these jobs only check out code and run tests/uploads — no repo writes.
+permissions:
+  contents: read
+
 jobs:
   backup:
     runs-on: ubuntu-latest

--- a/.github/workflows/live-e2e.yml
+++ b/.github/workflows/live-e2e.yml
@@ -12,6 +12,11 @@ on:
     - cron: "0 3 * * *" # 03:00 UTC nightly
   workflow_dispatch: {}
 
+# Least-privilege token (CodeQL actions/missing-workflow-permissions):
+# these jobs only check out code and run tests/uploads — no repo writes.
+permissions:
+  contents: read
+
 jobs:
   live-e2e:
     runs-on: ubuntu-latest

--- a/.github/workflows/synthetic-live.yml
+++ b/.github/workflows/synthetic-live.yml
@@ -13,6 +13,11 @@ on:
     - cron: "0 */6 * * *" # every 6h; tune to taste (authed run makes a real LLM call)
   workflow_dispatch: {}
 
+# Least-privilege token (CodeQL actions/missing-workflow-permissions):
+# these jobs only check out code and run tests/uploads — no repo writes.
+permissions:
+  contents: read
+
 jobs:
   live-smoke:
     runs-on: ubuntu-latest


### PR DESCRIPTION
CodeQL `actions/missing-workflow-permissions` — 5 workflows ran with GitHub's **default token scope** instead of an explicit least-privilege block.

| Workflow | Now |
|---|---|
| ci, ci-offline, db-backup, live-e2e, synthetic-live | `permissions: contents: read` |
| uptime (already fixed in #81) | `permissions: {}` — only curls a public URL |

None of these write to the repo — they check out code, run tests, upload artifacts. `contents: read` is all they need.

**Why it matters:** a compromised third-party action inside a workflow holding a *write*-scoped token can push to your repo. With `contents: read` it can't. This is the single highest-leverage supply-chain hardening in Actions.

All 5 YAMLs validated + asserted to still parse with their `jobs` intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)