### PR TITLE
fix: cap profile re-extraction spend (uncapped paid-LLM vector)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,11 +19,15 @@ POSTGRES_PASSWORD=
 DATABASE_URL=postgresql://job360:job360dev@localhost:5433/job360
 
 # === Runtime environment ===
-# Set to "prod" to mark session cookies Secure (HTTPS-only). Leave blank for dev.
-# NOTE: this is a SEPARATE gate from APP_ENV / RAILWAY_ENVIRONMENT (which drive
-# HSTS + required-env validation). If you deploy on Railway you must ALSO set
-# JOB360_ENV=prod, or the session cookie will ship WITHOUT the Secure flag.
-JOB360_ENV=
+# JOB360_ENV is DEAD — nothing in src/ reads it any more (only a comment at
+# auth.py:120 records that it once did). The session-cookie `Secure` flag now
+# gates on the SAME signal as HSTS/Sentry/CORS: middleware._is_production(),
+# i.e. APP_ENV=production OR RAILWAY_ENVIRONMENT set. Railway injects
+# RAILWAY_ENVIRONMENT automatically, so production cookies ARE Secure.
+#
+# This block previously told you the opposite — that cookies ship WITHOUT Secure
+# unless you set JOB360_ENV=prod — and that stale instruction cost a session
+# chasing a security hole that did not exist. Do not re-add it.
 # Marks production for HSTS + required-env validation. Railway sets
 # RAILWAY_ENVIRONMENT automatically; set APP_ENV=production elsewhere.
 APP_ENV=
@@ -172,6 +176,9 @@ MATCHER_MAX_JOBS=30
 # === AI CV & cover-letter (tailored documents) ===
 # Free-tier cap on tailored-document generations per user per month (paid LLM call each).
 TAILOR_FREE_PER_MONTH=10
+# Cost cap: max profile re-extractions per user per hour. Each one fans out
+# to 4+ paid LLM calls over CV/LinkedIn/GitHub/about_me. 0 disables the cap.
+PROFILE_EXTRACT_MAX_PER_HOUR=12
 
 # === Auth hardening ===
 # Brute-force login lockout: after N failed logins for one email within the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -260,6 +260,7 @@ Dropped in Batch 3: `yc_companies`, `nomis`, `findajob`. Dropped 2026-06 (M6 rot
 | ~~`JOB360_ENV`~~ | **DEAD** | No longer read anywhere in `src/` (only a comment at auth.py:120 records that it once was). The session-cookie `Secure` flag now gates on the SAME signal as HSTS/Sentry/CORS — `middleware._is_production()` = `APP_ENV=production` OR `RAILWAY_ENVIRONMENT` set (auth.py:115-121). Railway injects `RAILWAY_ENVIRONMENT` automatically, so prod cookies ARE `Secure`. **This row previously said the opposite and cost a session real time chasing a non-existent hole — do not re-add `JOB360_ENV`.** |
 | `SENTRY_DSN` | No | Sentry error tracking; empty = disabled |
 | `TAILOR_FREE_PER_MONTH` | No (default `10`) | Free-tier cap on AI CV/cover-letter generations per user/month |
+| `PROFILE_EXTRACT_MAX_PER_HOUR` | No (default `12`) | Cost cap on profile re-extraction. EVERY profile change re-runs the full two-pass extraction (4+ paid LLM calls); five routes reach `_extract_save_trigger` and nothing bounded it. Over the limit returns HTTP 429. `0` disables. Uses the shared limiter, so `RATE_LIMIT_REDIS=true` makes the cap hold across replicas |
 | `LOGIN_MAX_ATTEMPTS` / `LOGIN_LOCKOUT_WINDOW_SECONDS` | No (default `5` / `900`) | Brute-force login lockout (in-memory) |
 | `MAX_CONCURRENT_SEARCHES_PER_USER` | No (default `3`) | Per-user cap on concurrent `POST /search` (429 over cap) |
 | `ENRICHMENT_THRESHOLD` | No (default `60`) | Min match_score for a job to be LLM-enriched |

