### PR TITLE
fix(audit): sixth-pass — magic-link case-dup, /* */ splitter, APP_ENV case + MFA decision docs

### DIFF
--- a/backend/src/repositories/pg.py
+++ b/backend/src/repositories/pg.py
@@ -416,6 +416,24 @@ def _split_on_unquoted_semicolons(script: str) -> list[str]:
                 break  # comment runs to end of script — nothing more to keep
             i = nl
             continue
+        # ``/* ... */`` block comment — same hazard as ``--``: a ``;`` inside one
+        # must not sever a statement (pre-fix, the comment fragment was shipped
+        # to Postgres as its own "statement"). Postgres NESTS block comments, so
+        # track depth rather than stopping at the first ``*/``. Like ``--``,
+        # reached only outside strings/dollar bodies, so '/*' in a literal is data.
+        if script.startswith("/*", i):
+            depth = 1
+            i += 2
+            while i < n and depth:
+                if script.startswith("/*", i):
+                    depth += 1
+                    i += 2
+                elif script.startswith("*/", i):
+                    depth -= 1
+                    i += 2
+                else:
+                    i += 1
+            continue
         if ch == "'":
             in_single = True
             buf.append(ch)

--- a/backend/src/services/auth/magic_link.py
+++ b/backend/src/services/auth/magic_link.py
@@ -92,6 +92,11 @@ async def request_magic_link(
     Returns True if the email was actually sent, False otherwise. Never
     raises — the route returns 204 regardless (no-enumeration contract).
     """
+    # EMAIL-CASE: normalize before storing. users.email UNIQUE is case-
+    # SENSITIVE, so a token minted for 'Alice@Example.COM' used to flow raw
+    # into consume's INSERT OR IGNORE, sail past the conflict check (different
+    # case ≠ conflict), and mint a SECOND account for the same mailbox.
+    email = email.strip().lower()
     try:
         raw, h = tokens.generate_token()
         expires = (
@@ -152,7 +157,11 @@ async def consume_magic_link(
             logger.info("magic link consume: token expired")
             return None
 
-        email = row["email"]
+        # EMAIL-CASE belt-and-suspenders: tokens minted BEFORE the request-path
+        # normalization shipped may still hold a raw-case address — lowercase
+        # here too so the find-or-create below can never split one mailbox
+        # into two accounts.
+        email = (row["email"] or "").strip().lower()
         # Mark the token used first — single-use enforcement.
         await db.execute(
             "UPDATE magic_link_tokens SET used_at = ? WHERE id = ?",

--- a/backend/tests/test_magic_link.py
+++ b/backend/tests/test_magic_link.py
@@ -221,6 +221,37 @@ def test_consume_existing_user_verifies_no_duplicate(client, monkeypatch, temp_d
     assert user["email_verified_at"] is not None
 
 
+def test_consume_mixed_case_email_does_not_duplicate_user(client, monkeypatch, temp_db):
+    """EMAIL-CASE residual: users.email UNIQUE is case-SENSITIVE, so a magic-link
+    request typed as 'Alice@Example.COM' against an existing 'alice@example.com'
+    account used to sail past INSERT OR IGNORE (no conflict — different case) and
+    mint a SECOND user for the same mailbox. The request path must normalize the
+    email before storing/creating."""
+    async def _seed():
+        async with pg.connect(temp_db) as db:
+            await db.execute(
+                "INSERT INTO users(id, email, password_hash) VALUES (?, ?, ?)",
+                ("alice-id", "alice@example.com", "!"),
+            )
+            await db.commit()
+
+    asyncio.run(_seed())
+
+    raw = _request_capture_token(client, monkeypatch, "Alice@Example.COM")
+    r = client.post("/api/auth/magic-link/consume", json={"token": raw})
+    assert r.status_code == 200, r.text
+    assert r.json()["id"] == "alice-id"  # the EXISTING account, not a new one
+
+    async def _count_case_insensitive():
+        async with pg.connect(temp_db) as db:
+            cur = await db.execute(
+                "SELECT COUNT(*) FROM users WHERE LOWER(email) = 'alice@example.com'"
+            )
+            return (await cur.fetchone())[0]
+
+    assert asyncio.run(_count_case_insensitive()) == 1  # exactly ONE account
+
+
 def test_consume_reuses_soft_deleted_user(client, monkeypatch, temp_db):
     # Regression: a soft-deleted row still owns the email (users.email UNIQUE
     # ignores deleted_at). consume must REUSE + reactivate it, not INSERT a

--- a/backend/tests/test_pg_translate.py
+++ b/backend/tests/test_pg_translate.py
@@ -217,3 +217,39 @@ def test_split_statements_real_comment_outside_string_still_stripped():
     assert len(stmts) == 2, f"expected 2, got {len(stmts)}: {stmts}"
     assert stmts[0] == "SELECT 1"
     assert stmts[1] == "SELECT 2"
+
+
+# SPLIT-P3 residual #2 — /* block comments */. A ';' inside one severed the
+# statement and shipped a bare comment fragment to Postgres as its own
+# "statement" (syntax error at migration boot).
+
+
+def test_split_statements_semicolon_inside_block_comment_does_not_split():
+    script = (
+        "CREATE TABLE a (x int);\n"
+        "/* block comment; with a semicolon */\n"
+        "CREATE TABLE b (y int);"
+    )
+    stmts = pg.split_statements(script)
+    assert len(stmts) == 2, f"expected 2, got {len(stmts)}: {stmts}"
+    assert stmts[0] == "CREATE TABLE a (x int)"
+    assert stmts[1] == "CREATE TABLE b (y int)"
+
+
+def test_split_statements_nested_block_comment_postgres_style():
+    """Postgres (unlike standard SQL) NESTS block comments — /* /* */ */ must be
+    consumed fully, not closed at the first */."""
+    script = "SELECT 1; /* outer /* inner; */ still comment; */ SELECT 2;"
+    stmts = pg.split_statements(script)
+    assert len(stmts) == 2, f"expected 2, got {len(stmts)}: {stmts}"
+    assert stmts[0] == "SELECT 1"
+    assert stmts[1] == "SELECT 2"
+
+
+def test_split_statements_block_comment_opener_inside_string_is_literal():
+    """'/*' inside a quoted value is DATA, not a comment opener."""
+    script = "INSERT INTO t(msg) VALUES ('see /* not a comment'); SELECT 1;"
+    stmts = pg.split_statements(script)
+    assert len(stmts) == 2, f"expected 2, got {len(stmts)}: {stmts}"
+    assert stmts[0] == "INSERT INTO t(msg) VALUES ('see /* not a comment')"
+    assert stmts[1] == "SELECT 1"

--- a/docs/fable/AUDIT-2026-07-23-FULL-REVERIFY.md
+++ b/docs/fable/AUDIT-2026-07-23-FULL-REVERIFY.md
@@ -160,7 +160,7 @@ These are genuinely blocked on your decision/infra, not on engineering:
 | **05-P0-LEGAL** | **DECIDED (2026-07-24) — measure-first, cut before public launch.** Owner's decision recorded in `docs/fable/SCRAPING-DECISION.md`: keep all sources for now, run the §8 prod `run_log`/`jobs` queries to learn how many jobs *only* LinkedIn carries (dedup may make it near-zero), then remove LinkedIn (Indeed/Glassdoor are already inert in prod — `python-jobspy` isn't in the image) before public release; restore that coverage later via licensed paid APIs (Fantastic Jobs/TheirStack) at the pricing tier. **No source removed yet — the pending action is the owner running the §8 queries against prod (`railway connect postgres`).** |
 | **05-P1-POLICIES** | Privacy (48 lines) + Terms (47 lines) pages are stubs ending "will be expanded before public launch." Needs real legal text. |
 | **05-P1-SUBPROC** | No subprocessor disclosure (CV → Groq/Cerebras/Resend/OpenAI). Legal disclosure tied to the privacy policy. |
-| **05-P2-MFA** | No MFA/TOTP feature exists — a product decision + new auth flow. |
+| **05-P2-MFA** | **DECIDED (2026-07-24) — WON'T BUILD.** Magic-link email login is the chosen auth factor (possession of the inbox — functionally what an email-code MFA proves). No TOTP flow will be scoped. Closed as an owner product decision; do not re-raise. |
 | **05-P2-BREACH** | No breach-notification runbook (GDPR 72-hour). A policy doc for you to author. |
 | **PLAN** | `fable-harness-plan.md` is behavioral coaching about your own workflow habits — not a code defect. |
 | **PS-P1-ml-sentry** | "Magic-link Sentry issue resolved" is an external dashboard state — nothing in the repo to verify. |
@@ -408,3 +408,34 @@ risk), but "fully fixed" overstated it. Status: **PARTIAL (2/3 lenses).**
 
 **No code-fixable finding is silently broken. The three the fourth pass missed are
 the only new engineering work this pass produced — and they are fixed.**
+
+---
+
+# OWNER-ITEM CLOSURES — 2026-07-24 (post-fifth-pass)
+
+The owner-decision list above kept shrinking the same day. Verified against real
+code/infra, not claims:
+
+- **SI1 — CLOSED.** Prod was 121 commits stale (manual CLI deploys only, nothing
+  GitHub-connected; live worker predated the #94 `ctx['db']` fix and crash-looped
+  `KeyError: 'db'` on every 5-min tick). All three services redeployed from main
+  `3935417` on 2026-07-24: backend healthy (`/api/readyz` db+redis ok), **worker's
+  first clean tick at 13:00:00** (`j_complete=1 j_failed=0`), frontend live.
+  Notifications infrastructure is ON; end-to-end send awaits a user-connected
+  channel + rule. Deploy recipe + traps recorded (worker upload must exclude
+  `railway.json` — its `/api/health` healthcheck can't pass on a non-HTTP arq
+  process).
+- **05-P1-POLICIES + 05-P1-SUBPROC — CLOSED (PR #114).** Privacy 277 lines (was a
+  48-line stub) incl. the subprocessor disclosure; Terms 161 lines.
+- **05-P2-BREACH — CLOSED (PR #114).** `docs/BREACH-RUNBOOK.md` exists.
+- **05-P2-MFA — DECIDED: WON'T BUILD (2026-07-24).** Magic-link is the auth factor
+  (see the table row above). Not a gap; do not re-raise.
+- **M10 — CLOSED for the live deployment.** Prod DB is Railway-managed Postgres
+  with a Railway-generated password; the compose-file fix (#83) covers the
+  self-host path. No action remains for the running product.
+
+**Still open (all small):** external Sentry config sanity-check (dashboard),
+GitHub auto-deploy connection (kills the drift class permanently — backend +
+frontend ready to connect; worker blocked on its healthcheck config), the §8
+scraping measurement (owner, prod SQL), and the `08-GAPS` audit areas (schedule
+the perf/load test before public launch; rest can wait).

--- a/docs/fable/AUDIT-2026-07-23-FULL-REVERIFY.md
+++ b/docs/fable/AUDIT-2026-07-23-FULL-REVERIFY.md
@@ -439,3 +439,62 @@ GitHub auto-deploy connection (kills the drift class permanently — backend +
 frontend ready to connect; worker blocked on its healthcheck config), the §8
 scraping measurement (owner, prod SQL), and the `08-GAPS` audit areas (schedule
 the perf/load test before public launch; rest can wait).
+
+---
+
+# SIXTH PASS — post-deploy re-verify vs main `7aea468`, 2026-07-24
+
+Prod itself was redeployed this day (see OWNER-ITEM CLOSURES above), so this pass
+re-checked the full set against the main that is now actually LIVE, plus a
+**stranded-work sweep across all 16 unmerged remote branches** and 6 adversarial
+refuters. Numbers: **82 re-confirmed FIXED, zero regressions** in the spot-checked
+5-pass survivors — and the refuters broke three residuals AGAIN (the third pass
+in a row where "held under refutation" didn't survive the next refuter).
+
+## Three residuals broken by refuters — FIXED this session (each with a fail-first test)
+
+### EMAIL-CASE residual — magic-link could split one mailbox into two accounts
+Login/reset/consume lookups used `LOWER()` (the #99 fix) — but the magic-link
+REQUEST path stored the raw-case email, and consume's `INSERT OR IGNORE` conflicts
+on the case-SENSITIVE `users.email` UNIQUE. `Alice@Example.COM` vs existing
+`alice@example.com` → no conflict → **second account minted for the same mailbox**
+(test proved it: 2 rows). Fixed: normalize at request AND consume
+(`magic_link.py`); consume-side covers raw-case tokens already in the DB.
+Test: `test_consume_mixed_case_email_does_not_duplicate_user` (failed `2 == 1`).
+
+### SPLIT-P3 residual #2 — `/* block comments */` still severed scripts
+The one-scanner fix (fifth pass) handled `'...'`, `$$...$$`, and `--` — but not
+`/* ... */`. A `;` inside a block comment split the script and shipped a bare
+comment fragment to Postgres as its own "statement". Fixed in the same scanner
+with Postgres-style NESTED comment support; `/*` inside a string literal stays
+data. Tests: 3 new block-comment cases (pre-fix: split into 3–4 pieces).
+
+### F2 residual #2 — prod detection disagreed about case
+`middleware.ts` compared `APP_ENV === "production"` strictly; the backend's
+`_is_production()` lowercases. `APP_ENV=Production` = prod for cookie-Secure/HSTS
+but NOT for the bypass gate. Now `.toLowerCase()` on both sides.
+Test: "APP_ENV=Production also fails closed" (pre-fix: bypassed).
+
+## Stranded-work sweep — 16 unmerged branches examined
+**One real stranded fix found** — `backup/account-error-messages`: the four
+`settings/account` catch blocks show raw `err.message` instead of the mapped
+`apiErrorMessage(...)`. Rescued (the same branch's VerifyEmailCard removal was
+unrelated and deliberately NOT carried over). The other 15 branches: backups,
+superseded work, deliberate holds (`rescue/pillar1-extraction` = tp-final), or
+docs — **nothing else stranded.**
+
+## Also verified this pass
+- The pasted earlier-session items: SEARCH-TASK (strong task ref held), EMAIL-CASE
+  base fix, DOWN-ATOMIC (`runner.down()` transaction wrap), HARD-DELETE-VERIFY
+  (erasure counts survivors + raises), APPS-ORPHANS (still correctly NOT-a-bug),
+  DATE-FORMATS (still cosmetic — but note `sessions.py` uses offset-ISO, not Z;
+  each file is internally consistent so no functional bug), C1-POOL (real
+  `psycopg_pool` in the request path).
+- #114 policies + #115 magic-consume verified on main. CSP worker-src is in open
+  PR #117.
+
+## Sixth-pass bottom line
+The audit's steady state: **every re-verified finding holds; each new refuter
+generation finds ~2–3 residuals in the newest fixes; they are fixed same-day with
+fail-first tests.** Remaining owner actions are unchanged (connect GitHub
+auto-deploy, set `SENTRY_DSN`, merge open PRs, §8 measurement, channel test).

--- a/frontend/src/app/settings/account/page.tsx
+++ b/frontend/src/app/settings/account/page.tsx
@@ -30,6 +30,7 @@ import {
   logout,
   resendVerificationEmail,
 } from "@/lib/api";
+import { apiErrorMessage } from "@/lib/api-error";
 
 // ---------------------------------------------------------------------------
 // Zod schemas
@@ -93,7 +94,7 @@ function ChangePasswordCard() {
       setSuccess("Password updated successfully.");
       reset();
     } catch (err) {
-      setServerError(err instanceof Error ? err.message : "Failed to change password.");
+      setServerError(apiErrorMessage(err, "Failed to change password."));
     }
   }
 
@@ -175,7 +176,7 @@ function ChangeEmailCard() {
       await logout();
       router.push("/login");
     } catch (err) {
-      setServerError(err instanceof Error ? err.message : "Failed to change email.");
+      setServerError(apiErrorMessage(err, "Failed to change email."));
     }
   }
 
@@ -250,7 +251,7 @@ function DeleteAccountCard() {
       await deleteAccount(data.currentPassword);
       router.push("/login");
     } catch (err) {
-      setServerError(err instanceof Error ? err.message : "Failed to delete account.");
+      setServerError(apiErrorMessage(err, "Failed to delete account."));
     }
   }
 
@@ -358,7 +359,7 @@ function VerifyEmailCard() {
       await resendVerificationEmail();
       setSuccess("Verification email sent. Check your inbox (and Spam), then click the link.");
     } catch (err) {
-      setServerError(err instanceof Error ? err.message : "Failed to send verification email.");
+      setServerError(apiErrorMessage(err, "Failed to send verification email."));
     } finally {
       setSending(false);
     }

--- a/frontend/src/middleware.test.ts
+++ b/frontend/src/middleware.test.ts
@@ -130,4 +130,20 @@ describe("middleware — E2E bypass fails closed in production (F2)", () => {
     expect(res.status).toBe(200); // trusted, no verify round-trip
     expect(fetchMock).not.toHaveBeenCalled();
   });
+
+  it("prod detection is case-insensitive — APP_ENV=Production also fails closed", async () => {
+    // The backend's _is_production() lowercases before comparing; a strict
+    // === "production" here would treat APP_ENV=Production as NOT prod and
+    // re-open the bypass the backend would refuse. Both sides must agree.
+    vi.stubEnv("E2E_TEST_MODE", "1");
+    vi.stubEnv("RAILWAY_ENVIRONMENT", "");
+    vi.stubEnv("APP_ENV", "Production"); // capital P — still production
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response(null, { status: 401 }));
+    vi.stubGlobal("fetch", fetchMock);
+    const res = await middleware(protectedRequest());
+    expect(fetchMock).toHaveBeenCalled(); // bypass did NOT short-circuit
+    expect(res.status).toBe(307);
+  });
 });

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -49,8 +49,12 @@ export async function middleware(request: NextRequest) {
   // Docker / bare VM, where APP_ENV=production is the general signal) with a stray
   // E2E_TEST_MODE=1 also fails closed. CI/local set neither, so the bypass still
   // works there.
+  // Case-insensitive like the backend's _is_production() (.lower() there) —
+  // APP_ENV=Production must count as prod on BOTH sides, or the bypass gate
+  // and the cookie-Secure/HSTS gate disagree about what "production" means.
   const isProduction =
-    process.env.APP_ENV === "production" || !!process.env.RAILWAY_ENVIRONMENT;
+    (process.env.APP_ENV ?? "").toLowerCase() === "production" ||
+    !!process.env.RAILWAY_ENVIRONMENT;
   if (process.env.E2E_TEST_MODE === "1" && !isProduction) {
     return NextResponse.next();
   }


### PR DESCRIPTION
Sixth full re-verify vs current main (`7aea468`): 4 verify batches + a 16-branch stranded-work sweep + 6 adversarial refuters. **82 findings re-confirmed, zero regressions** — and the refuters broke 3 residuals (third pass in a row). All fixed here, each with a test verified to fail pre-fix.

## The 3 residuals
| Residual | The hole | Fix |
|---|---|---|
| **EMAIL-CASE** | Magic-link request stored the RAW-case email; consume's `INSERT OR IGNORE` conflicts on the case-SENSITIVE unique → `Alice@` vs `alice@` = **two accounts, one mailbox** (test proved: 2 rows) | normalize at request AND consume (`magic_link.py`) |
| **SPLIT-P3 #2** | Scanner handled `--` but not `/* */` — a `;` inside a block comment shipped a bare fragment to Postgres | same scanner, nested-comment aware; `/*` in strings stays data |
| **F2 #2** | `APP_ENV === "production"` strict vs backend's `.lower()` — `APP_ENV=Production` reopened the bypass | `.toLowerCase()` |

## Stranded-work sweep (16 unmerged branches)
**1 real stranded fix rescued**: `backup/account-error-messages` — settings/account's 4 catch blocks now use `apiErrorMessage(...)` instead of raw `err.message` (VerifyEmailCard removal on that branch was unrelated — NOT carried over). Other 15 branches: backups/superseded/deliberate — nothing else stranded.

## Also in this PR
- Cherry-picked from #116 (close that as folded-in): MFA decision (**won't build** — magic-link is the factor) + owner-item closures doc section.
- New SIXTH PASS audit-doc section (current as of this session).

Tests: magic-link 9/9 · pg_translate 22/22 · middleware 9/9 · tsc clean · gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6DsQH5EUxJc3Vnqz9YHgQ