### PR TITLE
fix(security): kill polynomial ReDoS in both email regexes (+ regression guard)

### DIFF
--- a/backend/src/api/routes/channels.py
+++ b/backend/src/api/routes/channels.py
@@ -35,13 +35,20 @@ _VALID_TYPES = {"email", "slack", "discord", "telegram", "webhook"}
 _CONNECT_ONLY_TYPES = {"slack", "discord", "telegram"}
 
 # Simple email regex — intentionally lenient; catches obvious non-emails.
-_EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+# ReDoS-safe (CodeQL py/polynomial-redos): the original
+# ``^[^@\s]+@[^@\s]+\.[^@\s]+$`` let ``.`` match inside BOTH domain classes, so
+# the engine had O(n) ways to split the domain → quadratic backtracking on a
+# non-matching tail (8 000 chars took 3.4 s and pinned an API worker). Excluding
+# ``.`` from the label class makes the split unambiguous → linear.
+_EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s.]+(?:\.[^@\s.]+)+$")
 
 
 class ChannelIn(BaseModel):
     channel_type: str = Field(pattern="^(email|slack|discord|telegram|webhook)$")
     display_name: str = Field(min_length=1, max_length=120)
-    credential: str = Field(min_length=1)  # interpreted per channel_type
+    # max_length caps the regex/parse work per request — defence in depth behind
+    # the ReDoS-safe _EMAIL_RE above. Webhook URLs and bot tokens fit well under 512.
+    credential: str = Field(min_length=1, max_length=512)  # interpreted per channel_type
 
 
 class ChannelOut(BaseModel):

--- a/backend/src/services/profile/linkedin_parser.py
+++ b/backend/src/services/profile/linkedin_parser.py
@@ -272,7 +272,21 @@ def _extract_inline_tech_skills(text: str) -> list[str]:
     return out
 
 
-_EMAIL_RE = re.compile(r"([A-Za-z0-9._%+\-]+)@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}")
+# ReDoS-safe (CodeQL py/polynomial-redos, same class as channels.py). This runs
+# via finditer over UPLOADED CV / LinkedIn text — attacker-supplied file content,
+# a bigger and less trusted surface than the channels.py case.
+#
+# The original ``@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}`` let ``.`` match inside the
+# domain class AND as the literal TLD separator → O(n) split points → quadratic
+# (measured 1.8 s on an 8 k payload). Note a "one dot excluded" rewrite is NOT
+# enough: ``(?:\.[label])*\.[A-Za-z]{2,}`` is still ambiguous because the star
+# group can also consume the final ``.tld`` — that variant still took 1.8 s.
+#
+# The trailing ``\.[A-Za-z]{2,}`` TLD assertion is therefore dropped entirely:
+# each ``.label`` is now consumed exactly once (linear, 0.001 s — 1800× faster),
+# and nothing is lost because the caller below only reads ``m.group(1)`` (the
+# local part) and already filters on ``len(local) >= 5``.
+_EMAIL_RE = re.compile(r"([A-Za-z0-9._%+\-]+)@[A-Za-z0-9\-]+(?:\.[A-Za-z0-9\-]+)+")
 _LINKEDIN_SLUG_RE = re.compile(r"linkedin\.com/in/([A-Za-z0-9\-]+)", re.IGNORECASE)
 
 

