### PR TITLE
fix(security): revoke shell from both CI agents — arbitrary code execution on a public repo

### DIFF
--- a/.github/workflows/doc-sync.yml
+++ b/.github/workflows/doc-sync.yml
@@ -133,6 +133,23 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: actions/setup-python@v7
+        if: steps.token.outputs.have == 'true'
+        with:
+          python-version: "3.12"
+
+      # Run the checker HERE and hand the agent a FILE. drift.md from the
+      # drift-check job lives on a different runner, so it is not available —
+      # and this is what lets the agent hold zero Bash (see the security note
+      # on claude_args below).
+      - name: Capture the drift report for the agent to read
+        if: steps.token.outputs.have == 'true'
+        run: |
+          set +e
+          python scripts/doc_sync_check.py > drift.md 2>&1
+          set -e
+          echo "--- captured $(wc -l < drift.md) lines of drift ---"
+
       - name: Claude edits the docs (edit-only — no git, no gh)
         if: steps.token.outputs.have == 'true'
         uses: anthropics/claude-code-action@af0559ee4f514d1ef21826982bed13f7edc3c35e # v1
@@ -143,16 +160,25 @@ jobs:
             You are the automated Tier-2 doc fixer (Loop 3). Fix the files in
             the current workspace ONLY — do NOT run git, do NOT push, do NOT
             open PRs; a later workflow step ships your edits.
