### PR TITLE
perf: hybrid rerank off the event loop + score cache + visible request timings

### DIFF
--- a/backend/src/api/middleware.py
+++ b/backend/src/api/middleware.py
@@ -93,14 +93,25 @@ class AccessLogMiddleware(BaseHTTPMiddleware):
             status = response.status_code
             return response
         finally:
+            duration_ms = round((time.perf_counter() - start) * 1000, 1)
+            # The timing MUST be in the message, not only in `extra`. The console
+            # handler renders `%(message)s`, so an extras-only duration is
+            # invisible wherever logs are actually read — `railway logs` showed
+            # nothing but a bare "http_request" for every request, which made
+            # "the site feels slow" impossible to answer. `extra` is kept for the
+            # structured JSON stream; the message carries it for humans.
             _access_log.info(
-                "http_request",
+                "%s %s %s %sms",
+                request.method,
+                request.url.path,
+                status,
+                duration_ms,
                 extra={
                     "event": "http_request",
                     "method": request.method,
                     "path": request.url.path,
                     "status_code": status,
-                    "duration_ms": round((time.perf_counter() - start) * 1000, 1),
+                    "duration_ms": duration_ms,
                     "request_id": get_request_id(),
                     # WHO made the request — set on request.state by require_user /
                     # optional_user (None for anonymous routes). Left unmasked: an

--- a/backend/src/api/routes/jobs.py
+++ b/backend/src/api/routes/jobs.py
@@ -1,5 +1,6 @@
 """Jobs list, export, and detail endpoints."""
 
+import asyncio
 import csv
 import io
 import json
@@ -471,7 +472,17 @@ async def list_jobs(
             from src.services.profile.storage import load_profile  # noqa: PLC0415 — lazy
 
             hybrid_profile = load_profile(user.id)
-        all_rows = _maybe_apply_hybrid_reorder(all_rows, profile=hybrid_profile)
+        # WORKER THREAD (same reasoning as main.py's scoring hand-off): the
+        # hybrid path is CPU-bound — a Chroma query plus a cross-encoder that
+        # scores up to 50 (profile, job) PAIRS one by one. Measured in prod at
+        # `Batches: 2/2 [00:14<00:00, 7.48s/it]`. Run inline it froze the whole
+        # event loop for the duration, so ONE user opening the dashboard stalled
+        # every other request in the process — including the 3-second
+        # /api/search/{id}/status polls, which is how a slow reorder turned into
+        # "Lost contact with the server while searching".
+        all_rows = await asyncio.to_thread(
+            _maybe_apply_hybrid_reorder, all_rows, profile=hybrid_profile
+        )
 
     # Filter by hours cutoff
     if hours is not None:

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -447,6 +447,31 @@ async def _enqueue_notifications(
         return 0
 
 
+def _encode_and_upsert(
+    vix: Any,
+    encode_job: Any,
+    job: Job,
+    enrichment: Any,
+    job_id: int,
+) -> None:
+    """Embed one job and push it into the vector index — the SYNCHRONOUS pair.
+
+    Split out purely so ``run_search`` can hand it to ``asyncio.to_thread``.
+    ``encode_job`` runs the sentence-transformer (~7.5 s per batch in prod) and
+    ``vix.upsert`` writes to Chroma; both block. Keeping them together in one
+    thread hop avoids paying the hand-off twice per job.
+
+    Typed ``Any`` deliberately: the heavy modules are lazy-imported inside
+    ``run_search`` (rules #11/#16), so their real types are not importable here.
+    """
+    vec = encode_job(job, enrichment)
+    vix.upsert(
+        job_id=job_id,
+        vector=vec,
+        metadata={"title": job.title, "company": job.company},
+    )
+
+
 def _score_dedup_and_filter(all_jobs: list[Job], scorer: JobScorer) -> list[Job]:
     """Score every job, extract deadlines, dedup, and score-filter — the whole
     SYNCHRONOUS, CPU-heavy stage of the pipeline in one place.
@@ -934,11 +959,18 @@ async def run_search(
                                 enrichment = await load_enrichment(conn, job_id)
                             except Exception:
                                 enrichment = None
-                            vec = encode_job(j, enrichment)
-                            vix.upsert(
-                                job_id=job_id,
-                                vector=vec,
-                                metadata={"title": j.title, "company": j.company},
+                            # WORKER THREAD — encode_job() runs the sentence
+                            # transformer, and vix.upsert() writes to Chroma;
+                            # both are synchronous and CPU-bound. Inline, this
+                            # loop blocked the event loop once per new job
+                            # (prod: ~7.5s per encode batch), so a run that
+                            # inserted enough jobs starved the 3-second
+                            # /api/search/{id}/status polls for over a minute
+                            # and the dashboard reported "Lost contact with the
+                            # server while searching". Same fix as the scoring
+                            # hand-off at the top of this function.
+                            await asyncio.to_thread(
+                                _encode_and_upsert, vix, encode_job, j, enrichment, job_id
                             )
                             await conn.execute(
                                 "INSERT INTO job_embeddings(job_id, model_version) VALUES (?, ?) "

--- a/backend/src/services/retrieval.py
+++ b/backend/src/services/retrieval.py
@@ -14,9 +14,11 @@ not installed), the retrieval gracefully falls back to keyword-only.
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import math
 import re
+from collections import OrderedDict
 from collections.abc import Iterable
 from typing import Any, Callable, Optional
 
@@ -293,6 +295,45 @@ def reset_cross_encoder_for_testing() -> None:
     """Discard the cached cross-encoder — tests call this between swaps."""
     global _CROSS_ENCODER
     _CROSS_ENCODER = None
+    _PAIR_SCORE_CACHE.clear()
+
+
+# --- (query, candidate) score cache -----------------------------------------
+#
+# A cross-encoder score is a pure function of the (query, text) pair, and BOTH
+# sides are stable in this product: `query` is built from the user's profile
+# (changes only when the profile does) and `text` comes from a catalog row
+# (immutable once inserted). So every dashboard load was paying to recompute
+# scores it had already computed — measured in prod at ~7.5 s per batch of
+# pairs, on the request path.
+#
+# Cached per PAIR rather than per result set, so a partial overlap still pays
+# off: refreshing a feed where 45 of 50 jobs are unchanged now scores only the
+# 5 new ones. Keys are digests, not the texts themselves, to bound memory.
+# Process-local and cleared on restart — a model swap can never serve stale
+# scores, because a new process starts with an empty cache.
+_PAIR_SCORE_CACHE: OrderedDict[tuple[str, str], float] = OrderedDict()
+_PAIR_CACHE_MAX = 4096
+
+
+def _pair_key(query: str, text: str) -> tuple[str, str]:
+    """Digest both sides of the pair — this is a cache key, never a credential.
+
+    blake2b rather than sha1/md5: not flagged by the security linters (S324),
+    faster than sha256, and an 8-byte digest is far more collision-headroom
+    than a few-thousand-entry cache needs.
+    """
+    return (
+        hashlib.blake2b(query.encode("utf-8", "replace"), digest_size=8).hexdigest(),
+        hashlib.blake2b(text.encode("utf-8", "replace"), digest_size=8).hexdigest(),
+    )
+
+
+def _cache_put(key: tuple[str, str], score: float) -> None:
+    _PAIR_SCORE_CACHE[key] = score
+    _PAIR_SCORE_CACHE.move_to_end(key)
+    while len(_PAIR_SCORE_CACHE) > _PAIR_CACHE_MAX:
+        _PAIR_SCORE_CACHE.popitem(last=False)
 
 
 def cross_encoder_rerank(
@@ -329,14 +370,36 @@ def cross_encoder_rerank(
 
     # `Any`: the encoder is a duck-typed CrossEncoder-compatible object (the
     # real class is lazily imported, tests inject a stub) exposing `.predict`.
-    encoder: Any = encoder_factory() if encoder_factory else _load_cross_encoder()
-    pairs = [(query, text) for _id, text in head]
-    scores = encoder.predict(pairs)
-    # Normalise to a plain Python list[float] in case a numpy array comes back.
-    try:
-        scores = [float(s) for s in scores]
-    except TypeError:
-        scores = [float(scores)]
+    #
+    # The cache is BYPASSED whenever a factory is injected: tests swap stub
+    # encoders that return different scores for the same pair, so a shared
+    # cache would leak one test's answers into the next.
+    use_cache = encoder_factory is None
+    keys = [_pair_key(query, text) for _id, text in head] if use_cache else []
+
+    if use_cache:
+        misses = [i for i, k in enumerate(keys) if k not in _PAIR_SCORE_CACHE]
+    else:
+        misses = list(range(len(head)))
+
+    fresh: list[float] = []
+    if misses:
+        encoder: Any = encoder_factory() if encoder_factory else _load_cross_encoder()
+        pairs = [(query, head[i][1]) for i in misses]
+        fresh = encoder.predict(pairs)
+        # Normalise to a plain Python list[float] in case a numpy array comes back.
+        try:
+            fresh = [float(s) for s in fresh]
+        except TypeError:
+            fresh = [float(fresh)]
+        if use_cache:
+            for i, score in zip(misses, fresh):
+                _cache_put(keys[i], score)
+
+    if use_cache:
+        scores = [_PAIR_SCORE_CACHE[k] for k in keys]
+    else:
+        scores = fresh
 
     reranked_head = sorted(
         ((item_id, score) for (item_id, _text), score in zip(head, scores)),

--- a/backend/tests/test_retrieval.py
+++ b/backend/tests/test_retrieval.py
@@ -233,6 +233,59 @@ def test_cross_encoder_rerank_empty_candidates():
     assert cross_encoder_rerank("query", []) == []
 
 
+def test_cross_encoder_rerank_caches_pairs_across_calls():
+    """A (query, text) pair is scored ONCE, not once per request.
+
+    The cross-encoder was re-scoring the same profile against the same jobs on
+    every dashboard load — ~7.5 s per batch, on the request path. Both sides of
+    the pair are stable (profile text, immutable catalog row), so the second
+    call must do NO model work at all, and a partially-overlapping call must
+    score only the genuinely new pairs.
+    """
+    from src.services import retrieval as retrieval_mod
+
+    retrieval_mod.reset_cross_encoder_for_testing()  # also clears the pair cache
+
+    # Route through the real (cached) path by installing the fake as the
+    # module-level encoder — encoder_factory deliberately BYPASSES the cache.
+    enc = _FakeCrossEncoder()
+    retrieval_mod._CROSS_ENCODER = enc
+
+    candidates = [(1, "alpha"), (2, "beta"), (3, "gamma")]
+
+    first = cross_encoder_rerank("q", candidates, top_n=10)
+    assert len(enc.calls) == 3, "first call must score every pair"
+
+    second = cross_encoder_rerank("q", candidates, top_n=10)
+    assert len(enc.calls) == 3, "second call must score NOTHING — all cached"
+    assert [r[0] for r in second] == [r[0] for r in first], "cached order must match"
+
+    # Partial overlap: two known pairs + one new one → only the new one runs.
+    cross_encoder_rerank("q", candidates[:2] + [(4, "delta")], top_n=10)
+    assert len(enc.calls) == 4, "only the unseen pair should be scored"
+
+    # A different query is a different pair — cache must not answer for it.
+    cross_encoder_rerank("other query", candidates, top_n=10)
+    assert len(enc.calls) == 7, "changing the query must re-score all pairs"
+
+    retrieval_mod.reset_cross_encoder_for_testing()
+
+
+def test_cross_encoder_rerank_factory_path_is_not_cached():
+    """Injected stubs must never share a cache — tests would leak into each other."""
+    from src.services import retrieval as retrieval_mod
+
+    retrieval_mod.reset_cross_encoder_for_testing()
+    candidates = [(1, "alpha"), (2, "beta")]
+
+    a = _FakeCrossEncoder()
+    cross_encoder_rerank("q", candidates, top_n=10, encoder_factory=lambda: a)
+    b = _FakeCrossEncoder()
+    cross_encoder_rerank("q", candidates, top_n=10, encoder_factory=lambda: b)
+
+    assert len(a.calls) == 2 and len(b.calls) == 2, "each stub scores its own pairs"
+
+
 def test_cross_encoder_rerank_preserves_candidate_ids():
     """Item IDs (first tuple element) must be returned verbatim — no
     implicit int conversion, no reordering by id."""


### PR DESCRIPTION
Chased **"the site feels slow"** and **"Lost contact with the server while searching"** to the same root cause: CPU-bound model work running **inline on the async event loop**.

## Measured first, in prod

| Endpoint | Time |
|---|---|
| `/api/health` | 0.24 s |
| `/api/jobs` | 0.27 s |
| `/api/jobs?mode=hybrid` **anonymous** | 0.27 s |
| frontend page | 0.33 s |
| **`/api/jobs?mode=hybrid` signed in** | **~20 s** — log: `Batches: 2/2 [00:14, 7.48 s/it]` |

The dashboard **always** sends `mode=hybrid` (`page.tsx:79`). That path cross-encodes up to **50 (profile, job) pairs one at a time**.

Anonymous probes take the branch that skips it — which is why every uptime check and synthetic smoke looked perfectly healthy. **The monitoring was structurally blind to the only path real users take.**

## Three fixes

**1. `jobs.py` — hybrid reorder now runs in a worker thread.**
Inline, it froze the whole process, so *one* user opening the dashboard stalled **every other request** — including the 3 s `/api/search/{id}/status` polls. The toast fires after 20 consecutive failures (`page.tsx:286,336`) = **60 s of silence**, which a ~20 s reorder plus a search run reaches easily. **This is why the two symptoms are one bug.**

**2. `main.py` — the per-job encode+upsert loop had the same problem.**
Your PR #123 moved scoring and dedup off the loop and stopped ~170 lines short of this one. Identical bug, identical symptom — which is why it looked like #123 had regressed.

**3. `retrieval.py` — cache cross-encoder scores per pair.**
A score is a pure function of `(query, text)`, and both sides are stable here: the query comes from the profile (changes only when the profile does), the text from an immutable catalog row. Every dashboard load was recomputing answers it already had.

Cached **per pair**, not per result set — so refreshing a feed where 45 of 50 jobs are unchanged scores only the **5 new ones**. Bounded LRU of blake2b digests, process-local, so a model swap can never serve stale scores. The `encoder_factory` path deliberately bypasses the cache (tests inject stubs that score the same pair differently).

**Ranking output is unchanged** — same model, same pairs, same order. Only *where* the work happens and *how often* changed.

## Also: you had no request timings at all

`middleware.py` measured `duration_ms` and **threw it away** — the console handler renders `%(message)s`, so `extra` never reached anywhere logs are read. Every line in `railway logs` was a bare `http_request`.

That's why "is it slow?" had been unanswerable. Timings are now in the message; `extra` is kept for the JSON stream.

## Tests

Two value-presence tests pin the cache: a second identical call must do **zero** model work; a partial overlap scores only the new pair; a different query must not be answered from cache; injected stubs never share one.

**68 passed** (`test_retrieval` + `test_api`) · `ruff` clean · **gate PASS**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpxEMPz2ZWG9Qed5BsFHvg