### PR TITLE
fix(scoring): H1 (id returning jobs before scoring) + L2 (future dates lose freshness)

### DIFF
--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -690,6 +690,25 @@ async def run_search(
 
             logger.info("Total raw jobs: %s", len(all_jobs))
 
+            # H1: attach each job's catalog id BEFORE scoring, so the multi-dim
+            # enrichment lookup (keyed on job.id, rules #19/#20) actually finds a
+            # RETURNING job's enrichment from a prior run. Previously score() ran
+            # here with job.id still None, so seniority/salary/visa/workplace dims
+            # silently scored 0; and if that dims-blind score missed
+            # ENRICHMENT_THRESHOLD, the job never reached the post-enrich re-score
+            # pass — so its persisted match_score stayed wrong forever. One query
+            # loads the whole (bounded, <=30-day) catalog's normalized-key → id map;
+            # brand-new jobs aren't in it and correctly stay id=None (they have no
+            # enrichment yet — scoring them dims-blind is right).
+            _catalog_ids: dict[tuple[str, str], int] = {}
+            _cur = await conn.execute(
+                "SELECT normalized_company, normalized_title, id FROM jobs"
+            )
+            for _row in await _cur.fetchall():
+                _catalog_ids[(_row[0], _row[1])] = _row[2]
+            for job in all_jobs:
+                job.id = _catalog_ids.get(job.normalized_key())
+
             # Score all jobs using the user's profile (scorer always exists — guarded at start).
             # Step-1 B4: JobScorer.score() now returns a ScoreBreakdown — surface
             # the scalar match_score on the Job so the MIN_MATCH_SCORE filter still works.
@@ -752,14 +771,11 @@ async def run_search(
             new_jobs.sort(key=lambda j: (j.match_score, salary_in_range(j)), reverse=True)
             logger.info("New jobs: %s", len(new_jobs))
 
-            # Attach each job's DB id (the PK assigned by INSERT, resolved via
-            # normalized key). The Job dataclass carries no id until now, and
-            # enrich_batch persists keyed on ``job.id`` — so this MUST happen
-            # before enrichment or every result is silently dropped.
-            # NOTE (real bug, reported not fixed — Job.id is a dynamically-set
-            # attribute, not a declared dataclass field in src/models.py; see
-            # project memory "Dim scoring id bug". Out of scope: models.py is
-            # not part of this fix and Pillar 2 scoring is hands-off.)
+            # Re-resolve the DB id for the jobs we just inserted this run (brand-new
+            # jobs had no catalog id during the pre-scoring H1 pass above). Returning
+            # jobs already carry their id from that earlier pass; re-setting it here
+            # is a harmless no-op. enrich_batch persists keyed on ``job.id``, so this
+            # MUST cover the just-inserted rows before enrichment runs.
             for job in unique_jobs:
                 cur = await conn.execute(
                     "SELECT id FROM jobs WHERE normalized_company = ? AND normalized_title = ?",

--- a/backend/src/services/skill_matcher.py
+++ b/backend/src/services/skill_matcher.py
@@ -294,9 +294,19 @@ def _recency_score(date_found: str) -> int:
         posted = datetime.fromisoformat(date_found)
         if posted.tzinfo is None:
             posted = posted.replace(tzinfo=timezone.utc)
-        days_old = (datetime.now(timezone.utc) - posted).days
+        delta_days = (datetime.now(timezone.utc) - posted).days
     except (ValueError, TypeError):
         return 0
+    # L2: a posting date in the FUTURE is implausible/fabricated data. The old
+    # `(now - posted).days` produced a NEGATIVE number for future dates, which
+    # slipped through the `<= 1` gate below and scored MAX freshness — so a job
+    # dated next year outranked a genuinely fresh one. Beyond ~1 day of clock
+    # skew, treat a future date as untrustworthy and give it no freshness boost.
+    # Within a day (source/clock skew on a just-posted job) it's clamped to 0 and
+    # still scores as fresh.
+    if delta_days < -1:
+        return 0
+    days_old = max(0, delta_days)
     if days_old <= 1:
         return RECENCY_WEIGHT
     if days_old <= 3:

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -734,3 +734,90 @@ def test_metrics_export_uses_resolved_path_not_none_string():
                 pass
 
     _run(_test())
+
+
+def test_run_search_returning_job_carries_id_before_scoring():
+    """H1: a job already in the catalog (a RETURNING job) must carry its DB id
+    when run_search scores it — otherwise the multi-dim enrichment lookup (keyed
+    on job.id, rules #19/#20) misses its prior-run enrichment and the
+    seniority/salary/visa/workplace dims silently score 0.
+
+    Before the fix, run_search scored every job with job.id still None (id was
+    only resolved AFTER scoring + insert). This seeds the exact job the arbeitnow
+    mock returns, then captures job.id at score() time. Verified to FAIL against
+    the pre-fix code (id was None).
+    """
+    import os as _os
+    from datetime import datetime as _dt
+    from datetime import timezone as _tz
+
+    from src.models import Job as _Job
+    from src.repositories.database import JobDatabase as _JobDatabase
+    from src.services.profile.models import CVData as _CVData
+    from src.services.skill_matcher import JobScorer as _RealScorer
+
+    fd, db_path = tempfile.mkstemp(suffix=".db")
+    _os.close(fd)
+
+    async def _seed() -> int:
+        db = _JobDatabase(db_path)
+        await db.init_db()
+        from migrations import runner  # noqa: PLC0415
+
+        await runner.up(db_path)
+        # The SAME job MOCK_JOB_PAYLOAD returns → it is a "returning" job.
+        job = _Job(
+            title="AI Engineer",
+            company="TestCo",
+            apply_url="https://example.com/ai-1",
+            source="arbeitnow",
+            date_found=_dt.now(_tz.utc).isoformat(),
+            location="London, UK",
+            description="Python role",
+        )
+        await db.insert_job(job)
+        await db.commit()
+        conn = db._conn
+        cur = await conn.execute(
+            "SELECT id FROM jobs WHERE normalized_company=? AND normalized_title=?",
+            job.normalized_key(),
+        )
+        seeded = (await cur.fetchone())[0]
+        await db.close()
+        return seeded
+
+    seeded_id = _run(_seed())
+
+    captured: dict = {}
+
+    class _SpyScorer(_RealScorer):
+        def score(self, job):
+            if job.title == "AI Engineer" and job.company == "TestCo":
+                captured["id_at_score"] = getattr(job, "id", "MISSING")
+            return super().score(job)
+
+    fake_profile = UserProfile(
+        cv_data=_CVData(raw_text="dummy CV content"),
+        preferences=UserPreferences(target_job_titles=["AI Engineer"]),
+    )
+
+    async def _test():
+        with aioresponses() as m:
+            _mock_free_sources(m, arbeitnow_payload=MOCK_JOB_PAYLOAD)
+            with (
+                _patch_no_notifications(),
+                patch("src.main.load_profile", return_value=fake_profile),
+                patch("src.main.JobScorer", _SpyScorer),
+            ):
+                await run_search(db_path=db_path, dry_run=True)
+
+    try:
+        _run(_test())
+    finally:
+        _os.unlink(db_path)
+
+    assert captured.get("id_at_score") == seeded_id, (
+        f"the returning job was scored with id={captured.get('id_at_score')!r}, "
+        f"expected the catalog id {seeded_id} — with id=None the enrichment lookup "
+        "misses and the multi-dim scores silently fall to 0 (finding H1)."
+    )

--- a/backend/tests/test_scorer.py
+++ b/backend/tests/test_scorer.py
@@ -5,6 +5,7 @@ import pytest
 from src.models import Job
 from src.services.profile.models import SearchConfig
 from src.services.skill_matcher import (
+    RECENCY_WEIGHT,
     JobScorer,
     ScoreBreakdown,
     _foreign_location_penalty,
@@ -206,6 +207,25 @@ def test_recency_invalid_date_no_crash():
     assert _recency_score("") == 0
     assert _recency_score("not-a-date") == 0
     assert _recency_score("2025-13-99") == 0
+
+
+def test_recency_far_future_date_gets_zero_not_max():
+    """L2: a job dated well in the future is implausible/fabricated data and must
+    NOT earn maximum freshness. Before the fix, `(now - posted).days` went
+    negative and slipped through the `<= 1` gate, so a future-dated job scored
+    the MAX recency band — outranking genuinely fresh jobs. It now scores 0."""
+    future = (datetime.now(timezone.utc) + timedelta(days=30)).isoformat()
+    assert _recency_score(future) == 0
+    # A year in the future — the extreme case that most clearly should not win.
+    far_future = (datetime.now(timezone.utc) + timedelta(days=365)).isoformat()
+    assert _recency_score(far_future) == 0
+
+
+def test_recency_slight_future_clock_skew_still_counts_as_fresh():
+    """A just-posted job whose source timestamp is a few hours ahead of our clock
+    (normal skew) should still score as fresh, not be penalised to 0."""
+    skewed = (datetime.now(timezone.utc) + timedelta(hours=2)).isoformat()
+    assert _recency_score(skewed) == RECENCY_WEIGHT
 
 
 def test_score_can_reach_100():


### PR DESCRIPTION
Two Pillar-2 scoring fixes (hands-off lifted by owner), each with a **test verified to fail against the pre-fix code**.

## H1 — returning jobs scored with `id=None` → dims silently 0
`main.py` scored jobs *before* resolving `job.id`, so the multi-dim enrichment lookup (keyed on `job.id`) missed a **returning** job's prior-run enrichment → seniority/salary/visa/workplace dims scored 0. If that dims-blind score then missed `ENRICHMENT_THRESHOLD`, the job never reached the post-enrich re-score pass, so its persisted `match_score` stayed wrong.
- Fix: one query loads the (≤30-day, bounded) catalog's normalized-key→id map and stamps `job.id` on every returning job **before** the scoring loop. Brand-new jobs correctly stay `id=None`.
- Read-time + worker paths were already fixed; this closes the orchestrator path.
- Test: `test_run_search_returning_job_carries_id_before_scoring` — **id=None without the fix**.

## L2 — future-dated posts scored MAX freshness
`_recency_score` used `(now - posted).days`, which went **negative** for a future date and slipped through the `<= 1` gate → MAX recency. A job dated next year outranked a genuinely fresh one.
- Fix: >~1 day future = untrustworthy → 0 recency; within ~1 day (clock skew) still scores fresh. Fixes both the legacy and 5-column paths (shared helper).
- Tests: `test_recency_far_future_date_gets_zero_not_max` (scored 10 without the fix) + `_slight_future_clock_skew_still_counts_as_fresh`.

## Verification
Gate PASS (`test_main` + `test_scorer`, 97 tests); no regression across scorer/main/profile (149 earlier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6DsQH5EUxJc3Vnqz9YHgQ