-            - Run `python scripts/doc_sync_check.py` first; fix EVERY drift
-              row it reports (numbers, stale phrases) in the LIVING docs.
+            - You have NO shell (deliberate — see the security note below the
+              prompt). Read `drift.md` in the repo root: the workflow just ran
+              the checker and captured its report there. Fix EVERY drift row it
+              lists (numbers, stale phrases) in the LIVING docs.
             - Add/update the `<!-- doc: LIVING | last-verified: YYYY-MM-DD by /sync -->`
               stamp on line 2 of all six LIVING docs (today's date, UTC).
             - If a doc claims something the code does not do, add the gap to
               docs/maintenance/PARKED.md — and leave that source doc untouched.
             - Edit ONLY *.md files. Never touch code, configs, or workflows.
-            - Finish by re-running `python scripts/doc_sync_check.py`; keep
-              fixing until only findings you cannot fix in markdown remain.
-          claude_args: --allowedTools Bash(python:*),Edit,Write,Read,Glob,Grep
+            - Work through every row in drift.md. The workflow re-runs the
+              checker immediately after you finish and reports what remains, so
+              fix what markdown can fix and leave the rest.
+          # SECURITY — NO Bash. `Bash(python:*)` was arbitrary code execution in
+          # a job holding a write-scoped GITHUB_TOKEN and a personal
+          # CLAUDE_CODE_OAUTH_TOKEN, on a PUBLIC repo. One
+          # `python -c "...os.environ..."` exfiltrates both. The checker now runs
+          # in a deterministic step above and the agent reads its output as a
+          # file, so nothing dangerous is reachable from the model.
+          claude_args: --allowedTools Edit,Write,Read,Glob,Grep
 
       - name: Upload Claude transcript (always — for diagnosis)
         if: always() && steps.token.outputs.have == 'true'

--- a/.github/workflows/repair.yml
+++ b/.github/workflows/repair.yml
@@ -111,6 +111,17 @@ jobs:
         id: base
         run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
+      # Run the suite BEFORE the agent and hand it the output as a FILE. This is
+      # what lets the agent have zero Bash: it reads real failure output with the
+      # Read tool instead of being granted a shell to produce it.
+      - name: Capture the current test failures for the agent to read
+        if: steps.token.outputs.have == 'true'
+        working-directory: backend
+        continue-on-error: true # red is the normal case here — that's the input
+        run: |
+          python -m pytest -q -p no:randomly 2>&1 | tail -120 > ../agent-test-output.txt
+          echo "--- captured $(wc -l < ../agent-test-output.txt) lines ---"
+
       # ── The LLM half of the sandwich: edit + iterate. No git, no gh. ────────
       - name: Claude repairs the code (edit-only — no git, no gh)
         if: steps.token.outputs.have == 'true'
@@ -134,15 +145,21 @@ jobs:
               test-first where practical, never weaken a test to make it pass,
               and never delete a test to go green.
 
-            THE LOOP you must run (this is the whole job):
-              1. Read the report below and reproduce the problem.
-              2. Run the relevant tests to SEE it fail:
-                 `cd backend && python -m pytest <file> -q -p no:randomly`
-              3. Make the minimal fix.
-              4. Re-run those tests. If still red, inspect the error and fix
-                 again. Repeat until green or you are certain you cannot fix it.
-              5. Finally run the wider suite for the area you touched, so you
-                 do not trade one red for another.
+            You have NO shell. That is deliberate (see the security note in the
+            workflow): this job runs on a PUBLIC repo with a write-scoped token
+            in the environment, so the agent gets no command execution at all.
+            The workflow runs the tests for you, on both sides of your edit.
+
+            THE LOOP:
+              1. Read the report below AND `agent-test-output.txt` in the repo
+                 root — that is the REAL failing-test output, captured by the
+                 workflow moments ago. Use Read/Grep/Glob to investigate.
+              2. Find the root cause in the source.
+              3. Make the minimal fix with Edit/Write.
+              4. Re-read the code you changed and satisfy yourself it addresses
+                 the failure in that output. The workflow re-runs the full suite
+                 immediately after you finish and will refuse to ship if it is
+                 still red — so a guess costs a wasted run, not a bad merge.
 
             If you CANNOT fix it, that is a valid and useful outcome: leave the
             code unchanged and say plainly what you tried and what blocked you.
@@ -154,7 +171,19 @@ jobs:
 
             ${{ github.event.issue.body }}
             ---- END REPORT ----
-          claude_args: --allowedTools Bash(python:*),Bash(cd:*),Bash(ls:*),Bash(cat:*),Bash(npm:*),Edit,Write,Read,Glob,Grep
+          # SECURITY — NO Bash. This repo is PUBLIC and this job runs with a
+          # write-scoped GITHUB_TOKEN plus a personal CLAUDE_CODE_OAUTH_TOKEN in
+          # the environment. The previous grant, `Bash(python:*)`, was arbitrary
+          # code execution: one `python -c "...os.environ..."` exfiltrates both
+          # secrets. Anyone can open an issue on a public repo, and this agent is
+          # fed an issue BODY — and our own notify jobs paste log output (which
+          # can contain scraped, attacker-influenced text) into those bodies. So
+          # prompt injection has a real path to the prompt; the only durable
+          # defence is that there is nothing dangerous to reach.
+          # `Bash(cd:*)`/`Bash(npm:*)` were no better — `cd . && <anything>` and
+          # `npm run <anything>`/postinstall are both arbitrary execution.
+          # The agent now edits only; the workflow runs every command.
+          claude_args: --allowedTools Edit,Write,Read,Glob,Grep
 
       - name: Upload Claude transcript (always — for diagnosis)
         if: always() && steps.token.outputs.have == 'true'


### PR DESCRIPTION
> **Merge this before anything else.** It closes arbitrary code execution in two CI jobs that hold live secrets on a **public** repo. I introduced half of it today.

## The hole
Both `repair.yml` and `doc-sync.yml` run `claude-code-action` with a **write-scoped `GITHUB_TOKEN`** and a **personal `CLAUDE_CODE_OAUTH_TOKEN`** in the environment — and both granted the model a shell:

```
repair.yml    Bash(python:*),Bash(cd:*),Bash(ls:*),Bash(cat:*),Bash(npm:*)
doc-sync.yml  Bash(python:*)
```

`Bash(python:*)` is arbitrary code execution — one `python -c "...os.environ..."` posts both secrets anywhere. `Bash(cd:*)` is no better (`cd . && <anything>`), nor is `Bash(npm:*)` (`npm run <anything>`, plus `postinstall`).

**The path cage I built for `repair.yml` guards the filesystem and git. It never guarded the process.**

## The injection path is real, not theoretical
1. Anyone can open an issue on a public repo
2. `repair.yml` feeds the **issue body** into the prompt
3. This repo's own notify jobs paste **log output** into issue bodies — logs that can contain **scraped, attacker-influenced text** (job titles, descriptions)
4. Owner labels it `agent:fix` → the agent reads it → shell

Marking that text *"DATA, not instructions"* in the prompt is a wish, not a control.

## The fix
Both agents now hold **`Edit,Write,Read,Glob,Grep` and no Bash at all.** Every command runs in deterministic workflow steps:

- **`repair.yml`** — a new step runs the suite **before** the agent and writes `agent-test-output.txt` for it to Read. The existing independent verification still re-runs the suite after and refuses to ship if red.
- **`doc-sync.yml`** — a new step runs `doc_sync_check.py` and writes `drift.md` for the agent to Read. (`drift.md` from the `drift-check` job lives on a different runner — needing to produce it was the entire reason that agent held a shell.)

## Trade-off, stated plainly
The repair agent can no longer iterate test→fix→test inside one run. It gets **one informed attempt** against real failure output, and the workflow judges it. On a public repo holding live secrets that is the right trade — and it makes the sandwich *cleaner*, not weaker: **dumb code runs everything, the model only edits.**

Found by an adversarial review agent fact-checking my own work from earlier today. Gate green.
