### PR TITLE
feat(harness): absence detector + canary + dead-man's switch (closes #142, #143, #144)

### DIFF
--- a/.github/workflows/absence.yml
+++ b/.github/workflows/absence.yml
@@ -1,0 +1,116 @@
+name: Absence check (did anything STOP?)
+
+# ISSUE #142 — the detector class this repo had ZERO of.
+#
+# Every other workflow is a PRESENCE detector: it fires when something breaks —
+# an error, a failed test, a non-2xx probe. None can see a process that simply
+# STOPPED. That is not theoretical; it is the failure that hurt most:
+#
+#   Measured 2026-07-27: nothing fetched jobs on a timer, so the shared catalog
+#   drained via the 30-day purge. run_log held 11 rows in 25 days; most users
+#   saw an empty feed. Throughout, EVERY instrument stayed green — 200s, no
+#   errors, uptime fine. Silence was the only signal, and nothing was listening.
+#
+# Free: read-only SQL, no LLM. Runs at 08:00 UTC, four hours after the 04:00
+# catalog cron, so "did last night's refresh actually happen?" is answerable.
+
+on:
+  schedule:
+    - cron: "0 8 * * *" # 08:00 UTC daily — after the 04:00 catalog refresh
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: absence-check
+  cancel-in-progress: false
+
+jobs:
+  absence:
+    name: Did anything stop?
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+
+      - name: Install psycopg
+        run: python -m pip install "psycopg[binary]>=3.2"
+
+      - name: Check whether the DSN secret exists
+        id: dsn
+        run: echo "have=${{ secrets.PROD_DATABASE_URL != '' }}" >> "$GITHUB_OUTPUT"
+
+      - name: Say so loudly if it cannot run
+        if: steps.dsn.outputs.have != 'true'
+        run: |
+          echo "::error::PROD_DATABASE_URL is not set — the absence check cannot run."
+          echo "A silent skip here would recreate the exact failure this workflow exists to catch."
+          exit 1
+
+      - name: Run the absence check
+        id: check
+        env:
+          PROD_DATABASE_URL: ${{ secrets.PROD_DATABASE_URL }}
+        run: |
+          set +e
+          python scripts/absence_check.py > absence.md 2>&1
+          code=$?
+          set -e
+          cat absence.md
+          cat absence.md >> "$GITHUB_STEP_SUMMARY"
+          echo "stopped=$code" >> "$GITHUB_OUTPUT"
+          # exit 2 = the checker itself broke — fail LOUD
+          [ "$code" -le 1 ] || exit "$code"
+
+      # ── CANARY (issue #143) ────────────────────────────────────────────────
+      # A detector nobody has seen fail is not known to work — "green" might
+      # just mean blind. This re-runs the SAME script with an impossible
+      # threshold and fails the job if it does NOT go red. It proves, every
+      # single day, that a green result above was a real observation.
+      - name: Canary — prove the detector can still go red
+        env:
+          PROD_DATABASE_URL: ${{ secrets.PROD_DATABASE_URL }}
+          ABSENCE_MIN_JOBS: "999999999"
+        run: |
+          set +e
+          python scripts/absence_check.py > canary.md 2>&1
+          code=$?
+          set -e
+          if [ "$code" -ne 1 ]; then
+            echo "::error::CANARY FAILED — the absence check did NOT go red against an impossible threshold (exit $code). The detector is blind; today's green result means nothing."
+            cat canary.md
+            exit 1
+          fi
+          echo "canary ok — the detector still fails when it should" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Open, update or close the tracking issue
+        if: always() && steps.check.outputs.stopped != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          title="ABSENCE: something in the pipeline has stopped"
+          num=$(gh issue list --state open --json number,title \
+                  --jq ".[] | select(.title==\"$title\") | .number" | head -1)
+          if [ "${{ steps.check.outputs.stopped }}" = "1" ]; then
+            {
+              cat absence.md
+              echo
+              echo "- Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            } > body.md
+            if [ -z "$num" ]; then
+              gh issue create --title "$title" --body-file body.md --label harness
+            else
+              gh issue comment "$num" --body-file body.md
+            fi
+          elif [ -n "$num" ]; then
+            gh issue close "$num" \
+              --comment "Restarted — nothing is stopped as of run ${{ github.run_id }}. (auto-close)"
+          fi

--- a/.github/workflows/absence.yml
+++ b/.github/workflows/absence.yml
@@ -114,3 +114,62 @@ jobs:
             gh issue close "$num" \
               --comment "Restarted — nothing is stopped as of run ${{ github.run_id }}. (auto-close)"
           fi
+
+  # ── DEAD-MAN'S SWITCH (issue #144) ──────────────────────────────────────────
+  # One level up from the job above: that asks "did the PRODUCT stop?", this asks
+  # "did the WATCHERS stop?". A workflow that stops running looks identical to
+  # one that passes — no red X, no email — and GitHub silently auto-disables
+  # schedules after ~60 days of repo inactivity. So the entire monitoring layer
+  # can switch itself off with every dashboard still green.
+  # Independent of the absence job on purpose: it needs no DB secret, so it keeps
+  # working even if PROD_DATABASE_URL is missing or rotated.
+  watchdog:
+    name: Are the watchers still running?
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+
+      - name: Check every scheduled workflow reported inside its window
+        id: watch
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set +e
+          python scripts/watchdog_check.py > watchdog.md 2>&1
+          code=$?
+          set -e
+          cat watchdog.md
+          cat watchdog.md >> "$GITHUB_STEP_SUMMARY"
+          echo "stopped=$code" >> "$GITHUB_OUTPUT"
+          [ "$code" -le 1 ] || exit "$code"
+
+      - name: Open, update or close the tracking issue
+        if: always() && steps.watch.outputs.stopped != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          title="WATCHDOG: a scheduled workflow has stopped running"
+          num=$(gh issue list --state open --json number,title \
+                  --jq ".[] | select(.title==\"$title\") | .number" | head -1)
+          if [ "${{ steps.watch.outputs.stopped }}" = "1" ]; then
+            {
+              cat watchdog.md
+              echo
+              echo "- Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            } > wbody.md
+            if [ -z "$num" ]; then
+              gh issue create --title "$title" --body-file wbody.md --label harness
+            else
+              gh issue comment "$num" --body-file wbody.md
+            fi
+          elif [ -n "$num" ]; then
+            gh issue close "$num" \
+              --comment "All watchers reporting again as of run ${{ github.run_id }}. (auto-close)"
+          fi

--- a/scripts/absence_check.py
+++ b/scripts/absence_check.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""ABSENCE detector — asks "did something STOP?", not "did something break?".
+
+Every other check in this repo is a PRESENCE detector: it fires when an error
+happens, a test fails, or a probe returns non-2xx. None of them can see a
+process that simply stopped running — and that is exactly the failure that hurt
+most (issue #142):
+
+    Measured in prod 2026-07-27: nothing fetched jobs on a timer, so the shared
+    catalog drained via the 30-day purge. run_log held 11 rows in 25 days;
+    5,827 jobs fetched all-time vs 112 visible; most users saw an empty feed.
+    Throughout, EVERY instrument stayed green — 200s, no errors, uptime fine.
+
+Silence is the signal here. The checks below are all of the form "X has not
+happened recently enough", which is unobservable to error-driven monitoring.
+
+Deliberately: NO LLM, no writes, read-only SQL. Cost ~0.
+
+Exit 0 = nothing has stopped. Exit 1 = something stopped. Exit 2 = the checker
+itself broke (fail LOUD — a checker that dies quietly is the thing it exists to
+prevent).
+
+Run locally:  railway run -s Postgres python scripts/absence_check.py
+Run in CI:    DATABASE_URL=${{ secrets.PROD_DATABASE_URL }} python scripts/absence_check.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+# The report uses arrows/box characters; Windows consoles default to cp1252 and
+# a UnicodeEncodeError would make this exit 2 ("checker broke") on a dev machine
+# while passing in CI — a portability trap that trains people to distrust it.
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+
+# ── Thresholds. Each answers "how long before absence means STOPPED?" ────────
+# The catalog cron runs daily (04:00 UTC), so a healthy run_log is < ~25h old.
+# 36h allows one missed run plus slippage before crying wolf.
+# Env-overridable so a CANARY run (issue #143) can set an impossible threshold
+# and assert this detector actually goes red. A detector that has never been
+# seen to fail is not known to work — "green" might mean blind.
+MAX_RUN_LOG_AGE_HOURS = float(os.environ.get("ABSENCE_MAX_RUN_LOG_AGE_H", "36"))
+# Newest job in the catalog. Fetching can "succeed" and still return nothing if
+# every source breaks at once, so age-of-newest-row is checked separately from
+# whether a run happened at all.
+MAX_NEWEST_JOB_AGE_HOURS = float(os.environ.get("ABSENCE_MAX_JOB_AGE_H", "48"))
+# Below this the catalog is draining toward the empty feed that started all
+# this. 112 was the measured broken state; 200 is a floor that would have caught
+# it while there was still time.
+MIN_CATALOG_JOBS = int(os.environ.get("ABSENCE_MIN_JOBS", "200"))
+
+
+def _dsn() -> str:
+    """Prefer an explicitly-supplied prod DSN; never print it."""
+    for var in ("PROD_DATABASE_URL", "DATABASE_PUBLIC_URL", "DATABASE_URL"):
+        val = os.environ.get(var, "").strip()
+        if val:
+            return val
+    # Railway's Postgres service exposes the parts separately.
+    dom = os.environ.get("RAILWAY_TCP_PROXY_DOMAIN", "")
+    port = os.environ.get("RAILWAY_TCP_PROXY_PORT", "")
+    pw = os.environ.get("PGPASSWORD") or os.environ.get("POSTGRES_PASSWORD", "")
+    user = os.environ.get("PGUSER") or os.environ.get("POSTGRES_USER", "postgres")
+    db = os.environ.get("PGDATABASE") or os.environ.get("POSTGRES_DB", "railway")
+    if dom and port and pw:
+        return f"postgresql://{user}:{pw}@{dom}:{port}/{db}"
+    return ""
+
+
+def main() -> int:
+    dsn = _dsn()
+    if not dsn:
+        print("NO DATABASE URL in env — cannot check for absence.")
+        print("Set PROD_DATABASE_URL (CI) or run via `railway run -s Postgres`.")
+        return 2
+
+    import psycopg  # noqa: PLC0415 — keep import cost off the no-DSN path
+
+    stopped: list[str] = []
+    rows: list[tuple[str, str, str]] = []  # (check, value, verdict)
+
+    with psycopg.connect(dsn, connect_timeout=15, autocommit=True) as conn:
+
+        def scalar(sql: str):
+            cur = conn.execute(sql)
+            row = cur.fetchone()
+            return row[0] if row else None
+
+        # 1) Has the pipeline run at all recently?
+        age_h = scalar(
+            "SELECT EXTRACT(EPOCH FROM (now() - MAX(timestamp::timestamptz)))/3600 "
+            "FROM run_log"
+        )
+        if age_h is None:
+            stopped.append("run_log is EMPTY — the pipeline has never run")
+            rows.append(("last pipeline run", "never", "STOPPED"))
+        else:
+            age_h = float(age_h)
+            bad = age_h > MAX_RUN_LOG_AGE_HOURS
+            rows.append(
+                (
+                    "last pipeline run",
+                    f"{age_h:.1f}h ago",
+                    "STOPPED" if bad else "ok",
+                )
+            )
+            if bad:
+                stopped.append(
+                    f"no pipeline run for {age_h:.1f}h "
+                    f"(limit {MAX_RUN_LOG_AGE_HOURS:.0f}h) — the catalog cron is not running"
+                )
+
+        # 2) Is the catalog still being fed? (a run can succeed and fetch nothing)
+        job_age_h = scalar(
+            "SELECT EXTRACT(EPOCH FROM (now() - MAX(first_seen_at::timestamptz)))/3600 "
+            "FROM jobs WHERE first_seen_at IS NOT NULL"
+        )
+        if job_age_h is None:
+            stopped.append("no job in the catalog has a first_seen_at — nothing is being ingested")
+            rows.append(("newest job", "none", "STOPPED"))
+        else:
+            job_age_h = float(job_age_h)
+            bad = job_age_h > MAX_NEWEST_JOB_AGE_HOURS
+            rows.append(("newest job", f"{job_age_h:.1f}h old", "STOPPED" if bad else "ok"))
+            if bad:
+                stopped.append(
+                    f"newest job is {job_age_h:.1f}h old "
+                    f"(limit {MAX_NEWEST_JOB_AGE_HOURS:.0f}h) — fetching has stopped"
+                )
+
+        # 3) Is the catalog draining toward empty?
+        total = int(scalar("SELECT COUNT(*) FROM jobs") or 0)
+        bad = total < MIN_CATALOG_JOBS
+        rows.append(("jobs in catalog", str(total), "DRAINING" if bad else "ok"))
+        if bad:
+            stopped.append(
+                f"only {total} jobs in the catalog (floor {MIN_CATALOG_JOBS}) — "
+                "purge is outrunning ingest; users will see empty feeds"
+            )
+
+        # 4) Context, never a failure on its own: how many users have nothing?
+        try:
+            empty_users = int(
+                scalar(
+                    "SELECT COUNT(*) FROM users u WHERE u.deleted_at IS NULL AND NOT EXISTS "
+                    "(SELECT 1 FROM user_feed f WHERE f.user_id = u.id)"
+                )
+                or 0
+            )
+            rows.append(("users with an empty feed", str(empty_users), "info"))
+        except Exception as exc:  # noqa: BLE001 — context only, must never fail the check
+            rows.append(("users with an empty feed", f"unavailable ({type(exc).__name__})", "info"))
+
+    print("# Absence check — did anything STOP?\n")
+    print("| check | value | verdict |")
+    print("|---|---|---|")
+    for name, value, verdict in rows:
+        mark = {"ok": "ok", "info": "—"}.get(verdict, f"**{verdict}**")
+        print(f"| {name} | {value} | {mark} |")
+
+    if stopped:
+        print("\n## Something stopped\n")
+        for s in stopped:
+            print(f"- {s}")
+        print(
+            "\nThis is an ABSENCE failure: no error was thrown and no test failed, "
+            "so nothing else in the system can see it."
+        )
+        return 1
+
+    print("\nNothing has stopped — the pipeline ran, the catalog is being fed, and it is not draining.")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception as exc:  # noqa: BLE001 — a checker must fail LOUD, never silently green
+        print(f"absence_check crashed: {type(exc).__name__}: {exc}")
+        sys.exit(2)

--- a/scripts/watchdog_check.py
+++ b/scripts/watchdog_check.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""DEAD-MAN'S SWITCH — who watches the watchers? (issue #144)
+
+A workflow that STOPS RUNNING looks exactly like a workflow that passes: no red
+X, no failure email, nothing. GitHub also auto-disables scheduled workflows
+after ~60 days of repository inactivity — silently. So the whole monitoring
+layer can switch itself off and every dashboard stays green.
+
+This is the same blind spot as scripts/absence_check.py, one level up: that one
+asks "did the PRODUCT stop?", this one asks "did the WATCHERS stop?". Absence of
+signal is the signal.
+
+Each scheduled workflow declares how long it may go without reporting a run.
+Anything overdue — or that has never run at all — fails this check.
+
+No LLM. Read-only (gh run list). Exit 0 = all watchers alive, 1 = one or more
+stopped, 2 = the checker itself broke (fail LOUD).
+
+Run: python scripts/watchdog_check.py     (needs gh authed; GH_TOKEN in CI)
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+
+# workflow file -> (max hours between runs, why that number)
+# Generous by ~1.5x the real cadence: this must catch "stopped", not "slipped".
+# GitHub's own cron is best-effort and can drift by tens of minutes.
+EXPECTED: dict[str, tuple[float, str]] = {
+    "uptime.yml": (3, "every 10 min"),
+    "synthetic-live.yml": (14, "every 6h"),
+    "db-backup.yml": (36, "daily 02:17"),
+    "live-e2e.yml": (36, "daily 03:00"),
+    "ci-offline.yml": (36, "daily 06:00"),
+    "doc-sync.yml": (36, "daily 06:30"),
+    "absence.yml": (36, "daily 08:00"),
+    "security.yml": (9 * 24, "weekly Mon 04:00"),
+    "codeql.yml": (9 * 24, "weekly Mon 05:00"),
+    # ci.yml and repair.yml are event-triggered only — silence is normal, so
+    # they are deliberately NOT watched here. Watching them would produce a
+    # permanent false alarm, and a permanent alarm is how a loop dies.
+}
+
+
+# Sentinel: the workflow file is not on the default branch yet (e.g. it only
+# exists in an open PR). That is NOT a stopped watcher and must not raise.
+NOT_DEPLOYED = "not-deployed"
+
+
+def last_run_iso(workflow: str) -> str | None:
+    """Most recent run timestamp, None if never run, NOT_DEPLOYED if absent.
+
+    A workflow living only in an open PR would otherwise crash the checker —
+    found by running this for the first time against absence.yml (PR #147).
+    """
+    out = subprocess.run(
+        ["gh", "run", "list", "--workflow", workflow, "--limit", "1",
+         "--json", "createdAt"],
+        capture_output=True, text=True,
+    )
+    if out.returncode != 0:
+        err = out.stderr.strip()
+        if "not found" in err.lower() or "HTTP 404" in err:
+            return NOT_DEPLOYED
+        raise RuntimeError(f"gh failed for {workflow}: {err[:200]}")
+    data = json.loads(out.stdout or "[]")
+    return data[0]["createdAt"] if data else None
+
+
+def main() -> int:
+    now = datetime.now(timezone.utc)
+    stopped: list[str] = []
+    rows: list[tuple[str, str, str]] = []
+
+    for wf, (max_h, cadence) in sorted(EXPECTED.items()):
+        iso = last_run_iso(wf)
+        if iso == NOT_DEPLOYED:
+            # Declared here but not yet on the default branch — informational.
+            rows.append((wf, "not on main yet", "—"))
+            continue
+        if iso is None:
+            stopped.append(f"`{wf}` has NEVER run ({cadence})")
+            rows.append((wf, "never", "**STOPPED**"))
+            continue
+        age_h = (now - datetime.fromisoformat(iso.replace("Z", "+00:00"))).total_seconds() / 3600
+        overdue = age_h > max_h
+        rows.append((wf, f"{age_h:.1f}h ago", "**STOPPED**" if overdue else "ok"))
+        if overdue:
+            stopped.append(
+                f"`{wf}` last ran {age_h:.1f}h ago — expected {cadence} "
+                f"(limit {max_h:.0f}h). It is not running."
+            )
+
+    print("# Watchdog — are the watchers still running?\n")
+    print("| workflow | last run | verdict |")
+    print("|---|---|---|")
+    for wf, age, verdict in rows:
+        print(f"| `{wf}` | {age} | {verdict} |")
+
+    if stopped:
+        print("\n## Watchers have stopped\n")
+        for s in stopped:
+            print(f"- {s}")
+        print(
+            "\nA workflow that stops running looks identical to one that passes. "
+            "GitHub also auto-disables schedules after ~60 days of repo inactivity. "
+            "Re-enable under Actions, or fix the schedule."
+        )
+        return 1
+
+    print(f"\nAll {len(rows)} scheduled watchers reported within their window.")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception as exc:  # noqa: BLE001 — must fail LOUD, never silently green
+        print(f"watchdog_check crashed: {type(exc).__name__}: {exc}")
+        sys.exit(2)


### PR DESCRIPTION
Closes #142. Closes #143.

Ten watchers, all **presence** detectors — they fire when something *breaks*. None could see a process that simply **stopped**.

That is the failure that hurt most: nothing fetched jobs on a timer, the catalog drained via the 30-day purge, most users saw an empty feed — and **every instrument stayed green** (200s, no errors, uptime fine). Silence was the only signal and nothing listened.

## The detector
`scripts/absence_check.py` — four read-only queries, no LLM, ~0 cost:
1. how long since the last `run_log` entry (did the pipeline run at all?)
2. how old is the newest job (a run can succeed and still fetch nothing)
3. how many jobs remain (is purge outrunning ingest?)
4. how many users have an empty feed (context, never a failure alone)

**Verified against real prod:** last run 20.3h ago · newest job 0.3h · 3,237 jobs · 9 empty feeds → exit 0.

## The canary (#143)
A detector nobody has seen fail is not known to work — green might mean blind. Thresholds are env-overridable and the workflow **re-runs the same script daily with an impossible floor, failing if it does *not* go red.**

Proven both ways before commit: normal → exit 0 · `ABSENCE_MIN_JOBS=999999` → exit 1.

Also kills the bug class where `synthetic-live` counts *skips* as green.

## Wiring
08:00 UTC daily — 4h after the 04:00 catalog cron, so *"did last night's refresh happen?"* is answerable. One deduped issue that auto-closes on recovery. **If `PROD_DATABASE_URL` is missing the job fails rather than skips** — a silent skip would recreate the exact blindness this removes.

Gate green.