### PR TITLE
feat(pipeline): capture 'ghosted' — the first-party ghost-job signal

### DIFF
--- a/backend/src/api/routes/pipeline.py
+++ b/backend/src/api/routes/pipeline.py
@@ -26,7 +26,14 @@ from src.utils.logger import get_audit_logger
 
 router = APIRouter(tags=["pipeline"])
 
-_VALID_STAGES = {"applied", "outreach", "interview", "offer", "rejected"}
+# "ghosted" is deliberately distinct from "rejected": rejected means the employer
+# REPLIED no; ghosted means SILENCE. That distinction is the whole point — it is
+# the only first-party signal that a posting took applications and never
+# responded, which is what an actual ghost job looks like from the outside.
+# (Contrast services/ghost_detection.py, which infers staleness from a listing
+# DISAPPEARING from its source — usually a sign the role was filled, i.e. the
+# opposite of a ghost job. User-confirmed silence is the stronger signal.)
+_VALID_STAGES = {"applied", "outreach", "interview", "offer", "rejected", "ghosted"}
 
 
 def _to_pipeline_application(row: dict[str, Any]) -> PipelineApplication:

--- a/backend/tests/test_ghosted_stage.py
+++ b/backend/tests/test_ghosted_stage.py
@@ -1,0 +1,131 @@
+"""Tests for the ``ghosted`` pipeline stage — the first-party ghost-job signal.
+
+WHY THIS STAGE EXISTS, and why it is not just another label:
+
+``rejected`` means the employer REPLIED no. ``ghosted`` means SILENCE — the
+application went in and nothing ever came back. Only the second one is evidence
+that a posting collected applications and answered nobody, which is what a ghost
+job actually looks like from the applicant's side.
+
+This matters because ``services/ghost_detection.py`` infers staleness from a
+listing DISAPPEARING from its source — which usually means the role was FILLED,
+i.e. the opposite of a ghost job. User-confirmed silence is the stronger, more
+honest signal, and it is the seed of a dataset nobody else has (every published
+ghost-job statistic today comes from surveys, not observed applications).
+
+All HTTP calls use ``authenticated_async_context`` so the routes pass
+``require_user`` (CLAUDE.md rule #12).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from src.api import dependencies as api_deps
+from src.api.routes.pipeline import _VALID_STAGES
+from src.repositories.database import JobDatabase
+
+
+async def _insert_job_row(db: JobDatabase, *, title: str = "AI Engineer", company: str = "Ghost Corp") -> int:
+    """Insert a minimal job row and return its id."""
+    now = datetime(2026, 4, 23, 12, 0, 0, tzinfo=timezone.utc).isoformat()
+    suffix = title.lower().replace(" ", "_")
+    cur = await db._conn.execute(
+        """INSERT INTO jobs
+           (title, company, location, description, apply_url, source, date_found,
+            match_score, visa_flag, experience_level,
+            normalized_company, normalized_title, first_seen,
+            first_seen_at, last_seen_at, date_confidence, staleness_state)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        (
+            title,
+            company,
+            "London, UK",
+            "A test job",
+            f"https://example.com/jobs/{suffix}",
+            "greenhouse",
+            now,
+            80,
+            0,
+            "mid",
+            company.lower(),
+            title.lower(),
+            now,
+            now,
+            now,
+            "high",
+            "active",
+        ),
+    )
+    await db._conn.commit()
+    return cur.lastrowid  # type: ignore[return-value]
+
+
+def test_ghosted_is_a_valid_stage():
+    """The stage must be accepted by the route's allow-list."""
+    assert "ghosted" in _VALID_STAGES
+
+
+def test_ghosted_is_distinct_from_rejected():
+    """Both exist and are separate — collapsing them would destroy the signal.
+
+    If ``ghosted`` were ever folded into ``rejected`` the dataset becomes
+    worthless: "they said no" and "they said nothing" would be indistinguishable.
+    """
+    assert "rejected" in _VALID_STAGES
+    assert "ghosted" in _VALID_STAGES
+    assert len({"rejected", "ghosted"} & _VALID_STAGES) == 2
+
+
+@pytest.mark.asyncio
+async def test_application_can_be_marked_ghosted(authenticated_async_context):
+    """apply → mark ghosted → the stage persists as 'ghosted'."""
+    db = await api_deps.get_db()
+    job_id = await _insert_job_row(db)
+
+    async with authenticated_async_context() as client:
+        resp = await client.post(f"/api/pipeline/{job_id}")
+        assert resp.status_code == 200, resp.text
+
+        resp = await client.post(f"/api/pipeline/{job_id}/advance", json={"stage": "ghosted"})
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["stage"] == "ghosted"
+
+        # And it survives a re-read — this is a recorded signal, not UI state.
+        resp = await client.get("/api/pipeline")
+        assert resp.status_code == 200, resp.text
+        rows = resp.json()
+        entries = rows if isinstance(rows, list) else rows.get("applications", [])
+        match = [a for a in entries if a["job_id"] == job_id]
+        assert match, "ghosted application missing from the pipeline listing"
+        assert match[0]["stage"] == "ghosted"
+
+
+@pytest.mark.asyncio
+async def test_ghosted_appears_in_stage_counts(authenticated_async_context):
+    """Counts must include ghosted so the dataset is measurable."""
+    db = await api_deps.get_db()
+    job_id = await _insert_job_row(db, title="Data Scientist", company="Silent Ltd")
+
+    async with authenticated_async_context() as client:
+        await client.post(f"/api/pipeline/{job_id}")
+        await client.post(f"/api/pipeline/{job_id}/advance", json={"stage": "ghosted"})
+
+        resp = await client.get("/api/pipeline/counts")
+        assert resp.status_code == 200, resp.text
+        assert resp.json().get("ghosted", 0) >= 1
+
+
+@pytest.mark.asyncio
+async def test_invalid_stage_still_rejected(authenticated_async_context):
+    """Adding 'ghosted' must not have opened the allow-list to anything else."""
+    db = await api_deps.get_db()
+    job_id = await _insert_job_row(db, title="QA Engineer", company="Bad Stage Inc")
+
+    async with authenticated_async_context() as client:
+        await client.post(f"/api/pipeline/{job_id}")
+        resp = await client.post(f"/api/pipeline/{job_id}/advance", json={"stage": "haunted"})
+        assert resp.status_code == 422, resp.text
+        assert "haunted" in resp.json()["detail"]

