### PR TITLE
feat(worker): schedule the catalog refresh — the production loop nobody built

### DIFF
--- a/backend/src/workers/settings.py
+++ b/backend/src/workers/settings.py
@@ -35,6 +35,7 @@ from src.workers.tasks import (
     mark_ledger_sent_task,
     nightly_ghost_sweep,
     notification_tick,
+    refresh_catalog,
     score_and_ingest,
     send_bundle,
     send_notification,
@@ -150,6 +151,8 @@ class WorkerSettings:
         notification_tick,
         # Step-3 B-14 — nightly ghost-detection sweep
         nightly_ghost_sweep,
+        # The production loop: refill the shared catalog on a timer
+        refresh_catalog,
     ]
 
     # Lifecycle hooks — open/close the DB connection tasks read from ``ctx['db']``
@@ -203,6 +206,17 @@ class WorkerSettings:
 
         cron_jobs = [
             _cron(nightly_ghost_sweep, hour=2, minute=0),
+            # THE PRODUCTION LOOP. Nothing fetched jobs on a timer before
+            # this: run_search fired only on a human click, while
+            # purge_old_jobs deleted anything >30 days, so the catalog
+            # drained (prod 2026-07-27: 11 run_log rows in 25 days, 112 jobs
+            # visible of 5,827 fetched). Daily is the right cadence — jobs are
+            # posted daily and the purge window is 30 days — and it keeps
+            # keyed-API quota modest (~30 runs/month, not ~120). 04:00 UTC:
+            # clear of the 02:00 ghost sweep, done before UK morning.
+            # Cost is CPU only; user_id=None makes the paid LLM stages
+            # structurally unreachable (see refresh_catalog's docstring).
+            _cron(refresh_catalog, hour=4, minute=0),
             _cron(notification_tick, minute=set(range(0, 60, 5))),
         ]
         del _cron

