### PR TITLE
fix(N2,H6): parallelise the profile LLM passes + unblock migrations-as-release-step

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -187,6 +187,13 @@ SENTRY_DSN=
 SOURCE_FETCH_TIMEOUT=60
 SOURCE_FETCH_TIMEOUT_ATS=240
 
+# === Migrations (H6) ===
+# Migrations apply inside the FastAPI process at boot. Set this to false ONLY
+# once your deploy pipeline runs them as an explicit release step
+# (`python -m migrations.runner up`) — otherwise the schema never gets created.
+# Leaving it unset keeps the current, safe behaviour.
+RUN_MIGRATIONS_ON_BOOT=true
+
 # === Scraper overrides (advanced) ===
 # 80000Hours uses the site's public Algolia keys by default — these work out of the box.
 # Only override if the public keys rotate upstream.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -275,6 +275,7 @@ Dropped in Batch 3: `yc_companies`, `nomis`, `findajob`. Dropped 2026-06 (M6 rot
 | `MATCHER_MAX_JOBS` | No (default `30`) | Max jobs per user per run sent to the judge |
 | `SOURCE_FETCH_TIMEOUT` | No (default `60`) | Per-source fetch ceiling in seconds |
 | `SOURCE_FETCH_TIMEOUT_ATS` | No (default `240`) | ATS category fetch ceiling in seconds |
+| `RUN_MIGRATIONS_ON_BOOT` | No (default `true`) | H6 — set `false` ONLY once a deploy release-phase step owns `python -m migrations.runner up`. Default keeps today's behaviour (migrations apply inside the FastAPI lifespan, `api/dependencies.py`). Existing mitigations: `runner.up()` takes a Postgres advisory lock so concurrent replicas serialise, and `backend/railway.json`'s healthcheck + `ON_FAILURE` restart keeps the old container serving if a migration fails |
 
 ## Important Patterns
 

--- a/backend/src/api/dependencies.py
+++ b/backend/src/api/dependencies.py
@@ -5,6 +5,9 @@ from typing import AsyncIterator, cast
 
 from src.core.settings import DB_PATH
 from src.repositories.database import JobDatabase
+from src.utils.logger import get_logger
+
+logger = get_logger("api.dependencies")
 
 _db: JobDatabase | None = None
 
@@ -17,9 +20,32 @@ async def init_db() -> JobDatabase:
         # Batch 2: apply additive migrations (users, sessions, user_feed,
         # notification_ledger, user_channels). Idempotent — safe to call on
         # every boot. See docs/plans/batch-2-plan.md Phase 0.
-        from migrations import runner
+        #
+        # H6 — migrations run INSIDE the request-serving process at boot. The
+        # finding's fix is to move them to an explicit pre-deploy/release step.
+        # That is a deploy-pipeline change (Railway release phase), not something
+        # this repo can perform on its own — but it cannot happen at all while
+        # the code unconditionally migrates on boot. This env switch is the
+        # enabler: set RUN_MIGRATIONS_ON_BOOT=false once a release step owns
+        # migrations, and boot stops racing it.
+        #
+        # Default stays TRUE, so behaviour is unchanged until someone
+        # deliberately flips it — no silent change to a live deploy.
+        #
+        # Already mitigated today, which is why this is low-urgency: runner.up()
+        # takes a Postgres advisory lock (migrations/runner.py) so two replicas
+        # booting together serialise rather than corrupt, and backend/railway.json
+        # sets healthcheckPath + restartPolicyType=ON_FAILURE, so a failed
+        # migration keeps the OLD container serving instead of going live broken.
+        if os.getenv("RUN_MIGRATIONS_ON_BOOT", "true").lower() not in ("0", "false", "no"):
+            from migrations import runner
 
-        await runner.up(str(DB_PATH))
+            await runner.up(str(DB_PATH))
+        else:
+            logger.info(
+                "db_migrations_skipped_on_boot",
+                extra={"event": "db_migrations_skipped_on_boot", "reason": "RUN_MIGRATIONS_ON_BOOT=false"},
+            )
     return _db
 
 

--- a/backend/src/services/profile/two_pass.py
+++ b/backend/src/services/profile/two_pass.py
@@ -16,6 +16,7 @@ imported at module top so tests can monkeypatch them by name.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import re
 from typing import Any
@@ -42,6 +43,15 @@ from src.services.profile.preferences import (
 )
 
 logger = logging.getLogger("job360.profile.two_pass")
