### PR TITLE
fix(auth): magic-link page no longer consumes the token on render (scanner lockout)

### DIFF
--- a/frontend/src/app/auth/magic/__tests__/magic-page-error.test.tsx
+++ b/frontend/src/app/auth/magic/__tests__/magic-page-error.test.tsx
@@ -1,16 +1,25 @@
 /**
- * H11 — auth pages must never render a raw ApiError string like
- * "API error 429: too many requests" (the `Error.message` format, which
- * bakes the HTTP status into the text) — they must go through
- * friendlyAuthError, which strips that prefix. Note: friendlyAuthError still
- * shows the backend's own `detail` verbatim for status codes it doesn't
- * specially map (e.g. 400) — that's intentional (mirrors apiErrorMessage),
- * since a backend detail is meant to be human-readable. What must never
- * leak is the raw "API error NNN: …" wrapper string.
+ * Two invariants for the magic-link landing page:
+ *
+ * 1. SCANNER SAFETY — rendering the page must NEVER consume the token.
+ *    Corporate email scanners (Outlook SafeLinks etc.) open links before the
+ *    human does; the old auto-consume-on-mount burned the single-use token
+ *    and locked the real user out with "link expired". Consumption must only
+ *    happen on an explicit button click.
+ *
+ * 2. H11 — auth pages must never render a raw ApiError string like
+ *    "API error 429: too many requests" (the `Error.message` format, which
+ *    bakes the HTTP status into the text) — they must go through
+ *    friendlyAuthError, which strips that prefix. Note: friendlyAuthError
+ *    still shows the backend's own `detail` verbatim for status codes it
+ *    doesn't specially map (e.g. 400) — that's intentional (mirrors
+ *    apiErrorMessage), since a backend detail is meant to be human-readable.
+ *    What must never leak is the raw "API error NNN: …" wrapper string.
  */
 
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { ApiError } from "@/lib/api-error";
 import MagicLinkPage from "../page";
 
