### PR TITLE
fix: close 10 audit findings + 4 real bugs found by the type-drain

### DIFF
--- a/.claude/hooks/commit-gate.sh
+++ b/.claude/hooks/commit-gate.sh
@@ -9,6 +9,28 @@ set -uo pipefail
 INPUT="$(cat)"
 CMD="$(echo "$INPUT" | python -c "import sys,json;print(json.load(sys.stdin).get('tool_input',{}).get('command',''))" 2>/dev/null)"
 
+# P4 — do not fail OPEN when the parse fails.
+#
+# Previously an empty CMD (python missing, JSON shape changed, malformed input)
+# fell straight through the `*)` arm below and ALLOWED the commit. The one input
+# the gate could not understand was the one it waved through — and silently,
+# because 2>/dev/null hides the reason.
+#
+# We cannot block on every unparseable Bash call (this hook sees ALL of them, so
+# that would wedge the session). Instead, fall back to scanning the RAW payload:
+# if the words "git commit" appear anywhere in it, treat it as a commit and let
+# the stamp check decide. Worst case we gate a command that merely mentions the
+# phrase — annoying, but it fails toward safety instead of away from it.
+if [ -z "$CMD" ]; then
+  case "$INPUT" in
+    *"git commit"*)
+      echo "[commit-gate] WARNING: could not parse tool_input; recovered 'git commit' from raw payload." >&2
+      CMD="git commit"
+      ;;
+    *) exit 0 ;;
+  esac
+fi
+
 case "$CMD" in
   *"git commit"*) ;;
   *) exit 0 ;;

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -257,7 +257,7 @@ Dropped in Batch 3: `yc_companies`, `nomis`, `findajob`. Dropped 2026-06 (M6 rot
 | `SESSION_SECRET` | Yes in prod | `itsdangerous` HMAC for session cookies |
 | `CHANNEL_ENCRYPTION_KEY` | Yes in prod | Fernet encryption of channel credentials |
 | `APP_ENV` / `RAILWAY_ENVIRONMENT` | No | Prod detection for HSTS + required-env validation (`APP_ENV=production` OR any `RAILWAY_ENVIRONMENT`) |
-| `JOB360_ENV` | No | **Separate** prod gate — session cookie `Secure` flag is on ONLY when `JOB360_ENV=="prod"` (auth.py:109). ⚠️ Does NOT follow `APP_ENV`/`RAILWAY_ENVIRONMENT` — set it explicitly on Railway or cookies ship without `Secure` |
+| ~~`JOB360_ENV`~~ | **DEAD** | No longer read anywhere in `src/` (only a comment at auth.py:120 records that it once was). The session-cookie `Secure` flag now gates on the SAME signal as HSTS/Sentry/CORS — `middleware._is_production()` = `APP_ENV=production` OR `RAILWAY_ENVIRONMENT` set (auth.py:115-121). Railway injects `RAILWAY_ENVIRONMENT` automatically, so prod cookies ARE `Secure`. **This row previously said the opposite and cost a session real time chasing a non-existent hole — do not re-add `JOB360_ENV`.** |
 | `SENTRY_DSN` | No | Sentry error tracking; empty = disabled |
 | `TAILOR_FREE_PER_MONTH` | No (default `10`) | Free-tier cap on AI CV/cover-letter generations per user/month |
 | `LOGIN_MAX_ATTEMPTS` / `LOGIN_LOCKOUT_WINDOW_SECONDS` | No (default `5` / `900`) | Brute-force login lockout (in-memory) |

--- a/backend/Dockerfile.worker
+++ b/backend/Dockerfile.worker
@@ -1,6 +1,11 @@
 # ARQ background worker — same image as the API, different start command.
 # Selected on Railway via the service var RAILWAY_DOCKERFILE_PATH=Dockerfile.worker.
-# No EXPOSE / HEALTHCHECK: the worker does not serve HTTP (it drains the Redis queue).
+#
+# No EXPOSE: the worker serves no HTTP, it drains the Redis queue.
+# It DOES have a HEALTHCHECK (see below). The previous comment here claimed a
+# healthcheck was impossible because there is no HTTP endpoint — that premise was
+# wrong, and it is why this gap stayed open: arq ships `arq --check`, which reads
+# the heartbeat key the worker writes to Redis. No HTTP required.
 FROM python:3.12-slim
 
 WORKDIR /app
@@ -15,6 +20,23 @@ RUN addgroup --system job360 \
  && adduser --system --ingroup job360 --no-create-home job360 \
  && chown -R job360:job360 /app
 USER job360
+
+# M4 — liveness without HTTP. `arq --check` reads the heartbeat key this worker
+# writes to Redis every WorkerSettings.health_check_interval (30s) and exits
+# non-zero if it is missing or stale, so a hung or dead worker is detectable.
+#
+# start-period 45s > the 30s interval, so the first heartbeat exists before the
+# first check runs; interval 60s keeps the check cheap; 3 retries avoids
+# flapping on a single slow Redis round-trip.
+#
+# NOTE for whoever deploys this: Railway does not honour Dockerfile HEALTHCHECK
+# for non-HTTP services — it uses railway.json's restartPolicy instead. So this
+# hardens docker-compose deployments and makes liveness *checkable by hand*
+# (`docker inspect`, or run `arq --check ...` in the container), but it will NOT
+# by itself restart a dead worker on Railway. External uptime monitoring is
+# still the thing that would have caught the P0 in commit 7f906c6.
+HEALTHCHECK --interval=60s --timeout=10s --start-period=45s --retries=3 \
+  CMD ["arq", "--check", "src.workers.settings.WorkerSettings"]
 
 # Drains the ARQ queue + runs the crons (notification_tick, nightly_ghost_sweep).
 CMD ["arq", "src.workers.settings.WorkerSettings"]

--- a/backend/src/api/routes/jobs.py
+++ b/backend/src/api/routes/jobs.py
@@ -583,7 +583,7 @@ def _row_to_scoring_job(row: dict[str, Any]) -> "Job":
         posted_at=row.get("posted_at"),
         date_confidence=row.get("date_confidence") or "low",
     )
-    job.id = row.get("id")  # type: ignore[attr-defined]
+    job.id = row.get("id")
     return job
 
 

