### PR TITLE
fix(security): pin third-party actions to SHAs (CodeQL actions/unpinned-tag)

### DIFF
--- a/.github/workflows/doc-sync.yml
+++ b/.github/workflows/doc-sync.yml
@@ -135,7 +135,7 @@ jobs:
 
       - name: Claude edits the docs (edit-only — no git, no gh)
         if: steps.token.outputs.have == 'true'
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@3553f84341b92da26052e28acf1aa898f9511f32 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -81,7 +81,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Run gitleaks
-        uses: gitleaks/gitleaks-action@v3
+        uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
`gitleaks/gitleaks-action@v3` and `anthropics/claude-code-action@v1` were referenced by **moving tag**. Tags are mutable — whoever controls the action repo (or an attacker who compromises it) can repoint `v1`/`v3` at malicious code, and it executes in your CI on the next run with that workflow's token scope.

**Highest impact here:** `claude-code-action` runs in doc-sync's auto-fix job with `contents: write` + `pull-requests: write`. A moved tag there could push to your repo.

Now pinned to immutable commit SHAs, version kept as a trailing comment for readability (Dependabot still updates SHA pins):

| Action | Pin |
|---|---|
| gitleaks-action | `e0c47f4...` `# v3` |
| claude-code-action | `3553f84...` `# v1` |

Both YAMLs validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)