@@ -28,12 +37,55 @@ vi.mock("@/lib/api", () => ({
   consumeMagicLink: (...args: unknown[]) => consumeMagicLinkMock(...args),
 }));
 
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("MagicLinkPage — scanner safety (no consume without a click)", () => {
+  it("does NOT consume the token on render", async () => {
+    mockGet.mockReturnValue("good-token");
+
+    render(<MagicLinkPage />);
+
+    // The sign-in button must be offered instead of auto-consuming.
+    expect(
+      await screen.findByRole("button", { name: /sign in/i })
+    ).toBeInTheDocument();
+    expect(consumeMagicLinkMock).not.toHaveBeenCalled();
+  });
+
+  it("consumes the token and redirects to /dashboard only after the click", async () => {
+    mockGet.mockReturnValue("good-token");
+    consumeMagicLinkMock.mockResolvedValue(undefined);
+
+    render(<MagicLinkPage />);
+    await userEvent.click(screen.getByRole("button", { name: /sign in/i }));
+
+    await waitFor(() => expect(mockReplace).toHaveBeenCalledWith("/dashboard"));
+    expect(consumeMagicLinkMock).toHaveBeenCalledTimes(1);
+    expect(consumeMagicLinkMock).toHaveBeenCalledWith("good-token");
+  });
+
+  it("shows the missing-token error without a sign-in button when the URL has no token", () => {
+    mockGet.mockReturnValue(null);
+
+    render(<MagicLinkPage />);
+
+    expect(screen.getByText(/token missing/i)).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /sign in/i })
+    ).not.toBeInTheDocument();
+    expect(consumeMagicLinkMock).not.toHaveBeenCalled();
+  });
+});
+
 describe("MagicLinkPage — H11 friendly error rendering", () => {
   it("never renders the raw 'API error NNN:' prefix for a mapped status (429)", async () => {
     mockGet.mockReturnValue("bad-token");
     consumeMagicLinkMock.mockRejectedValue(new ApiError(429, "rate limited"));
 
     render(<MagicLinkPage />);
+    await userEvent.click(screen.getByRole("button", { name: /sign in/i }));
 
     // 429 is one of friendlyAuthError's specially-mapped statuses.
     await waitFor(() => {
@@ -50,6 +102,7 @@ describe("MagicLinkPage — H11 friendly error rendering", () => {
     );
 
     render(<MagicLinkPage />);
+    await userEvent.click(screen.getByRole("button", { name: /sign in/i }));
 
     await waitFor(() => {
       expect(
@@ -60,14 +113,5 @@ describe("MagicLinkPage — H11 friendly error rendering", () => {
     // The raw "API error 400: …" wrapper string must never reach the DOM,
     // even though the clean detail text is shown.
     expect(screen.queryByText(/API error 400/i)).not.toBeInTheDocument();
-  });
-
-  it("redirects to /dashboard on success", async () => {
-    mockGet.mockReturnValue("good-token");
-    consumeMagicLinkMock.mockResolvedValue(undefined);
-
-    render(<MagicLinkPage />);
-
-    await waitFor(() => expect(mockReplace).toHaveBeenCalledWith("/dashboard"));
   });
 });

--- a/frontend/src/app/auth/magic/page.tsx
+++ b/frontend/src/app/auth/magic/page.tsx
@@ -2,15 +2,18 @@
 
 // Passwordless magic-link landing page.
 // Reached from the link in the sign-in email. Reads ?token=… from the URL
-// and posts to /api/auth/magic-link/consume. On success the backend sets the
-// session cookie, so we just redirect to /dashboard. On failure we show an
-// error with a link back to /login.
+// and posts to /api/auth/magic-link/consume ONLY when the user clicks the
+// button. Consuming on mount would let corporate email scanners (which
+// prefetch/render links before the human clicks) burn the single-use token
+// and lock the real user out — scanners load pages, they don't click buttons.
+// On success the backend sets the session cookie, so we redirect to
+// /dashboard. On failure we show an error with a link back to /login.
 //
 // Mirrors the verify-email page pattern: a client component using
 // useSearchParams inside <Suspense> (the Next.js 16 way to read query params
 // in the browser — confirmed via Context7 /vercel/next.js).
 
-import { Suspense, useEffect, useState } from "react";
+import { Suspense, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 
@@ -19,46 +22,46 @@ import { friendlyAuthError } from "@/lib/api-error";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 
-type State = "pending" | "error";
+type State = "confirm" | "submitting" | "error";
 
 function MagicBody() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const token = searchParams.get("token") ?? "";
-  const [state, setState] = useState<State>(token ? "pending" : "error");
+  const [state, setState] = useState<State>(token ? "confirm" : "error");
   const [error, setError] = useState<string | null>(
     token ? null : "Sign-in token missing from the URL. Use the link from your email."
   );
 
-  useEffect(() => {
-    if (!token) return; // missing-token case already reflected in initial state
-    let cancelled = false;
-    (async () => {
-      try {
-        await consumeMagicLink(token);
-        if (!cancelled) router.replace("/dashboard");
-      } catch (err) {
-        if (!cancelled) {
-          setState("error");
-          setError(
-            friendlyAuthError(
-              err,
-              "This sign-in link is invalid or expired. Request a new one from the login page."
-            )
-          );
-        }
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [token, router]);
+  async function signIn() {
+    setState("submitting");
+    try {
+      await consumeMagicLink(token);
+      router.replace("/dashboard");
+    } catch (err) {
+      setState("error");
+      setError(
+        friendlyAuthError(
+          err,
+          "This sign-in link is invalid or expired. Request a new one from the login page."
+        )
+      );
+    }
+  }
 
-  if (state === "pending") {
+  if (state === "confirm" || state === "submitting") {
     return (
       <div className="space-y-4">
-        <p className="text-sm text-muted-foreground">Signing you in…</p>
-        <div className="h-2 animate-pulse rounded-md bg-muted" />
+        <p className="text-sm text-muted-foreground">
+          Click below to finish signing in to Job360.
+        </p>
+        <Button
+          className="w-full"
+          onClick={signIn}
+          disabled={state === "submitting"}
+        >
+          {state === "submitting" ? "Signing you in…" : "Sign in to Job360"}
+        </Button>
       </div>
     );
   }
@@ -78,7 +81,7 @@ export default function MagicLinkPage() {
     <div className="mx-auto max-w-md py-16">
       <Card>
         <CardHeader>
-          <CardTitle>Signing you in</CardTitle>
+          <CardTitle>Sign in</CardTitle>
           <CardDescription>Completing your passwordless sign-in.</CardDescription>
         </CardHeader>
         <CardContent>


### PR DESCRIPTION
## The bug

Magic-link edge-case #1 from the auth review: corporate email security (Outlook SafeLinks and friends) opens links **before the user does**. Our landing page auto-consumed the single-use token in a `useEffect` on mount (`magic/page.tsx:33-38`), so:

scanner renders page → token consumed → real user clicks → **"link expired"** → user with a work email can never log in, and it looks like our bug (it is).

## The fix

Consume only on an explicit **"Sign in to Job360"** button click. Scanners load pages; they don't click buttons. Backend untouched — TTL, single-use, hashing, rate-limit all stay as they are.

## Verification

- TDD: tests rewritten first → 4/5 red on the old page → implementation → **5/5 green**
- New regression pin: rendering the page must NOT call `consumeMagicLink`
- `tsc --noEmit` clean; gate PASS
- `landing-cta-auth.spec.ts` only exercises the login-form magic/password toggle — unaffected

## UX cost

One extra click at login. That click is what keeps corporate-mailbox users able to log in at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpxEMPz2ZWG9Qed5BsFHvg