--- a/frontend/src/app/pipeline/page.tsx
+++ b/frontend/src/app/pipeline/page.tsx
@@ -10,6 +10,7 @@ import {
   Trophy,
   XCircle,
   AlertTriangle,
+  Ghost,
 } from "lucide-react";
 import { Skeleton } from "@/components/ui/skeleton";
 import { EmptyState } from "@/components/ui/empty-state";
@@ -136,11 +137,26 @@ export default function PipelinePage() {
       }
       const label = stage.charAt(0).toUpperCase() + stage.slice(1);
       toast.success(`Moved to ${label}`);
+      return true;
     } catch (err) {
       const msg = err instanceof Error ? err.message : "Failed to advance stage";
       setError(msg);
       toast.error(msg);
+      return false;
     }
+  }
+
+  // ---- Mark as ghosted (no reply) ----
+  // The reminder banner already knows which applications went silent — this
+  // turns that observation into a recorded first-party signal instead of
+  // discarding it. "ghosted" is deliberately NOT "rejected": rejected means the
+  // employer replied no; ghosted means they never replied at all, which is the
+  // only direct evidence that a posting took applications and answered nobody.
+  async function handleMarkGhosted(jobId: number) {
+    const ok = await handleAdvance(jobId, "ghosted");
+    // Only drop it from the reminder list if the write actually landed —
+    // otherwise the user loses the row and the signal with it.
+    if (ok) setReminders((prev) => prev.filter((r) => r.job_id !== jobId));
   }
 
   // ---- Total count ----
