### PR TITLE
fix(audit): M6 (ghost sweep skipped NULL-last_seen) + L5 (.env.example drift) — caught by re-verify

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -206,3 +206,37 @@ RUN_MIGRATIONS_ON_BOOT=true
 # Only override if the public keys rotate upstream.
 EIGHTYKHOURS_ALGOLIA_APP_ID=
 EIGHTYKHOURS_ALGOLIA_API_KEY=
+
+# ---------------------------------------------------------------------------
+# L5 — vars the backend reads that were missing from this file (added 2026-07-23).
+# `python backend/scripts/check_env_example.py` enforces this list stays complete.
+# ---------------------------------------------------------------------------
+
+# Email delivery (Resend is the live path; SMTP_* are the generic fallback).
+RESEND_API_KEY=
+SMTP_HOST=
+SMTP_PORT=587
+SMTP_USER=
+SMTP_FROM=login@job360.uk
+
+# Auth: enforce email verification on gated routes (default on).
+REQUIRE_EMAIL_VERIFICATION=true
+# Trust the first X-Forwarded-For hop for the client IP (ONLY behind a trusted
+# proxy — else the source IP is spoofable). Unset = don't trust XFF.
+JOB360_TRUST_PROXY=
+
+# Rate limiting: use a shared Redis backend so caps hold across replicas
+# (default false = in-process only).
+RATE_LIMIT_REDIS=false
+
+# LLM tuning (CV parsing / matcher). Defaults shown.
+LLM_TEMPERATURE=0
+LLM_CALL_TIMEOUT_S=60
+LLM_RATE_LIMIT_RETRIES=2
+LLM_RATE_LIMIT_BASE_DELAY_S=2
+LLM_RATE_LIMIT_MAX_WAIT_S=8
+CEREBRAS_MODEL=gpt-oss-120b
+
+# Auto-injected by Railway on every deployed service — used for prod detection
+# (cookie Secure / HSTS / Sentry / the E2E-bypass guard). Do NOT set locally.
+RAILWAY_ENVIRONMENT=

