### PR TITLE
fix(H7): make 3 of 4 security scanners blocking + unbreak the commit gate

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -3,10 +3,27 @@ name: Security scanning
 # H7 — continuous security scanning: dependency CVEs (backend + frontend),
 # leaked secrets, and Python static analysis. Runs on every push/PR and weekly.
 #
-# The dependency-audit jobs are non-blocking for now (continue-on-error /
-# `|| true`) so they SURFACE issues without blocking existing PRs; tighten to
-# blocking once the current backlog is triaged. gitleaks + bandit are advisory
-# too until the codebase is clean.
+# H7 follow-up (2026-07-18): THREE OF FOUR JOBS ARE NOW BLOCKING. They were all
+# advisory "until the codebase is clean"; nobody came back to check whether that
+# day had arrived. It had — verified against a clean CI runner (run 29648821735,
+# PR #88), which is the only trustworthy source here (a local pip-audit reads
+# whatever else shares your interpreter):
+#   npm audit  — "found 0 vulnerabilities"   -> BLOCKING
+#   gitleaks   — "no leaks found"            -> BLOCKING
+#   bandit     — "No issues identified" (22,619 lines) -> BLOCKING
+#   pip-audit  — 11 CVEs, ALL in aiohttp 3.13.5 -> still advisory, see below
+#
+# pip-audit is the one real gap, and it is a single stale pin: aiohttp is held at
+# <3.14 because 3.14 broke aioresponses 0.7.8 (our offline HTTP mock, rule #4).
+# aioresponses 0.7.9 supports aiohttp 3.14, so the bump closes all 11 CVEs. That
+# is deliberately a SEPARATE change — a dependency bump must be verified by the
+# full suite against the NEW version, which only CI can do (it installs clean;
+# a local run tests whatever is already installed, i.e. the old version).
+# Flip pip-audit to blocking in the same PR as that bump.
+#
+# Do NOT reintroduce `continue-on-error` or `|| true` to turn a red build green.
+# A scanner that cannot fail the build is a scanner nobody reads: all four
+# reported "pass" for months while pip-audit sat on 11 known CVEs.
 
 # Unfiltered `push` + `pull_request` double-fires: a push to a branch with an open
 # PR runs the same commit twice. Filtering push to main gives branches exactly one
@@ -34,6 +51,8 @@ jobs:
     name: pip-audit (backend deps)
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    # ADVISORY — the ONLY non-blocking scanner left, and only because of the
+    # aiohttp<3.14 pin (11 CVEs). Flip to blocking together with that bump.
     continue-on-error: true
     steps:
       - uses: actions/checkout@v7
@@ -48,11 +67,8 @@ jobs:
           python -m pip install pip-audit
       - name: Audit installed dependencies
         working-directory: backend
-        # Advisory (reports but does not block) until the backlog is triaged.
-        # The only outstanding finding is aiohttp <3.14 (11 CVEs, fixed in 3.14.1),
-        # but aiohttp is deliberately pinned <3.14 because 3.14 breaks aioresponses
-        # 0.7.8 — our offline test HTTP mock (see backend/pyproject.toml). Lift the
-        # `|| true` and bump aiohttp the moment aioresponses supports 3.14.
+        # Advisory until the aiohttp bump lands (see header). `|| true` keeps the
+        # step green; the findings are still printed in the log every run.
         run: python -m pip_audit --progress-spinner off || true
 
   npm-audit:
@@ -69,13 +85,12 @@ jobs:
         run: npm ci
       - name: Audit frontend dependencies (high+)
         working-directory: frontend
-        run: npm audit --audit-level=high || true
+        run: npm audit --audit-level=high
 
   gitleaks:
     name: gitleaks (secret scan)
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v7
         with:
@@ -89,7 +104,6 @@ jobs:
     name: bandit (python static analysis)
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v6

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -137,8 +137,17 @@ if [ "$BACKEND_CHANGED" -gt 0 ]; then
         *) [ -f "backend/tests/test_${base}.py" ] && TARGETS="$TARGETS tests/test_${base}.py" ;;
       esac
     done
