### PR TITLE
fix(deploy): worker config mirrors working backend (no build section) — fixes auto-deploy

### DIFF
--- a/backend/railway.worker.json
+++ b/backend/railway.worker.json
@@ -1,10 +1,7 @@
 {
   "$schema": "https://railway.com/railway.schema.json",
-  "build": {
-    "builder": "DOCKERFILE",
-    "dockerfilePath": "Dockerfile.worker"
-  },
   "deploy": {
+    "startCommand": "arq src.workers.settings.WorkerSettings",
     "restartPolicyType": "ON_FAILURE",
     "restartPolicyMaxRetries": 10
   }


### PR DESCRIPTION
Third fix for the worker auto-deploy (follow-up to #120, #121). Three deploys failed; the last two died at `scheduling build` before building — Railway read `railway.worker.json` but couldn't resolve `build.dockerfilePath: Dockerfile.worker`.

**Root cause:** the *working* `backend/railway.json` has **no `build` section** — Railway auto-detects `backend/Dockerfile`. Specifying `build.dockerfilePath` is what broke it.

**Fix — mirror the proven backend config:**
- No `build` section (auto-detect the default Dockerfile)
- `deploy.startCommand: arq src.workers.settings.WorkerSettings` (in the config, not reliant on a dashboard override)
- **No `healthcheckPath`** (headless worker can't answer /api/health — that gate rolled back attempt #1)
- ON_FAILURE restart

**Trade-off:** worker builds from the heavier default Dockerfile, not the lean `Dockerfile.worker` — a size/time cost, not correctness. Can optimize later via `RAILWAY_DOCKERFILE_PATH` once green.

**After merge:** valid backend-shaped config → builds → arq starts → no health gate → SUCCESS. **No new dashboard clicks** (repo + config path already set). No outage — prior good worker deploy kept running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6DsQH5EUxJc3Vnqz9YHgQ