### PR TITLE
fix(security): central CRLF scrubber kills 30 log-injection findings

### DIFF
--- a/backend/src/utils/logger.py
+++ b/backend/src/utils/logger.py
@@ -48,6 +48,46 @@ def get_request_id() -> str | None:
 from src.core.settings import LOGS_DIR  # noqa: E402  — after the ContextVar so importers see helpers
 
 
+def _scrub(value: object) -> object:
+    """Escape CR/LF (and other control chars) in a value destined for a log line.
+
+    Non-strings pass through untouched so ``%d``/``%s`` formatting still works.
+    """
+    if not isinstance(value, str):
+        return value
+    if "\r" not in value and "\n" not in value:
+        return value
+    return value.replace("\r", "\\r").replace("\n", "\\n")
+
+
+class CRLFScrubFilter(logging.Filter):
+    """Neutralise log-injection (CodeQL py/log-injection) for EVERY call site.
+
+    User-controlled values — emails, usernames, GitHub handles, channel
+    credentials — reach ``logger.info("... %s", value)`` in ~30 places. A value
+    containing a newline lets an attacker forge whole log lines ("…login
+    status=success…"), poisoning the audit trail an operator reads during an
+    incident.
+
+    Fixing 30 call sites individually is unmaintainable and the 31st would slip
+    through, so the escaping happens once here: attached to the ``job360``
+    logger, this filter escapes CR/LF in the message and in every ``%``-style
+    argument before any handler formats the record. The JSON handler was already
+    safe (json.dumps escapes newlines); this closes the plain-text console/file
+    handlers, which are what operators actually read.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:  # noqa: D401 — short
+        if isinstance(record.msg, str):
+            record.msg = _scrub(record.msg)
+        if record.args:
+            if isinstance(record.args, dict):
+                record.args = {k: _scrub(v) for k, v in record.args.items()}
+            else:
+                record.args = tuple(_scrub(a) for a in record.args)
+        return True  # never drop a record — this filter only sanitises
+
+
 class _RunUuidFormatter(logging.Formatter):
     """Formatter that appends ``[run_uuid:...]`` when the contextvar is set."""
 
@@ -117,6 +157,13 @@ def setup_logging(log_level: str | None = None) -> logging.Logger:
     )
     json_handler.setFormatter(JSONFormatter())
     logger.addHandler(json_handler)
+    # Log-injection guard. MUST be attached to the HANDLERS, not to the logger:
+    # a logger-level filter only sees records logged directly on that logger,
+    # while every finding lives on CHILD loggers (job360.api.auth, …) whose
+    # records merely propagate to these handlers. Handler filters see them all.
+    _scrubber = CRLFScrubFilter()
+    for _h in (console, file_handler, json_handler):
+        _h.addFilter(_scrubber)
     return logger
 
 
@@ -145,6 +192,11 @@ def setup_audit_logger() -> logging.Logger:
         LOGS_DIR / "audit.log", maxBytes=5_000_000, backupCount=5
     )
     handler.setFormatter(JSONFormatter())
+    # The audit trail is the MOST injection-sensitive stream — it records login
+    # attempts with attacker-supplied emails, and it is what an operator reads
+    # during an incident. propagate=False means it never reaches the main
+    # handlers' scrubber, so it needs its own.
+    handler.addFilter(CRLFScrubFilter())
     audit.addHandler(handler)
     # docs/fable/05 C8 — tee the same records into the audit_log DB table so
     # audit history survives file rotation and is queryable with SQL. Lazy

--- a/backend/tests/test_log_injection.py
+++ b/backend/tests/test_log_injection.py
@@ -1,0 +1,98 @@
+"""Log-injection guard tests (CodeQL py/log-injection, ~30 call sites).
+
+User-controlled values — emails, usernames, GitHub handles — are logged all over
+the API (``logger.info("... %s", email)``). A value containing a newline lets an
+attacker forge entire log lines, e.g. an email of::
+
+    victim@x.com\\n2026-01-01 [INFO] job360.api.auth: login status=success
+
+poisons the audit trail an operator reads during an incident.
+
+``CRLFScrubFilter`` escapes CR/LF once, on the HANDLERS, so every call site is
+covered — including the ~30 that live on CHILD loggers. That distinction is the
+whole point of these tests: a filter attached to the *logger* would silently
+miss propagated records, which is exactly where the findings are.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from src.utils.logger import CRLFScrubFilter, _scrub
+
+_PAYLOAD = "victim@x.com\n2026-01-01 [INFO] job360.api.auth: login status=success"
+
+
+def test_scrub_escapes_crlf():
+    assert _scrub("a\nb") == "a\\nb"
+    assert _scrub("a\r\nb") == "a\\r\\nb"
+
+
+def test_scrub_passes_clean_and_nonstring_through():
+    assert _scrub("plain@example.com") == "plain@example.com"
+    assert _scrub(42) == 42  # %d formatting must still work
+    assert _scrub(None) is None
+
+
+def test_filter_scrubs_positional_args():
+    record = logging.LogRecord(
+        name="job360.api.auth", level=logging.INFO, pathname=__file__, lineno=1,
+        msg="login attempt email=%s", args=(_PAYLOAD,), exc_info=None,
+    )
+    CRLFScrubFilter().filter(record)
+    out = record.getMessage()
+    assert "\n" not in out, "newline survived — log forging still possible"
+    assert "\\n" in out
+
+
+def test_filter_scrubs_dict_args_and_msg():
+    # NB: dict args must be passed inside a 1-tuple — LogRecord unwraps
+    # ``args[0]`` when it is a Mapping (passing the dict bare raises KeyError: 0).
+    record = logging.LogRecord(
+        name="job360.api.auth", level=logging.INFO, pathname=__file__, lineno=1,
+        msg="user=%(u)s", args=({"u": _PAYLOAD},), exc_info=None,
+    )
+    assert isinstance(record.args, dict)  # confirm the unwrap happened
+    CRLFScrubFilter().filter(record)
+    assert "\n" not in record.getMessage()
+
+    record2 = logging.LogRecord(
+        name="job360", level=logging.INFO, pathname=__file__, lineno=1,
+        msg=_PAYLOAD, args=None, exc_info=None,
+    )
+    CRLFScrubFilter().filter(record2)
+    assert "\n" not in record2.getMessage()
+
+
+def test_filter_never_drops_records():
+    record = logging.LogRecord(
+        name="job360", level=logging.INFO, pathname=__file__, lineno=1,
+        msg="clean", args=None, exc_info=None,
+    )
+    assert CRLFScrubFilter().filter(record) is True
+
+
+def test_child_logger_output_is_scrubbed_end_to_end(tmp_path):
+    """The case that matters: a CHILD logger propagating to a scrubbed handler.
+
+    A filter on the *logger* would NOT cover this — only a handler filter does.
+    """
+    parent = logging.getLogger("job360_testparent")
+    parent.setLevel(logging.INFO)
+    parent.handlers.clear()
+    log_file = tmp_path / "out.log"
+    handler = logging.FileHandler(log_file, encoding="utf-8")
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    handler.addFilter(CRLFScrubFilter())  # same wiring as setup_logging()
+    parent.addHandler(handler)
+
+    logging.getLogger("job360_testparent.api.auth").info("email=%s", _PAYLOAD)
+    handler.close()
+
+    written = log_file.read_text(encoding="utf-8")
+    assert written.count("\n") == 1, (
+        f"expected exactly one line, got {written.count(chr(10))} — "
+        "forged log lines got through"
+    )
+    assert "\\n" in written
+    assert "status=success" in written  # payload preserved, just neutralised


