### PR TITLE
fix(H1): carry job.id into worker-ingested Jobs — enrichment dims were silently scoring 0

### DIFF
--- a/backend/src/workers/tasks.py
+++ b/backend/src/workers/tasks.py
@@ -153,12 +153,12 @@ async def score_and_ingest(
     # share across the per-user scorer cache. Empty dict ⇒ no rows ⇒
     # multi-dim contributes 0 (legacy 4-component path preserved).
     enrichment_lookup_dict = await _build_enrichment_lookup(db)
-    # getattr(job, "id", None) -> Optional[int] at runtime (Job has no
-    # declared `id` field; see the enrich_job_task note below on the same
-    # pattern), but mypy can only see `Any | None`, hence the ignore. This is
-    # the documented call pattern from job_enrichment._build_enrichment_lookup's
-    # own docstring — dict.get(None) safely returns None, not a crash.
-    enrichment_lookup_fn = lambda job: enrichment_lookup_dict.get(getattr(job, "id", None))  # type: ignore[arg-type]  # noqa: E731
+    # `Job.id` is a declared field now (models.py) and _job_from_row populates
+    # it from the row, so this lookup actually finds enrichment instead of
+    # always calling get(None). Reads `job.id` directly rather than through
+    # getattr — the getattr dance existed only because the field was previously
+    # stapled on at runtime and might genuinely be absent.
+    enrichment_lookup_fn = lambda job: enrichment_lookup_dict.get(job.id)  # noqa: E731
 
     def _scorer_for(user_id: str) -> JobScorer:
         if user_id not in user_scorers:
@@ -442,6 +442,23 @@ def _job_from_row(job_row: Any) -> Job:
     shape. Pinned by tests/test_recency_date_type.py.
     """
     return Job(
+        # H1 — carry the row id onto the Job. The enrichment lookup is keyed on
+        # it (`enrichment_lookup_dict.get(getattr(job, "id", None))`), so an
+        # unset id meant `get(None)`, which ALWAYS misses — silently scoring
+        # every enrichment dimension (seniority / salary / visa / workplace) as
+        # 0 for every job ingested through the worker. Nothing raised: dict.get
+        # on a missing key returns None, and the scorer treats None as "no
+        # enrichment", which is indistinguishable from "this job genuinely has
+        # none".
+        #
+        # This is the documented dim-scoring-id bug, in the worker path.
+        # enrich_job_task already does it right (`job.id = row["id"]`); this
+        # call site was simply never given the same treatment.
+        #
+        # Scope note: with ENRICHMENT_ENABLED off the lookup dict is empty, so
+        # every get() misses either way and behaviour is unchanged. With it on,
+        # the dimensions finally contribute what they were always meant to.
+        id=job_row["id"],
         title=job_row["title"],
         company=job_row["company"],
         apply_url=job_row["apply_url"],

--- a/backend/tests/test_recency_date_type.py
+++ b/backend/tests/test_recency_date_type.py
@@ -75,6 +75,11 @@ def test_score_and_ingest_builds_job_with_string_date_found() -> None:
     from src.workers.tasks import _job_from_row, _parse_dt
 
     row = {
+        # Real rows come from `SELECT * FROM jobs WHERE id = ?`, so `id` is
+        # always present. _job_from_row indexes it directly (not .get) on
+        # purpose: a missing id must be LOUD, because a silently-None id is
+        # exactly what zeroed every enrichment dimension (H1).
+        "id": 1,
         "title": "Data Engineer",
         "company": "Acme",
         "apply_url": "https://example.test/1",

--- a/backend/tests/test_worker_boot_surface.py
+++ b/backend/tests/test_worker_boot_surface.py
@@ -1,0 +1,157 @@
+"""Worker-boot surface: the things that fail SILENTLY when they break.
+
+Both bugs pinned here share one shape — nothing raises, so a green suite proves
+nothing:
+
+* **H1**: `score_and_ingest` built its Job without an `id`, so the enrichment
+  lookup did `dict.get(None)` — which always misses. Every enrichment dimension
+  (seniority / salary / visa / workplace) silently scored 0 for every job the
+  worker ingested. `dict.get` on a missing key returns None, and the scorer
+  reads None as "this job has no enrichment", which is indistinguishable from
+  the real thing.
+* **cron_jobs**: `WorkerSettings.cron_jobs` must be a REAL iterable in the class
+  body. A previous implementation used a descriptor that returned itself, and
+  newer arq reads `__dict__['cron_jobs']` directly without triggering
+  descriptors — so the worker crashed at boot with
+  "'_CronJobsDescriptor' object is not iterable" and every cron
+  (notification_tick, nightly_ghost_sweep) stopped. That path had NO test.
+
+The related dead-worker P0 (`ctx['db']`/`ctx['enqueue']` never populated) is
+already covered by test_worker_tasks.py::test_worker_startup_populates_ctx.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+
+
+def test_job_from_row_carries_the_row_id() -> None:
+    """H1: without `id`, the enrichment lookup can only ever miss."""
+    from src.workers.tasks import _job_from_row
+
+    row = {
+        "id": 4242,
+        "title": "Data Engineer",
+        "company": "Acme",
+        "apply_url": "https://example.test/1",
+        "source": "test",
+        "date_found": datetime.now(timezone.utc),
+        "location": "London",
+        "description": "",
+        "match_score": 0,
+    }
+
+    job = _job_from_row(row)
+    assert job.id == 4242, (
+        "Job.id must come from the row — the enrichment lookup is keyed on it, "
+        "so an unset id silently zeroes every enrichment dimension"
+    )
+
+
+def test_enrichment_lookup_actually_hits_with_a_real_id() -> None:
+    """The end-to-end consequence: lookup by job.id must FIND the enrichment.
+
+    Asserts the value, not just that the call succeeds (rule #21) — the bug's
+    whole signature was a call that succeeded and returned None.
+    """
+    from src.workers.tasks import _job_from_row
+
+    row = {
+        "id": 77,
+        "title": "Data Engineer",
+        "company": "Acme",
+        "apply_url": "https://example.test/1",
+        "source": "test",
+        "date_found": datetime.now(timezone.utc),
+        "location": "London",
+        "description": "",
+        "match_score": 0,
+    }
+    job = _job_from_row(row)
+
+    enrichment_lookup_dict = {77: {"seniority": "senior"}}
+    # the exact lambda shape score_and_ingest builds
+    lookup = lambda j: enrichment_lookup_dict.get(j.id)  # noqa: E731
+
+    assert lookup(job) == {"seniority": "senior"}, (
+        "enrichment lookup missed for a job that HAS enrichment — this is the "
+        "dim-scoring-id bug: every dimension would score 0 with no error"
+    )
+
+
+def test_cron_jobs_is_a_real_iterable_in_the_class_body() -> None:
+    """arq reads WorkerSettings.__dict__['cron_jobs'] WITHOUT triggering descriptors.
+
+    A descriptor here returned itself and the worker died at boot with
+    "'_CronJobsDescriptor' object is not iterable" — killing notification_tick
+    and nightly_ghost_sweep. Read it the way arq does, not via attribute access,
+    or a descriptor would pass this test while still breaking the worker.
+    """
+    from src.workers.settings import WorkerSettings
+
+    raw = WorkerSettings.__dict__.get("cron_jobs")
+    assert raw is not None, "cron_jobs missing from the class body"
+    assert isinstance(raw, (list, tuple)), (
+        f"cron_jobs must be a real list/tuple in the class body, got {type(raw).__name__} — "
+        "arq does not trigger descriptors and the worker will not boot"
+    )
+    # must survive iteration: the exact operation that crashed
+    assert list(raw) is not None
+
+
+def test_every_registered_function_is_callable() -> None:
+    """A name in `functions` that isn't a real coroutine fn breaks dispatch silently."""
+    import inspect
+
+    from src.workers.settings import WorkerSettings
+
+    assert WorkerSettings.functions, "no tasks registered — the worker would idle forever"
+    for fn in WorkerSettings.functions:
+        assert callable(fn), f"registered task {fn!r} is not callable"
+        assert inspect.iscoroutinefunction(fn), (
+            f"registered task {getattr(fn, '__name__', fn)!r} is not async — arq requires a coroutine"
+        )
+
+
+def test_send_notification_is_registered() -> None:
+    """SI1 depends on this exact name being enqueueable.
+
+    `_enqueue_notifications` calls enqueue("send_notification", ...) by STRING.
+    If the function were renamed or dropped from the registry, the enqueue would
+    succeed and the job would never run — silent, again.
+    """
+    from src.workers.settings import WorkerSettings
+
+    names = {getattr(f, "__name__", "") for f in WorkerSettings.functions}
+    assert "send_notification" in names, (
+        f"send_notification missing from the ARQ registry: {sorted(names)} — "
+        "notifications would be enqueued into a queue nobody consumes"
+    )
+
+
+@pytest.mark.parametrize("attr,expected", [("max_jobs", 1), ("job_timeout", 600)])
+def test_worker_concurrency_and_timeout_pinned(attr: str, expected: int) -> None:
+    """max_jobs=1 is load-bearing: tasks share ONE ctx['db'] connection.
+
+    Raising it lets two coroutines use one psycopg connection concurrently
+    ("another operation in progress"). job_timeout bounds a hung LLM call.
+    """
+    from src.workers.settings import WorkerSettings
+
+    assert getattr(WorkerSettings, attr) == expected
+
+
+def test_health_check_interval_is_short_enough_to_notice_death() -> None:
+    """arq's default is 3600 — a worker dead at 00:01 still looks alive at 00:59.
+
+    The heartbeat key expires at interval+1, so this bounds how long a dead
+    worker can masquerade as healthy. This worker HAS died silently in
+    production before (commit 7f906c6).
+    """
+    from src.workers.settings import WorkerSettings
+
+    interval = getattr(WorkerSettings, "health_check_interval", 3600)
+    assert interval <= 60, (
+        f"health_check_interval={interval}s is too coarse to detect a dead worker; "
+        "arq's 3600 default is what let one die unnoticed"
+    )


### PR DESCRIPTION
Found by sweeping `docs/FABLE_FINDINGS.md` + `fable-harness-plan.md` + `00-EXECUTIVE-SUMMARY.md` — docs the numbered audit never captured. **58 items in those docs; 47 were already fixed.** This was the one live bug.

## The bug

`score_and_ingest` builds its Job through `_job_from_row`, which set title, company, url, source, date, location, description and match_score — but **not `id`**. The scorers enrichment hook is keyed on exactly that:

```python
enrichment_lookup_dict.get(getattr(job, "id", None))
```

With no id that is `get(None)` — **always a miss**. So **every enrichment dimension** (seniority, salary, visa, workplace) scored **0** for every job the worker ingested.

Nothing raised. `dict.get` returns `None`, and the scorer reads `None` as *"this job has no enrichment"* — indistinguishable from a job that genuinely has none.

This is the documented dim-scoring-id bug, in the worker path. `enrich_job_task` already does it right (`job.id = row["id"]`), which is what makes this an oversight rather than a design choice.

## Partly self-inflicted — worth recording

I declared `Job.id` on `models.py` **earlier tonight** and extracted `_job_from_row` in the same session, and didnt wire the two together. **Declaring a field makes the bug expressible; it doesnt populate it.** Worth asking after any "I added the missing field" change: *is anyone actually setting it?*

## Scope

With `ENRICHMENT_ENABLED` **off**, the lookup dict is empty so every `get()` misses either way — behaviour unchanged. With it **on**, the dimensions finally contribute what they were meant to. ⚠️ Scores move, in the direction the feature intended.

## Tests — `test_worker_boot_surface.py` (8)

Targeting the class of bug that fails **silently at worker boot**:

| Test | Note |
|---|---|
| `_job_from_row` carries the row id | **verified to fail without the fix** |
| enrichment lookup actually **hits** | asserts the returned value, not that the call succeeded — "succeeded, returned None" *was* the bug (rule #21). **verified to fail without the fix** |
| `cron_jobs` is a real iterable | **had ZERO coverage** despite a documented crash (`'_CronJobsDescriptor' object is not iterable`) that killed the worker and with it `notification_tick` + `nightly_ghost_sweep`. Read via `__dict__` the way arq reads it — `getattr` would let a descriptor pass while still breaking the worker |
| every registered task is an async callable | |
| `send_notification` is registered | SI1 enqueues it **by string**; a rename would enqueue into a queue nobody consumes |
| `max_jobs=1`, `job_timeout=600` pinned | `max_jobs` is load-bearing — tasks share ONE `ctx['db']` connection |
| `health_check_interval <= 60` | arqs 3600 default is what let a worker die unnoticed |

## One fixture corrected — deliberately not the code

The full gate then failed: `KeyError: id` in my own `test_recency_date_type.py`, whose row fixture had no `id`. Real rows come from `SELECT * FROM jobs`, so `id` is always present.

**I kept the strict `job_row["id"]` and fixed the fixture.** Softening it to `.get("id")` would have silently restored the exact `None`-id bug this PR fixes. A missing id must be loud.

## Verification

```
full suite   1948 passed, 3 skipped, 18m55s
ruff         clean
mypy ratchet 0 errors
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6DsQH5EUxJc3Vnqz9YHgQ