-    TARGETS="$(echo "$TARGETS" | tr ' ' '\n' | grep -v '^$' | sort -u | tr '\n' ' ')"
-    LINT_FILES="$(echo "$CHANGED" | grep '^backend/.*\.py$' | sed 's|^backend/||' | while read -r p; do [ -f "backend/$p" ] && echo "$p"; done | tr '\n' ' ')"
+    # `|| true` is load-bearing: grep exits 1 on no match, and under `set -o
+    # pipefail` that killed the whole gate — silently, exit 1 with NO output —
+    # whenever a backend change mapped to zero test files (e.g. a pyproject.toml
+    # or Dockerfile-only change). The conservative full-suite fallback below was
+    # therefore unreachable in exactly the case it exists for, making any
+    # non-.py backend change impossible to commit. Found via H7 (bumping
+    # aiohttp in backend/pyproject.toml).
+    TARGETS="$(echo "$TARGETS" | tr ' ' '\n' | grep -v '^$' | sort -u | tr '\n' ' ' || true)"
+    # Same `|| true` requirement as TARGETS above — no changed .py files means
+    # grep exits 1, which under `set -o pipefail` killed the gate outright.
+    LINT_FILES="$(echo "$CHANGED" | grep '^backend/.*\.py$' | sed 's|^backend/||' | while read -r p; do [ -f "backend/$p" ] && echo "$p"; done | tr '\n' ' ' || true)"
     if [ -n "${TARGETS// /}" ]; then
       echo "[gate] backend targeted tests: $TARGETS"
       (cd backend && python -m pytest -q -p no:randomly $TARGETS 2>&1 | tee -a "$GATE_LOG")


### PR DESCRIPTION
Two changes, the second found by attempting the first.

## 1. Security scanners (H7)

All four scanners were advisory *"until the codebase is clean"*. Nobody came back to check whether that day had arrived — **it had**.

Verified against **CI's own logs** (run `29648821735`), not a local run. That distinction matters: a local `pip-audit` audits whatever shares your interpreter — mine reported `torch`, `yt-dlp` and `tornado` CVEs from entirely unrelated projects.

| Scanner | Real result in CI | Now |
|---|---|---|
| npm audit | `found 0 vulnerabilities` | **BLOCKING** |
| gitleaks | `no leaks found` | **BLOCKING** |
| bandit | `No issues identified` (22,619 lines) | **BLOCKING** |
| pip-audit | **11 CVEs, all `aiohttp` 3.13.5** | advisory (see below) |

### Why pip-audit stays advisory — deliberately

Its 11 findings are **one stale pin**. `aiohttp` is held at `<3.14` because 3.14 broke `aioresponses` 0.7.8 (the offline HTTP mock, rule #4). `aioresponses` 0.7.9 supports aiohttp 3.14, so the bump closes all 11.

That ships as **its own PR**, because a dependency bump has to be tested against the *new* version — and only CI can do that. A local suite tests whatever is already installed, i.e. the old one. pip-audit flips to blocking in that PR.

`mypy` also stays non-blocking: a documented **395-error backlog** (`docs/mypy_backlog.md`). Draining it is a separate project.

**So H7 is PARTIAL, not closed** — stated plainly rather than marked done.

## 2. The commit gate was silently broken

Found because this change touches `backend/pyproject.toml`, which is not a `.py` file.

`scripts/agent-gate.sh:140` and `:141` build file lists with `grep` in a pipeline. `grep` exits 1 on no match, and under `set -euo pipefail` **that killed the whole gate — exit 1, zero output.**

It fired for any backend change that maps to no test file: `pyproject.toml`, `Dockerfile`, config, dependency bumps.

The script has a fallback for exactly this case — `:152`, *"no changed file maps to a test — running FULL backend suite"*. It was **unreachable**. Those changes were uncommittable and the gate never explained why.

`|| true` on both lines restores the intended behaviour. Verified with `bash -x`: with only `pyproject.toml` staged, the gate now reaches `:152` and starts the full suite instead of dying.

## Verification

Gate: PASS. This PR touches no `backend/`/`frontend/` files, so the gate correctly skips the suite — the change is CI config plus a shell script. The scanners themselves are verified by this PR's own CI run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6DsQH5EUxJc3Vnqz9YHgQ