--- a/backend/src/services/ghost_detection.py
+++ b/backend/src/services/ghost_detection.py
@@ -66,7 +66,20 @@ def evaluate_job_state(
     misses = int(row.get("consecutive_misses") or 0)
     last_seen = row.get("last_seen_at")
     if not last_seen:
-        return StalenessState.ACTIVE
+        # M6: a NULL last_seen_at used to short-circuit to ACTIVE, so a job missed
+        # many times but lacking that timestamp could NEVER transition to stale —
+        # the nightly sweep silently excluded it forever. Fall back to
+        # first_seen_at as the age proxy; if there's no timestamp at all, let
+        # consecutive_misses alone decide (a job missed 3+ times is stale
+        # regardless of when we last saw it). A brand-new job has a recent
+        # first_seen_at, so it correctly stays ACTIVE.
+        last_seen = row.get("first_seen_at") or row.get("first_seen")
+        if not last_seen:
+            if misses >= 3:
+                return StalenessState.LIKELY_STALE
+            if misses >= 2:
+                return StalenessState.POSSIBLY_STALE
+            return StalenessState.ACTIVE
 
     now = now or datetime.now(timezone.utc)
     try:

--- a/backend/src/workers/tasks.py
+++ b/backend/src/workers/tasks.py
@@ -533,7 +533,7 @@ async def nightly_ghost_sweep(ctx: dict[str, Any]) -> dict[str, int]:
     # Load all non-expired jobs (CONFIRMED_EXPIRED is sticky; skip it).
     cursor = await db.execute(
         """
-        SELECT id, staleness_state, consecutive_misses, last_seen_at
+        SELECT id, staleness_state, consecutive_misses, last_seen_at, first_seen_at
         FROM jobs
         WHERE staleness_state IS NULL OR staleness_state != 'confirmed_expired'
         """

--- a/backend/tests/test_ghost_detection.py
+++ b/backend/tests/test_ghost_detection.py
@@ -218,3 +218,44 @@ def test_pass_skips_failed_sources(db):
         missed = await _ghost_detection_pass(db, [source], [None], {})
         assert missed == {}
     asyncio.run(_run())
+
+
+# --- M6: NULL last_seen_at must not permanently short-circuit to ACTIVE ---
+
+from datetime import datetime, timedelta, timezone  # noqa: E402
+
+
+def test_m6_null_last_seen_with_misses_and_no_timestamp_goes_stale():
+    """M6: a row with NULL last_seen_at AND no first_seen_at, but many misses,
+    used to be forced ACTIVE forever (never swept). It must now transition on
+    consecutive_misses alone."""
+    row = {"staleness_state": "active", "consecutive_misses": 3, "last_seen_at": None}
+    assert evaluate_job_state(row) == StalenessState.LIKELY_STALE
+    row2 = {"staleness_state": "active", "consecutive_misses": 2, "last_seen_at": None}
+    assert evaluate_job_state(row2) == StalenessState.POSSIBLY_STALE
+
+
+def test_m6_null_last_seen_falls_back_to_first_seen_at():
+    """When last_seen_at is NULL, first_seen_at is used as the age proxy."""
+    old = (datetime.now(timezone.utc) - timedelta(hours=48)).isoformat()
+    row = {
+        "staleness_state": "active",
+        "consecutive_misses": 3,
+        "last_seen_at": None,
+        "first_seen_at": old,
+    }
+    # 3 misses + 48h old (via first_seen fallback) => likely stale
+    assert evaluate_job_state(row) == StalenessState.LIKELY_STALE
+
+
+def test_m6_brand_new_job_with_null_last_seen_stays_active():
+    """A just-discovered job (recent first_seen_at, NULL last_seen_at, few misses)
+    must NOT be wrongly marked stale by the fallback."""
+    fresh = datetime.now(timezone.utc).isoformat()
+    row = {
+        "staleness_state": "active",
+        "consecutive_misses": 0,
+        "last_seen_at": None,
+        "first_seen_at": fresh,
+    }
+    assert evaluate_job_state(row) == StalenessState.ACTIVE

--- a/docs/fable/AUDIT-2026-07-23-FULL-REVERIFY.md
+++ b/docs/fable/AUDIT-2026-07-23-FULL-REVERIFY.md
@@ -252,3 +252,54 @@ fixed**. Everything else is **not engineering debt**:
 
 **No open, code-fixable finding remains in any of the 15 fable docs.** What's left is
 owner decisions and scheduled audit efforts — this backlog is complete.
+
+---
+
+# FOURTH PASS — re-verify vs CURRENT main (post-merge), 2026-07-23 (PR #110)
+
+After #104–#108 all merged, the whole 108-finding set was re-verified against the
+**current** `origin/main` (HEAD `bf823e6`) by 13 parallel agents reading real code,
+plus an adversarial refutation pass. This pass superseded the "backlog closed"
+claim above — because it caught **two findings the earlier docs had recorded WRONG.**
+
+- **94 VERIFIED FIXED** on current main. The previously-in-PR fixes (C1 pool, C2,
+  H1, L2, F2, SPLIT-P3, MASKEMAIL) now confirm fixed **on main**.
+- **Adversarial pass overturned ZERO** fixed claims.
+- **Nothing stranded in a branch** (`not_on_main = 0`) — every fix is genuinely on main.
+
+### The docs were wrong on two — code proof beat the doc claim:
+
+### M6 — doc said "UNKNOWN"; it was a real bug — IT IS FIXED (PR #110)
+`ghost_detection.evaluate_job_state` returned `ACTIVE` whenever `last_seen_at` was
+NULL, so a job missed many times but lacking that timestamp could **never** go stale
+— `nightly_ghost_sweep` excluded it forever. Fixed: fall back to `first_seen_at`,
+then to `consecutive_misses` alone (3+ = stale); the sweep query now SELECTs
+`first_seen_at`. 3 new tests (the NULL+misses row now returns `LIKELY_STALE`).
+
+### L5 — doc claimed "covered by T3"; it was FALSE — IT IS FIXED (PR #110)
+`backend/scripts/check_env_example.py` **failed** on origin/main: 15 env vars the
+backend reads were missing from `.env.example` (RESEND_API_KEY, SMTP_HOST/PORT/USER/
+FROM, REQUIRE_EMAIL_VERIFICATION, RATE_LIMIT_REDIS, JOB360_TRUST_PROXY, LLM_* tuning,
+CEREBRAS_MODEL, RAILWAY_ENVIRONMENT). Added all 15; the check now passes (74/74, exit 0).
+
+### M2 — still open, your prior accepted decision (unchanged)
+`/register` returns 409 on a taken email → an unauthenticated caller can tell whether
+an email is registered. The login timing side-channel IS fixed (constant-time verify
+against `_DUMMY_PW_HASH`); only the register-409 enumeration remains, which you
+previously accepted (revealing email-taken is a deliberate UX choice). Left flagged,
+not silently changed.
+
+## Current bottom line (as of this session)
+
+Of 108 findings: **96 fixed** (94 verified on current main + M6, L5 fixed this pass).
+Remaining:
+- **M2** — open by your prior decision (register email-enumeration UX trade-off).
+- **N2, S5, V2, P3, P5, H6** — resolved / won't-fix / code-done-deploy-yours (as above).
+- **7 owner decisions** — SI1 (deploy worker+Redis+SMTP), 05-P0-LEGAL (scraping),
+  05-P1-POLICIES (privacy/terms), 05-P1-SUBPROC, 05-P2-MFA, 05-P2-BREACH,
+  PS-P1-ml-sentry (external dashboard), PLAN (behavioral), M10 (prod secret).
+- **`08-GAPS`** — audit areas to schedule (perf, cost dashboard, UX).
+
+**Every code-fixable finding is now fixed on main or in an open PR (#110). The only
+open item that is code AND not an owner decision is M2 — and that one you already
+decided. Nothing is silently broken.**


### PR DESCRIPTION
A fresh re-verification of **all 108 findings against current `origin/main`** (94 verified fixed, adversarial pass overturned nothing, nothing stranded in branches) caught **3 still-open** — **two the docs had wrong.** Fixing the two clear ones here.

## M6 — docs said "UNKNOWN"; real bug
`ghost_detection.evaluate_job_state` returned `ACTIVE` whenever `last_seen_at` was NULL, so a job missed many times but lacking that timestamp could **never** go stale — `nightly_ghost_sweep` silently excluded it forever.
- Fix: fall back to `first_seen_at` as the age proxy; if there's no timestamp at all, decide on `consecutive_misses` alone (3+ misses = stale). A brand-new job (recent `first_seen`, few misses) stays ACTIVE.
- The sweep query now also SELECTs `first_seen_at` so the fallback has data.
- Tests: 3 new — the NULL+misses row now returns `LIKELY_STALE`, a value the old `ACTIVE`-returning path could never produce.

## L5 — docs claimed "covered by T3"; false
`check_env_example.py` **failed** on `origin/main` — **15 env vars** the backend reads were missing from `.env.example` (RESEND_API_KEY, SMTP_HOST/PORT/USER/FROM, REQUIRE_EMAIL_VERIFICATION, RATE_LIMIT_REDIS, JOB360_TRUST_PROXY, the LLM_* tuning vars, CEREBRAS_MODEL, RAILWAY_ENVIRONMENT).
- Fix: added all 15 with real defaults + comments. Check now passes (74/74 documented, exit 0).

## Not fixed — your prior decision
**M2** — `/register` returns 409 on a taken email (reveals the email exists). You previously accepted this trade-off (revealing email-taken is a common, deliberate UX choice). Left as-is; flagged, not silently changed.

## Verification
Gate PASS (`test_ghost_detection` 24). Full current status in `docs/fable/AUDIT-2026-07-23-FULL-REVERIFY.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6DsQH5EUxJc3Vnqz9YHgQ