### PR TITLE
fix(M10): remove hardcoded prod DB password + kill misleading empty-secret defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,10 @@
 SESSION_SECRET=
 # Fernet key for encrypting channel credentials. Generate: python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
 CHANNEL_ENCRYPTION_KEY=
+# Postgres password used by docker-compose.prod.yml (M10). It has NO default
+# there on purpose — compose REFUSES to start without it rather than fall back
+# to a committed password. Generate: python -c "import secrets; print(secrets.token_urlsafe(32))"
+POSTGRES_PASSWORD=
 
 # === Database (REQUIRED IN PROD) ===
 # PostgreSQL DSN (psycopg3). The backend is Postgres-only — SQLite is gone.

--- a/backend/src/core/settings.py
+++ b/backend/src/core/settings.py
@@ -266,9 +266,21 @@ SOURCE_FETCH_TIMEOUT = int(os.getenv("SOURCE_FETCH_TIMEOUT", "60"))
 # discarding their results, so the "ats" category gets its own ceiling.
 SOURCE_FETCH_TIMEOUT_ATS = int(os.getenv("SOURCE_FETCH_TIMEOUT_ATS", "240"))
 
-# Auth / encryption secrets (required in production only).
-SESSION_SECRET = os.getenv("SESSION_SECRET", "")
-CHANNEL_ENCRYPTION_KEY = os.getenv("CHANNEL_ENCRYPTION_KEY", "")
+# Auth / encryption secrets — deliberately NOT bound as module constants here.
+#
+# M10: this file used to define
+#     SESSION_SECRET = os.getenv("SESSION_SECRET", "")
+#     CHANNEL_ENCRYPTION_KEY = os.getenv("CHANNEL_ENCRYPTION_KEY", "")
+# Both were DEAD (nothing imported them — verified across src/ and tests/) and
+# actively misleading: the `""` default reads as "an empty secret is a valid
+# state". It is not. The real consumers read the env var at CALL time and
+# FAIL CLOSED:
+#   * api/auth_deps.py::_secret()          -> raises if SESSION_SECRET unset
+#   * services/channels/crypto.py::_key()  -> raises if CHANNEL_ENCRYPTION_KEY unset
+# Keeping a defaulted-to-empty binding around invites a future caller to read it
+# and silently sign/encrypt with "". If you need a secret, call the accessor —
+# never re-add a module constant with an empty default.
+# (Their NAMES still appear in _REQUIRED_PROD_VARS below for the prod check.)
 
 # Sentry error tracking (Phase 3). Empty string → Sentry is disabled (no-op
 # at init time). Populate in production via the SENTRY_DSN env var.

--- a/backend/tests/test_m10_secrets.py
+++ b/backend/tests/test_m10_secrets.py
@@ -1,0 +1,80 @@
+"""M10 — secrets must fail CLOSED, never default to an empty value.
+
+Two guarantees pinned here:
+
+1. ``src.core.settings`` must NOT expose ``SESSION_SECRET`` /
+   ``CHANNEL_ENCRYPTION_KEY`` as module constants. They used to be bound as
+   ``os.getenv(NAME, "")`` — dead (nothing imported them) but actively
+   misleading, because an empty-string default reads as "an empty secret is a
+   valid state". A future caller reading that constant would silently sign
+   cookies / encrypt credentials with "".
+
+2. The REAL accessors read the env var at call time and raise when it is
+   missing. That is the actual enforcement point and must stay fail-closed.
+"""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+
+def test_settings_does_not_export_empty_defaulted_secrets():
+    from src.core import settings
+
+    assert not hasattr(settings, "SESSION_SECRET"), (
+        "settings.SESSION_SECRET must not exist — an empty-default constant "
+        "invites silently signing with ''. Use auth_deps._secret() instead."
+    )
+    assert not hasattr(settings, "CHANNEL_ENCRYPTION_KEY"), (
+        "settings.CHANNEL_ENCRYPTION_KEY must not exist — use crypto._key()."
+    )
+
+
+def test_required_prod_vars_still_lists_the_secrets():
+    """Removing the constants must NOT remove them from the prod env check."""
+    from src.core import settings
+
+    assert "SESSION_SECRET" in settings._REQUIRED_PROD_VARS
+    assert "CHANNEL_ENCRYPTION_KEY" in settings._REQUIRED_PROD_VARS
+    assert "DATABASE_URL" in settings._REQUIRED_PROD_VARS
+
+
+def test_session_secret_accessor_fails_closed_when_unset():
+    from src.api.auth_deps import _secret
+
+    with patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("SESSION_SECRET", None)
+        with pytest.raises(RuntimeError, match="SESSION_SECRET"):
+            _secret()
+
+
+def test_channel_encryption_key_accessor_fails_closed_when_unset():
+    """``_fernet()`` is the real enforcement point and is lru_cached, so the
+    cache must be cleared to exercise the env lookup."""
+    from src.services.channels import crypto
+
+    saved = os.environ.get("CHANNEL_ENCRYPTION_KEY")
+    try:
+        os.environ.pop("CHANNEL_ENCRYPTION_KEY", None)
+        crypto._fernet.cache_clear()
+        with pytest.raises(RuntimeError, match="CHANNEL_ENCRYPTION_KEY"):
+            crypto._fernet()
+    finally:
+        # Restore the suite's key and drop the poisoned cache entry.
+        if saved is not None:
+            os.environ["CHANNEL_ENCRYPTION_KEY"] = saved
+        crypto._fernet.cache_clear()
+
+
+def test_prod_validation_raises_when_secrets_missing():
+    """validate_required_env must still hard-fail in production."""
+    from src.core import settings
+
+    with patch.dict(
+        os.environ,
+        {"APP_ENV": "production", "SESSION_SECRET": "", "CHANNEL_ENCRYPTION_KEY": "", "DATABASE_URL": ""},
+        clear=False,
+    ):
+        with pytest.raises(RuntimeError, match="Missing required environment variables"):
+            settings.validate_required_env()

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -6,7 +6,9 @@
 #   docker compose -f docker-compose.prod.yml up -d
 #
 # Required env vars (set in .env or your deploy platform):
