### PR TITLE
fix: close the 11 aiohttp CVEs for real (bump to 3.14.1 behind a test-only shim)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -11,9 +11,10 @@ name: Security scanning
 #   npm audit  — "found 0 vulnerabilities"
 #   gitleaks   — "no leaks found"
 #   bandit     — "No issues identified" (22,619 lines)
-#   pip-audit  — 11 CVEs, ALL in aiohttp 3.13.5, waived BY ID (see the job).
-#                The 3.14.1 fix is blocked by aioresponses, not by us — the
-#                attempted bump is measured in PR #90, run 29657510744.
+#   pip-audit  — was 11 CVEs, ALL in aiohttp 3.13.5. Now ZERO: aiohttp is
+#                >=3.14.1 and the waiver list is empty. The aioresponses
+#                incompatibility that blocked the upgrade is handled by a
+#                test-only shim in backend/tests/conftest.py.
 #
 # Do NOT reintroduce `continue-on-error` or `|| true` to turn a red build green.
 # A scanner that cannot fail the build is a scanner nobody reads: all four
@@ -60,38 +61,17 @@ jobs:
           python -m pip install pip-audit
       - name: Audit installed dependencies
         working-directory: backend
-        # BLOCKING, with 11 EXPLICIT waivers — not a muted scanner.
+        # BLOCKING with ZERO waivers. A CVE in ANY backend dependency fails the
+        # build — there is nothing on the ignore list to hide behind.
         #
-        # All 11 are aiohttp <3.14, fixed in 3.14.1. We cannot take that fix yet:
-        # aiohttp 3.14 made `stream_writer` a required kwarg of
-        # ClientResponse.__init__ and aioresponses (offline HTTP mock, rule #4)
-        # does not pass it, so the whole suite dies with
-        #   TypeError: ClientResponse.__init__() missing 1 required keyword-only
-        #   argument: 'stream_writer'
-        # aioresponses 0.7.9 (latest) declares aiohttp>=3.8,<4.0 and LOOKS
-        # compatible; it is not — measured in CI, PR #90 run 29657510744.
+        # The 11 aiohttp waivers that used to live here are GONE because the
+        # underlying CVEs are actually fixed: aiohttp is now >=3.14.1. The pin
+        # that blocked that upgrade (aioresponses not passing `stream_writer`)
+        # is handled by a test-only shim in backend/tests/conftest.py.
         #
