### PR TITLE
fix(search): read the shared catalog + stop deleting jobs below the display floor

### DIFF
--- a/backend/src/core/settings.py
+++ b/backend/src/core/settings.py
@@ -99,7 +99,18 @@ TELEGRAM_BOT_TOKEN = os.getenv("TELEGRAM_BOT_TOKEN", "")
 TELEGRAM_BOT_USERNAME = os.getenv("TELEGRAM_BOT_USERNAME", "")
 
 # Search
+# MIN_MATCH_SCORE is the *display* floor — the default "good enough to show"
+# threshold used by the CLI viewer and sent by the dashboard as ``min_score``.
+# It is NOT a storage floor: filtering at read time means a job can be recovered
+# by lowering the filter, and a score that drifts (recency decays up to 10 pts
+# as a posting ages) no longer silently destroys the row.
 MIN_MATCH_SCORE = 30
+# MIN_STORE_SCORE is the *storage* floor — the spam cut. A job must beat this to
+# be persisted/fed at all. Deliberately far below MIN_MATCH_SCORE: the pipeline
+# used to hard-DELETE everything under 30 before it was ever stored, so a thin
+# profile (or a job that simply aged past the recency bands) lost jobs forever
+# with no way to get them back. Store broadly, filter at read time.
+MIN_STORE_SCORE = int(os.getenv("MIN_STORE_SCORE", "1"))
 MAX_RESULTS_PER_SOURCE = 100
 MAX_DAYS_OLD = 7
 

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -20,6 +20,7 @@ from src.core.settings import (
     JOOBLE_API_KEY,
     JSEARCH_API_KEY,
     MIN_MATCH_SCORE,
+    MIN_STORE_SCORE,
     REED_API_KEY,
     REPORTS_DIR,
     REQUEST_TIMEOUT,
@@ -511,9 +512,25 @@ def _score_dedup_and_filter(all_jobs: list[Job], scorer: JobScorer) -> list[Job]
 
     unique_jobs = deduplicate(all_jobs)
     logger.info("After dedup: %s unique jobs", len(unique_jobs))
-    unique_jobs = [j for j in unique_jobs if j.match_score >= MIN_MATCH_SCORE]
-    logger.info("After score filter (>=%s): %s jobs", MIN_MATCH_SCORE, len(unique_jobs))
-    return unique_jobs
+    # Storage floor, NOT the display floor. This used to drop everything under
+    # MIN_MATCH_SCORE (30) *before* the job was ever persisted, which meant:
+    #   - a thin extracted profile scored most jobs low -> they were destroyed,
+    #     so the user was permanently stuck with a handful of results;
+    #   - recency decays up to 10 pts as a posting ages, so a job that scored 35
+    #     one week scored 25 the next and silently vanished.
+    # Both are unrecoverable data loss for a *ranked feed* product, where ranking
+    # already handles precision. Store broadly above a spam cut; the dashboard
+    # and CLI still default to min_score=MIN_MATCH_SCORE at READ time.
+    kept = [j for j in unique_jobs if (j.match_score or 0) >= MIN_STORE_SCORE]
+    logger.info(
+        "After store floor (>=%s): %s jobs kept, %s dropped as spam "
+        "(display floor is %s, applied at read time)",
+        MIN_STORE_SCORE,
+        len(kept),
+        len(unique_jobs) - len(kept),
+        MIN_MATCH_SCORE,
+    )
+    return kept
 
 
 async def run_search(
@@ -921,6 +938,26 @@ async def run_search(
                     await _enqueue_notifications(
                         conn, user_id, _written_for_notify, enqueue
                     )
+
+            # Catalog backfill — make a search a READ over the shared catalog,
+            # not just a crawl. The block above only feeds jobs THIS run fetched;
+            # the shared `jobs` table is filled by every user's runs, and none of
+            # those were ever offered to this user unless their own crawl happened
+            # to re-fetch the same posting. That is why two accounts with the same
+            # CV diverged (37 jobs vs 4) purely on how often each had searched.
+            #
+            # Runs even when `unique_jobs` is empty — a run that fetched nothing
+            # (dead source, exhausted API quota) is exactly when the user most
+            # needs the catalog. Never allowed to fail the run.
+            if user_id is not None:
+                try:
+                    from src.services.rescore import (  # noqa: PLC0415 — import cycle
+                        backfill_feed_from_catalog,
+                    )
+
+                    await backfill_feed_from_catalog(user_id, db)
+                except Exception as e:  # noqa: BLE001 — best-effort enrichment of the feed
+                    logger.warning("catalog backfill failed for user %s: %s", user_id, e)
 
             # Funnel -> judge (LLM matcher). Per-user, post-feed-write so the
             # verdict UPDATE always finds its user_feed row. Default OFF.

--- a/backend/src/services/rescore.py
+++ b/backend/src/services/rescore.py
@@ -64,6 +64,127 @@ def score_catalog_row(scorer: Any, row: dict[str, Any]) -> Any:
     return scorer.score(job)
 
 
+async def _build_user_scorer(db: Any, profile: Any) -> Any:
+    """Build the ``JobScorer`` for ``profile`` exactly as run_search does.
+
+    Shared by ``rescore_user_feed`` and ``backfill_feed_from_catalog`` so the two
+    paths can never drift apart in how they score (CLAUDE.md rules #19/#20: pass
+    BOTH user_preferences and enrichment_lookup, or neither).
+    """
+    from src.core.settings import ENGINE2_ENABLED  # noqa: PLC0415
+    from src.services.job_enrichment import (  # noqa: PLC0415
+        ENRICHMENT_ENABLED,
+        _build_enrichment_lookup,
+    )
+    from src.services.profile.keyword_generator import generate_search_config  # noqa: PLC0415
+    from src.services.skill_matcher import JobScorer  # noqa: PLC0415
+
+    search_config = generate_search_config(profile)
+    enrichment_lookup_dict: dict[Any, Any]
+    if ENGINE2_ENABLED or ENRICHMENT_ENABLED:
+        enrichment_lookup_dict = await _build_enrichment_lookup(db._db)
+    else:
+        enrichment_lookup_dict = {}
+    return JobScorer(
+        search_config,
+        user_preferences=profile.preferences,
+        enrichment_lookup=lambda j: enrichment_lookup_dict.get(
+            cast(int, getattr(j, "id", None))
+        ),
+    )
+
+
+async def backfill_feed_from_catalog(
+    user_id: str,
+    db: Any,
+    *,
+    profile: Any = None,
+    version: Any = None,
+) -> int:
+    """Score the SHARED catalog for ``user_id`` and upsert the matches into their feed.
+
+    Why this exists
+    ---------------
+    ``run_search`` only ever wrote the jobs *that run itself fetched* into
+    ``user_feed``. The ``jobs`` table is a shared catalog (rule #10) that other
+    users' runs keep filling — but none of those jobs were ever offered to this
+    user unless their own crawl happened to re-fetch the identical posting. Two
+    accounts with the SAME CV could therefore end up with wildly different feeds
+    (observed: 37 jobs vs 4), purely from how many times each had searched.
+    This makes a search a READ over the catalog, not just a crawl of whatever
+    the sources returned in that minute.
+
+    Deliberately NOT ``rescore_user_feed``: that helper clears and re-runs the
+    LLM judge verdicts, which would re-pay the per-job LLM cost on *every*
+    search. This one only scores + upserts, so it is safe to call every run.
+    Existing verdicts are left untouched.
+
+    Args:
+        user_id: the user whose feed to fill.
+        db: an already-open ``JobDatabase`` (reuses the caller's connection).
+        profile: optional pre-loaded profile; loaded if omitted.
+        version: optional profile-version stamp; resolved if omitted.
+
+    Returns:
+        Number of feed rows written/updated. ``0`` when there's no usable profile.
+    """
+    from src.core.settings import MIN_STORE_SCORE  # noqa: PLC0415
+    from src.services.feed import FeedService  # noqa: PLC0415
+    from src.services.profile.storage import (  # noqa: PLC0415
+        current_profile_version_id,
+        load_profile,
+    )
+
+    if profile is None:
+        profile = load_profile(user_id)
+    if not profile or not profile.is_complete:
+        return 0
+    if version is None:
+        version = current_profile_version_id(user_id)
+
+    scorer = await _build_user_scorer(db, profile)
+    rows = await db.get_catalog_jobs_for_rescore()
+
+    # recency bucket — imported lazily to dodge the main.py import cycle
+    from src.main import _recency_bucket  # noqa: PLC0415
+
+    feed = FeedService(db._db)
+    written = 0
+    for row in rows:
+        jid = row.get("id")
+        if jid is None:
+            continue
+        # Per-row guard: one malformed catalog row must never abort the backfill
+        # (mirrors run_search's per-job guard).
+        try:
+            breakdown = score_catalog_row(scorer, row)
+            ms = int(breakdown.match_score or 0)
+            if ms < MIN_STORE_SCORE:
+                continue
+            await with_write_retry(
+                lambda jid=jid, ms=ms, row=row: feed.upsert_feed_row(  # type: ignore[misc]
+                    user_id=user_id,
+                    job_id=jid,
+                    score=ms,
+                    bucket=_recency_bucket(row.get("date_found")),
+                    profile_version=version,
+                )
+            )
+            written += 1
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("catalog backfill: skipping job %s: %s", jid, exc)
+            continue
+
+    logger.info(
+        "catalog backfill: user %s matched %s of %s catalog jobs (floor %s)",
+        user_id,
+        written,
+        len(rows),
+        MIN_STORE_SCORE,
+    )
+    return written
+
+
 async def rescore_user_feed(
     user_id: str,
     db_path: Optional[str] = None,

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -306,11 +306,12 @@ def test_run_search_offloads_scoring_dedup_to_a_worker_thread():
 
 def test_score_dedup_and_filter_preserves_scoring_and_filtering():
     """The extracted CPU stage scores every job (mapping all dim components), dedups,
-    and drops sub-threshold jobs — byte-identical behaviour to the old inline block,
-    just now threadable. No scoring change."""
+    and drops only SPAM (below the storage floor) — jobs below the *display* floor
+    are now kept and filtered at read time instead of being destroyed."""
     import types
 
-    from src.main import MIN_MATCH_SCORE, _score_dedup_and_filter
+    from src.core.settings import MIN_MATCH_SCORE, MIN_STORE_SCORE
+    from src.main import _score_dedup_and_filter
     from src.models import Job
 
     class _FakeScorer:
@@ -347,9 +348,17 @@ def test_score_dedup_and_filter_preserves_scoring_and_filtering():
     # Every dim component is surfaced onto the Job (the API round-trip depends on this).
     assert all(j.role == 40 and j.skill == 41 and j.recency == 9 and j.seniority_score == 8 for j in out)
 
-    # Below-threshold jobs are filtered out entirely.
-    dropped = _score_dedup_and_filter([_job("Cook", "Diner", "https://y/1")], _FakeScorer(MIN_MATCH_SCORE - 1))
-    assert dropped == []
+    # REGRESSION (37-vs-4): a job below the DISPLAY floor must still be STORED.
+    # It used to be deleted here, so a thin profile — or simply a posting whose
+    # recency component decayed as it aged — lost jobs permanently with no way to
+    # recover them. Ranking handles precision; storage must not.
+    kept = _score_dedup_and_filter([_job("Cook", "Diner", "https://y/1")], _FakeScorer(MIN_MATCH_SCORE - 1))
+    assert len(kept) == 1, "sub-display-threshold jobs must be kept, filtered at read time"
+    assert kept[0].match_score == MIN_MATCH_SCORE - 1
+
+    # Only genuine spam (below the storage floor) is dropped.
+    spam = _score_dedup_and_filter([_job("Cook", "Diner", "https://y/2")], _FakeScorer(MIN_STORE_SCORE - 1))
+    assert spam == []
 
 
 def test_run_search_with_mock_jobs():

--- a/backend/tests/test_rescore.py
+++ b/backend/tests/test_rescore.py
@@ -624,6 +624,124 @@ def test_score_catalog_row_sets_job_id_from_row():
     )
 
 
+@pytest.mark.asyncio
+async def test_backfill_gives_user_catalog_jobs_their_own_run_never_fetched(full_db, monkeypatch):
+    """REGRESSION (the 37-vs-4 bug): a user whose own search fetched NOTHING must
+    still receive matching jobs that are already in the shared catalog.
+
+    Before the fix, ``user_feed`` was written only from the jobs that user's own
+    run happened to fetch, so two accounts with the SAME CV diverged purely on how
+    many times each had searched (observed live: 37 jobs vs 4). The shared catalog
+    could already hold perfect matches the user would never, ever be shown.
+    """
+    import src.services.profile.storage as storage_mod
+
+    monkeypatch.setattr(storage_mod, "DB_PATH", Path(full_db), raising=True)
+
+    user_id = _seed_user(full_db)
+    _seed_profile(full_db, user_id)
+
+    db = JobDatabase(full_db)
+    await db.init_db()
+    try:
+        # Catalog jobs some OTHER user's run put here. THIS user fetched nothing.
+        await db.insert_job(Job(
+            title="Senior Python Engineer",
+            company="Acme",
+            apply_url="https://example.com/backfill-1",
+            source="reed",
+            date_found=_NOW,
+            location="London, UK",
+            description="Senior python machine learning role. python pytorch.",
+        ))
+        await db.insert_job(Job(
+            title="ML Engineer",
+            company="Globex",
+            apply_url="https://example.com/backfill-2",
+            source="reed",
+            date_found=_NOW,
+            location="London, UK",
+            description="Machine learning engineer. python, pytorch, ml pipelines.",
+        ))
+        await db._conn.commit()
+
+        # Precondition: this user's feed is completely empty.
+        cur = await db._db.execute(
+            "SELECT COUNT(*) FROM user_feed WHERE user_id = ?", (user_id,)
+        )
+        assert (await cur.fetchone())[0] == 0, "precondition: feed must start empty"
+
+        from src.services.rescore import backfill_feed_from_catalog
+
+        written = await backfill_feed_from_catalog(user_id, db)
+
+        assert written > 0, "backfill must surface catalog jobs to a user who fetched none"
+        cur = await db._db.execute(
+            "SELECT COUNT(*) FROM user_feed WHERE user_id = ?", (user_id,)
+        )
+        assert (await cur.fetchone())[0] > 0, "user_feed must be populated from the shared catalog"
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_backfill_does_not_clear_existing_llm_verdicts(full_db, monkeypatch):
+    """Cost guard: the backfill runs on EVERY search, so unlike rescore_user_feed
+    it must NOT clear LLM judge verdicts — doing so would re-pay the per-job LLM
+    bill on every single search."""
+    import src.services.profile.storage as storage_mod
+
+    monkeypatch.setattr(storage_mod, "DB_PATH", Path(full_db), raising=True)
+
+    user_id = _seed_user(full_db)
+    _seed_profile(full_db, user_id)
+
+    db = JobDatabase(full_db)
+    await db.init_db()
+    try:
+        await db.insert_job(Job(
+            title="Senior Python Engineer",
+            company="Acme",
+            apply_url="https://example.com/verdict-keep",
+            source="reed",
+            date_found=_NOW,
+            location="London, UK",
+            description="Senior python machine learning role. python pytorch.",
+        ))
+        await db._conn.commit()
+
+        from src.services.rescore import backfill_feed_from_catalog
+
+        await backfill_feed_from_catalog(user_id, db)
+
+        # Stamp a judge verdict on the row the backfill just created.
+        cur = await db._db.execute(
+            "SELECT job_id FROM user_feed WHERE user_id = ? LIMIT 1", (user_id,)
+        )
+        row = await cur.fetchone()
+        assert row is not None, "backfill should have written at least one feed row"
+        job_id = row[0]
+        await db._db.execute(
+            "UPDATE user_feed SET llm_fit_score = 88, llm_verdict = 'strong fit' "
+            "WHERE user_id = ? AND job_id = ?",
+            (user_id, job_id),
+        )
+        await db._db.commit()
+
+        # A second search (second backfill) must leave the verdict intact.
+        await backfill_feed_from_catalog(user_id, db)
+
+        cur = await db._db.execute(
+            "SELECT llm_fit_score, llm_verdict FROM user_feed WHERE user_id = ? AND job_id = ?",
+            (user_id, job_id),
+        )
+        kept = await cur.fetchone()
+        assert kept[0] == 88, "backfill must not wipe llm_fit_score (would re-bill the judge)"
+        assert kept[1] == "strong fit", "backfill must not wipe llm_verdict"
+    finally:
+        await db.close()
+
+
 def test_rescore_logger_is_under_job360_namespace():
     """Regression guard: the rescore logger MUST be under the 'job360' namespace
     so setup_logging()'s handlers (stdout/file/JSON) actually emit its records.


### PR DESCRIPTION
## The bug this fixes
The owner ran the **same CV on two of his own accounts**. One got **37 jobs**, the other got **4**.

Root cause, confirmed in code — **two independent mechanisms**:

### 1. Your feed only ever contained jobs *your own run* fetched
`run_search` wrote `user_feed` solely from `unique_jobs` — the jobs that one run happened to fetch (`main.py`). The `jobs` table is a **shared catalog** (rule #10) that every user's runs keep filling, but none of those were ever offered to you unless your own crawl re-fetched the identical posting.

The only code path that scored a user against the whole catalog was `rescore_user_feed()`, which fires **only on a profile edit** — never on "New Search". Feed writes are additive, so **the account that had searched more times simply accumulated more jobs.** That alone explains 37 vs 4.

### 2. Jobs scoring under 30 were destroyed before they were ever stored
`unique_jobs = [j for j in unique_jobs if j.match_score >= MIN_MATCH_SCORE]` deleted them pre-persistence. Two ways that silently loses jobs forever:
- a **thin extracted profile** scores most jobs low → they're deleted → that user is permanently stuck with a handful of results;
- **recency decays up to 10 points** as a posting ages, so a job scoring 35 one week scores 25 the next and **vanishes**.

Unrecoverable data loss in a *ranked feed* product, where ranking already handles precision.

## The fix
1. **`backfill_feed_from_catalog()`** (new, `rescore.py`) — called from `run_search` after the per-run feed write. Scores the shared catalog for the user and upserts matches. Runs **even when the search fetched nothing** (dead source / exhausted quota is exactly when the catalog matters most). Never allowed to fail the run.

   Deliberately **not** `rescore_user_feed`: that clears and re-runs the LLM judge, which would re-bill the judge on *every* search. A test pins this.

2. **`MIN_STORE_SCORE`** (new, default `1`) is the storage/spam floor; **`MIN_MATCH_SCORE` (30) is now the display floor only** — already applied at read time by the dashboard and CLI. No visible UX change; the data simply survives and the threshold becomes tunable.

## Tests (+3)
- `test_backfill_gives_user_catalog_jobs_their_own_run_never_fetched` — the 37-vs-4 regression: a user who fetched **nothing** must still receive matching catalog jobs.
- `test_backfill_does_not_clear_existing_llm_verdicts` — cost guard.
- `_score_dedup_and_filter` — sub-display-threshold jobs are now **kept**; only genuine spam is dropped.

## Verification
Gate PASS on a fresh DB — `tests/test_main.py` + `tests/test_rescore.py`, ruff + mypy clean. No change to the scoring formula itself.

## Related
`d8c8577` lowered the dashboard's display default 30→20 for the same symptom ("new users saw 4 jobs instead of 65"). That's complementary but can't fix it alone — the backend had already **deleted** those jobs and still never read the catalog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)