### PR TITLE
fix(dashboard): default min_score 30 → 20 — new users saw 4 jobs instead of 65

### DIFF
--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -9,7 +9,7 @@ import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
 import { JobList } from "@/components/jobs/JobList";
 import { TimeBuckets } from "@/components/jobs/TimeBuckets";
-import { FilterPanel } from "@/components/jobs/FilterPanel";
+import { FilterPanel, DEFAULT_MIN_SCORE } from "@/components/jobs/FilterPanel";
 import {
   getJobs,
   getStatus,
@@ -75,7 +75,7 @@ export default function DashboardPage() {
   // is off or the vector index is empty — so this is always safe to request.
   const [filters, setFilters] = useState<JobFilters>({
     hours: 168,
-    min_score: 30,
+    min_score: DEFAULT_MIN_SCORE,
     mode: "hybrid",
   });
 
@@ -151,7 +151,7 @@ export default function DashboardPage() {
   // ---------------------------------------------------------------------------
 
   const allJobsKey = useMemo<JobFilters>(
-    () => ({ min_score: filters.min_score ?? 30, hours: 168 }),
+    () => ({ min_score: filters.min_score ?? DEFAULT_MIN_SCORE, hours: 168 }),
     [filters.min_score]
   );
 
@@ -207,7 +207,7 @@ export default function DashboardPage() {
   // Count active non-default filters (excluding hours/bucket)
   const activeFilterCount = useMemo(() => {
     let count = 0;
-    if (filters.min_score && filters.min_score !== 30) count++;
+    if (filters.min_score && filters.min_score !== DEFAULT_MIN_SCORE) count++;
     if (filters.source) count++;
     if (filters.visa_only) count++;
     if (filters.action) count++;

--- a/frontend/src/components/jobs/FilterPanel.tsx
+++ b/frontend/src/components/jobs/FilterPanel.tsx
@@ -28,8 +28,27 @@ import type { JobFilters } from "@/lib/types";
 // Defaults
 // ---------------------------------------------------------------------------
 
+/**
+ * Minimum match score applied before the user touches anything.
+ *
+ * Was 30, which was calibrated against profiles from before
+ * `merge_cv_and_preferences` stopped folding the whole CV into
+ * `preferences.additional_skills`. Those legacy profiles scored every CV skill
+ * as `user_declared` (weight 3.0, the top tier), which floored their scores so
+ * high that EVERY job cleared 30.
+ *
+ * Measured in prod 2026-07-26, two accounts with the same CV:
+ *   legacy profile : 103 feed rows -> 103 at >=30   (nothing is ever filtered)
+ *   current profile: 104 feed rows ->  13 at >=30, 65 at >=20, 103 at >=10
+ *
+ * So a 30 default hides 87% of the feed from every NEW user — the product
+ * looks empty on day one. 20 keeps a real filter (drops the weakest ~38%)
+ * while leaving a populated feed. Change this one constant to re-tune.
+ */
+export const DEFAULT_MIN_SCORE = 20;
+
 const DEFAULT_FILTERS: JobFilters = {
-  min_score: 30,
+  min_score: DEFAULT_MIN_SCORE,
   source: undefined,
   visa_only: false,
   visa_sponsorship: undefined,


### PR DESCRIPTION
**Reported:** same person, two accounts, **same CV** — one sees 37 jobs, the other 4.

## Measured in prod, not guessed

Both accounts, identical `cv.raw_text` (5676 bytes):

| account | feed | ≥10 | **≥20** | ≥25 | **≥30 (old default)** | ≥40 |
|---|---|---|---|---|---|---|
| legacy profile | 103 | 103 | 103 | 103 | **103** | 27 |
| current profile | 104 | 103 | **65** | 30 | **13** | 1 |

Add the 7-day recency filter and those become the reported **37 vs 4**.

## The legacy account is the anomaly — not the other one

It clears 30 on **every single row**. That is a floor effect, not a good profile.

Its `preferences.additional_skills` holds **131 skills copied from its own CV** by the old `merge_cv_and_preferences`. `skill_tiering` scores each of those as `user_declared` = weight **3.0**, the top tier — so everything matched something and nothing could fall below 30.

That merge was **deliberately removed** (`preferences.py:175-182` — it *"stuffed the preferences box with the entire CV"*). So the second account is the **correct current behaviour**, and the first is stale pre-change data.

## Which means the default was never re-tuned

`min_score: 30` was calibrated against inflated legacy profiles. Today every **new** user lands on a dashboard showing **13 of 104 rows — 87% hidden** — and reasonably concludes the product found nothing.

## Fix

`DEFAULT_MIN_SCORE = 20`, exported from `FilterPanel` and used everywhere the literal `30` was duplicated (initial state, `allJobsKey` fallback, active-filter comparison). 20 still drops the weakest ~38% while leaving a populated feed. **One constant re-tunes it** — the doc comment carries the measurement table so the next person can pick a different number with evidence.

### Also fixes a silent lie

```ts
if (filters.min_score && filters.min_score !== 30) count++;
```

At the default this reported **zero active filters** while hiding 91 of 104 jobs. It now compares against the shared constant, so the badge tracks whatever the default actually is.

## Scope

**Scoring / search-engine code is untouched** — this is a UI default only.

**Not fixed here** (own change): the dashboard shows no "X of Y", so a user still cannot see how many rows a threshold is hiding.

## Verification

`tsc --noEmit` clean · `eslint` clean · FilterPanel **4 passed** · **gate PASS**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpxEMPz2ZWG9Qed5BsFHvg