### PR TITLE
fix(security): M2 — /register no longer reveals whether an email exists

### DIFF
--- a/backend/src/api/routes/auth.py
+++ b/backend/src/api/routes/auth.py
@@ -96,6 +96,15 @@ class UserResponse(BaseModel):
     email: str
 
 
+class RegisterResponse(BaseModel):
+    # M2 — deliberately generic and IDENTICAL whether or not the email was already
+    # registered, so /register cannot be used to enumerate accounts. Carries no
+    # id/email (returning the real ones for a new user but not a duplicate would
+    # itself leak existence).
+    status: str = "ok"
+    message: str = "Account request received. Please sign in to continue."
+
+
 def _client_meta(request: Request) -> dict[str, Any]:
     """Extract safe client metadata for audit log extra fields.
 
@@ -129,13 +138,13 @@ def _set_session_cookie(response: Response, cookie: str) -> None:
     )
 
 
-@router.post("/register", response_model=UserResponse, status_code=status.HTTP_201_CREATED)
+@router.post("/register", response_model=RegisterResponse, status_code=status.HTTP_201_CREATED)
 async def register(
     req: RegisterRequest,
     response: Response,
     request: Request,
     background_tasks: BackgroundTasks,
-) -> UserResponse:
+) -> RegisterResponse:
     # M3 — per-IP registration throttle. Without this, register had ZERO rate
     # limit, so a single host could mass-create accounts. Derive the client IP
     # the SAME way login does: request.client.host, trusting the first
@@ -156,6 +165,7 @@ async def register(
         )
     user_id = uuid.uuid4().hex
     pw_hash = hash_password(req.password)
+    created = False
     async with open_db(str(DB_PATH)) as db:
         try:
             await db.execute(
@@ -165,31 +175,41 @@ async def register(
                 (user_id, req.email.lower(), pw_hash),
             )
             await db.commit()
+            created = True
         except pg.IntegrityError:
-            raise HTTPException(
-                status_code=status.HTTP_409_CONFLICT,
-                detail="email already registered",
-            )
-    cookie = await auth_sessions.create_session(str(DB_PATH), user_id=user_id, secret=_secret())
-    _set_session_cookie(response, cookie)
-    get_audit_logger().info(
-        "auth",
-        extra={"event": "register", "user_id": user_id, "status": "ok", **_client_meta(request)},
-    )
-    # Phase −2 item B + post-review fix #1 + #2: schedule the verification
-    # email as a FastAPI BackgroundTask. The task runs AFTER the response
-    # is queued so register isn't blocked on SMTP I/O (300ms–30s), and the
-    # _safe_ wrapper guarantees a DB error in the verification path can't
-    # propagate as HTTP 500 after the user row was already committed
-    # (orphan-account avoidance).
-    background_tasks.add_task(
-        _safe_request_email_verification,
-        db_path=str(DB_PATH),
-        user_id=user_id,
-        email=str(req.email),
-        frontend_origin=_frontend_origin(),
-    )
-    return UserResponse(id=user_id, email=req.email)
+            # M2 — the email already exists. Do NOT reveal that and do NOT touch the
+            # existing account; fall through to the SAME response a new signup gets.
+            created = False
+
+    # M2 — /register no longer auto-logs-in and no longer 409s on a taken email, so
+    # it can't be used to enumerate accounts. A session cookie for a new user but
+    # none for a duplicate would itself leak existence, so NEITHER path sets one —
+    # the user signs in next (sign up → sign in). Response body + status are
+    # identical whether the account was just created or already existed.
+    if created:
+        get_audit_logger().info(
+            "auth",
+            extra={"event": "register", "user_id": user_id, "status": "ok", **_client_meta(request)},
+        )
+        # Schedule the verification email as a FastAPI BackgroundTask so register
+        # isn't blocked on SMTP I/O, and the _safe_ wrapper keeps a DB error in the
+        # verification path from 500-ing after the user row was committed.
+        background_tasks.add_task(
+            _safe_request_email_verification,
+            db_path=str(DB_PATH),
+            user_id=user_id,
+            email=str(req.email),
+            frontend_origin=_frontend_origin(),
+        )
+    else:
+        # A duplicate — audited server-side (never surfaced to the caller). The real
+        # owner already has an account and can sign in / reset; we send no signal
+        # that would confirm the address is registered.
+        get_audit_logger().info(
+            "auth",
+            extra={"event": "register_duplicate", "status": "ok", **_client_meta(request)},
+        )
+    return RegisterResponse()
 
 
 @router.post("/login", response_model=UserResponse)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -269,6 +269,12 @@ def authenticated_async_context(monkeypatch, tmp_path):
         json={"email": "test@example.com", "password": "s3cretpassword"},
     )
     assert r.status_code == 201, r.text
+    # M2 — register no longer auto-logs-in (no-enumeration); sign in for the cookie.
+    lr = sync_client.post(
+        "/api/auth/login",
+        json={"email": "test@example.com", "password": "s3cretpassword"},
+    )
+    assert lr.status_code == 200, lr.text
     session_cookie = sync_client.cookies.get("job360_session")
     assert session_cookie, "authenticated_async_context: failed to capture session cookie"
     # Step-1.5 — capture the registered user's id BEFORE closing the

--- a/backend/tests/test_account_mgmt.py
+++ b/backend/tests/test_account_mgmt.py
@@ -102,10 +102,13 @@ def client(temp_db):
 
 
 def _register(client: TestClient, email: str, password: str = "s3cretpassword") -> dict:
-    """Register a user and return the JSON body. Cookie is set on client."""
+    """Register then sign in — register no longer auto-logs-in (M2, no-enumeration).
+    Leaves the client authenticated (session cookie set)."""
     r = client.post("/api/auth/register", json={"email": email, "password": password})
     assert r.status_code == 201, r.text
-    return r.json()
+    lr = client.post("/api/auth/login", json={"email": email, "password": password})
+    assert lr.status_code == 200, lr.text
+    return lr.json()
 
 
 def _login(client: TestClient, email: str, password: str = "s3cretpassword") -> int:

--- a/backend/tests/test_api_idor.py
+++ b/backend/tests/test_api_idor.py
@@ -141,6 +141,9 @@ def _register(client, email, password="s3cretpassword"):
     )
     _c.commit()
     _c.close()
+    # M2 — register no longer auto-logs-in; sign in so the client is authenticated.
+    lr = client.post("/api/auth/login", json={"email": email, "password": password})
+    assert lr.status_code == 200, lr.text
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_api_security.py
+++ b/backend/tests/test_api_security.py
@@ -139,6 +139,12 @@ def _register_user_and_get_cookie(app, email: str) -> str:
         json={"email": email, "password": "s3cretpassword"},
     )
     assert r.status_code == 201, r.text
+    # M2 — register no longer auto-logs-in; sign in for the session cookie.
+    lr = sync_client.post(
+        "/api/auth/login",
+        json={"email": email, "password": "s3cretpassword"},
+    )
+    assert lr.status_code == 200, lr.text
     cookie = sync_client.cookies.get("job360_session")
     sync_client.close()
     assert cookie

--- a/backend/tests/test_auth_routes.py
+++ b/backend/tests/test_auth_routes.py
@@ -93,26 +93,46 @@ async def _noop_lifespan(app):
 
 # ----- register --------------------------------------------------------
 
-def test_register_creates_user_and_returns_cookie(client):
+def test_register_creates_user_but_does_not_auto_login(client):
+    """M2 — register succeeds (201) but no longer sets a session cookie. A cookie
+    for a new user but none for a duplicate would itself enumerate accounts, so
+    NEITHER path sets one; the user signs in next. The user IS created — they can
+    log in immediately."""
     r = client.post(
         "/api/auth/register",
         json={"email": "alice@example.com", "password": "s3cretpassword"},
     )
     assert r.status_code == 201, r.text
-    assert r.json()["email"] == "alice@example.com"
-    assert "job360_session" in r.cookies
+    assert "job360_session" not in r.cookies
+    # The account was really created — login works.
+    lr = client.post(
+        "/api/auth/login",
+        json={"email": "alice@example.com", "password": "s3cretpassword"},
+    )
+    assert lr.status_code == 200, lr.text
+    assert "job360_session" in lr.cookies
 
 
-def test_register_rejects_duplicate_email(client):
-    client.post(
+def test_register_does_not_reveal_existing_email(client):
+    """M2 — registering a NEW email and re-registering an EXISTING one must be
+    indistinguishable (same status, same body, no cookie) so /register can't be
+    used to enumerate accounts. The existing account is NOT modified."""
+    new = client.post(
         "/api/auth/register",
         json={"email": "dup@example.com", "password": "s3cretpassword"},
     )
-    r = client.post(
+    dup = client.post(
         "/api/auth/register",
         json={"email": "dup@example.com", "password": "anothers3cretpassword"},
     )
-    assert r.status_code == 409
+    assert new.status_code == dup.status_code == 201
+    assert new.json() == dup.json(), "responses differ → email existence is observable"
+    assert "job360_session" not in dup.cookies
+    # The existing account's password was NOT overwritten by the duplicate attempt.
+    ok = client.post("/api/auth/login", json={"email": "dup@example.com", "password": "s3cretpassword"})
+    assert ok.status_code == 200
+    bad = client.post("/api/auth/login", json={"email": "dup@example.com", "password": "anothers3cretpassword"})
+    assert bad.status_code == 401
 
 
 def test_register_rejects_short_password(client):
@@ -163,6 +183,11 @@ def test_me_returns_user_with_valid_session(client):
         "/api/auth/register",
         json={"email": "z@example.com", "password": "s3cretpassword"},
     )
+    # M2 — register no longer auto-logs-in; sign in for the session.
+    client.post(
+        "/api/auth/login",
+        json={"email": "z@example.com", "password": "s3cretpassword"},
+    )
     r = client.get("/api/auth/me")
     assert r.status_code == 200
     assert r.json()["email"] == "z@example.com"
@@ -171,6 +196,11 @@ def test_me_returns_user_with_valid_session(client):
 def test_logout_revokes_session(client):
     client.post(
         "/api/auth/register",
+        json={"email": "lo@example.com", "password": "s3cretpassword"},
+    )
+    # M2 — register no longer auto-logs-in; sign in so there's a real session to revoke.
+    client.post(
+        "/api/auth/login",
         json={"email": "lo@example.com", "password": "s3cretpassword"},
     )
     r1 = client.post("/api/auth/logout")

--- a/backend/tests/test_channels_oauth.py
+++ b/backend/tests/test_channels_oauth.py
@@ -95,6 +95,9 @@ def api(monkeypatch, tmp_path):
 def _register(client: TestClient, email: str, password: str = "s3cretpassword") -> None:
     r = client.post("/api/auth/register", json={"email": email, "password": password})
     assert r.status_code == 201, r.text
+    # M2 — register no longer auto-logs-in; sign in so the client is authenticated.
+    lr = client.post("/api/auth/login", json={"email": email, "password": password})
+    assert lr.status_code == 200, lr.text
 
 
 _FAKE_SLACK_DATA = {

--- a/backend/tests/test_channels_routes.py
+++ b/backend/tests/test_channels_routes.py
@@ -105,6 +105,9 @@ def _register(client, email, password="s3cretpassword"):
         "/api/auth/register", json={"email": email, "password": password}
     )
     assert r.status_code == 201, r.text
+    # M2 — register no longer auto-logs-in; sign in so the client is authenticated.
+    lr = client.post("/api/auth/login", json={"email": email, "password": password})
+    assert lr.status_code == 200, lr.text
     return r
 
 

--- a/backend/tests/test_e2e_lifecycle.py
+++ b/backend/tests/test_e2e_lifecycle.py
@@ -87,7 +87,10 @@ def client(app_db):
 def _register(client, email) -> str:
     r = client.post("/api/auth/register", json={"email": email, "password": _PW})
     assert r.status_code == 201, r.text
-    return r.json()["id"]
+    # M2 — register no longer auto-logs-in or returns the id; sign in for both.
+    lr = client.post("/api/auth/login", json={"email": email, "password": _PW})
+    assert lr.status_code == 200, lr.text
+    return lr.json()["id"]
 
 
 def _mark_verified(db_path, email):

--- a/backend/tests/test_email_verification.py
+++ b/backend/tests/test_email_verification.py
@@ -136,10 +136,12 @@ def _register_capture_token(client, monkeypatch, email, password="s3cretpassword
     monkeypatch.setattr(tokens, "generate_token", _spy)
     r = client.post("/api/auth/register", json={"email": email, "password": password})
     assert r.status_code == 201, r.text
-    # Register currently issues exactly one verification token; if that
-    # changes (e.g. password-reset auto-issue) the test will tell us.
+    # Register (for a new email) still issues exactly one verification token.
     assert len(captured["raws"]) == 1, captured["raws"]
-    return r.json()["id"], captured["raws"][0]
+    # M2 — register no longer auto-logs-in or returns the id; sign in to read it.
+    lr = client.post("/api/auth/login", json={"email": email, "password": password})
+    assert lr.status_code == 200, lr.text
+    return lr.json()["id"], captured["raws"][0]
 
 
 # ─── register flow auto-issues a token ──────────────────────────────────────

--- a/backend/tests/test_password_reset.py
+++ b/backend/tests/test_password_reset.py
@@ -142,7 +142,10 @@ async def _count_sessions(db_path, user_id):
 def _register(client, email, password="s3cretpassword"):
     r = client.post("/api/auth/register", json={"email": email, "password": password})
     assert r.status_code == 201, r.text
-    return r.json()["id"]
+    # M2 — register no longer auto-logs-in or returns the id; sign in for both.
+    lr = client.post("/api/auth/login", json={"email": email, "password": password})
+    assert lr.status_code == 200, lr.text
+    return lr.json()["id"]
 
 
 def _issue_reset_and_get_raw_token(client, monkeypatch, email, db_path):

--- a/backend/tests/test_pipeline_timeline.py
+++ b/backend/tests/test_pipeline_timeline.py
@@ -162,6 +162,12 @@ async def test_timeline_idor(authenticated_async_context):
         json={"email": "userb_idor_timeline@example.com", "password": "password_B_123"},
     )
     assert r.status_code == 201, r.text
+    # M2 — register no longer auto-logs-in; sign in for User B's session.
+    lr = sync_client_b.post(
+        "/api/auth/login",
+        json={"email": "userb_idor_timeline@example.com", "password": "password_B_123"},
+    )
+    assert lr.status_code == 200, lr.text
     session_b = sync_client_b.cookies.get("job360_session")
     sync_client_b.close()
 

--- a/backend/tests/test_post_review_fixes.py
+++ b/backend/tests/test_post_review_fixes.py
@@ -124,8 +124,11 @@ def test_register_returns_201_even_if_verification_email_raises(
     )
     # Pre-fix this would have been 500; post-fix it's still 201.
     assert r.status_code == 201, r.text
-    assert r.json()["email"] == "alice@example.com"
-    assert "job360_session" in r.cookies
+    # M2 — register now returns a generic body (no email) and sets no cookie.
+    # This test's point is that a failing verification email doesn't turn register
+    # into a 500; the sibling test asserts the user row persists.
+    assert r.json().get("status") == "ok"
+    assert "job360_session" not in r.cookies
 
 
 def test_register_user_row_persists_after_simulated_verification_error(
@@ -175,6 +178,11 @@ def test_verify_email_resend_rate_limited_to_429(client, monkeypatch):
         "/api/auth/register",
         json={"email": "alice@example.com", "password": "s3cretpassword"},
     )
+    # M2 — register no longer auto-logs-in; verify-email/request needs a session.
+    client.post(
+        "/api/auth/login",
+        json={"email": "alice@example.com", "password": "s3cretpassword"},
+    )
     # The register itself triggers one verification email — that consumed
     # the user's bucket too? No: register routes through register, not
     # verify-email/request, so the bucket is fresh on first resend.
@@ -190,6 +198,11 @@ def test_verify_email_resend_429_does_not_issue_token(client, monkeypatch, temp_
     """Rate-limited request must not consume an issue: no row added on 429."""
     client.post(
         "/api/auth/register",
+        json={"email": "alice@example.com", "password": "s3cretpassword"},
+    )
+    # M2 — register no longer auto-logs-in; verify-email/request needs a session.
+    client.post(
+        "/api/auth/login",
         json={"email": "alice@example.com", "password": "s3cretpassword"},
     )
     client.post("/api/auth/verify-email/request")  # 204

--- a/backend/tests/test_profile_upload.py
+++ b/backend/tests/test_profile_upload.py
@@ -70,6 +70,9 @@ def api(monkeypatch, tmp_path):
 def _register_and_login(client: TestClient, email: str = "user@example.com") -> None:
     r = client.post("/api/auth/register", json={"email": email, "password": "s3cretpassword"})
     assert r.status_code == 201, r.text
+    # M2 — register no longer auto-logs-in; sign in so the client is authenticated.
+    lr = client.post("/api/auth/login", json={"email": email, "password": "s3cretpassword"})
+    assert lr.status_code == 200, lr.text
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_search_audit.py
+++ b/backend/tests/test_search_audit.py
@@ -78,6 +78,9 @@ def _register_verified(client, db_path, email):
     con.execute("UPDATE users SET email_verified_at=datetime('now') WHERE email=?", (email,))
     con.commit()
     con.close()
+    # M2 — register no longer auto-logs-in; sign in so the client is authenticated.
+    lr = client.post("/api/auth/login", json={"email": email, "password": "Correct-Horse-9"})
+    assert lr.status_code == 200, lr.text
 
 
 def test_search_emits_started_audit(client, temp_db, caplog, monkeypatch):

--- a/backend/tests/test_source_health.py
+++ b/backend/tests/test_source_health.py
@@ -127,7 +127,10 @@ async def _seed_run(
 def _register(client, email="alice@example.com", password="s3cretpassword"):
     r = client.post("/api/auth/register", json={"email": email, "password": password})
     assert r.status_code == 201, r.text
-    return r.json()["id"]
+    # M2 — register no longer auto-logs-in or returns the id; sign in for both.
+    lr = client.post("/api/auth/login", json={"email": email, "password": password})
+    assert lr.status_code == 200, lr.text
+    return lr.json()["id"]
 
 
 # ─── Anonymous → 401 ────────────────────────────────────────────────────────

--- a/backend/tests/test_user_action_audit.py
+++ b/backend/tests/test_user_action_audit.py
@@ -96,6 +96,9 @@ def _register_verified(client, db_path, email):
     con.execute("UPDATE users SET email_verified_at=datetime('now') WHERE email=?", (email,))
     con.commit()
     con.close()
+    # M2 — register no longer auto-logs-in; sign in so the client is authenticated.
+    lr = client.post("/api/auth/login", json={"email": email, "password": "Correct-Horse-9"})
+    assert lr.status_code == 200, lr.text
 
 
 def test_like_and_pipeline_emit_audit_events(client, temp_db, caplog):

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -1758,6 +1758,22 @@
         "title": "RegisterRequest",
         "type": "object"
       },
+      "RegisterResponse": {
+        "properties": {
+          "message": {
+            "default": "Account request received. Please sign in to continue.",
+            "title": "Message",
+            "type": "string"
+          },
+          "status": {
+            "default": "ok",
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "title": "RegisterResponse",
+        "type": "object"
+      },
       "RunEntry": {
         "description": "Single ``run_log`` row exposed over the API.\n\nMaps every column from the baseline + migration-0010 schema.  Optional\nfields may be NULL on rows inserted before the observability migration\nran; Pydantic coerces them to None rather than raising.",
         "properties": {
@@ -2882,7 +2898,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/UserResponse"
+                  "$ref": "#/components/schemas/RegisterResponse"
                 }
               }
             },

--- a/frontend/src/app/(auth)/login/page.tsx
+++ b/frontend/src/app/(auth)/login/page.tsx
@@ -121,6 +121,9 @@ function PasswordForm({ onUseMagic }: { onUseMagic: () => void }) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const next = searchParams.get("next");
+  // M2 — set after /register. The message is deliberately neutral: it does NOT
+  // reveal whether the email was newly created or already existed.
+  const justRegistered = searchParams.get("registered") === "1";
 
   const [serverError, setServerError] = useState<string | null>(null);
 
@@ -142,6 +145,11 @@ function PasswordForm({ onUseMagic }: { onUseMagic: () => void }) {
 
   return (
     <form onSubmit={onSubmit} noValidate className="space-y-4">
+      {justRegistered && (
+        <p role="status" className="text-sm text-muted-foreground">
+          Almost there — please sign in to continue.
+        </p>
+      )}
       <div className="space-y-2">
         <Label htmlFor="email">Email</Label>
         <Input

--- a/frontend/src/app/(auth)/register/page.tsx
+++ b/frontend/src/app/(auth)/register/page.tsx
@@ -58,7 +58,11 @@ function RegisterForm() {
     try {
       await registerUser(data.email, data.password);
       posthog.capture("signup_completed");
-      router.push(safeNext(next));
+      // M2 — register no longer signs you in (that would leak whether an email
+      // already exists). Send the user to sign in; preserve their intended
+      // destination. This message is identical whether or not the email existed.
+      const dest = safeNext(next);
+      router.push(`/login?registered=1&next=${encodeURIComponent(dest)}`);
     } catch (err) {
       setServerError(friendlyAuthError(err, "Sign-up failed. Please try again."));
     }

--- a/frontend/src/lib/api-types.ts
+++ b/frontend/src/lib/api-types.ts
@@ -2174,6 +2174,19 @@ export interface components {
             /** Password */
             password: string;
         };
+        /** RegisterResponse */
+        RegisterResponse: {
+            /**
+             * Message
+             * @default Account request received. Please sign in to continue.
+             */
+            message: string;
+            /**
+             * Status
+             * @default ok
+             */
+            status: string;
+        };
         /**
          * RunEntry
          * @description Single ``run_log`` row exposed over the API.
@@ -2744,7 +2757,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["UserResponse"];
+                    "application/json": components["schemas"]["RegisterResponse"];
                 };
             };
             /** @description Validation Error */

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -363,8 +363,15 @@ export async function getPipelineCounts(): Promise<Record<string, number>> {
 
 export type User = { id: string; email: string };
 
-export async function register(email: string, password: string): Promise<User> {
-  return request<User>("/api/auth/register", {
+// M2 — register no longer returns the user or a session (no account-enumeration:
+// a new-user response that differs from a duplicate would leak whether an email
+// exists). It returns a generic acknowledgement; the caller sends the user to
+// sign in.
+export async function register(
+  email: string,
+  password: string,
+): Promise<{ status: string; message: string }> {
+  return request<{ status: string; message: string }>("/api/auth/register", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ email, password }),

--- a/frontend/tests/e2e/landing-cta-auth.spec.ts
+++ b/frontend/tests/e2e/landing-cta-auth.spec.ts
@@ -123,7 +123,7 @@ test.describe("Landing CTA → profile journeys", () => {
 
   // ── Journey 1: new visitor → create account → /profile ────────────────────
 
-  test("new visitor creating an account lands on /profile", async ({
+  test("new visitor creating an account is sent to sign in", async ({
     page,
     context,
   }) => {
@@ -133,7 +133,8 @@ test.describe("Landing CTA → profile journeys", () => {
       route.fulfill({
         status: 201,
         contentType: "application/json",
-        body: JSON.stringify(USER),
+        // M2 — register now returns a generic body (no user), and no cookie.
+        body: JSON.stringify({ status: "ok", message: "Please sign in to continue." }),
       })
     );
 
@@ -142,7 +143,9 @@ test.describe("Landing CTA → profile journeys", () => {
     await page.getByLabel(/password/i).fill("Password123");
     await page.getByRole("button", { name: /create account/i }).click();
 
-    // register's safeNext defaults to /profile, so a fresh sign-up lands there.
-    await expect(page).toHaveURL(/\/profile/, { timeout: 40_000 });
+    // M2 — register no longer auto-logs-in (that would leak whether an email
+    // exists), so a fresh sign-up is sent to /login to sign in. `next` is
+    // preserved so they still land on /profile after signing in.
+    await expect(page).toHaveURL(/\/login\?registered=1/, { timeout: 40_000 });
   });
 });


### PR DESCRIPTION
Closes the last open code finding from the audit. Registering a **new** email and re-registering an **existing** one are now indistinguishable — same 201, same generic body, no cookie — so `/register` can't be used to enumerate accounts.

## The UX change (why it's not a silent internal fix)
A session cookie for a new user but none for a duplicate would *itself* leak existence — so **register no longer auto-logs-in**. New flow: **sign up → sign in** (the standard secure pattern). You flagged wanting this fixed; this is the honest cost.

- **Duplicate email** = silent no-op. The existing account is never touched (password not overwritten), and no response signal confirms the address exists.
- **New email** still gets its verification email (server-side, unobservable in the response).

## Changes
- **Backend:** register returns a generic `RegisterResponse` (no id/email/cookie); duplicate handled as insert-or-ignore.
- **Frontend:** register page → `/login?registered=1` with a neutral "please sign in" notice (identical whether or not the email existed); `api.ts` + regenerated `api-types` updated.
- **Tests:** 2 new no-enumeration tests (new vs duplicate identical response; existing password not overwritten; no cookie set). **14 test files'** register helpers updated to sign in after registering.

## Verification
Gate **PASS** — 159 backend targeted + 204 frontend + drift check. All 14 affected auth files verified green individually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6DsQH5EUxJc3Vnqz9YHgQ