### PR TITLE
fix(observability): init Sentry at import time — backend tracing was silently dead

### DIFF
--- a/backend/src/api/main.py
+++ b/backend/src/api/main.py
@@ -100,8 +100,9 @@ def _init_sentry() -> None:
 
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncIterator[None]:
-    # Phase 3 — Sentry must be up before anything else so boot errors are captured.
-    _init_sentry()
+    # Sentry init moved to MODULE scope (below, before `app = FastAPI(...)`) —
+    # see the comment there. Initialising it here was too late for the tracing
+    # integration and left backend performance monitoring silently dead.
     # Tier-A Step-0 #9 — honour LOG_LEVEL env var at process boot.
     # setup_logging() configures the "job360" subtree; we also set the root
     # logger so libraries (uvicorn, fastapi, httpx) inherit the same level
@@ -124,6 +125,16 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     # Idempotent — a no-op if the pool was never opened (e.g. TEST_MODE).
     await pool.close_pool()
 
+
+# Sentry MUST initialise BEFORE the FastAPI/Starlette app object is created:
+# Starlette builds its middleware stack at construction time, and Sentry's
+# Starlette/FastAPI tracing integration patches at `sentry_sdk.init` time.
+# When init ran inside the lifespan (post-construction), error capture still
+# worked (global logging hooks) but performance tracing could NEVER emit a
+# request transaction — the prod Sentry project had arq-worker transactions
+# yet zero backend http.server transactions in its entire history. Prod-gated
+# inside init_sentry, so this is a no-op in dev/tests.
+_init_sentry()
 
 app = FastAPI(title="Job360 API", version="1.0.0", lifespan=lifespan)
 

--- a/backend/tests/test_sentry_init_order.py
+++ b/backend/tests/test_sentry_init_order.py
@@ -1,0 +1,63 @@
+"""Sentry must initialise at IMPORT time, before the FastAPI app is built.
+
+Found during the 2026-07-24 prod verification: `_init_sentry()` ran inside the
+lifespan hook — AFTER `app = FastAPI(...)` was constructed. Starlette builds its
+middleware stack when the app object is created, so Sentry's Starlette/FastAPI
+tracing integration (which patches at `sentry_sdk.init` time) came too late:
+error capture worked (global logging hooks), but **performance tracing could
+never emit a single http.server transaction** — confirmed by the Sentry project
+containing arq-worker transactions yet zero backend request transactions in its
+entire history.
+
+The test runs in a SUBPROCESS so the fake DSN and the initialised SDK cannot
+leak into (or send anything from) the rest of the offline suite.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+_BACKEND_DIR = str(Path(__file__).resolve().parents[1])
+
+_PROBE = """
+import os
+os.environ["APP_ENV"] = "production"
+os.environ.setdefault("SESSION_SECRET", "x" * 40)
+os.environ.setdefault("CHANNEL_ENCRYPTION_KEY", "x" * 40)
+os.environ.setdefault("DATABASE_URL", "postgresql://job360:job360dev@localhost:5433/job360")
+
+import src.core.settings as settings
+# Fake but well-formed DSN. Import alone must not send anything (Sentry only
+# talks to the network when an event/envelope is captured).
+settings.SENTRY_DSN = "https://0123456789abcdef0123456789abcdef@o0.ingest.sentry.io/0"
+
+import src.api.main  # noqa: F401 — the import IS the test subject
+
+import sentry_sdk
+client = sentry_sdk.get_client()
+print("ACTIVE" if client.is_active() else "INACTIVE")
+"""
+
+
+def test_sentry_is_active_at_import_time_in_production() -> None:
+    """Importing src.api.main with a DSN + prod env must initialise Sentry
+    BEFORE the app object exists — i.e. by the time the import returns.
+
+    Pre-fix this printed INACTIVE: init only happened once the lifespan ran,
+    which is too late for the tracing integration.
+    """
+    proc = subprocess.run(
+        [sys.executable, "-c", _PROBE],
+        cwd=_BACKEND_DIR,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert proc.returncode == 0, f"probe crashed:\n{proc.stderr[-2000:]}"
+    # EXACT match — "INACTIVE" contains the substring "ACTIVE", so a substring
+    # check here silently passes on the broken state (it did, once).
+    assert proc.stdout.splitlines()[-1].strip() == "ACTIVE", (
+        "Sentry was NOT initialised at import time — the tracing integration "
+        f"is dead when init waits for the lifespan. stdout={proc.stdout!r}"
+    )


### PR DESCRIPTION
Found while end-to-end verifying the SENTRY_DSN setup: the worker traced fine (10 transactions) but the backend produced **zero traces across 150 sampled requests** — and zero in the project's entire history.

**Root cause:** `_init_sentry()` ran in the **lifespan**, after `app = FastAPI(...)`. Starlette builds its middleware stack at construction; Sentry's tracing integration patches at `init` time → too late. Errors still captured (global hooks); performance tracing structurally dead.

**Fix:** init at module scope, immediately before the app is constructed (canonical placement). Prod-gated as before — dev/tests no-op.

**Test:** subprocess probe asserts the SDK is ACTIVE at import time with prod env + DSN (INACTIVE pre-fix). Exact-match assertion — "INACTIVE" contains "ACTIVE", which bit v1 of the test.

**After merge:** auto-deploy ships it, and backend request traces appearing in Sentry = the definitive proof the owner's backend DSN is correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6DsQH5EUxJc3Vnqz9YHgQ