@@ -266,6 +282,15 @@ export default function PipelinePage() {
                     <span className="text-muted-foreground/60 ml-auto font-mono">
                       {r.stage}
                     </span>
+                    <button
+                      type="button"
+                      onClick={() => handleMarkGhosted(r.job_id)}
+                      title="They never replied — record this as a ghosted application"
+                      className="flex-shrink-0 inline-flex items-center gap-1 rounded-md border border-zinc-500/25 bg-zinc-500/10 px-2 py-0.5 font-medium text-zinc-300 transition-colors hover:bg-zinc-500/20 hover:text-zinc-100"
+                    >
+                      <Ghost className="h-3 w-3" />
+                      No reply
+                    </button>
                   </li>
                 ))}
               </ul>

--- a/frontend/src/components/pipeline/KanbanBoard.tsx
+++ b/frontend/src/components/pipeline/KanbanBoard.tsx
@@ -18,6 +18,7 @@ import {
   Users,
   Trophy,
   XCircle,
+  Ghost,
   ChevronRight,
   Clock,
   AlertTriangle,
@@ -114,14 +115,33 @@ const STAGES = [
     headerBg: "bg-rose-500/[0.06]",
     badgeBg: "bg-rose-500/15 text-rose-400",
   },
+  {
+    // Distinct from Rejected: rejected = they replied no, ghosted = silence.
+    // This column is the seed of the first-party ghost-job dataset.
+    key: "ghosted",
+    label: "No reply",
+    icon: Ghost,
+    color: "text-zinc-400",
+    bgColor: "bg-zinc-500/10",
+    borderColor: "border-zinc-500/20",
+    ringColor: "ring-zinc-500/20",
+    headerBg: "bg-zinc-500/[0.06]",
+    badgeBg: "bg-zinc-500/15 text-zinc-400",
+  },
 ] as const;
 
 const STAGE_ORDER: string[] = STAGES.map((s) => s.key);
 
 function nextStage(current: string): string | null {
   const idx = STAGE_ORDER.indexOf(current);
-  // No advance from offer or rejected
-  if (idx === -1 || current === "offer" || current === "rejected") return null;
+  // Terminal stages — nothing advances out of an outcome.
+  if (
+    idx === -1 ||
+    current === "offer" ||
+    current === "rejected" ||
+    current === "ghosted"
+  )
+    return null;
   return STAGE_ORDER[idx + 1] ?? null;
 }
 


### PR DESCRIPTION
## The gap this closes
Your pipeline already tracked `applied → outreach → interview → offer → rejected`, and already warned *"N applications have had no progress for over 7 days"*.

**It detected silence and then threw it away.** There was nowhere to record *"they never replied."*

## Why `ghosted` ≠ `rejected`
- **rejected** = the employer replied *no*
- **ghosted** = they never replied at all

Only the second is evidence that a posting collected applications and answered nobody — which is what a ghost job looks like from the applicant's side.

⚠️ Note this is a *different and stronger* signal than `services/ghost_detection.py`, which infers staleness from a listing **disappearing** from its source — usually meaning the role was **filled**, i.e. the opposite of a ghost job.

## Why it's worth building now
Every published ghost-job statistic today (Forbes, Enhancv, Greenhouse) comes from **surveys** — people's recollections. This produces **observed applications with timestamps**. That's a dataset nobody else has, and it's what press cites, recruiters buy, and future skill/course targeting builds on.

## What changed
| Layer | Change |
|---|---|
| Backend | `ghosted` added to `_VALID_STAGES` (stage is free text in DB — **no migration**) |
| Frontend | **"No reply"** column + one-tap button *inside the existing attention banner* — where the user is already told it went quiet |
| Safety | `ghosted` is terminal in `nextStage()`; the reminder row is removed **only if the write lands**, so a failed request can't silently lose the signal |

## Verified
5 new tests + 8 existing pipeline tests + **210 frontend unit tests**, `tsc --noEmit` and eslint clean.

One test deliberately fails if `ghosted` is ever collapsed into `rejected` — that would make *"said no"* and *"said nothing"* indistinguishable and destroy the dataset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)