### PR TITLE
fix(sources): aijobs_ai parses the new card layout — source was silently blind

### DIFF
--- a/backend/src/sources/scrapers/aijobs_ai.py
+++ b/backend/src/sources/scrapers/aijobs_ai.py
@@ -1,3 +1,4 @@
+import html as html_lib
 import logging
 import re
 from datetime import datetime, timezone
@@ -7,11 +8,38 @@ from src.sources.base import BaseJobSource, _is_uk_or_remote
 
 logger = logging.getLogger("job360.sources.aijobs_ai")
 
-# Broader patterns to match aijobs.ai HTML structure
-_JOB_LINK_RE = re.compile(
-    r'<a[^>]+href="((?:https://aijobs\.ai)?/job[s]?/[^"]+)"[^>]*>\s*([^<]+?)\s*</a>',
-    re.IGNORECASE,
+# Match the job-card ANCHOR and capture its whole inner HTML.
+#
+# The previous pattern ended in `>\s*([^<]+?)\s*</a>`, i.e. it required the
+# anchor to contain plain text and NOTHING else. In 2026-07 aijobs.ai moved to
+# card components — the <a> now wraps nested <div>s — so that pattern matched
+# zero anchors and the source silently returned no jobs (Sentry
+# PYTHON-FASTAPI-7). Capturing inner HTML and pulling the text out afterwards
+# survives markup churn: only the URL scheme (/job/<slug>) has to stay stable.
+#
+# Anchoring the group right after `href="` keeps third-party ad links out —
+# e.g. https://www.telusinternational.ai/.../jobs/available/123 contains
+# "/jobs/" but is not an aijobs.ai listing.
+_JOB_ANCHOR_RE = re.compile(
+    r'<a\s[^>]*href="((?:https?://(?:www\.)?aijobs\.ai)?/jobs?/[^"#?]+)"[^>]*>(.*?)</a>',
+    re.IGNORECASE | re.DOTALL,
 )
+
+# Company sits in a `*card-title*` span inside the card. Class names are the
+# first thing a redesign changes, so treat this as a HINT — `_parse_html`
+# falls back to the surrounding block, then to "Unknown".
+_CARD_TITLE_RE = re.compile(
+    r'class="[^"]*card-title[^"]*"[^>]*>\s*([^<]+?)\s*<', re.IGNORECASE
+)
+
+_SCRIPT_RE = re.compile(r"<(script|style)\b.*?</\1>", re.IGNORECASE | re.DOTALL)
+# Comments MUST be stripped before tags: `<[^>]+>` stops at the first `>`, so a
+# comment containing one (very common in build output) leaves a stray `-->`
+# behind that then reads as visible text. Two live cards reported their company
+# as "-->" until this was added.
+_COMMENT_RE = re.compile(r"<!--.*?-->", re.DOTALL)
+_TAG_RE = re.compile(r"<[^>]+>")
+_NAV_TITLES = {"view all", "see more", "load more", "apply now", "view job"}
 
 # S4: structural health check. If a non-trivially large page comes back but
 # the anchor regex above matches ZERO raw job-link candidates, the site's
@@ -48,26 +76,62 @@ class AIJobsAISource(BaseJobSource):
         logger.info("AI Jobs AI: found %s relevant jobs", len(jobs))
         return jobs
 
+    @staticmethod
+    def _card_texts(inner_html: str) -> list[str]:
+        """Visible text runs inside a card anchor, in document order.
+
+        For the card layout this yields roughly [title, age, job type,
+        company]; for the older plain-text anchor it yields just [title].
+        """
+        cleaned = _COMMENT_RE.sub(" ", _SCRIPT_RE.sub(" ", inner_html))
+        parts = (re.sub(r"\s+", " ", p).strip() for p in _TAG_RE.split(cleaned))
+        return [html_lib.unescape(p) for p in parts if p]
+
     def _parse_html(self, html: str) -> list[Job]:
         try:
             jobs = []
             now = datetime.now(timezone.utc).isoformat()
             raw_matches = 0
 
-            for match in _JOB_LINK_RE.finditer(html):
+            for match in _JOB_ANCHOR_RE.finditer(html):
                 raw_matches += 1
-                path, title = match.group(1), match.group(2).strip()
+                path, inner = match.group(1), match.group(2)
+
+                texts = self._card_texts(inner)
+                if not texts:
+                    continue
+                title = texts[0]
 
                 # Skip navigation/non-job links
-                if len(title) < 5 or title.lower() in ("view all", "see more", "load more"):
+                if len(title) < 5 or title.lower() in _NAV_TITLES:
                     continue
 
-                # Try to extract company/location from nearby HTML
                 pos = match.start()
                 block = html[max(0, pos - 500):pos + 1000]
 
-                company = self._extract_nearby(block, r'(?:company|employer|org)[^"]*"[^>]*>\s*([^<]+)')
-                location = self._extract_nearby(block, r'(?:location|city)[^"]*"[^>]*>\s*([^<]+)')
+                # Company: the card-title span, else the surrounding block
+                # (how the older markup exposed it). Deliberately NO
+                # "last text run" fallback — sponsored cards omit the
+                # card-title span and their last run is the LOCATION, which
+                # produced company="United States" on two live listings. A
+                # wrong company is worse than a missing one: `company` feeds
+                # `normalized_key()` dedup (hard rule #1), so a bogus value
+                # silently splits or merges the wrong postings.
+                card_title = _CARD_TITLE_RE.search(inner)
+                if card_title:
+                    company = html_lib.unescape(card_title.group(1).strip())
+                else:
+                    company = self._extract_nearby(
+                        block, r'(?:company|employer|org)[^"]*"[^>]*>\s*([^<]+)'
+                    )
+
+                # Cards carry NO location (verified against the live page), so
+                # this stays empty for them — and `_is_uk_or_remote("")` is
+                # True ("unknown, don't filter", base.py), which is what we
+                # want: never drop a job for a field the site stopped showing.
+                location = self._extract_nearby(
+                    block, r'(?:location|city)[^"]*"[^>]*>\s*([^<]+)'
+                )
 
                 if not _is_uk_or_remote(location):
                     continue

--- a/backend/tests/test_sources.py
+++ b/backend/tests/test_sources.py
@@ -2108,7 +2108,85 @@ AIJOBS_AI_HTML = """<html><body>
 </body></html>"""
 
 
+# The CURRENT (2026-07) aijobs.ai markup: each listing is a card whose <a>
+# wraps nested <div>s instead of plain text. The old regex required
+# `>text</a>` with no tags inside, so it matched ZERO and the source went
+# silently blind in prod (Sentry PYTHON-FASTAPI-7). Structure below is copied
+# from the live page — title div, age, job type, then company in a
+# `*card-title*` span. Note: the live page carries NO location in the card.
+AIJOBS_AI_CARD_HTML = """<html><body>
+<div class="col-xl-4 col-md-6 fade-in-bottom rt-mb-24 cat-1 cat-3">
+  <div class="tw-relative tw-h-full">
+    <a href="https://aijobs.ai/job/senior-robotics-systems-engineer"
+       class="tw-h-full card tw-card tw-block jobcardStyle1 ">
+      <div class="tw-p-6 tw-h-full">
+        <div class="tw-mb-1.5 d-flex justify-content-between">
+          <div class="tw-text-[#18191C] tw-text-lg tw-font-medium">
+            Senior Robotics Systems Engineer
+          </div>
+          <div class="tw-text-sm tw-text-[#767F8C] mt-1 tw-pl-3">0D</div>
+        </div>
+        <div class="tw-text-sm">Full Time</div>
+        <span class="iconbox-icon"><div><img src="/x.jpeg" alt="" draggable="false"></div></span>
+        <div class="iconbox-content"><div class="tw-mb-1 tw-inline-flex">
+          <span class="tw-text-base tw-font-medium tw-card-title">RoboForce</span>
+        </div></div>
+      </div>
+    </a>
+  </div>
+</div>
+<div class="col-xl-4">
+  <a href="/job/mission-operations-lead" class="card jobcardStyle1">
+    <div class="tw-p-6">
+      <div class="tw-text-lg tw-font-medium">Mission Operations &amp; AI Enablement Lead</div>
+      <div class="tw-text-sm">2D</div>
+      <div class="iconbox-content">
+        <span class="tw-card-title">OceanX</span>
+      </div>
+    </div>
+  </a>
+</div>
+<a href="/about">About us</a>
+</body></html>"""
+
+
+def test_aijobs_ai_parses_card_layout():
+    """VALUE-presence (rule #21): the live card markup must yield real jobs.
+
+    Regression pin for the 2026-07 breakage — asserting a non-empty list with
+    correct field VALUES, not merely `isinstance(jobs, list)`.
+    """
+    async def _test():
+        session = aiohttp.ClientSession()
+        try:
+            with aioresponses() as m:
+                m.get(re.compile(r"https://aijobs\.ai/.*"),
+                      body=AIJOBS_AI_CARD_HTML, content_type="text/html", repeat=True)
+                source = AIJobsAISource(session)
+                jobs = await source.fetch_jobs()
+
+            assert len(jobs) == 2, f"expected 2 cards parsed, got {len(jobs)}"
+            by_title = {j.title: j for j in jobs}
+
+            first = by_title["Senior Robotics Systems Engineer"]
+            assert first.company == "RoboForce"
+            assert first.apply_url == "https://aijobs.ai/job/senior-robotics-systems-engineer"
+            assert first.source == "aijobs_ai"
+
+            # HTML entities decoded, and a relative href absolutised.
+            second = by_title["Mission Operations & AI Enablement Lead"]
+            assert second.company == "OceanX"
+            assert second.apply_url == "https://aijobs.ai/job/mission-operations-lead"
+
+            # The nav link must never become a job.
+            assert all("/about" not in j.apply_url for j in jobs)
+        finally:
+            await session.close()
+    _run(_test())
+
+
 def test_aijobs_ai_parses_html():
+    """Legacy plain-text anchor layout must keep working (backward compat)."""
     async def _test():
         session = aiohttp.ClientSession()
         try:
@@ -2117,9 +2195,13 @@ def test_aijobs_ai_parses_html():
                       body=AIJOBS_AI_HTML, content_type="text/html", repeat=True)
                 source = AIJobsAISource(session)
                 jobs = await source.fetch_jobs()