### PR DESCRIPTION
## The vulnerability
CodeQL `py/log-injection` ×30. User data (emails, usernames, GitHub handles, channel credentials) is logged across auth routes, `email_sender`, `github_enricher`, `channels`, `tailor`, `pipeline`, `actions`. An attacker registers with an email containing a newline:

```
victim@x.com
2026-01-01 [INFO] job360.api.auth: login status=success
```

…and your log now contains a **forged line**. That poisons the exact evidence an operator reads during an incident.

## The fix — one filter, not 30 edits
`CRLFScrubFilter` escapes CR/LF in `record.msg` and every `%`-style arg. Call-site fixes decay the moment someone adds call site #31; a filter covers code that doesn't exist yet.

## ⚠️ Placement is the whole trick
The filter goes on the **handlers**, not the logger.

In Python, **handlers are inherited through propagation — filters are not**. A logger-level filter only sees records logged *directly* on it, but every one of the 30 findings lives on a **child** logger (`job360.api.auth`, …) whose records merely propagate. A logger-level filter would have passed unit tests and done **nothing in production**.

The audit logger is wired separately (`propagate=False` keeps it away from the main handlers) — and it's the most injection-sensitive stream, since it records login attempts with attacker-supplied emails.

## Verified
6 new tests — including an **end-to-end child-logger case** asserting exactly one line lands in the file — plus 10 existing logging/audit tests. All pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)