### PR TITLE
fix(audit): F2 (E2E auth-bypass hardening) + SPLIT-P3 ($$-aware SQL splitter)

### DIFF
--- a/backend/migrations/runner.py
+++ b/backend/migrations/runner.py
@@ -140,28 +140,16 @@ def _discover_pairs(migrations_dir: Path) -> list[str]:
 
 
 def _split_sql_statements(sql: str) -> list[str]:
-    """Split a SQL script into statements on naive ``;`` boundaries.
+    """Split a SQL script into statements on ``;`` boundaries.
 
-    Strips both full-line AND inline ``--`` comments before splitting, so a
-    ``;`` inside a trailing comment doesn't sever a statement mid-way. (0015's
-    ``-- NULL = not yet used; set on successful consume`` did exactly that,
-    producing ``pgsync.OperationalError: incomplete input``.)
-
-    Still naive about ``;`` inside string literals — but no repo migration has
-    one, and none has ``--`` inside a string literal either (verified against
-    ``migrations/*.sql``), so line-wise comment stripping is safe here. If a
-    future migration needs either, route it through ``executescript`` instead.
+    Delegates to ``pg.split_statements`` (single source of truth) which strips
+    ``--`` comments, then splits on ``;`` that is NOT inside a single-quoted
+    string or a ``$$``/``$tag$`` dollar-quoted body. SPLIT-P3: this used to be a
+    plain ``cleaned.split(";")`` here and in pg.py — safe for today's migrations
+    but a future one with a Postgres function body / DO block (``$$ ... ; ... $$``)
+    would have been severed mid-statement at boot.
     """
-    stripped: list[str] = []
-    for line in sql.splitlines():
-        # Drop everything from the first ``--`` to end of line (full-line and
-        # inline comments alike). Safe given no string literal contains ``--``.
-        comment = line.find("--")
-        if comment != -1:
-            line = line[:comment]
-        stripped.append(line)
-    cleaned = "\n".join(stripped)
-    return [s.strip() for s in cleaned.split(";") if s.strip()]
+    return pg.split_statements(sql)
 
 
 async def _apply_up_sql(db: pg.Connection, sql: str) -> None:

--- a/backend/src/repositories/pg.py
+++ b/backend/src/repositories/pg.py
@@ -355,12 +355,82 @@ def translate(sql: str) -> str:
     return out
 
 
+def _match_dollar_tag(s: str, i: int) -> Optional[str]:
+    """If ``s[i:]`` opens a Postgres dollar-quote tag (``$$`` or ``$tag$``),
+    return the tag text, else None. Tag body is ``[A-Za-z0-9_]*``."""
+    if i >= len(s) or s[i] != "$":
+        return None
+    j = i + 1
+    while j < len(s) and (s[j].isalnum() or s[j] == "_"):
+        j += 1
+    if j < len(s) and s[j] == "$":
+        return s[i : j + 1]
+    return None
+
+
+def _split_on_unquoted_semicolons(cleaned: str) -> list[str]:
+    """Split on ``;`` that sits OUTSIDE a single-quoted string or a dollar-quoted
+    body. SPLIT-P3: Postgres function bodies / DO blocks use ``$$ ... ; ... $$``
+    and a naive ``.split(';')`` would sever them mid-body."""
+    statements: list[str] = []
+    buf: list[str] = []
+    i, n = 0, len(cleaned)
+    in_single = False
+    dollar_tag: Optional[str] = None
+    while i < n:
+        ch = cleaned[i]
+        if dollar_tag is not None:
+            if cleaned.startswith(dollar_tag, i):  # closing tag
+                buf.append(dollar_tag)
+                i += len(dollar_tag)
+                dollar_tag = None
+                continue
+            buf.append(ch)
+            i += 1
+            continue
+        if in_single:
+            buf.append(ch)
+            if ch == "'":
+                if i + 1 < n and cleaned[i + 1] == "'":  # escaped '' inside a string
+                    buf.append("'")
+                    i += 2
+                    continue
+                in_single = False
+            i += 1
+            continue
+        if ch == "'":
+            in_single = True
+            buf.append(ch)
+            i += 1
+            continue
+        tag = _match_dollar_tag(cleaned, i)
+        if tag is not None:
+            dollar_tag = tag
+            buf.append(tag)
+            i += len(tag)
+            continue
+        if ch == ";":
+            stmt = "".join(buf).strip()
+            if stmt:
+                statements.append(stmt)
+            buf = []
+            i += 1
+            continue
+        buf.append(ch)
+        i += 1
+    tail = "".join(buf).strip()
+    if tail:
+        statements.append(tail)
+    return statements
+
+
 def split_statements(script: str) -> list[str]:
     """Split a multi-statement script on ``;`` boundaries.
 
     Strips full-line and inline ``--`` comments first (a ``;`` inside a trailing
-    comment must not sever a statement). Naive about ``;`` inside string
-    literals, but no repo SQL has one.
+    comment must not sever a statement), then splits on ``;`` that is NOT inside
+    a single-quoted string or a ``$$``/``$tag$`` dollar-quoted body (SPLIT-P3 —
+    a Postgres function body or DO block would otherwise be severed mid-statement).
     """
     stripped: list[str] = []
     for line in script.splitlines():
@@ -369,7 +439,7 @@ def split_statements(script: str) -> list[str]:
             line = line[:c]
         stripped.append(line)
     cleaned = "\n".join(stripped)
-    return [s.strip() for s in cleaned.split(";") if s.strip()]
+    return _split_on_unquoted_semicolons(cleaned)
 
 
 # ==========================================================================

--- a/backend/tests/test_pg_translate.py
+++ b/backend/tests/test_pg_translate.py
@@ -128,3 +128,50 @@ async def test_lastval_probe_is_savepoint_safe_inside_transaction(tmp_path):
         row = await check.fetchone()
         assert row is not None and row[0] == "val"
     await pg.drop_schema(path)
+
+
+# --- SPLIT-P3: statement splitter must not sever $$ bodies / string literals ---
+
+
+def test_split_statements_keeps_dollar_quoted_function_body_intact():
+    """SPLIT-P3: a ';' inside a $$...$$ Postgres function body must NOT split.
+
+    A naive `.split(';')` would sever this CREATE FUNCTION into 3 broken pieces,
+    each an incomplete statement that errors at migration boot. The $$-aware
+    splitter keeps the whole function as one statement.
+    """
+    script = """
+    CREATE TABLE t (id int);
+    CREATE FUNCTION bump() RETURNS trigger AS $$
+    BEGIN
+        NEW.updated_at := now();
+        INSERT INTO audit(msg) VALUES ('changed; logged');
+        RETURN NEW;
+    END;
+    $$ LANGUAGE plpgsql;
+    CREATE INDEX idx ON t (id);
+    """
+    stmts = pg.split_statements(script)
+    assert len(stmts) == 3, f"expected 3 statements, got {len(stmts)}: {stmts}"
+    body = stmts[1]
+    assert body.startswith("CREATE FUNCTION")
+    # the semicolons inside the body survived as one statement
+    assert "NEW.updated_at := now();" in body
+    assert "RETURN NEW;" in body
+    assert "END;" in body
+    assert body.rstrip().endswith("LANGUAGE plpgsql")
+
+
+def test_split_statements_keeps_semicolon_inside_string_literal():
+    """A ';' inside a '...' string literal must not split the statement."""
+    script = "INSERT INTO t(msg) VALUES ('a; b; c'); SELECT 1;"
+    stmts = pg.split_statements(script)
+    assert len(stmts) == 2, f"expected 2, got {len(stmts)}: {stmts}"
+    assert stmts[0] == "INSERT INTO t(msg) VALUES ('a; b; c')"
+    assert stmts[1] == "SELECT 1"
+
+
+def test_split_statements_normal_multi_statement_unchanged():
+    """Ordinary multi-statement scripts still split exactly as before."""
+    stmts = pg.split_statements("CREATE TABLE a(x int); CREATE TABLE b(y int);")
+    assert stmts == ["CREATE TABLE a(x int)", "CREATE TABLE b(y int)"]

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -35,17 +35,19 @@ export async function middleware(request: NextRequest) {
   const session = request.cookies.get("job360_session");
   if (!session?.value) return bounceToLogin();
 
-  // E2E test bypass — gated SOLELY on E2E_TEST_MODE, which is set ONLY by
-  // playwright.config.ts's webServer env. It is never in .env.example, Railway,
-  // or any real deploy, so it cannot weaken a deployed auth guard. We must NOT
-  // also gate on NODE_ENV: the CI e2e runs a PRODUCTION build (npm run build &&
-  // start) for speed, so NODE_ENV==="production" there too — a non-prod gate
-  // silently disables this bypass in CI, and only the (now removed) fail-open
-  // catch was masking it. With the catch failing CLOSED (F4), that mask is gone,
-  // so the NODE_ENV gate turns every protected-route spec into a /login redirect.
-  // With E2E_TEST_MODE=1 a PRESENT cookie is trusted without the /api/auth/me
-  // round-trip, so hermetic (mocked, no live backend) specs pass deterministically.
-  if (process.env.E2E_TEST_MODE === "1") {
+  // E2E test bypass — with E2E_TEST_MODE=1 a PRESENT cookie is trusted without
+  // the /api/auth/me round-trip, so hermetic (mocked, no live backend) specs pass
+  // deterministically. Set ONLY by playwright.config.ts's webServer env.
+  //
+  // F2 hardening — a single `E2E_TEST_MODE==="1"` gate meant one stray env var in
+  // a real deploy would silently disable auth for everyone. NODE_ENV can't be the
+  // guard (CI e2e runs a PROD build, so NODE_ENV==="production" there too — it
+  // would kill the bypass in CI). RAILWAY_ENVIRONMENT is the right signal: Railway
+  // injects it into every deployed service, and CI/local never have it. So we ALSO
+  // require its ABSENCE — an accidental E2E_TEST_MODE=1 on Railway can no longer
+  // bypass auth, while CI (no RAILWAY_ENVIRONMENT) still works. Same prod signal
+  // the backend gates cookie-Secure/HSTS on, kept in sync deliberately.
+  if (process.env.E2E_TEST_MODE === "1" && !process.env.RAILWAY_ENVIRONMENT) {
     return NextResponse.next();
   }
 


### PR DESCRIPTION
Two findings a full re-scan of **all 15 fable docs** surfaced — both had **no ID** in the 106-item inventory (they fell through the finding renumbering), both real and code-fixable.

## F2 — E2E auth bypass could be flipped on in prod ⚠️
`frontend/src/middleware.ts` gated the auth bypass **solely** on `E2E_TEST_MODE==="1"`. One stray env var in a real deploy would disable auth for everyone. `NODE_ENV` can't guard it (CI e2e runs a prod build). 
- Fix: also require `!process.env.RAILWAY_ENVIRONMENT`. Railway injects that into every deployed service; CI/local never have it. So an accidental `E2E_TEST_MODE=1` on Railway **can't** bypass auth, and CI still works. Same prod signal the backend uses for cookie-Secure/HSTS.

## SPLIT-P3 — migration splitter would sever `$$` function bodies
`pg.py` + `runner.py` split SQL on a naive `.split(";")`. Safe today, but a future migration with a Postgres function body / DO block (`$$ ... ; ... $$`) or a `;` inside a string literal would be **severed mid-statement at boot**.
- Fix: `pg.split_statements` now skips `;` inside single-quoted strings and `$$`/`$tag$` dollar-quoted bodies; `runner.py` delegates to it (one source of truth).
- Tests **verified to fail on the naive split**: the `$$` body split into 8 pieces instead of 1; the string literal into 4 instead of 2.

## Verification
Gate PASS — `test_pg_translate` (16, incl. 3 new) + frontend (204). Migration suite unaffected (33).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6DsQH5EUxJc3Vnqz9YHgQ