--- a/backend/src/api/routes/profile.py
+++ b/backend/src/api/routes/profile.py
@@ -22,6 +22,8 @@ from src.api.models import (
     ProfileVersionsListResponse,
     ProfileVersionSummary,
 )
+from src.core.settings import PROFILE_EXTRACT_MAX_PER_HOUR
+from src.services.auth import rate_limit as auth_rate_limit
 from src.services.profile.cv_parser import extract_text
 from src.services.profile.github_enricher import (
     enrich_cv_from_github,
@@ -323,7 +325,41 @@ async def _extract_save_trigger(profile: UserProfile, user_id: str) -> None:
 
     Used by every profile-input route so the merged single-extraction flow is
     defined once.
+
+    COST CAP (docs/fable/08 "Cost economics — NOT audited"):
+    Each call fans out to 4+ paid LLM passes, and ANY profile change re-runs ALL
+    of them from stored data. Nothing bounded how often a user could trigger that
+    — five routes reach this function, and a user editing their profile in a loop
+    was an unbounded spend vector.
+
+    This became real rather than theoretical on 2026-07-19: `openai` had never
+    actually been installed in production (the import raised, a broad `except`
+    swallowed it, and every parse silently fell back to a free tier). Declaring
+    the dependency turned the primary PAID provider on for the first time — so the
+    uncapped loop that previously cost nothing now bills.
+
+    Reuses the existing limiter rather than inventing a counter: it already
+    supports a shared Redis backend (RATE_LIMIT_REDIS), so the cap holds across
+    replicas instead of being multiplied by replica count.
     """
+    if PROFILE_EXTRACT_MAX_PER_HOUR > 0 and not auth_rate_limit.check_and_record(
+        f"profile_extract:{user_id}",
+        max_in_window=PROFILE_EXTRACT_MAX_PER_HOUR,
+        window_seconds=3600,
+    ):
+        logger.warning(
+            "profile_extract_rate_limited",
+            extra={"event": "profile_extract_rate_limited", "user_id": user_id},
+        )
+        raise HTTPException(
+            status_code=429,
+            detail=(
+                f"Too many profile updates in the last hour "
+                f"(limit {PROFILE_EXTRACT_MAX_PER_HOUR}). Each update re-runs AI "
+                "extraction over your CV, LinkedIn and GitHub — please wait a "
+                "few minutes and try again."
+            ),
+        )
     await run_two_pass_extraction(profile)
     save_profile(profile, user_id)
     await _maybe_trigger_rescore(user_id)

--- a/backend/src/core/settings.py
+++ b/backend/src/core/settings.py
@@ -157,6 +157,18 @@ WORKPLACE_WEIGHT = int(os.getenv("WORKPLACE_WEIGHT", "6"))
 # cap (no plan column exists yet — everyone is on the free cap for now).
 TAILOR_FREE_PER_MONTH = int(os.getenv("TAILOR_FREE_PER_MONTH", "10"))
 
+# Cost cap on profile re-extraction (docs/fable/08 "Cost economics — NOT audited").
+# Every profile change re-runs the FULL two-pass extraction — 4+ paid LLM calls
+# over CV / LinkedIn / GitHub / about_me — from stored data. Nothing bounded how
+# often a user could trigger that, and five routes reach the same code path.
+#
+# 12/hour is deliberately generous: a person genuinely setting up a profile edits
+# it a handful of times in a sitting, so this should never be felt by a real user.
+# It exists to stop a loop (or a bored user) from running up a bill.
+#
+# Set 0 to disable the cap entirely.
+PROFILE_EXTRACT_MAX_PER_HOUR = int(os.getenv("PROFILE_EXTRACT_MAX_PER_HOUR", "12"))
+
 # Pillar 2 Batch 2.6 — semantic stack feature flag.
 # When false (default), embeddings + ChromaDB + ESCO normalisation all skip.
 # When true, callers that check this flag activate the semantic retrieval path.

--- a/backend/tests/test_profile_extract_cost_cap.py
+++ b/backend/tests/test_profile_extract_cost_cap.py
@@ -1,0 +1,115 @@
+"""The profile re-extraction cost cap must actually bite.
+
+Why this exists
+---------------
+Every profile change re-runs the FULL two-pass extraction — 4+ paid LLM calls
+over CV / LinkedIn / GitHub / about_me — from stored data. Five routes reach the
+same code path (`_extract_save_trigger`), and nothing bounded how often a user
+could trigger it.
+
+That was harmless while it was free. It stopped being free on 2026-07-19: the
+`openai` dependency had never actually been installed in production (the import
+raised, a broad `except` swallowed it, and every parse quietly fell back to a
+free tier), so declaring it turned the primary PAID provider on for the first
+time. The uncapped loop that previously cost nothing now bills.
+
+These tests assert BEHAVIOUR (the 13th call is refused, the extraction does not
+run) rather than "the setting exists" — a config-presence test would pass against
+a cap that was never wired in (rule #21).
+"""
+
+import pytest
+
+import src.api.routes.profile as profile_routes
+from src.services.auth import rate_limit as auth_rate_limit
+
+
+@pytest.fixture(autouse=True)
+def _clear_limiter():
+    """Each test starts with an empty window — the limiter is process-global."""
+    auth_rate_limit.reset_for_tests()
+    yield
+    auth_rate_limit.reset_for_tests()
+
+
+@pytest.mark.asyncio
+async def test_cap_allows_normal_use_then_refuses(monkeypatch):
+    """12 extractions allowed in the hour; the 13th is refused with 429."""
+    from fastapi import HTTPException
+
+    calls = {"n": 0}
+
+    async def _fake_extract(profile):
+        calls["n"] += 1
+        return profile
+
+    monkeypatch.setattr(profile_routes, "run_two_pass_extraction", _fake_extract)
+    monkeypatch.setattr(profile_routes, "save_profile", lambda *a, **k: None)
+
+    async def _noop(_user_id):
+        return None
+
+    monkeypatch.setattr(profile_routes, "_maybe_trigger_rescore", _noop)
+    monkeypatch.setattr(profile_routes, "PROFILE_EXTRACT_MAX_PER_HOUR", 12)
+
+    for i in range(12):
+        await profile_routes._extract_save_trigger(object(), "user-cap")
+        assert calls["n"] == i + 1, "a within-limit call must run the extraction"
+
+    with pytest.raises(HTTPException) as exc:
+        await profile_routes._extract_save_trigger(object(), "user-cap")
+
+    assert exc.value.status_code == 429
+    assert calls["n"] == 12, (
+        "the refused call must NOT have run the extraction — otherwise the cap "
+        "costs money while pretending to save it"
+    )
+
+
+@pytest.mark.asyncio
+async def test_cap_is_per_user(monkeypatch):
+    """One user hitting the cap must not lock out everyone else."""
+    from fastapi import HTTPException
+
+    async def _fake_extract(profile):
+        return profile
+
+    monkeypatch.setattr(profile_routes, "run_two_pass_extraction", _fake_extract)
+    monkeypatch.setattr(profile_routes, "save_profile", lambda *a, **k: None)
+
+    async def _noop(_user_id):
+        return None
+
+    monkeypatch.setattr(profile_routes, "_maybe_trigger_rescore", _noop)
+    monkeypatch.setattr(profile_routes, "PROFILE_EXTRACT_MAX_PER_HOUR", 2)
+
+    for _ in range(2):
+        await profile_routes._extract_save_trigger(object(), "alice")
+    with pytest.raises(HTTPException):
+        await profile_routes._extract_save_trigger(object(), "alice")
+
+    # bob is untouched by alice's spending
+    await profile_routes._extract_save_trigger(object(), "bob")
+
+
+@pytest.mark.asyncio
+async def test_cap_can_be_disabled_with_zero(monkeypatch):
+    """PROFILE_EXTRACT_MAX_PER_HOUR=0 disables the cap (documented escape hatch)."""
+    calls = {"n": 0}
+
+    async def _fake_extract(profile):
+        calls["n"] += 1
+        return profile
+
+    monkeypatch.setattr(profile_routes, "run_two_pass_extraction", _fake_extract)
+    monkeypatch.setattr(profile_routes, "save_profile", lambda *a, **k: None)
+
+    async def _noop(_user_id):
+        return None
+
+    monkeypatch.setattr(profile_routes, "_maybe_trigger_rescore", _noop)
+    monkeypatch.setattr(profile_routes, "PROFILE_EXTRACT_MAX_PER_HOUR", 0)
+
+    for _ in range(25):
+        await profile_routes._extract_save_trigger(object(), "unlimited")
+    assert calls["n"] == 25


### PR DESCRIPTION
From `docs/fable/08-GAPS-NOT-YET-AUDITED.md`, *"Cost economics — NOT audited"*:

> *"the two-pass extraction re-runs ALL LLM passes on any profile change — thats an uncapped cost vector."*

**Verified true.** Five routes reach `_extract_save_trigger` (cv / preferences / profile / linkedin / github), each fanning out to **4+ paid LLM calls**, re-run in full from stored data on *any* change. Nothing bounded how often a user could trigger it.

## Why this stopped being theoretical tonight

It was harmless while it was **free**. `openai` had never actually been installed in production — the import raised, a broad `except` in the provider chain swallowed it as *"provider failed, try the next one"*, and every parse silently fell back to a free tier.

**Declaring the dependency (#91) turned the primary PAID provider on for the first time.** The same uncapped loop that cost nothing now bills.

Worth recording as a pattern, not just an incident: fixing a silently-dead dependency doesnt only restore a feature — it **activates whatever cost path that feature sits on**. Worth asking after any "this was never actually running" fix: *what else starts running now?*

## The cap

`PROFILE_EXTRACT_MAX_PER_HOUR` (default **12**), enforced at the single chokepoint every route already passes through. Over the limit → **HTTP 429 explaining why** ("each update re-runs AI extraction over your CV, LinkedIn and GitHub"), not a bare code.

Reuses `services/auth/rate_limit` rather than inventing a counter — **deliberately**: that limiter already has a shared-Redis mode (`RATE_LIMIT_REDIS`), so the cap holds **across replicas** instead of being silently multiplied by replica count. Thats the same trap the login lockout has.

12/hour is generous on purpose: someone genuinely setting up a profile edits it a handful of times in a sitting and will never feel it. It exists to stop a loop, not to ration users. `0` disables it.

## Tests — behaviour, not config

`tests/test_profile_extract_cost_cap.py`, 3 passing. A test that only checked "the setting exists" would pass against a cap that was never wired in (rule #21), so these assert what actually happens:

| Test | Asserts |
|---|---|
| limit bites | 13th call in an hour → 429, **and the extraction does not run** — a cap that still spends money while refusing would be worse than none |
| per-user | alice exhausting hers does not lock out bob |
| escape hatch | `PROFILE_EXTRACT_MAX_PER_HOUR=0` disables it, as documented |

## Also

`.env.example` still carried the stale `JOB360_ENV` block telling the reader that session cookies ship **without** `Secure` unless they set it. That is false (`auth.py:121` gates on `_is_production()`; Railway sets `RAILWAY_ENVIRONMENT` automatically) — and it is the exact instruction that cost a session chasing a security hole that did not exist. Corrected, as it already was in `CLAUDE.md`, with a note not to re-add it.

## Verification

```
full suite   1943 passed, 3 skipped, 20m02s
ruff         clean
mypy ratchet 0 errors
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6DsQH5EUxJc3Vnqz9YHgQ