-#   SESSION_SECRET, CHANNEL_ENCRYPTION_KEY
+#   POSTGRES_PASSWORD, SESSION_SECRET, CHANNEL_ENCRYPTION_KEY
+# POSTGRES_PASSWORD has NO default on purpose (M10) — compose refuses to start
+# without it rather than fall back to a committed password.
 # Optional LLM keys: GEMINI_API_KEY, GROQ_API_KEY, CEREBRAS_API_KEY, etc.
 # See .env.example for the full list.
 
@@ -19,7 +21,10 @@ services:
     restart: unless-stopped
     environment:
       POSTGRES_USER: job360
-      POSTGRES_PASSWORD: job360dev
+      # M10 — never commit a production password. `:?` makes compose FAIL LOUDLY
+      # if POSTGRES_PASSWORD is unset, rather than silently starting Postgres
+      # with an empty/!default password. Set it in the deploy environment.
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}
       POSTGRES_DB: job360
     volumes:
       - pgdata:/var/lib/postgresql/data
@@ -55,7 +60,7 @@ services:
     ports:
       - "8000:8000"
     environment:
-      DATABASE_URL: postgresql://job360:job360dev@postgres:5432/job360
+      DATABASE_URL: postgresql://job360:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}@postgres:5432/job360
       REDIS_URL: redis://redis:6379
       SESSION_SECRET: ${SESSION_SECRET}
       CHANNEL_ENCRYPTION_KEY: ${CHANNEL_ENCRYPTION_KEY}
@@ -94,7 +99,7 @@ services:
     # ARQ worker — confirmed entry point: arq src.workers.settings.WorkerSettings
     command: ["arq", "src.workers.settings.WorkerSettings"]
     environment:
-      DATABASE_URL: postgresql://job360:job360dev@postgres:5432/job360
+      DATABASE_URL: postgresql://job360:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}@postgres:5432/job360
       REDIS_URL: redis://redis:6379
       SESSION_SECRET: ${SESSION_SECRET}
       CHANNEL_ENCRYPTION_KEY: ${CHANNEL_ENCRYPTION_KEY}


### PR DESCRIPTION
Closes Fable finding **M10** (docs/fable/AUDIT-2026-07-17-VERIFIED.md).

## Part 1 — the real issue: a production password committed to git
`docker-compose.prod.yml` hardcoded `job360dev` in **three** places (the postgres service env + both `DATABASE_URL`s). All three now use `${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}` so compose **refuses to start** rather than fall back to a password visible in `git log`.

**Verified:**
```
$ docker compose -f docker-compose.prod.yml config     # no POSTGRES_PASSWORD
error while interpolating services.backend.environment.DATABASE_URL:
  required variable POSTGRES_PASSWORD is missing a value: POSTGRES_PASSWORD must be set

$ POSTGRES_PASSWORD=… docker compose -f docker-compose.prod.yml config   # ✅ valid
```
Documented in `.env.example` + the compose header.

## Part 2 — correcting the finding
Fable said non-prod "boots with empty signing/encryption keys." **That is not true.** The real consumers read the env var at call time and already **fail closed**:
- `api/auth_deps.py::_secret()` → raises if `SESSION_SECRET` unset
- `services/channels/crypto.py::_fernet()` → raises if `CHANNEL_ENCRYPTION_KEY` unset

Implementing the suggested "ephemeral dev secrets" would have **weakened** that guard.

What *was* wrong: `settings.py` bound two **dead** constants — `SESSION_SECRET = os.getenv(..., "")` and the same for `CHANNEL_ENCRYPTION_KEY` — imported by nothing (verified across `src/` and `tests/`) and actively misleading, because an empty default reads as "an empty secret is a valid state." Removed, with a comment pointing to the real enforcement. Their names remain in `_REQUIRED_PROD_VARS` for the prod check.

## Tests
`backend/tests/test_m10_secrets.py` (5, all passing):
- settings must NOT re-export empty-defaulted secrets (guards re-introduction)
- `_REQUIRED_PROD_VARS` still lists them
- both accessors fail closed when the env var is unset
- prod validation still hard-fails

Gate: PASS (targeted). No API/schema change.