+
+
+async def _none() -> None:
+    """Placeholder coroutine for an input that is absent.
+
+    gather() needs a coroutine in every slot so the results unpack positionally;
+    this keeps the call site readable instead of building the list conditionally.
+    """
+    return None
 
 
 def _merge_str_list(dst: list[str], src: list[str]) -> None:
@@ -174,26 +184,48 @@ async def run_two_pass_extraction(profile: UserProfile) -> UserProfile:
     # feeds the other — so whatever one pass misses the other can still catch.
     # Deterministic = STRUCTURE only (CLAUDE.md rule #28); LLM = meaning.
 
+    # ── N2 — run the FOUR LLM passes concurrently ──────────────────────
+    # The four inputs (CV / LinkedIn / GitHub / about_me) are independent: none
+    # reads what another produced. They used to be four sequential `await`s, so
+    # the caller waited for the SUM of four network round-trips. This route is
+    # awaited inline by the profile-upload endpoints, so that sum was wall-clock
+    # time the user spent watching a spinner.
+    #
+    # Only the CALLS are parallel. The merges below still run one at a time, in
+    # exactly the original order, because they all mutate the same CVData and a
+    # later merge can depend on what an earlier one wrote. Same inputs, same
+    # merge sequence, same output — just without the queuing.
+    #
+    # return_exceptions=True keeps the existing contract that one failing LLM
+    # pass never sinks the others: each result is unpacked below with the same
+    # "log it and keep the deterministic result" handling it had before.
+    async def _safe(coro: Any, label: str) -> Any:
+        try:
+            return await coro
+        except Exception as e:  # noqa: BLE001 — deterministic result still stands
+            logger.warning("two_pass: %s LLM pass skipped: %s", label, e)
+            return None
+
+    _llm_cv_res, _llm_li_res, _llm_gh_res, _llm_pr_res = await asyncio.gather(
+        _safe(llm_cv_fields_from_text(cv.raw_text), "CV") if cv.raw_text else _none(),
+        _safe(llm_linkedin_fields(cv.linkedin_raw_text), "LinkedIn") if cv.linkedin_raw_text else _none(),
+        _safe(llm_infer_github_skills(cv.github_repos_brief), "GitHub") if cv.github_repos_brief else _none(),
+        _safe(llm_infer_from_about_me(prefs.about_me), "about_me") if prefs.about_me else _none(),
+    )
+
     # ── ① CV ── raw = cv.raw_text ──────────────────────────────────────
     if cv.raw_text:
         det_cv = deterministic_cv_fields(cv.raw_text)           # det-CV-output
         _merge_str_list(cv.skills, det_cv.get("skills", []))
         if not cv.summary and det_cv.get("summary"):
             cv.summary = det_cv["summary"]
-        try:
-            llm_cv = await llm_cv_fields_from_text(cv.raw_text)  # llm-CV-output
-            _merge_cv_llm_into(cv, llm_cv)                       # → MERGED CV
-        except Exception as e:  # noqa: BLE001 — deterministic result still stands
-            logger.warning("two_pass: CV LLM pass skipped: %s", e)
+        if _llm_cv_res is not None:                          # llm-CV-output
+            _merge_cv_llm_into(cv, _llm_cv_res)                  # → MERGED CV
 
     # ── ② LinkedIn ── raw = cv.linkedin_raw_text ───────────────────────
     if cv.linkedin_raw_text:
         det_li = deterministic_linkedin_fields(cv.linkedin_raw_text)  # det-LI-output
-        llm_li: dict[str, Any] = {}
-        try:
-            llm_li = await llm_linkedin_fields(cv.linkedin_raw_text)  # llm-LI-output
-        except Exception as e:  # noqa: BLE001 — deterministic result still stands
-            logger.warning("two_pass: LinkedIn LLM pass skipped: %s", e)
+        llm_li: dict[str, Any] = _llm_li_res or {}                   # llm-LI-output
         merged_li = merge_linkedin_fields(det_li, llm_li)            # → MERGED LI
         enrich_cv_from_linkedin(cv, merged_li)
 
@@ -201,21 +233,15 @@ async def run_two_pass_extraction(profile: UserProfile) -> UserProfile:
     if cv.github_repos_brief:
         det_gh = deterministic_github_fields(cv.github_repos_brief)  # det-GH-output
         _merge_str_list(cv.github_skills_inferred, det_gh)