-        # Waiving these 11 by ID keeps the scanner BLOCKING for everything else:
-        # a new CVE in any other package — or a NEW aiohttp CVE — fails the
-        # build. That is strictly stronger than the `|| true` this replaces,
-        # which hid every finding including these.
-        #
-        # REMOVE these flags when aioresponses supports aiohttp 3.14 (or the mock
-        # is replaced), then bump aiohttp to >=3.14.1. Track: the waiver list
-        # should shrink to zero, never grow.
-        run: |
-          python -m pip_audit --progress-spinner off \
-            --ignore-vuln PYSEC-2026-237 \
-            --ignore-vuln PYSEC-2026-2104 \
-            --ignore-vuln PYSEC-2026-2105 \
-            --ignore-vuln PYSEC-2026-2106 \
-            --ignore-vuln PYSEC-2026-2107 \
-            --ignore-vuln PYSEC-2026-2108 \
-            --ignore-vuln PYSEC-2026-2109 \
-            --ignore-vuln PYSEC-2026-2110 \
-            --ignore-vuln PYSEC-2026-2111 \
-            --ignore-vuln PYSEC-2026-2112 \
-            --ignore-vuln PYSEC-2026-2113
+        # If a new CVE appears: fix it. Waive by ID only as a last resort, with
+        # a comment naming what blocks the fix and what would unblock it.
+        run: python -m pip_audit --progress-spinner off
 
   npm-audit:
     name: npm audit (frontend deps)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -4,18 +4,15 @@ version = "1.0.0"
 description = "Automated UK job search system supporting any professional domain"
 requires-python = ">=3.9"
 dependencies = [
-    # STILL PINNED <3.14, and the reason is now measured rather than assumed.
-    # 3.14.1 would close 11 CVEs (PYSEC-2026-237, -2104..-2113), but aiohttp 3.14
-    # made `stream_writer` a REQUIRED kwarg of ClientResponse.__init__, and
-    # aioresponses (our offline HTTP mock, rule #4) does not pass it:
-    #   TypeError: ClientResponse.__init__() missing 1 required keyword-only
-    #   argument: 'stream_writer'   (aioresponses/core.py:197, build_response)
-    # aioresponses 0.7.9 declares aiohttp>=3.8,<4.0 so it LOOKS compatible — it
-    # is not; CI proved it (PR #90, run 29657510744). 0.7.9 is the latest release.
-    # The 11 CVEs are waived explicitly in .github/workflows/security.yml so
-    # pip-audit still BLOCKS on anything new. Lift this pin when aioresponses
-    # ships aiohttp 3.14 support, or when the mock is replaced.
-    "aiohttp>=3.9.0,<3.14",
+    # UNPINNED FROM <3.14 — this closes 11 CVEs (PYSEC-2026-237, -2104..-2113).
+    # The old pin existed because aiohttp 3.14 made `stream_writer` a REQUIRED
+    # kwarg of ClientResponse.__init__ and aioresponses (our offline HTTP mock,
+    # rule #4) never passes it, killing the whole suite. aioresponses 0.7.9 is
+    # the latest release and still does not pass it, so waiting upstream was not
+    # an option. A TEST-ONLY shim in tests/conftest.py now fills the argument in
+    # when (and only when) the caller omitted it, which is exactly aioresponses'
+    # case; real aiohttp traffic is untouched and nothing ships to production.
+    "aiohttp>=3.14.1",
     "defusedxml>=0.7.1",  # M18: XXE-safe parsing of untrusted RSS/XML job feeds
     "psycopg[binary]>=3.2",  # async Postgres driver (Phase 1 migration)
     "python-dotenv>=1.0.0",

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -22,6 +22,72 @@ import sys
 if sys.platform == "win32":
     asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 
+
+# --- aiohttp 3.14 <-> aioresponses compatibility shim (TEST-ONLY) -----------
+# aiohttp 3.14 made ``stream_writer`` a REQUIRED keyword-only argument of
+# ClientResponse.__init__. aioresponses builds its fake responses by calling
+# that constructor directly (core.py ``_build_response``) and never passes it,
+# so every mocked request died with:
+#
+#   TypeError: ClientResponse.__init__() missing 1 required
+#   keyword-only argument: 'stream_writer'
+#
+# That single incompatibility is why aiohttp was pinned <3.14 — which left 11
+# CVEs (PYSEC-2026-237, -2104..-2113) unfixable in production and waived by ID
+# in .github/workflows/security.yml. aioresponses 0.7.9 is the latest release
+# and still does not pass it, so waiting upstream was not an option.
+#
+# What the shim does: fill in ``stream_writer`` ONLY when the caller omitted it.
+# aioresponses always passes ``writer=None``, and in that branch aiohttp reads
+# exactly one attribute -- ``stream_writer.output_size`` -- and does NOT retain
+# the object (``self._stream_writer`` stays None, so every later guard on it is
+# already False). A stub exposing ``output_size`` is therefore sufficient AND
+# complete; this is not a guess, it was read off aiohttp 3.14.1's source.
+#
+# Safety: ``setdefault`` means any caller that DOES pass a real stream_writer --
+# i.e. all genuine aiohttp traffic -- is completely untouched. This lives in
+# tests/conftest.py, so it never ships to production. Delete the whole block
+# when aioresponses gains aiohttp-3.14 support.
+def _install_aioresponses_aiohttp314_shim() -> None:
+    try:
+        import inspect as _inspect
+
+        from aiohttp import client_reqrep as _client_reqrep
+    except Exception:  # pragma: no cover - aiohttp always present in tests
+        return
+
+    _response_cls = _client_reqrep.ClientResponse
+    _orig_init = _response_cls.__init__
+    try:
+        _params = _inspect.signature(_orig_init).parameters
+    except (TypeError, ValueError):  # pragma: no cover - C-accelerated init
+        return
+
+    # aiohttp < 3.14 has no such parameter -> nothing to do, leave it alone.
+    if "stream_writer" not in _params:
+        return
+    if getattr(_orig_init, "_job360_shimmed", False):  # pragma: no cover
+        return
+
+    class _NoopStreamWriter:
+        """Minimal AbstractStreamWriter stand-in for mocked responses.
+
+        Only ``output_size`` is ever read on the ``writer is None`` path that
+        aioresponses uses; nothing is written through it.
+        """
+
+        output_size = 0
+
+    def _patched_init(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+        kwargs.setdefault("stream_writer", _NoopStreamWriter())
+        return _orig_init(self, *args, **kwargs)
+
+    _patched_init._job360_shimmed = True  # type: ignore[attr-defined]
+    _response_cls.__init__ = _patched_init  # type: ignore[method-assign]
+
+
+_install_aioresponses_aiohttp314_shim()
+
 # --- Postgres test mode ------------------------------------------------------
 # Everything runs on Postgres via ``src.repositories.pg`` / ``pgsync`` — tests
 # import those directly (the old ``sys.modules["aiosqlite"/"sqlite3"]`` disguise


### PR DESCRIPTION
Closes the last real gap in H7. The 11 CVEs (`PYSEC-2026-237`, `-2104`..`-2113`) were **waived by ID** in #90, not fixed — production kept running aiohttp 3.13.5 with all 11 present. This removes them.

## Why the upgrade was blocked

**Nothing in production code was incompatible with aiohttp 3.14.** Only the *test mock* was.

aiohttp 3.14 made `stream_writer` a **required** keyword-only argument of `ClientResponse.__init__`. `aioresponses` constructs that class directly (`core.py _build_response`) and never passes it, so every mocked request died:

```
TypeError: ClientResponse.__init__() missing 1 required
  keyword-only argument: 'stream_writer'
```

`aioresponses` 0.7.9 is the **latest** release and still doesn't pass it, so waiting upstream wasn't a plan.

## The fix — `backend/tests/conftest.py`, test-only, ~40 lines

Fill in `stream_writer` **only when the caller omitted it**. This was read off aiohttp 3.14.1's own source, not guessed: aioresponses always passes `writer=None`, and on that branch aiohttp reads exactly **one** attribute — `stream_writer.output_size` — and does **not** retain the object (`self._stream_writer` stays `None`, so every later guard on it is already `False`). A stub exposing `output_size` is therefore both sufficient and complete.

Safety properties:

| Property | How |
|---|---|
| Real aiohttp traffic untouched | `setdefault` — only fills when absent |
| No-op on aiohttp < 3.14 | version-gated: parameter doesn't exist → returns immediately |
| Never ships to production | lives in `tests/conftest.py` |

## Verified — each claim by the instrument that can actually see it

1. **Failure reproduced** in an isolated venv (aiohttp 3.14.1 + aioresponses 0.7.9) → the exact `TypeError`. Isolated because this machine's interpreter is shared with unrelated projects.
2. **Shim fixes it** — same venv: mocked GET returns correct **json, status and text**.
3. **No-op on 3.13.5** — inspected the live signature: `stream_writer` absent → shim returns early.
4. **Full suite on 3.13.5: 1,936 passed, 3 skipped** (1:37:12). No regression from the shim being present.
5. **CI verifies 3.14 itself** — clean install from `pyproject.toml`, full suite on Linux. That is the check that caught the **first** attempt at this bump (#90, run `29657510744`), when I reasoned from aioresponses' declared version range instead of testing it. I did not repeat that.

## Scanner

All 11 `--ignore-vuln` flags **deleted**. `pip-audit` now runs bare and blocking — **zero waivers**.

```diff
- run: |
-     python -m pip_audit --progress-spinner off \
-       --ignore-vuln PYSEC-2026-237 \
-       ... (11 total)
+ run: python -m pip_audit --progress-spinner off
```

If CI goes red, the shim is wrong and I will fix it — not re-waive the CVEs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6DsQH5EUxJc3Vnqz9YHgQ