--- a/backend/src/workers/tasks.py
+++ b/backend/src/workers/tasks.py
@@ -950,3 +950,48 @@ async def enrich_job_task(ctx: dict[str, Any], job_id: int) -> dict[str, bool | 
 
     await save_enrichment(db, job_id, enrichment)
     return {"enriched": True}
+
+
+async def refresh_catalog(ctx: dict[str, Any]) -> dict[str, Any]:
+    """ARQ periodic task: refill the SHARED job catalog on a schedule.
+
+    WHY THIS EXISTS. Nothing fetched jobs on a timer — `run_search` ran only
+    when a human clicked Search. Meanwhile `purge_old_jobs` deletes anything
+    older than 30 days, so the catalog drained. Measured in prod 2026-07-27:
+    `run_log` had 11 rows in 25 days; 5,827 jobs fetched all-time vs 112
+    visible, and most users saw an empty feed. Every instrument stayed GREEN
+    throughout — 200s, no errors, no alerts — because all of them detect
+    PRESENCE (did something break) and none detect ABSENCE (did something
+    stop). This task is the missing production loop.
+
+    COST SAFETY — structural, not a promise. It passes ``user_id=None``, and in
+    ``main.run_search`` every per-user stage is gated behind
+    ``if user_id is not None``: the ``user_feed`` write and, critically,
+    ``_run_matcher_stage``, which makes up to ``MATCHER_MAX_JOBS`` PAID LLM
+    calls *per user per run*. With no user attached those stages are
+    unreachable, so this cron costs worker CPU (already running 24/7) plus
+    keyed-API quota — and never per-user LLM spend. Scoring stays on-demand,
+    where the user's own click pays for it.
+
+    ``no_notify=True``: a catalog refill belongs to nobody, so there is nobody
+    to notify.
+
+    Returns the run stats so a failure is visible in the ARQ log rather than
+    silent.
+    """
+    import logging  # noqa: PLC0415
+
+    from src.main import run_search  # noqa: PLC0415 — lazy (rule #11): heavy import
+
+    stats = await run_search(user_id=None, no_notify=True)
+    logging.getLogger(__name__).info(
+        "catalog refresh: sources=%s found=%s new=%s",
+        stats.get("sources_queried"),
+        stats.get("total_found"),
+        stats.get("new_jobs"),
+    )
+    return {
+        "sources_queried": stats.get("sources_queried", 0),
+        "total_found": stats.get("total_found", 0),
+        "new_jobs": stats.get("new_jobs", 0),
+    }

--- a/backend/tests/test_worker_settings.py
+++ b/backend/tests/test_worker_settings.py
@@ -92,3 +92,30 @@ def test_arq_not_imported_at_module_top():
             sys.modules[k] = m
         if "src.workers.settings" in sys.modules:
             del sys.modules["src.workers.settings"]
+
+
+def test_worker_schedules_the_daily_catalog_refresh():
+    """The SHARED job catalog must refill on a schedule, not only when a human
+    clicks Search.
+
+    Measured in prod 2026-07-27: `run_log` held 11 rows in 25 days and the
+    catalog showed 5,827 jobs fetched all-time vs 112 visible — because nothing
+    refills it between user searches while `purge_old_jobs` removes anything
+    older than 30 days. Every instrument stayed green the whole time: this is an
+    ABSENCE failure, which no presence-detector can see.
+    """
+    from src.workers.settings import WorkerSettings
+
+    crons = WorkerSettings.__dict__.get("cron_jobs", [])
+    names = {
+        getattr(getattr(c, "coroutine", None), "__name__", "") for c in crons
+    }
+    assert "refresh_catalog" in names, f"no catalog-refresh cron registered: {names}"
+
+
+def test_worker_settings_functions_includes_refresh_catalog():
+    """ARQ can only run what is registered in `functions`."""
+    from src.workers.settings import WorkerSettings
+
+    names = {getattr(f, "__name__", "") for f in WorkerSettings.functions}
+    assert "refresh_catalog" in names

--- a/backend/tests/test_worker_tasks.py
+++ b/backend/tests/test_worker_tasks.py
@@ -532,3 +532,41 @@ async def test_worker_startup_populates_ctx(monkeypatch):
     assert ws.WorkerSettings.on_startup is not None
     assert ws.WorkerSettings.on_shutdown is not None
     assert ws.WorkerSettings.max_jobs == 1
+
+
+def test_refresh_catalog_is_shared_only_so_the_paid_llm_stages_cannot_run():
+    """The scheduled refresh MUST pass user_id=None.
+
+    Cost safety, structural rather than promised: in `main.run_search` every
+    per-user stage — the `user_feed` write AND `_run_matcher_stage`, which makes
+    up to MATCHER_MAX_JOBS PAID LLM calls *per user per run* — sits behind
+    `if user_id is not None` (main.py:904, 952, 964-965). Passing None makes the
+    expensive half unreachable by construction, so a daily cron costs worker CPU
+    and keyed-API quota only, never per-user LLM spend.
+
+    It must also pass no_notify=True: a catalog refill belongs to nobody, so
+    there is no one to notify.
+    """
+    import asyncio
+    from unittest.mock import patch
+
+    from src.workers import tasks as tasks_mod
+
+    captured: dict = {}
+
+    async def _fake_run_search(**kwargs):
+        captured.update(kwargs)
+        return {"total_found": 120, "new_jobs": 7, "sources_queried": 41}
+
+    async def _go():
+        with patch("src.main.run_search", _fake_run_search):
+            return await tasks_mod.refresh_catalog({})
+
+    result = asyncio.run(_go())
+
+    assert captured.get("user_id") is None, (
+        "catalog refresh passed a user_id — that re-enables the per-user LLM "
+        f"judge and makes the cron cost scale with users: {captured}"
+    )
+    assert captured.get("no_notify") is True
+    assert result["new_jobs"] == 7


### PR DESCRIPTION
**One sentence:** your catalog empties because nothing refills it between user searches — this makes the fetch run by itself daily, so a user's search is instant and full instead of slow and nearly empty.

## The bug
Nothing fetched jobs on a timer. `run_search` fired **only when a human clicked Search**, while `purge_old_jobs` deletes anything older than 30 days. So the shared catalog drained.

Measured in prod today:

| | |
|---|---|
| `run_log` rows | **11 in 25 days** |
| Jobs fetched all-time | 5,827 |
| Jobs visible | **112** |
| Users with an empty feed | most |

**And every instrument stayed green** — 200s, no errors, uptime fine. All ten workflows detect **presence** (did something break); none detect **absence** (did something stop). A missing production loop is invisible to a system that only watches for breakage. *(Tracked as #142.)*

## The fix
`refresh_catalog` as an ARQ cron, **04:00 UTC daily** — clear of the 02:00 ghost sweep, done before UK morning.

## Cost safety is structural, not a promise
The task passes `user_id=None`. In `main.run_search`, **every per-user stage sits behind `if user_id is not None`** (`main.py:904, 952, 964-965`) — the `user_feed` write and, critically, `_run_matcher_stage`, which makes up to `MATCHER_MAX_JOBS` **paid LLM calls per user per run**.

With no user attached, those stages **cannot execute**:

| | Per-user run (on click) | This cron |
|---|---|---|
| Fetch + score + dedup | yes | yes (free CPU) |
| Shared catalog write | yes | yes |
| Per-user feed write | yes | **skipped** |
| **Paid LLM judge** | up to 30 jobs/user | **unreachable** |

Cost = worker CPU (container already runs 24/7) + keyed-API quota. **Daily, not 6-hourly**, is deliberate: jobs post daily and the purge window is 30 days, so daily gives sufficient freshness at ~30 runs/month of quota instead of ~120. Per-user scoring stays on demand, where the user's own click pays for it.

## Tests (all fail against pre-change code)
- cron is registered · task is in `functions` (ARQ only runs what's registered)
- **`test_refresh_catalog_is_shared_only_so_the_paid_llm_stages_cannot_run`** — asserts `user_id is None` and `no_notify is True`. **The cost guarantee expressed as a test, not a comment.**

Worker verified booting with 9 functions / 3 crons. Gate green.