-                assert isinstance(jobs, list)
-                if jobs:
-                    assert all(j.source == "aijobs_ai" for j in jobs)
+
+            # Previously `if jobs:` — which passed on ZERO jobs and is exactly
+            # why the prod breakage never turned a test red.
+            assert len(jobs) == 1
+            assert jobs[0].title == "Deep Learning Researcher"
+            assert jobs[0].apply_url == "https://aijobs.ai/job/deep-learning-researcher-456"
+            assert all(j.source == "aijobs_ai" for j in jobs)
         finally:
             await session.close()
     _run(_test())


### PR DESCRIPTION
Closes the live Sentry issue **[PYTHON-FASTAPI-7](https://job360.sentry.io/issues/PYTHON-FASTAPI-7)** (culprit `/api/search`), which was still firing an hour before this fix.

> `[aijobs_ai] STRUCTURE CHANGED: expected job-link anchor pattern not found in a 161928-byte response`

## Root cause

aijobs.ai moved each listing into a **card component** — the `<a>` now wraps nested `<div>`s:

```html
<a href="https://aijobs.ai/job/senior-robotics-systems-engineer" class="... jobcardStyle1">
  <div class="tw-p-6"><div class="tw-text-lg tw-font-medium">Senior Robotics Systems Engineer</div>
```

The old regex ended in `>\s*([^<]+?)\s*</a>` — it demanded the anchor contain **plain text and nothing else**. On a perfectly healthy 157 KB page it matched **zero** anchors. The source returned no jobs and kept doing so silently.

## Fix

Capture the anchor **plus its whole inner HTML**, then extract text afterwards. Only the URL scheme (`/job/<slug>`) has to stay stable, so the next redesign won't kill it. Anchoring the href group also excludes third-party ad links that merely contain `/jobs/` (`telusinternational.ai`).

## Two more bugs — found only by running against the REAL page

A hand-written fixture would have passed while prod produced garbage:

| Bug | Why | Fix |
|---|---|---|
| Company came out as **`-->`** | `<[^>]+>` stops at the first `>`, so an HTML comment containing one leaves a stray token that reads as visible text | strip comments before tags |
| Company came out as **"United States"** on 2 sponsored cards | they have no `card-title` span, so the positional fallback grabbed their last text run — the **location** | fallback deleted |

That second one matters beyond cosmetics: `company` feeds `normalized_key()` **dedup (hard rule #1)**, so a bogus value silently splits or merges the wrong postings. **A wrong company is worse than a missing one** — those two now say `Unknown`.

Cards carry **no location at all**. That field stays empty, and `_is_uk_or_remote("")` is `True` — *"unknown, don't filter"* (`base.py:47`). A job is never dropped for a field the site stopped showing.

## Why no test caught this

`test_aijobs_ai_parses_html` asserted **`if jobs:`** — it passed on **zero jobs**. A test that cannot fail didn't. Now strict, plus a new card-layout regression test with real value assertions (rule #21): exact titles, companies, absolute URLs, decoded entities, nav links excluded.

## Verification

- **Live page: 18 jobs parsed in 16 ms**, 0 blank titles, 0 wrong companies
- aijobs tests **4 passed**; gate targeted suite **97 passed**; `ruff` clean; **gate PASS**

## Reported, deliberately NOT fixed here (keeps this PR one thing)

- `climatebase.py:125` carries the **identical** text-only-anchor regex — same time bomb, not yet fired
- `tests/test_sources.py:1968, 2093` have the same `if jobs:` weakness

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpxEMPz2ZWG9Qed5BsFHvg