### PR TITLE
fix(deploy): remove invalid '//' key rejecting worker auto-deploy config

### DIFF
--- a/backend/railway.worker.json
+++ b/backend/railway.worker.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://railway.com/railway.schema.json",
-  "//": "Config for the WORKER service ONLY — set 'Config file path' to this file in the worker's Railway settings. The worker is a background arq process with NO HTTP server, so the sibling railway.json's healthcheckPath (/api/health) can never pass and rolled back every worker deploy (seen live 2026-07-24). Liveness is covered instead by Dockerfile.worker's `arq --check` HEALTHCHECK plus the restart policy below.",
   "build": {
     "builder": "DOCKERFILE",
     "dockerfilePath": "Dockerfile.worker"


### PR DESCRIPTION
Follow-up to #120. The worker's first auto-deploys kept FAILING. Root cause is two-layered:

1. **Config-file-path was doubled** — set to `backend/railway.worker.json` while the worker's root dir is already `backend`, so Railway never read the file, fell back to the default `railway.json` HTTP healthcheck, and rolled back the headless worker (deploy 2beb35d9). Correct value: `railway.worker.json` (relative to root) — already fixed in the dashboard.
2. **Once the path was right, the file itself was invalid** — it carried a fake `"//"` comment key. JSON has no comments and Railway's schema rejects unknown keys, so the config failed validation and the deploy died before building (`scheduling build` then nothing — deploy 51f99522).

**This PR:** removes the `"//"` key. Config is now only `$schema`/`build`/`deploy` — all valid. No healthcheckPath (headless worker isn't health-gated); liveness stays on `Dockerfile.worker`'s `arq --check`.

**After merge:** the worker's auto-deploy reads a valid no-healthcheck config → builds `Dockerfile.worker` → succeeds. No owner clicks needed beyond the merge (repo + config path already set). No outage throughout — the prior successful worker deploy kept running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6DsQH5EUxJc3Vnqz9YHgQ