### PR TITLE
fix(auth): clear the previous account's cached data on a session identity change

### DIFF
--- a/frontend/src/components/layout/AuthProvider.test.tsx
+++ b/frontend/src/components/layout/AuthProvider.test.tsx
@@ -9,8 +9,25 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { render, waitFor } from "@testing-library/react";
+import { render, waitFor, act } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { AuthProvider } from "./AuthProvider";
+
+// AuthProvider reads the query cache (to drop one account's data when a
+// different account signs in), so every render needs a QueryClientProvider —
+// mirroring layout.tsx, where QueryProvider wraps AuthProvider.
+let testQueryClient: QueryClient;
+
+function renderAuth(children: React.ReactNode = "child") {
+  testQueryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={testQueryClient}>
+      <AuthProvider>{children}</AuthProvider>
+    </QueryClientProvider>
+  );
+}
 
 // ---------------------------------------------------------------------------
 // Mocks — hoisted before module evaluation
@@ -54,7 +71,7 @@ describe("AuthProvider — email-not-verified redirect (M16)", () => {
   });
 
   it("subscribes on mount and redirects to /verify-email when notified", async () => {
-    render(<AuthProvider>child</AuthProvider>);
+    renderAuth();
 
     await waitFor(() => expect(capturedListener).not.toBeNull());
     // Simulate the fetch client reporting an email-not-verified failure.
@@ -65,7 +82,7 @@ describe("AuthProvider — email-not-verified redirect (M16)", () => {
 
   it("does NOT redirect when the user is already on /verify-email", async () => {
     mockPathname = "/verify-email";
-    render(<AuthProvider>child</AuthProvider>);
+    renderAuth();
 
     await waitFor(() => expect(capturedListener).not.toBeNull());
     capturedListener!();
@@ -74,9 +91,76 @@ describe("AuthProvider — email-not-verified redirect (M16)", () => {
   });
 
   it("unsubscribes on unmount", async () => {
-    const { unmount } = render(<AuthProvider>child</AuthProvider>);
+    const { unmount } = renderAuth();
     await waitFor(() => expect(capturedListener).not.toBeNull());
     unmount();
     expect(unsubscribeSpy).toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Account switch — one browser profile has ONE cookie jar, so signing into a
+// second account in another tab REPLACES the session cookie for every tab.
+// The stale tab keeps rendering the previous account's cached jobs/profile, and
+// a click there is sent with the NEW account's cookie — i.e. an action recorded
+// against the wrong account. The same shape covers the far more common case:
+// the session expires or is revoked elsewhere and a tab stays open.
+// ---------------------------------------------------------------------------
+
+describe("AuthProvider — account switch clears the previous account's data", () => {
+  beforeEach(() => {
+    mockPush.mockClear();
+    capturedListener = null;
+    mockPathname = "/dashboard";
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const USER_A = { id: "user-a", email: "a@example.com" };
+  const USER_B = { id: "user-b", email: "b@example.com" };
+
+  async function renderThenRefocusAs(first: unknown, second: unknown) {
+    const { me } = await import("@/lib/api");
+    (me as ReturnType<typeof vi.fn>).mockResolvedValueOnce(first);
+
+    renderAuth();
+    await waitFor(() => expect(me).toHaveBeenCalledTimes(1));
+
+    // Seed cache entries that belong to the FIRST account.
+    testQueryClient.setQueryData(["jobs"], [{ id: 1, title: "A's job" }]);
+    testQueryClient.setQueryData(["profile"], { name: "A" });
+
+    (me as ReturnType<typeof vi.fn>).mockResolvedValueOnce(second);
+    // Focus is AuthProvider's existing re-validation trigger.
+    await act(async () => {
+      window.dispatchEvent(new Event("focus"));
+    });
+    await waitFor(() => expect(me).toHaveBeenCalledTimes(2));
+  }
+
+  it("wipes cached data when a DIFFERENT account signs in", async () => {
+    await renderThenRefocusAs(USER_A, USER_B);
+
+    expect(testQueryClient.getQueryData(["jobs"])).toBeUndefined();
+    expect(testQueryClient.getQueryData(["profile"])).toBeUndefined();
+  });
+
+  it("wipes cached data when the session ends (logged out elsewhere)", async () => {
+    await renderThenRefocusAs(USER_A, null);
+
+    expect(testQueryClient.getQueryData(["jobs"])).toBeUndefined();
+  });
+
+  it("KEEPS cached data when the same account re-validates", async () => {
+    // The common case by far — a focus event must not nuke a healthy cache,
+    // or every alt-tab would trigger a full refetch storm.
+    await renderThenRefocusAs(USER_A, { ...USER_A });
+
+    expect(testQueryClient.getQueryData(["jobs"])).toEqual([
+      { id: 1, title: "A's job" },
+    ]);
+    expect(testQueryClient.getQueryData(["profile"])).toEqual({ name: "A" });
   });
 });

--- a/frontend/src/components/layout/AuthProvider.tsx
+++ b/frontend/src/components/layout/AuthProvider.tsx
@@ -9,6 +9,7 @@ import {
   useState,
 } from "react";
 import { usePathname, useRouter } from "next/navigation";
+import { useQueryClient } from "@tanstack/react-query";
 import posthog from "posthog-js";
 import { me, logout as apiLogout, onEmailNotVerified } from "@/lib/api";
 import type { User } from "@/lib/api";
@@ -32,9 +33,15 @@ const AuthContext = createContext<AuthContextValue | null>(null);
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const router = useRouter();
   const pathname = usePathname();
+  const queryClient = useQueryClient();
   const [user, setUser] = useState<User | null>(null);
   const [loading, setLoading] = useState(true);
   const fetchingRef = useRef(false);
+
+  // Last resolved account id. `undefined` = never resolved (first load);
+  // `null` = resolved as signed-out. Distinguishing the two matters: only a
+  // change between two KNOWN values means the account actually switched.
+  const lastUserIdRef = useRef<string | null | undefined>(undefined);
 
   // Keep the latest pathname readable from the (stable) notifier callback
   // without re-subscribing on every navigation.
@@ -46,6 +53,30 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     fetchingRef.current = true;
     try {
       const data = await me();
+      const nextId = data?.id ?? null;
+      const prevId = lastUserIdRef.current;
+      lastUserIdRef.current = nextId;
+
+      // WHOSE data is cached? A browser profile has ONE cookie jar, so signing
+      // into a second account in ANOTHER tab replaces the session cookie for
+      // every tab. Without this, the stale tab keeps rendering the previous
+      // account's jobs and profile while the cookie underneath belongs to
+      // someone else — and a click there is sent with the NEW cookie, i.e. the
+      // action lands on the wrong account. Same shape covers the far more
+      // common case: the session expires or is revoked elsewhere.
+      //
+      // `undefined` means "not resolved yet" (first load, nothing cached), so
+      // only a CHANGE between two known values wipes the cache. Same id must
+      // not, or every alt-tab focus would trigger a full refetch storm.
+      const identityChanged = prevId !== undefined && prevId !== nextId;
+      if (identityChanged) {
+        queryClient.clear();
+        // Stop attributing the new account's events to the old identity.
+        if (posthog.__loaded) {
+          posthog.reset();
+        }
+      }
+
       setUser(data);
       // Identify the user in PostHog so events are linked to their account.
       if (data && posthog.__loaded) {
@@ -55,7 +86,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       fetchingRef.current = false;
       setLoading(false);
     }
-  }, []);
+  }, [queryClient]);
 
   // Initial fetch on mount
   useEffect(() => {
@@ -87,9 +118,14 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     if (posthog.__loaded) {
       posthog.reset();
     }
+    // Drop every cached row belonging to the account that just left. Without
+    // this, signing in as someone else in the SAME tab renders the previous
+    // account's jobs and profile until each query happens to refetch.
+    queryClient.clear();
+    lastUserIdRef.current = null;
     setUser(null);
     router.push("/login");
-  }, [router]);
+  }, [router, queryClient]);
 
   return (
     <AuthContext.Provider value={{ user, loading, logout }}>


### PR DESCRIPTION
## The problem

A browser profile has **one cookie jar** shared by every tab, and the session is a **single cookie** (`auth.py:131`). Signing into a second account in another tab **replaces that cookie for every tab**.

So tab 1 keeps rendering account **A's** jobs and profile, while the cookie underneath now belongs to account **B**. A click in that stale tab is sent with **B's cookie** — the action lands on the **wrong account** while the user is looking at A's data.

This is **not a Chrome bug** and not fixable by "logging out properly" — it's how cookies work. Gmail only *appears* to juggle accounts because Google built a bespoke multi-session layer for it.

The far more common case has the identical shape: **a session expires or is revoked elsewhere**, the tab stays open, and every click goes somewhere unexpected.

## The fix

`AuthProvider` already re-validated on window focus, but only called `setUser()` — it never noticed the identity had **changed**, so every cached query stayed keyed to the old account.

It now tracks the last resolved account id and, on a change between two **known** values:
- clears the query cache (drops every row belonging to the previous account)
- resets the analytics identity, so B's events aren't attributed to A

`undefined` (never resolved) is deliberately distinct from `null` (resolved as signed-out):

| transition | action | why |
|---|---|---|
| `undefined` → X | none | first load, nothing cached |
| A → B | **clear** | account switched |
| A → `null` | **clear** | session ended elsewhere |
| `null` → B | **clear** | logout-then-login in the same tab |
| A → A | **none** | otherwise every alt-tab = refetch storm |

`logout()` clears too — signing in as someone else in the *same* tab hit the identical problem.

## Tests

Three new cases pin it: a different account wipes the cache, an ended session wipes it, and **the same account keeps it** (the regression that would otherwise make every focus event refetch everything). Existing tests moved onto a `QueryClientProvider` wrapper, mirroring `layout.tsx`.

**6 passed** · `tsc` clean · `eslint` clean · **gate PASS**

## Still worth knowing

For **testing** two accounts, this fix doesn't give you two simultaneous logins — nothing can, short of building Gmail's multi-session system. Use an **incognito window** or a second browser profile for the second account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpxEMPz2ZWG9Qed5BsFHvg