### PR TITLE
fix(csp): allow same-origin blob workers — PostHog worker blocked on every page

### DIFF
--- a/frontend/src/lib/__tests__/security-headers.test.ts
+++ b/frontend/src/lib/__tests__/security-headers.test.ts
@@ -36,4 +36,12 @@ describe("SECURITY_HEADERS (M15)", () => {
     expect(CONTENT_SECURITY_POLICY).toMatch(/eu\.i\.posthog\.com/);
     expect(CONTENT_SECURITY_POLICY).toMatch(/us\.i\.posthog\.com/);
   });
+
+  it("CSP worker-src allows same-origin blob workers (PostHog)", () => {
+    // Without an explicit worker-src, the browser falls back to script-src,
+    // which has no blob: — so PostHog's blob Web Worker was blocked with a
+    // console error on EVERY page load. Allow self + blob: for workers only
+    // (NOT in script-src — page scripts stay locked to 'self').
+    expect(CONTENT_SECURITY_POLICY).toMatch(/worker-src 'self' blob:/);
+  });
 });

--- a/frontend/src/lib/security-headers.ts
+++ b/frontend/src/lib/security-headers.ts
@@ -16,6 +16,11 @@ export const CONTENT_SECURITY_POLICY = [
   // 'unsafe-eval' is required in dev (React Refresh) and harmless to keep in
   // prod since 'self' already scopes script origins.
   "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+  // PostHog spawns a blob: Web Worker (session-independent processing). With no
+  // explicit worker-src the browser falls back to script-src, which lacks blob:
+  // — so the worker was blocked with a console error on every page. Scope blob:
+  // to WORKERS only; page scripts above stay locked to 'self'.
+  "worker-src 'self' blob:",
   "style-src 'self' 'unsafe-inline'",
   "img-src 'self' data: blob: https:",
   "font-src 'self' data:",


### PR DESCRIPTION
Live-site UX pass found a console error on **every page** of job360.uk: the CSP has no `worker-src`, so browsers fall back to `script-src` (which lacks `blob:`) and block PostHog's blob Web Worker — silently degrading analytics.

**Fix:** add `worker-src 'self' blob:` to `frontend/src/lib/security-headers.ts`. Scoped to workers only — `script-src` is untouched, page scripts stay locked to `'self'`.

**Test-first:** new assertion in `security-headers.test.ts` fails against the old headers; 7/7 pass with the fix. Gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6DsQH5EUxJc3Vnqz9YHgQ