--- a/backend/src/api/routes/tailor.py
+++ b/backend/src/api/routes/tailor.py
@@ -225,10 +225,13 @@ async def save_edit(
     if existing is None:
         raise HTTPException(status_code=404, detail="No draft to edit — generate first.")
     row = await db.save_tailored_polished(user.id, job_id, doc_kind, body.text)
-    # LATENT: save_tailored_polished re-reads the row and can return None if it
-    # was deleted between the check above and the UPDATE (would TypeError -> 500).
-    # Left as-is deliberately — fixing it is a behaviour change, not a type fix.
-    return _doc_out(row)  # type: ignore[arg-type]
+    if row is None:
+        # The doc existed at the check above but was deleted before the UPDATE
+        # landed. save_tailored_polished re-reads the row, so it returns None.
+        # Without this guard _doc_out(None) raised TypeError -> HTTP 500, which
+        # tells the user "we broke" for what is really "it's gone".
+        raise HTTPException(status_code=404, detail="Draft no longer exists.")
+    return _doc_out(row)
 
 
 @router.post("/tailor/{job_id}/{doc_kind}/keep", response_model=TailoredDocOut)
@@ -244,12 +247,16 @@ async def keep(
     if existing is None:
         raise HTTPException(status_code=404, detail="Nothing to keep — generate first.")
     row = await db.keep_tailored_doc(user.id, job_id, doc_kind)
-    # Same latent None as save_edit above (row deleted mid-request).
+    if row is None:
+        # Deleted between the existence check and the UPDATE — same race as
+        # save_edit. Guarding here also protects _learn_universal, which would
+        # otherwise be fed None and pollute the learned-patterns store.
+        raise HTTPException(status_code=404, detail="Document no longer exists.")
     await _learn_universal(db, doc_kind, row)
     get_audit_logger().info(
         "tailor_keep", extra={"user_id": user.id, "job_id": job_id, "doc_kind": doc_kind}
     )
-    return _doc_out(row)  # type: ignore[arg-type]
+    return _doc_out(row)
 
 
 @router.post("/tailor/{job_id}/{doc_kind}/download")

--- a/backend/src/core/settings.py
+++ b/backend/src/core/settings.py
@@ -218,6 +218,17 @@ RATE_LIMITS: dict[str, RateLimitConfig] = {
     "pinpoint": {"concurrent": 2, "delay": 1.5},
     "recruitee": {"concurrent": 2, "delay": 1.5},
     "indeed": {"concurrent": 1, "delay": 3.0},
+    # S8 — NEVER READ AT RUNTIME, and kept deliberately. `indeed` and `glassdoor`
+    # are two SOURCE_REGISTRY keys pointing at ONE class (JobSpySource), which
+    # hardcodes `name = "indeed"` (sources/other/indeed.py:16). base.py:82 looks
+    # up RATE_LIMITS by `self.name`, so this row is unreachable — a single
+    # instance fetches both sites through the "indeed" limiter, which is the
+    # correct behaviour for one instance making one stream of requests.
+    # It stays because tests/test_cli.py:49 names the RATE_LIMITS entry as one of
+    # the FIVE surfaces that must move together when a source is added/removed
+    # (CLAUDE.md rule #8) — deleting it would break that contract for a row that
+    # costs nothing. Job rows are still labelled "glassdoor" correctly: that comes
+    # per-row from JobSpy's own `site` column, not from `self.name`.
     "glassdoor": {"concurrent": 1, "delay": 3.0},
     "workday": {"concurrent": 2, "delay": 1.5},
     "google_jobs": {"concurrent": 1, "delay": 2.0},

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -766,7 +766,7 @@ async def run_search(
                     job.normalized_key(),
                 )
                 r = await cur.fetchone()
-                job.id = r[0] if r is not None else None  # type: ignore[attr-defined]
+                job.id = r[0] if r is not None else None
 
             # Step-1 B7 — gate LLM enrichment by score. No-op when the flag is
             # OFF (CLAUDE.md rule #18). B7-2 fix: this runs AFTER insert so the
@@ -842,18 +842,18 @@ async def run_search(
                         # re-querying it here doubled the point-queries per run.
                         # (job.id is a dynamically-set attribute, not a declared
                         # dataclass field — see note earlier in this function.)
-                        if job.id is None:  # type: ignore[attr-defined]
+                        if job.id is None:
                             continue
                         _score = int(job.match_score or 0)
                         await feed.upsert_feed_row(
                             user_id=user_id,
-                            job_id=job.id,  # type: ignore[attr-defined]
+                            job_id=job.id,
                             score=_score,
                             bucket=_recency_bucket(job.date_found),
                             profile_version=feed_profile_version,
                         )
                         feed_written += 1
-                        _written_for_notify.append((job.id, _score))  # type: ignore[attr-defined]
+                        _written_for_notify.append((job.id, _score))
                     except Exception as e:  # never let a feed write fail the whole run
                         logger.warning("user_feed write failed for %r: %s", job.title, e)
                 logger.info("Wrote %s jobs to user_feed for user %s", feed_written, user_id)

--- a/backend/src/models.py
+++ b/backend/src/models.py
@@ -62,6 +62,22 @@ class Job:
     recency: int = 0
     semantic: int = 0
     penalty: int = 0
+    # Database row id, populated AFTER the row is inserted (None for a Job that
+    # has not been persisted yet). Declared last so positional construction is
+    # unaffected.
+    #
+    # This field was previously absent and stapled on at runtime
+    # (`job.id = row[0]`), which worked only because the dataclass isn't
+    # slotted. The cost was real: every reader had to guess with
+    # `getattr(job, "id", None)`, and when the attribute was missing at scoring
+    # time the enrichment lookup silently missed, scoring every enrichment
+    # dimension 0 — the documented dim-scoring bug.
+    #
+    # Declaring it does NOT by itself fix that bug (the ordering of "set id"
+    # vs "score" is the real defect, and lives in the scoring path). It removes
+    # the mine: the attribute now always exists, so a missing id is a visible
+    # None instead of an AttributeError dodged by getattr.
+    id: Optional[int] = None
 
     def __post_init__(self) -> None:
         # Decode HTML entities in title and company

--- a/backend/src/repositories/database.py
+++ b/backend/src/repositories/database.py
@@ -486,39 +486,47 @@ class JobDatabase:
         rows = await cursor.fetchall()
         now = datetime.now(timezone.utc)
         missed_count = 0
-        for row in rows:
-            job_id = row[0]
-            key = (row[1], row[2])
-            if key in seen_keys:
-                continue
-            current_state = row[5] or StalenessState.ACTIVE.value
-            # Sticky: confirmed_expired never demoted by absence sweep.
-            if current_state == StalenessState.CONFIRMED_EXPIRED.value:
+        # M7 — wrap the whole sweep in ONE transaction. Under autocommit each
+        # UPDATE committed on its own, so a crash (or a connection drop) part-way
+        # through left the source half-swept: some jobs with an incremented
+        # consecutive_misses and a new staleness_state, the rest untouched. The
+        # next run would then re-increment only the survivors, drifting the two
+        # halves apart. A ghost sweep is one logical decision about one source;
+        # it should land completely or not at all.
+        async with self._db.transaction():
+            for row in rows:
+                job_id = row[0]
+                key = (row[1], row[2])
+                if key in seen_keys:
+                    continue
+                current_state = row[5] or StalenessState.ACTIVE.value
+                # Sticky: confirmed_expired never demoted by absence sweep.
+                if current_state == StalenessState.CONFIRMED_EXPIRED.value:
+                    await self._db.execute(
+                        "UPDATE jobs SET consecutive_misses = consecutive_misses + 1 WHERE id = ?",
+                        (job_id,),
+                    )
+                    missed_count += 1
+                    continue
+
+                new_misses = int(row[3] or 0) + 1
+                last_seen = row[4]
+                age_hours = 0.0
+                if last_seen:
+                    try:
+                        last_seen_dt = datetime.fromisoformat(last_seen)
+                        if last_seen_dt.tzinfo is None:
+                            last_seen_dt = last_seen_dt.replace(tzinfo=timezone.utc)
+                        age_hours = (now - last_seen_dt).total_seconds() / 3600
+                    except (ValueError, TypeError):
+                        age_hours = 0.0
+                next_state = transition(new_misses, age_hours).value
                 await self._db.execute(
-                    "UPDATE jobs SET consecutive_misses = consecutive_misses + 1 WHERE id = ?",
-                    (job_id,),
+                    "UPDATE jobs SET consecutive_misses = ?, staleness_state = ? " "WHERE id = ?",
+                    (new_misses, next_state, job_id),
                 )
                 missed_count += 1
-                continue
-
-            new_misses = int(row[3] or 0) + 1
-            last_seen = row[4]
-            age_hours = 0.0
-            if last_seen:
-                try:
-                    last_seen_dt = datetime.fromisoformat(last_seen)
-                    if last_seen_dt.tzinfo is None:
-                        last_seen_dt = last_seen_dt.replace(tzinfo=timezone.utc)
-                    age_hours = (now - last_seen_dt).total_seconds() / 3600
-                except (ValueError, TypeError):
-                    age_hours = 0.0
-            next_state = transition(new_misses, age_hours).value
-            await self._db.execute(
-                "UPDATE jobs SET consecutive_misses = ?, staleness_state = ? " "WHERE id = ?",
-                (new_misses, next_state, job_id),
-            )
-            missed_count += 1
-        await self._db.commit()
+        # (transaction() above commits on exit — no explicit commit here)
         return missed_count
 
     async def commit(self) -> None:

--- a/backend/src/services/feed.py
+++ b/backend/src/services/feed.py
@@ -1,12 +1,26 @@
-"""FeedService — single source of truth for per-user job view.
+"""FeedService — helpers over the per-user ``user_feed`` table.
 
-Both the FastAPI dashboard endpoints AND the notification worker read from
-the same ``user_feed`` rows via this service, guaranteeing parity.
+SI4 — WHAT THIS IS, ACCURATELY:
+This module used to describe itself as "the single source of truth for the
+per-user job view", read by "both the FastAPI dashboard endpoints AND the
+notification worker". That was aspirational, not true, and the gap was
+invisible because the docstring sounded authoritative:
 
-Blueprint §3 rationale: "one PostgreSQL table (user_feed) serving both
-dashboard and notifications ... both surfaces always see identical data."
+  * ``list_for_user`` has NO production callers — only tests. The dashboard
+    reads ``user_feed`` through ``database.py`` (see the join at
+    database.py:1217), not through this class.
+  * ``get_score`` / the write helpers ARE used in production (api/routes/jobs.py,
+    workers/tasks.py), so this module is not dead as a whole — only that one
+    read method is.
 
-Phase 3 ships the read surface. Phase 4 adds ``ingest_job`` (write path).
+Blueprint §3 still describes the intended end state ("one Postgres table serving
+both dashboard and notifications"). Keeping ``list_for_user`` is deliberate: it
+is the read surface that end state needs. But it is documented here as NOT the
+live path, so nobody again assumes parity that does not exist.
+
+If you wire it up, check it still matches database.py's ordering — the two are
+kept in sync by hand, and a divergence there is exactly the kind of silent
+inconsistency that produces "the dashboard and the email disagree" bugs.
 """
 from __future__ import annotations
 
@@ -65,7 +79,20 @@ class FeedService:
         status: str = "active",
         limit: int = 200,
     ) -> list[FeedRow]:
-        """Dashboard query: active rows for a user, newest-highest-score first."""
+        """Active rows for a user, ranked the way the live dashboard ranks them.
+
+        NOT currently called in production (see the module docstring) — the
+        dashboard reads via database.py. Kept as the intended read surface.
+
+        SI4: the ordering used to be plain ``score DESC``, which silently
+        disagreed with the live query (database.py:1217), where an LLM judge
+        verdict outranks the keyword score:
+            ORDER BY COALESCE(f.llm_fit_score, f.score) DESC
+        Two orderings over one table is how "the dashboard and the notification
+        disagree" bugs are born, so this now matches. With MATCHER_ENABLED off
+        every ``llm_fit_score`` is NULL and COALESCE collapses to ``score`` —
+        i.e. behaviour is unchanged unless the judge is actually running.
+        """
         query = (
             "SELECT * FROM user_feed "
             "WHERE user_id = ? AND status = ?"
@@ -74,7 +101,7 @@ class FeedService:
         if bucket is not None:
             query += " AND bucket = ?"
             params.append(bucket)
-        query += " ORDER BY score DESC, created_at DESC LIMIT ?"
+        query += " ORDER BY COALESCE(llm_fit_score, score) DESC, created_at DESC LIMIT ?"
         params.append(limit)
         cur = await self._db.execute(query, params)
         return [_row(r) for r in await cur.fetchall()]

--- a/backend/src/services/profile/github_enricher.py
+++ b/backend/src/services/profile/github_enricher.py
@@ -192,14 +192,18 @@ async def _fetch_repo_frameworks(
     skills: list[str] = []
     seen: set[str] = set()
     for (filename, _), content in zip(MANIFEST_FILES, contents):
-        if isinstance(content, Exception) or not content:
+        # BaseException, not Exception: gather(return_exceptions=True) also
+        # returns BaseExceptions such as CancelledError, and those are truthy,
+        # so `not content` would NOT catch them either. Narrowing to Exception
+        # let a cancelled fetch through to be parsed as if it were file text.
+        if isinstance(content, BaseException) or not content:
             continue
         # The guard above drops every ``Exception`` gather returned, so this is a
         # real ``str``. mypy can't subtract ``Exception`` from ``BaseException``,
         # hence the narrow ignore. (A bare ``BaseException`` — e.g. CancelledError
         # — would slip past the guard, but that is pre-existing behaviour and is
         # left untouched here rather than silently changed.)
-        _ecosystem, dep_names = parse_manifest(filename, content)  # type: ignore[arg-type]
+        _ecosystem, dep_names = parse_manifest(filename, content)
         for dep in dep_names:
             d = (dep or "").strip()
             if d and d.lower() not in seen:
@@ -303,13 +307,15 @@ async def fetch_github_profile(
         frameworks_inferred: list[str] = []
         seen_framework: set[str] = set()
         for result in dep_results:
-            if isinstance(result, Exception):
+            # BaseException for the same reason as _fetch_repo_frameworks above:
+            # a cancelled task returns a BaseException that Exception misses.
+            if isinstance(result, BaseException):
                 logger.debug("Dep fetch failed: %s", result)
                 continue
             # Same narrowing gap as in ``_fetch_repo_frameworks``: the guard above
             # removes every ``Exception``, leaving a real ``list[str]``, but mypy
             # cannot subtract ``Exception`` from ``BaseException``.
-            for skill in result or []:  # type: ignore[union-attr]
+            for skill in result or []:
                 if skill.lower() not in seen_framework:
                     frameworks_inferred.append(skill)
                     seen_framework.add(skill.lower())

--- a/backend/src/services/rescore.py
+++ b/backend/src/services/rescore.py
@@ -60,7 +60,7 @@ def score_catalog_row(scorer: Any, row: dict[str, Any]) -> Any:
     # FIX 5 — set job.id so the enrichment_lookup keyed on job.id can find
     # the enrichment row (project dim-scoring-id-bug: job.id was unset here,
     # causing enrichment dims to always score 0).
-    job.id = row.get("id")  # type: ignore[attr-defined]
+    job.id = row.get("id")
     return scorer.score(job)
 
 
@@ -244,7 +244,7 @@ async def rescore_user_feed(
                             posted_at=row.get("posted_at"),
                             date_confidence=row.get("date_confidence") or "low",
                         )
-                        job.id = jid  # type: ignore[attr-defined]
+                        job.id = jid
                         job.match_score = int(ms)
                         shortlist_jobs.append(job)  # type: ignore[union-attr]
                 except Exception as exc:  # noqa: BLE001

--- a/backend/src/sources/apis_keyed/reed.py
+++ b/backend/src/sources/apis_keyed/reed.py
@@ -5,6 +5,7 @@ from typing import Any, Optional, cast
 
 import aiohttp
 
+from src.core.settings import RATE_LIMITS, SOURCE_FETCH_TIMEOUT
 from src.models import Job
 from src.services.profile.models import SearchConfig
 from src.sources.base import BaseJobSource, _is_uk_or_remote
@@ -31,9 +32,25 @@ class ReedSource(BaseJobSource):
         jobs = []
         auth = base64.b64encode(f"{self._api_key}:".encode()).decode()
         headers = {"Authorization": f"Basic {auth}"}
-        # Search top job titles in key locations
-        queries = self.job_titles[:8]
+        # S2 — size the fan-out from the actual time budget instead of a
+        # hand-picked constant. Reed is rate-limited to one request every
+        # RATE_LIMITS["reed"]["delay"] seconds, so N requests cost at LEAST
+        # N * delay before any network time. At the previous 8 titles x 3
+        # locations that was 24 * 2.0s = 48s of pure waiting against a 60s
+        # SOURCE_FETCH_TIMEOUT — it did not always blow the ceiling, which is
+        # worse than always failing: the source died intermittently, and a
+        # timeout looks identical to "Reed had nothing today".
+        #
+        # Deriving the cap means a later change to the delay or the timeout
+        # cannot silently push this back over the edge.
         locations = ["London", "UK", "Remote"]
+        _reed_limits = RATE_LIMITS.get("reed")
+        _delay = float(_reed_limits["delay"]) if _reed_limits else 2.0
+        # Spend at most 60% of the budget on enforced delay, leaving the rest
+        # for real HTTP latency and parsing.
+        _max_requests = max(1, int((SOURCE_FETCH_TIMEOUT * 0.6) / _delay))
+        _max_titles = max(1, _max_requests // len(locations))
+        queries = self.job_titles[:_max_titles]
         for query in queries:
             for loc in locations:
                 params = {

--- a/backend/src/workers/settings.py
+++ b/backend/src/workers/settings.py
@@ -168,6 +168,27 @@ class WorkerSettings:
     # hung LLM call tie up the (single) worker slot indefinitely.
     job_timeout = 600  # seconds
 
+    # M4 — liveness. arq writes a heartbeat key to Redis every
+    # ``health_check_interval`` seconds and `arq --check` reads it back; the key
+    # is set with a TTL of interval+1, so a dead worker stops looking alive one
+    # interval after it dies.
+    #
+    # arq's default is 3600, which means a worker that died at 00:01 still
+    # reported healthy at 00:59. That is not hypothetical here — this worker has
+    # died silently in production before (commit 7f906c6, "revive dead ARQ
+    # worker (P0)"), and nothing noticed because nothing was watching. 30s makes
+    # death observable within roughly one minute.
+    #
+    # Cost is one small Redis SET per interval — negligible next to the queue
+    # traffic itself.
+    health_check_interval = 30  # seconds
+
+    # M4 — explicit retry ceiling. arq's default is also 5, but stating it means
+    # a future arq upgrade cannot change our retry behaviour silently, and it
+    # documents that a poisoned job gives up rather than looping forever on the
+    # single (max_jobs=1) worker slot.
+    max_tries = 5
+
     # Periodic / cron jobs — Step-3 B-14.
     # ARQ cron format: ``cron(func, *, hour=None, minute=None, ...)``.
     # IMPORTANT: newer arq reads ``WorkerSettings.__dict__['cron_jobs']`` directly

--- a/backend/src/workers/tasks.py
+++ b/backend/src/workers/tasks.py
@@ -124,24 +124,7 @@ async def score_and_ingest(
     if job_row is None:
         return {"ingested": 0, "notifications_queued": 0}
 
-    job = Job(
-        title=job_row["title"],
-        company=job_row["company"],
-        apply_url=job_row["apply_url"],
-        source=job_row["source"],
-        # FINDING (not fixed — logic change, out of scope): _parse_dt returns
-        # datetime, but Job.date_found is typed `str` everywhere else in the
-        # codebase (models.py:23, main.py). Downstream, skill_matcher.py's
-        # `_recency_score(date_found: str)` does
-        # `datetime.fromisoformat(date_found)`, which raises TypeError on a
-        # datetime object — caught by its own `except (ValueError, TypeError):
-        # return 0`, so this doesn't crash, it silently zeroes the recency
-        # component whenever score_and_ingest scores a job via this path.
-        date_found=_parse_dt(job_row["date_found"]),  # type: ignore[arg-type]
-        location=job_row["location"] or "",
-        description=job_row["description"] or "",
-        match_score=job_row["match_score"],
-    )
+    job = _job_from_row(job_row)
 
     feed = FeedService(db)
     ingested = 0
@@ -441,6 +424,33 @@ def _default_search_config() -> SearchConfig:
     from src.core.tenancy import DEFAULT_TENANT_ID
 
     return _search_config_for(DEFAULT_TENANT_ID)
+
+
+def _job_from_row(job_row: Any) -> Job:
+    """Build a ``Job`` from a ``jobs`` row.
+
+    ``date_found`` is normalised to an ISO **string**. That is not cosmetic:
+    ``Job.date_found`` is typed ``str`` (models.py:23) and
+    ``skill_matcher._recency_score`` calls ``datetime.fromisoformat(date_found)``
+    on it. Passing the ``datetime`` that ``_parse_dt`` returns raised TypeError
+    there, which that function's own ``except (ValueError, TypeError): return 0``
+    swallowed — silently zeroing the recency component of EVERY job scored
+    through ``score_and_ingest``. Nothing errored; the score was just wrong.
+
+    Postgres hands back a ``datetime`` for this column, so the conversion has to
+    happen somewhere; doing it here keeps every Job in the codebase the same
+    shape. Pinned by tests/test_recency_date_type.py.
+    """
+    return Job(
+        title=job_row["title"],
+        company=job_row["company"],
+        apply_url=job_row["apply_url"],
+        source=job_row["source"],
+        date_found=_parse_dt(job_row["date_found"]).isoformat(),
+        location=job_row["location"] or "",
+        description=job_row["description"] or "",
+        match_score=job_row["match_score"],
+    )
 
 
 def _parse_dt(value: Any) -> datetime:
@@ -820,7 +830,18 @@ async def notification_tick(ctx: dict[str, Any]) -> dict[str, int]:
     now_utc = datetime.now(timezone.utc)
 
     try:
-        cur = await db.execute("SELECT * FROM notification_rules WHERE enabled = 1")
+        # N7 — one LEFT JOIN instead of a per-rule `SELECT timezone FROM users`.
+        # This cron fires every 5 minutes, so the old shape cost 1 + N queries
+        # per tick and grew linearly with the number of users who have
+        # notifications enabled. LEFT (not INNER) so a rule whose user row is
+        # missing still gets evaluated, exactly as before — it just falls back
+        # to UTC, which is what the old per-row `except` did.
+        cur = await db.execute(
+            "SELECT r.*, u.timezone AS _user_timezone "
+            "FROM notification_rules r "
+            "LEFT JOIN users u ON u.id = r.user_id "
+            "WHERE r.enabled = 1"
+        )
         rules = [dict(r) for r in await cur.fetchall()]
     except Exception:  # noqa: BLE001
         return {"checked": 0, "enqueued": 0}
@@ -828,13 +849,7 @@ async def notification_tick(ctx: dict[str, Any]) -> dict[str, int]:
     enqueued = 0
     for rule in rules:
         user_id = rule["user_id"]
-        # Get user timezone
-        try:
-            cur = await db.execute("SELECT timezone FROM users WHERE id = ?", (user_id,))
-            row = await cur.fetchone()
-            user_tz = (row["timezone"] if row and row["timezone"] else "UTC")
-        except Exception:  # noqa: BLE001
-            user_tz = "UTC"
+        user_tz = rule.get("_user_timezone") or "UTC"
 
         due = _bundle_due(rule, now_utc=now_utc, user_tz=user_tz)
         # SI2 — quiet-hours flush. An instant-mode user's matches are queued
@@ -906,7 +921,7 @@ async def enrich_job_task(ctx: dict[str, Any], job_id: int) -> dict[str, bool | 
     # set correctly *before* the enrich_job call that reads it — unlike the
     # previously-identified "dim scoring id bug" (job.id unset at scoring
     # time in main.py/jobs.py), this call site looks correct, just untyped.
-    job.id = row["id"]  # type: ignore[attr-defined]
+    job.id = row["id"]
 
     try:
         enrichment = await enrich_job(

--- a/backend/tests/test_recency_date_type.py
+++ b/backend/tests/test_recency_date_type.py
@@ -1,0 +1,100 @@
+"""Regression: ``Job.date_found`` must be a STRING, or recency silently scores 0.
+
+The bug this pins
+-----------------
+``Job.date_found`` is declared ``str`` (models.py:23). ``workers/tasks.py`` built
+its Job with ``date_found=_parse_dt(...)``, which returns a ``datetime``.
+
+Nothing crashed. ``skill_matcher._recency_score`` does
+``datetime.fromisoformat(date_found)``, a ``datetime`` raises ``TypeError``, and
+the surrounding ``except (ValueError, TypeError): return 0`` swallowed it.
+
+Net effect: every job scored through ``score_and_ingest`` got ZERO freshness
+points. A job posted an hour ago ranked identically to one from last week, and
+there was no error anywhere to notice — the score was simply, quietly, wrong.
+
+That is why these tests assert on the VALUE, not just that the call succeeds
+(CLAUDE.md rule #21: value-presence beats schema-presence). A test that only
+checked "returns an int" would have passed against the bug.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+from src.models import Job
+from src.services.skill_matcher import _recency_score, recency_score_for_job
+
+
+def _job(**kw):
+    base = dict(
+        title="Data Engineer",
+        company="Acme",
+        apply_url="https://example.test/1",
+        source="test",
+        date_found="",
+    )
+    base.update(kw)
+    return Job(**base)
+
+
+def test_recency_scores_a_fresh_iso_string() -> None:
+    """Baseline: a fresh ISO string must score > 0, or the rest proves nothing."""
+    fresh = datetime.now(timezone.utc).isoformat()
+    assert _recency_score(fresh) > 0
+
+
+def test_recency_is_zero_for_a_datetime_object() -> None:
+    """A datetime silently scores 0 — this is the trap, pinned so it stays visible.
+
+    We are not asserting desired behaviour here; we are documenting the sharp
+    edge. ``_recency_score`` takes a STRING. Hand it a datetime and you get 0
+    with no exception, which is exactly how the bug hid.
+    """
+    now = datetime.now(timezone.utc)
+    assert _recency_score(now) == 0  # type: ignore[arg-type]
+
+
+def test_job_built_with_datetime_date_found_loses_all_recency() -> None:
+    """The actual production path: Job(date_found=<datetime>) -> 0 recency."""
+    now = datetime.now(timezone.utc)
+    bad = _job(date_found=now)  # type: ignore[arg-type]
+    assert recency_score_for_job(bad) == 0
+
+    good = _job(date_found=now.isoformat())
+    assert recency_score_for_job(good) > 0, (
+        "a job found right now must earn recency points; if this is 0 the "
+        "date_found type regressed back to datetime"
+    )
+
+
+def test_score_and_ingest_builds_job_with_string_date_found() -> None:
+    """THE REGRESSION GUARD: tasks.py must hand Job a str, never a datetime.
+
+    Asserts against the real helper tasks.py uses, so if someone reintroduces
+    ``date_found=_parse_dt(row)`` this fails immediately.
+    """
+    from src.workers.tasks import _job_from_row, _parse_dt
+
+    row = {
+        "title": "Data Engineer",
+        "company": "Acme",
+        "apply_url": "https://example.test/1",
+        "source": "test",
+        "date_found": datetime.now(timezone.utc) - timedelta(hours=2),
+        "location": "London",
+        "description": "",
+        "salary_min": None,
+        "salary_max": None,
+        "match_score": 0,
+        "visa_flag": False,
+    }
+
+    job = _job_from_row(row)
+    assert isinstance(job.date_found, str), (
+        f"Job.date_found must be a str (models.py:23) — got {type(job.date_found).__name__}. "
+        "A datetime here silently zeroes every recency score."
+    )
+    # and it must actually score, end to end
+    assert recency_score_for_job(job) > 0
+
+    # _parse_dt itself still returns a datetime — that is fine, it is a parser.
+    assert isinstance(_parse_dt(row["date_found"]), datetime)

--- a/docs/fable/AUDIT-2026-07-19-REVERIFIED.md
+++ b/docs/fable/AUDIT-2026-07-19-REVERIFIED.md
@@ -1,0 +1,123 @@
+# Fable findings — RE-VERIFIED against main, 2026-07-19
+
+**This file supersedes `AUDIT-2026-07-17-VERIFIED.md`.** That document's verdicts had
+drifted badly out of date and were actively misleading (details below).
+
+Every verdict here was produced by reading the **current code on main** and quoting the
+decisive line. No verdict was copied from the previous audit; several contradict it.
+
+## Headline
+
+| Verdict | Count | Meaning |
+|---|---:|---|
+| **FIXED** | **57** | the described problem no longer exists in the code |
+| **PARTIAL** | **9** | the main risk is closed; a named sub-part remains |
+| **OPEN** | **9** | still exactly as described |
+| | **75** | (+ H7 counted twice in the source doc = 77 sections) |
+
+The previous doc claimed **83 OPEN**. The true number is **9**.
+
+## Why the old doc was dangerous, not merely out of date
+
+A findings document that is never re-verified stops being a record and becomes
+misinformation — and because it *looks* authoritative, it stops people from checking.
+Two concrete costs, both incurred on 2026-07-19:
+
+1. **H5 / `JOB360_ENV`** — the old doc (and the root `CLAUDE.md` env table) stated the
+   session cookie only gets `Secure` when `JOB360_ENV=prod`, which was never set on
+   Railway. A session was spent preparing to raise this as a live security hole.
+   **It was fixed a week earlier.** `auth.py:121` now reads
+   `secure = _is_production()`, which is `APP_ENV=production OR RAILWAY_ENVIRONMENT`
+   (`middleware.py:34-38`) — and Railway injects `RAILWAY_ENVIRONMENT` automatically.
+   `JOB360_ENV` survives only in a comment at `auth.py:120`. The `CLAUDE.md` row has
+   now been corrected.
+2. **M9** — listed as "client IP written unredacted to disk". Actually fixed:
+   `middleware.py:112` hashes it via `mask_ip()` (`logger.py:245`, SHA-256 → `ip_<12hex>`).
+
+The same staleness ran deeper: several sections near the top of the old file were
+already superseded by "CLOSED in Batch N" sections **further down the same file**
+(N4, T6-T9, T5, T12, S4). A reader taking the top-level verdicts at face value would
+have re-done finished work.
+
+**Rule going forward: re-verify against code before acting on any finding here.**
+
+---
+
+## OPEN (9) — still exactly as described
+
+| ID | What | Proof |
+|---|---|---|
+| **L6** | Frontend image ships full `node_modules`; Next standalone output never configured | `frontend/Dockerfile:41-42` states it outright; no `output: "standalone"` in `next.config.ts` |
+| **S8** | `indeed`/`glassdoor` share one class with a hardcoded `name = "indeed"`, so the `glassdoor` rate-limit entry is dead code | `sources/other/indeed.py:16`; `core/settings.py:221` |
+| **N2** | Two-pass profile extraction (~8 sequential LLM calls) runs **inline**, blocking the HTTP response | `api/routes/profile.py:327` `await run_two_pass_extraction(profile)` |
+| **SI4** | `FeedService.list_for_user` is dead code with zero production callers, still ordering by keyword score only while calling itself the "single source of truth" | `services/feed.py:60,77` |
+| **P3** | The verify-reminder hook only prints a message; nothing enforces the verification skill | `.claude/hooks/verify-reminder.sh:6`; no `verify-job360` reference in `agent-gate.sh` |
+| **P4** | Commit-gate hook matches the literal string `git commit` and **fails open** if JSON parsing yields an empty command | `.claude/hooks/commit-gate.sh:12-14` |
+| **P5** | `settings.local.json` has grown to 224 lines and still carries dead `chrome-devtools` permissions for a server that isn't enabled | `.claude/settings.local.json:81-88,199-203` |
+| **H6** | DB migrations still run **in-process** inside the FastAPI lifespan at every boot | `api/dependencies.py:22` `await runner.up(...)`; `api/main.py:113` |
+| **S5** | JobSpy scrape runs in a detached `asyncio.to_thread`; on timeout the OS thread leaks | `services/scheduler.py:160-161`; `sources/other/indeed.py:41` |
+
+**H6 is mitigated, not unguarded:** `backend/railway.json` sets `healthcheckPath`
+`/api/health` + `restartPolicyType: ON_FAILURE`, so a failed migration keeps the old
+container serving rather than going live broken. The literal fix (a separate release
+step) is the owner's call — it matters most the day the API scales past one replica.
+
+**S5 is accepted-by-design**, documented in the code comment itself.
+
+---
+
+## PARTIAL (9) — main risk closed, named remainder
+
+| ID | Closed | Still remaining |
+|---|---|---|
+| **S2** | Adzuna fan-out bounded to 8 queries | Reed still issues **24 sequential requests × 2.0s delay ≈ 48s**, tight under the 60s `SOURCE_FETCH_TIMEOUT` once real latency is added (`sources/apis_keyed/reed.py:35`) |
+| **N7** | 2 of 3 N+1s fixed (`main.py:833`, `tasks.py:593`) | `notification_tick` still does a per-rule `SELECT timezone FROM users` inside its loop (`tasks.py:843`) |
+| **M2** | Login timing side-channel closed via dummy-hash compare (`auth.py:233-235`) | `/register` still returns 409 on a taken email → email enumeration (owner-accepted) |
+| **M7** | `upsert_tailored_doc` DELETE+INSERT now in one transaction (`database.py:799`) | `mark_missed_for_source` still loops bare `UPDATE`s under autocommit (`database.py:489-521`) |
+| **V2** | Always-on `lastval()` round-trip now gated on `cur.rowcount` (`pg.py:531-535`) | Client-side cursor still not closed before return (`pg.py:544`) — low impact |
+| **AGT1** | R1 (conventions) + R3 (bugs) extracted to agent files | R2 (history) never extracted; still inline in `worker/SKILL.md:30` |
+| **M4** | `job_timeout = 600` + app-level DLQ for notification bundles | **No Docker HEALTHCHECK, no `health_check_interval`, no global `max_tries`** (`Dockerfile.worker:3`; `workers/settings.py`) |
+| **M9** | Client IP SHA-256 hashed before logging (`middleware.py:112`) | `user_id` still logged unmasked — **deliberate**, documented at `middleware.py:105-109` as an opaque internal UUID kept for correlation |
+| **T10** | `CLAUDE.md:221` now marks legacy `score_job()` test-only | The dead function itself still exists (`skill_matcher.py:403`) |
+
+---
+
+## FIXED tonight (2026-07-19) — with the PR that did it
+
+| ID | Fix | PR |
+|---|---|---|
+| **H7** | All 4 security scanners BLOCKING with **zero** waivers; mypy BLOCKING via ratchet at **0 errors** (was 803, non-blocking) | #89, #90, #91, #92 |
+| **H7 (cont.)** | 11 aiohttp CVEs genuinely closed — bumped to >=3.14.1 behind a test-only `conftest.py` shim, because `aioresponses` never passes the now-required `stream_writer` | #93 |
+| — | `openai` declared as a dependency. It had **never been installed in production**: the import failed, a broad `except` swallowed it, and every CV parse silently fell back to a free tier — while `openai` was the documented *primary* provider | #91 |
+
+Proof, on main:
+```
+security.yml   — 4/4 jobs blocking, 0 --ignore-vuln flags
+pip-audit (CI) — "No known vulnerabilities found"  (with aiohttp-3.14.1 installed)
+ci.yml         — runs scripts/mypy_ratchet.py, no continue-on-error
+mypy_baseline  — "# total errors: 0"
+full suite     — 1936 passed, 3 skipped
+```
+
+## Bugs found by the type-drain (not in the original audit)
+
+Surfaced while draining 803 mypy errors — each was invisible at runtime because
+something swallowed it.
+
+| Bug | Status |
+|---|---|
+| `workers/tasks.py` passed a `datetime` into `Job.date_found` (typed `str`); `skill_matcher.py:298` caught the `TypeError` and returned **0**, silently zeroing the recency component of **every** job scored via `score_and_ingest` | **Fixed** — `_job_from_row()` now emits ISO strings; pinned by `tests/test_recency_date_type.py`, which fails if reintroduced |
+| `tailor.py` — delete landing mid-request returned `None` → `TypeError` → HTTP 500 where 404 is correct (2 endpoints) | **Fixed** |
+| `github_enricher.py` — `gather(return_exceptions=True)` guards tested `Exception`, missing `BaseException` (e.g. `CancelledError`) | **Fixed** (2 sites; a third was already safe) |
+| `models.py` — `Job` had no `id` field; it was stapled on at runtime, forcing `getattr(job, "id", None)` everywhere. Root of the documented dim-scoring-0 bug | **Fixed** — field declared. The scoring-order defect itself remains the owner's call |
+| `salary.py:91` — reported as an `int > None` comparison | **NOT A BUG** — `salary.py:64-65` returns early when both bounds are `None`. A reminder that agent-reported findings need verifying before "fixing" |
+
+## Not covered by any finding — worth knowing
+
+- **Backup/restore has never been mentioned anywhere in this audit.** Real users' CVs,
+  profiles and applications live in one Railway Postgres. Does a *tested restore* exist?
+- **Nothing detects "process not running."** Sentry catches exceptions; the ARQ worker
+  died silently once already (commit `7f906c6`, "revive dead ARQ worker (P0)"). M4 above
+  plus an external uptime check on `/api/readyz` would close that class.
+- **In-memory state won't survive replicas** — login lockout and the per-user concurrent
+  search cap are per-process. Fine at one replica; a trap at two.

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -38,16 +38,32 @@ ENV NEXT_TELEMETRY_DISABLED=1
 # Non-root user
 RUN addgroup --system nodejs && adduser --system --ingroup nodejs nextjs
 
-# Next.js standalone output is NOT configured in next.config.ts, so we
-# ship the full .next/ build output + production node_modules.
-COPY --from=builder  --chown=nextjs:nodejs /app/.next        ./.next
-COPY --from=builder  --chown=nextjs:nodejs /app/public       ./public
-COPY --from=builder  --chown=nextjs:nodejs /app/next.config.ts ./next.config.ts
-COPY --from=builder  --chown=nextjs:nodejs /app/package.json  ./package.json
-COPY --from=prod-deps --chown=nextjs:nodejs /app/node_modules ./node_modules
+# L6 — standalone output (next.config.ts `output: "standalone"`).
+#
+# Next traces the modules actually reachable at runtime and emits a
+# self-contained server in `.next/standalone`, including its own minimal
+# node_modules. So the runner copies three things instead of the whole
+# dependency tree:
+#   .next/standalone  — the server + only the modules it really needs
+#   .next/static      — hashed build assets (NOT included in standalone)
+#   public            — static files served as-is
+#
+# The prod-deps stage is intentionally no longer copied from: shipping the full
+# production node_modules was the finding (L6). Keep that stage for now — it is
+# still a useful cache layer and a fallback if standalone is ever reverted.
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static     ./.next/static
+COPY --from=builder --chown=nextjs:nodejs /app/public           ./public
 
 USER nextjs
 
 EXPOSE 3000
 
-CMD ["npm", "start"]
+# standalone emits its own server.js — `npm start` (next start) is NOT used
+# here and would fail, since the Next CLI is not part of the traced bundle.
+# PORT/HOSTNAME are read by that server; bind 0.0.0.0 so the container is
+# reachable from outside (default would be localhost only).
+ENV PORT=3000
+ENV HOSTNAME=0.0.0.0
+
+CMD ["node", "server.js"]

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -7,6 +7,17 @@ import { SECURITY_HEADERS } from "./src/lib/security-headers";
 const BACKEND_ORIGIN = process.env.BACKEND_ORIGIN || "http://localhost:8000";
 
 const nextConfig: NextConfig = {
+  // L6 — emit a self-contained server bundle in `.next/standalone`, so the
+  // runtime image copies just that plus static assets instead of the whole
+  // `node_modules` tree. Next traces the modules actually reached at runtime;
+  // dev/build-only dependencies never make it into the image.
+  //
+  // This is purely a packaging change: same code paths, same rewrites, same
+  // headers — the app is byte-identical, it just ships without the build
+  // toolchain riding along. Smaller image = faster deploys and a smaller
+  // surface for dependency CVEs to be reported against.
+  output: "standalone",
+
   // Same-origin proxy: the browser calls `/api/*` on the frontend origin and
   // Next forwards it to the backend. This keeps frontend + backend same-origin
   // so the host-only session cookie is always sent and the middleware auth gate


### PR DESCRIPTION
Re-verified **all 77 findings** in `AUDIT-2026-07-17-VERIFIED.md` against the actual code before touching anything. That doc claimed **83 OPEN**. The true number was **9**.

It had drifted into misinformation — and because it *looked* authoritative, it stopped people checking. Two findings recorded OPEN (H5 cookie `Secure`, M9 client IP) had been fixed a week earlier; a session was spent preparing to raise H5 as a live security hole **that did not exist**.

New re-verification with `file:line` proof for every verdict: **`docs/fable/AUDIT-2026-07-19-REVERIFIED.md`**.

## Bugs the mypy drain found

Each was invisible at runtime because something swallowed it.

**1. Recency silently scored ZERO** ⚠️ *changes rankings*

`tasks.py` built `Job(date_found=_parse_dt(...))` — a `datetime` — while `Job.date_found` is typed `str`. `skill_matcher._recency_score` calls `datetime.fromisoformat(...)`, a datetime raises `TypeError`, and its own `except (ValueError, TypeError): return 0` ate it.

**Every job scored via `score_and_ingest` lost its entire freshness component.** A job posted an hour ago ranked identically to one from last week. No error, anywhere.

Fixed by extracting `_job_from_row()`. Pinned by `tests/test_recency_date_type.py` — I verified it **fails** with the bug reintroduced (`got datetime`) and passes with the fix. A test asserting only "returns an int" would have passed against the bug (rule #21).

**2.** `tailor.py` delete-race → 500 instead of 404 (2 endpoints). Guarded.
**3.** `github_enricher` `gather()` guards tested `Exception`, missing `BaseException` (`CancelledError`). Widened at both unsafe sites; the third was already safe.
**4.** `Job` had no `id` field — stapled on at runtime, forcing `getattr(job, "id", None)` everywhere. Declared it; that removed **10 now-stale type-ignores** which `warn_unused_ignores` flagged. Did **not** wire the dim-scoring fix on top — that stays yours.

**A fifth reported bug was a FALSE POSITIVE.** `salary.py:64` returns early when both bounds are `None`. Verified before "fixing" working code.

## Audit findings closed

| ID | What |
|---|---|
| **M4** | arq `health_check_interval` defaults to **3600** — a worker dead at 00:01 looked alive at 00:59. Not hypothetical: this worker died silently in prod (`7f906c6`, "revive dead ARQ worker (P0)"). Now 30s + `max_tries` + `HEALTHCHECK` via `arq --check`. The Dockerfile comment claiming a healthcheck was *impossible without HTTP* is **why this stayed open** — that premise was false |
| **L6** | Next standalone output. **Verified by real build**: `.next/standalone/server.js` exists, which is what the new CMD runs |
| **N7** | `notification_tick` queried each user's timezone inside its loop — on a cron that fires every 5 min. Now one `LEFT JOIN` |
| **M7** | Ghost sweep ran UPDATEs under autocommit; a crash left a source half-swept and the halves drifted. Now one transaction |
| **S2** | Reed: 24 requests × 2.0s ≈ **48s** against a 60s timeout — *intermittent* death, worse than always failing because a timeout looks like "Reed had nothing today". Fan-out now **derived from the budget** |
| **SI4** | `feed.py` called itself "single source of truth… read by both dashboard AND worker". `list_for_user` has **zero** production callers. Docstring now true; ordering aligned to the live query |
| **S8** | Dead `glassdoor` rate-limit row documented rather than deleted — `test_cli.py:49` names it as one of the five surfaces (rule #8) |
| **P4** | **The commit gate failed OPEN.** An unparseable payload left `CMD` empty and the commit was allowed — silently, since `2>/dev/null` hid why. Now falls back to raw-payload scanning. Verified 4 cases; the unparseable-commit case went **0 → 2**. It blocked its own test payload mid-development, which is the fix demonstrating itself |

## Declined, with reasons (not silently skipped)

- **V2** — that cursor is *returned to the caller* to read from. Closing it breaks every query. A real fix changes the cursor contract shim-wide; wrong trade for a cheap client-side cursor.
- **N2** — backgrounding extraction changes **what the upload endpoint returns**, so the frontend must poll. Full-stack UX change, not a bug fix.

## Also

`CLAUDE.md`'s env table still documented `JOB360_ENV` as the live cookie-`Secure` gate. It's dead. Corrected — with a note that the row previously said the opposite, since that row is what cost the session.

## Verification

```
full suite   1940 passed, 3 skipped, 25m15s   (--full: touches database.py + pg shim)
ruff         clean
mypy ratchet 0 errors
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6DsQH5EUxJc3Vnqz9YHgQ