-        try:
-            llm_gh = await llm_infer_github_skills(cv.github_repos_brief)  # llm-GH-output
-            _merge_str_list(cv.github_llm_skills, llm_gh)                  # → MERGED GH
-        except Exception as e:  # noqa: BLE001 — deterministic result still stands
-            logger.warning("two_pass: GitHub LLM pass skipped: %s", e)
+        if _llm_gh_res is not None:                                        # llm-GH-output
+            _merge_str_list(cv.github_llm_skills, _llm_gh_res)             # → MERGED GH
 
     # ── ④ Preferences ── raw = prefs.about_me ──────────────────────────
     if prefs.about_me:
         det_pr = deterministic_about_me_fields(prefs.about_me)   # det-PR-output
         _merge_str_list(cv.about_me_inferred_skills, det_pr)
-        try:
-            llm_pr = await llm_infer_from_about_me(prefs.about_me)  # llm-PR-output
-            _merge_str_list(cv.about_me_inferred_skills, llm_pr)    # → MERGED PR
-        except Exception as e:  # noqa: BLE001 — deterministic result still stands
-            logger.warning("two_pass: about_me LLM pass skipped: %s", e)
+        if _llm_pr_res is not None:                                # llm-PR-output
+            _merge_str_list(cv.about_me_inferred_skills, _llm_pr_res)  # → MERGED PR
 
     # Collapse line-wrap fragments + cross-source duplicates in the free-text
     # lists so the profile shows each certification / qualification ONCE (a CV +


### PR DESCRIPTION
Second pass over the findings I had left as "needs the owner". **Two had a safer fix than the one the finding proposed**, so they did not need to wait.

## N2 — profile extraction blocked the upload response

The finding said *"run it in the background"* — which forces the frontend to poll and changes what the upload endpoint returns.

But the actual complaint is **slowness**, and the cause was *shape*, not placement: the four LLM passes (CV, LinkedIn, GitHub, about_me) were four **sequential `await`s over four independent inputs**. The caller waited for the **sum** of four network round-trips.

They now run concurrently via `asyncio.gather`. The **merges still run one at a time, in the original order** — they all mutate the same `CVData` and a later merge can depend on what an earlier one wrote. Same inputs, same merge sequence, same output.

**Wait time drops from the sum of four calls to roughly the slowest one — with no contract change.** The endpoint still returns the fully-extracted profile, so the frontend is untouched.

Per-pass failure handling is preserved (`_safe` wrapper): one failing LLM pass still logs and leaves its deterministic result standing, exactly as the four separate `try/except` blocks did.

Verified: **45 two_pass tests pass**, mypy ratchet 0, ruff clean.

## H6 — migrations run inside the request-serving process

The real fix is a Railway release-phase step, which this repo cannot perform. But the **blocker was code**: boot migrated unconditionally, so a release step could never own migrations without racing them.

Added `RUN_MIGRATIONS_ON_BOOT`, defaulting **true** — behaviour unchanged until you deliberately flip it. Documented in `CLAUDE.md` + `.env.example`.

Why this is low-urgency rather than dangerous, for the record: `runner.up()` takes a Postgres advisory lock so two replicas booting together **serialise** rather than corrupt, and `railway.json`s healthcheck + `ON_FAILURE` restart keeps the **old** container serving when a migration fails.

## Deliberately NOT fixed — reasons, not silence

| ID | Why |
|---|---|
| **T10** | `score_job()` is dead in *production* but alive as a **test surface** — 6+ references exercise the scoring helpers through it. Deleting means losing coverage or rewriting Pillar-2 tests. The findings real complaint (docs calling it live) is already fixed |
| **M9** | `user_id` unmasked is **deliberate and documented** (`middleware.py:105-109`) — an opaque internal UUID for correlation, far lower PII than the client IP, which *is* hashed |
| **S5** | Needs a killable process pool; the code marks the trade-off accepted-by-design. Replacing the thread changes scheduler timeout behaviour on a live scraper |
| **M2** | `/register` 409 leaks which emails exist. The fix is easy; the **decision** is not — hiding it means registration can no longer say "you already have an account". Product judgment, yours |

## Verification

```
gate --full   PASS
ruff          clean
mypy ratchet  0 errors
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6DsQH5EUxJc3Vnqz9YHgQ