### PR TITLE
feat(deploy): worker Railway config without HTTP healthcheck

### DIFF
--- a/backend/railway.worker.json
+++ b/backend/railway.worker.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "//": "Config for the WORKER service ONLY — set 'Config file path' to this file in the worker's Railway settings. The worker is a background arq process with NO HTTP server, so the sibling railway.json's healthcheckPath (/api/health) can never pass and rolled back every worker deploy (seen live 2026-07-24). Liveness is covered instead by Dockerfile.worker's `arq --check` HEALTHCHECK plus the restart policy below.",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "Dockerfile.worker"
+  },
+  "deploy": {
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 10
+  }
+}


### PR DESCRIPTION
Adds backend/railway.worker.json so the worker service can join GitHub auto-deploy. The worker inherits backend/railway.json today, whose /api/health healthcheck can never pass on a headless arq process (Railway rolled back every worker deploy, seen live 2026-07-24). New file: same Dockerfile.worker build + ON_FAILURE restart, minus the HTTP healthcheck; liveness stays on the Dockerfile arq --check.

Owner activation after merge: worker service Settings -> Config file path = backend/railway.worker.json -> Connect Repo (main, root dir backend).