--- a/backend/tests/test_redos_regex.py
+++ b/backend/tests/test_redos_regex.py
@@ -1,0 +1,74 @@
+"""ReDoS regression guard for the email regexes (CodeQL py/polynomial-redos).
+
+Before the fix, ``channels._EMAIL_RE`` was ``^[^@\\s]+@[^@\\s]+\\.[^@\\s]+$``:
+``.`` matched inside BOTH domain classes, so a non-matching tail gave the engine
+O(n) ways to split the domain — quadratic backtracking. Measured on this repo:
+2 000 chars = 0.18 s, 4 000 = 0.65 s, 8 000 = 3.38 s (doubling input quadrupled
+time). An authenticated user could pin an API worker with one POST /channels.
+
+``linkedin_parser._EMAIL_RE`` had the same shape and a WORSE input surface — it
+runs via ``finditer`` over uploaded CV / LinkedIn text.
+
+These tests assert (a) the regexes still accept/reject correctly, and (b) a
+pathological payload completes fast. The timing bound is deliberately loose
+(1 s vs the 3.4 s the old regex took at this size) so it flags a genuine
+complexity regression, not CI jitter.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from src.api.routes.channels import _EMAIL_RE as CHANNEL_EMAIL_RE
+from src.services.profile.linkedin_parser import _EMAIL_RE as CV_EMAIL_RE
+
+# Non-matching tail (trailing space) forces full backtracking on the old regex.
+_PATHOLOGICAL = "a@" + "b." * 8000 + " "
+_MAX_SECONDS = 1.0
+
+
+@pytest.mark.real_sleep  # measures wall-clock; conftest mocks asyncio.sleep, not time
+def test_channel_email_regex_is_not_quadratic():
+    start = time.perf_counter()
+    CHANNEL_EMAIL_RE.match(_PATHOLOGICAL)
+    elapsed = time.perf_counter() - start
+    assert elapsed < _MAX_SECONDS, (
+        f"channels._EMAIL_RE took {elapsed:.2f}s on an 8k payload — "
+        "ReDoS regression (the vulnerable version took ~3.4s)"
+    )
+
+
+@pytest.mark.real_sleep
+def test_cv_email_regex_is_not_quadratic():
+    start = time.perf_counter()
+    list(CV_EMAIL_RE.finditer(_PATHOLOGICAL))
+    elapsed = time.perf_counter() - start
+    assert elapsed < _MAX_SECONDS, (
+        f"linkedin_parser._EMAIL_RE took {elapsed:.2f}s on an 8k payload — "
+        "ReDoS regression (uploaded-CV input surface)"
+    )
+
+
+@pytest.mark.parametrize(
+    "email",
+    ["a@b.co", "user@example.com", "first.last@sub.example.co.uk", "x+tag@mail-host.io"],
+)
+def test_channel_regex_still_accepts_valid_emails(email):
+    assert CHANNEL_EMAIL_RE.match(email), f"{email} should be accepted"
+
+
+@pytest.mark.parametrize(
+    "bad",
+    ["no-at-sign", "a@b", "a@@b.co", "a b@c.co", "@b.co", "a@.co"],
+)
+def test_channel_regex_still_rejects_invalid(bad):
+    assert not CHANNEL_EMAIL_RE.match(bad), f"{bad} should be rejected"
+
+
+def test_cv_regex_still_extracts_emails_from_prose():
+    text = "Contact me at first.last@sub.example.co.uk or backup@mail-host.io please."
+    found = [m.group(0) for m in CV_EMAIL_RE.finditer(text)]
+    assert "first.last@sub.example.co.uk" in found
+    assert "backup@mail-host.io" in found


### PR DESCRIPTION
## The real one
CodeQL `py/polynomial-redos` on `channels.py` — **confirmed real and measured**:

| payload | time |
|---|---|
| 2 000 chars | 0.18 s |
| 4 000 chars | 0.65 s |
| 8 000 chars | **3.38 s** |

Doubling the input quadruples the time. Any authenticated user could `POST /channels` with one oversized `credential` and pin an API worker — cheap CPU-exhaustion DoS. The field had **no `max_length`**.

**Cause:** `^[^@\s]+@[^@\s]+\.[^@\s]+$` lets `.` match inside *both* domain classes → O(n) ways to split the domain, all tried on a non-matching tail.

**Fix:** de-ambiguated regex + `max_length=512` on the field.

## The one CodeQL missed
`linkedin_parser.py` had the **same shape** — but running via `finditer` over **uploaded CV text** (attacker-supplied file, bigger and less trusted than the API route).

⚠️ Worth knowing: the obvious *"exclude one dot"* rewrite is **still quadratic** (measured 1.8 s) because the star group can also consume the final `.tld`. Dropping the trailing TLD assertion makes each label consume exactly once → **0.001 s (1800×)**. Nothing lost — the caller only reads `group(1)` (local part) and already filters `len >= 5`.

## Regression guard
`tests/test_redos_regex.py` — **timing-based**, so it fails if anyone reintroduces super-linear behaviour. It already earned its keep: it caught my incomplete first attempt at the linkedin_parser fix.

## Verified
13 ReDoS tests + **108 consumer tests** (channels_routes, linkedin_expanded, linkedin_github) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)