### PR TITLE
docs: main IS production and auto-deploys + the prod-observability inventory

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,10 +16,36 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 If you have time for nothing else: **read this section, the Hard Rules index below, and the Commands section**. Then dive into the task.
 
+> ## 🔴 `main` IS PRODUCTION. MERGING SHIPS TO REAL USERS.
+>
+> Railway is GitHub-linked to `Ranjith36963/job360`, branch `main`. **Every merge auto-deploys** — no manual step, no staging gate. Proven 2026-07-27 (four deploys fired inside 70 seconds as PRs landed), and re-provable any time:
+>
+> ```bash
+> railway deployment list --service backend --json   # read meta.commitHash + meta.branch
+> ```
+>
+> `/api/health` is **useless** for this — it returns a hardcoded `"version": "1.0.0"` with no commit SHA, so the deploy API is the only trustworthy source. Never conclude "prod is running X" from a timestamp alone; a failed deploy or rollback looks identical.
+>
+> **What this means for you:**
+> - Never merge "to tidy up" — merging is a release. Land it because it is ready.
+> - **When the owner reports a problem, he is describing LIVE PRODUCTION.** Not the repo, not your worktree. Diagnose against prod first (below), then read code.
+> - Before asserting how prod behaves, check that prod is on the commit you are reading. Several sessions merge into this repo; `main` moves under you between questions.
+
+- **You can read production directly — do it, don't ask the owner to paste things.** All verified working 2026-07-26/27:
+  | Source | How |
+  |---|---|
+  | Errors | Sentry MCP — `organizationSlug: "job360"`, `regionUrl: "https://de.sentry.io"` |
+  | Logs (5 services: backend, frontend, worker, Postgres, Redis) | `railway logs --service <name>` from the repo root |
+  | Database | `railway run -s Postgres python <script>` using **`DATABASE_PUBLIC_URL`** (plain `DATABASE_URL` points at `postgres.railway.internal`, which only resolves *inside* Railway) |
+  | Product analytics | PostHog MCP (EU) |
+  | Deploys | `railway deployment list --service <svc> --json` |
+
+  **Two traps that cost real time:** `railway logs` *streams*, so piping it to `tail` returns nothing and looks exactly like "no access" — always `| head -N` with a `timeout`. And **never print secret values** (`railway variables` once dumped a live API key into a transcript); filter to key NAMES only.
+
 - **Branch:** `main`. Multi-commit work demands a preflight: verify `git branch --show-current`, clean tree, and `git fetch origin <branch>` HEAD alignment. Halt and surface to the user on divergence — never silent rebase.
 - **Canonical pre-commit verification:** `cd backend && python -m pytest -q -p no:randomly` (~1,716 collected, 2 live tests deselected — always defer to the runtime collected count, this number drifts). `test_main.py` is included: it was rehabbed offline in the M8 batch (JobSpy stubbed via autouse fixture) and runs in ~8 s. **The suite runs against a real Postgres** via the `sqlite3`/`aiosqlite` shims in `tests/conftest.py` (schema-per-test isolation), not SQLite — see the DB note below.
 - **State of play:** Step 3 (control-surface batch) merged at origin/main `7194d0e`. Post-Step-3, the funnel→judge matcher batch (a925f42..d801f78, migration 0017) landed on branch `fix/per-user-search-and-scoring-gate`, adding the LLM judge engine (engine #4). An autonomous maintenance loop (worker/integrator/scout/health agents, missions in `docs/maintenance/MISSIONS.md`) is running. Step 4 (ops hardening) is still pending. See `STATUS.md` for current phase + carry-overs; see `docs/IMPLEMENTATION_LOG.md` for the batch-by-batch history.
-- **Two deployables:** `backend/` (Python 3.9+, FastAPI, **Postgres via psycopg3** — `src/repositories/pg.py` is the aiosqlite-shaped driver; the old SQLite path is gone) and `frontend/` (Next.js 16, React 19). Runtime data lives in `backend/data/`. **Live on Railway** since 2026-07-02.
+- **Two deployables:** `backend/` (Python 3.9+, FastAPI, **Postgres via psycopg3** — `src/repositories/pg.py` is the aiosqlite-shaped driver; the old SQLite path is gone) and `frontend/` (Next.js 16, React 19). Runtime data lives in `backend/data/`. **Live on Railway** since 2026-07-02 at **job360.uk**, auto-deployed from `main` (see the banner above). Five services: `backend`, `frontend`, `worker`, `Postgres`, `Redis`.
 - **What surprises new sessions:** `SOURCE_REGISTRY` has 47 entries but only 46 unique source classes (`indeed` and `glassdoor` both alias `JobSpySource`). Heavy deps must be lazy-imported (rules #11 + #16). Next.js 16 broke `params` to async (rule #22). Adding/removing a source touches **five** files, not four (rule #13).
 
 ## Hard Rules (load-bearing, numbered, do not violate)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,27 @@ Scope is optional. Body (blank line, wrap at 72) explains the *why*.
 7. Open the PR against `main`. Fill the template. Link the issue.
 8. Request review. Do not self-merge unless explicitly authorised.
 
+## ⚠️ Merging to `main` deploys to production
+
+Railway is GitHub-linked to this repo on `main`. **A merge is a release** — it goes
+straight to real users at **job360.uk**, with no manual step and no staging
+environment. There is nowhere to catch a bad merge after the fact.
+
+So: **never merge to tidy up the PR list.** Land a branch because the change is
+ready to be live, or leave it open.
+
+Check what is actually deployed:
+
+```bash
+railway deployment list --service backend --json   # meta.commitHash, meta.branch
+```
+
+`/api/health` cannot tell you — it returns a hardcoded `"version": "1.0.0"` with no
+commit SHA.
+
+If a merge does break production, the fastest recovery is Railway → Deployments →
+redeploy the previous SUCCESS build, then fix forward on a branch.
+
 ## Test-before-merge gate
 
 **Invariant baseline: ~1,409 collected (2 live deselected), 0 failing.**

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -1,21 +1,33 @@
 # Job360 — Deploy Runbook (Railway)
 
-> **Status: ✅ LIVE (2026-07-02).** Railway Hobby active. Project `job360`, 5 services all Online.
-> - **Frontend (the site):** https://frontend-production-c608f.up.railway.app
+## 🔴 `main` IS PRODUCTION — deploys are AUTOMATIC
+
+**Railway is GitHub-linked to `Ranjith36963/job360`, branch `main`. Every merge ships to real users.** There is no manual deploy step and no staging gate. Merging is a release — never merge "to tidy up".
+
+Live at **job360.uk**. Five services: `backend`, `frontend`, `worker`, `Postgres`, `Redis`.
+
+### How to check what is actually deployed
+
+```bash
+railway deployment list --service backend --json   # read meta.commitHash, meta.branch
+```
+
+Verified 2026-07-27: `meta.commitHash` equalled `origin/main` HEAD exactly, and four deploys fired within 70 seconds as PRs merged.
+
+> **`/api/health` cannot answer this.** It returns a hardcoded `{"status":"ok","version":"1.0.0"}` with no commit SHA. Timestamp correlation is the only alternative signal and it fails silently on a rollback or a failed build — so use the deploy API, not the clock.
+
+### If you ever need to deploy WITHOUT the GitHub link
+
+The manual `railway up` recipe further down still works, but it is the fallback path, not the normal one. Do not use it while the GitHub link is active — a manual upload and an auto-deploy can race and leave services on different commits.
+
+---
+
+> **Status: ✅ LIVE since 2026-07-02.** Railway Hobby active. Project `job360`, 5 services all Online.
+> - **Custom domain:** https://job360.uk
+> - **Frontend:** https://frontend-production-c608f.up.railway.app
 > - **Backend API:** https://backend-production-80e8e.up.railway.app
 > - Verified live: `/readyz` → `{db:ok, redis:ok}`, security headers, full register→login→/me auth flow.
 > - Worker running 10 ARQ functions + 2 crons. Managed Postgres + Redis attached.
->
-> To redeploy after code changes: `cd backend && railway up --service backend --detach` (and `--service worker`), `cd frontend && railway up --service frontend --detach`. Env vars already set per-service in Railway.
-
-## 🔴 What YOU must do (one time, ~2 min)
-The Railway **free trial has expired**. To deploy, activate a plan + payment:
-1. Go to **https://railway.com/account/plans** (logged in as `rahulranjith369@gmail.com`).
-2. Pick **Hobby** (~$5/mo; includes usage credit that covers Postgres + Redis + the app at small scale).
-3. Add a payment method.
-4. Tell me "Railway plan active" — I run the deploy below and give you the live URL.
-
-*(Alternative if you'd rather not pay Railway: say the word and I'll target a free host — Render/Fly for the API, Vercel for the frontend. That needs an account on that host, though.)*
 
 ## 🟢 What's already done (no action needed)
 - Backend + frontend **Dockerfiles**, **`docker-compose.prod.yml`** (5 services) — validated.
@@ -24,7 +36,13 @@ The Railway **free trial has expired**. To deploy, activate a plan + payment:
 - **DB backup script** (`backend/scripts/backup_db.py`).
 - All prod env values staged in the local `.env` (LLM keys, `SESSION_SECRET`, `CHANNEL_ENCRYPTION_KEY`, `SENTRY_DSN`, `POSTHOG_KEY`).
 
-## Deploy commands (I run these once the plan is active)
+## First-time provisioning (HISTORICAL — already done 2026-07-02)
+
+> These commands **created** the project, databases and services. They are kept as a
+> record of how prod was built, and as the recipe if it ever has to be rebuilt from
+> scratch. **They are NOT how you deploy a code change** — merging to `main` does
+> that automatically (see the banner at the top).
+
 ```bash
 # From repo root, logged in as rahulranjith369@gmail.com
 railway init --name job360 --workspace "ranjith36963's Projects" --json


### PR DESCRIPTION
Two facts every session needs, and **none of the docs stated either**. Both cost real time this week.

## 1. Merging to `main` ships to real users

Railway is GitHub-linked to `Ranjith36963/job360` on `main`. No manual step, no staging gate.

**Proven, not inferred:**

```
railway deployment list --service backend --json
  → meta.commitHash = 99b14a5a…   meta.branch = main   meta.repo = Ranjith36963/job360
```

…and that hash equalled `origin/main` HEAD **exactly**. Four deploys fired inside 70 seconds as PRs landed.

**Both existing sources said the opposite:**
- `docs/DEPLOY.md` — *"the free trial has expired, activate a plan"* + manual `railway up` to redeploy
- a saved memory — *"prod does NOT auto-deploy, drifted 121 commits"*

A session trusting either would **merge freely believing nothing shipped**. Corrected. The manual recipe is kept and relabelled as historical first-time provisioning, and as the fallback if the GitHub link is ever removed.

Also recorded: **`/api/health` cannot identify the build** — it returns a hardcoded `{"status":"ok","version":"1.0.0"}` with no SHA. Timestamp correlation is the only alternative and it fails silently on a rollback or failed build, so the deploy API is the only trustworthy source.

## 2. Production is directly readable — stop asking the owner to paste logs

| Source | How |
|---|---|
| Errors | Sentry MCP — org `job360`, region `https://de.sentry.io` |
| Logs (backend, frontend, worker, Postgres, Redis) | `railway logs --service <name>` |
| Database | `railway run -s Postgres python <script>` using **`DATABASE_PUBLIC_URL`** |
| Analytics | PostHog MCP (EU) |
| Deploys | `railway deployment list --service <svc> --json` |

**Two traps documented, because both look exactly like "no access":**
- `railway logs` **streams** — piping to `tail` returns nothing forever. Use `| head -N` with a `timeout`.
- `DATABASE_URL` points at `postgres.railway.internal`, which only resolves *inside* Railway. Use `DATABASE_PUBLIC_URL` from a laptop.

Plus the standing constraint: **never print secret VALUES** — `railway variables` once dumped a live API key into a transcript. Key NAMES only.

## The consequence, now written down

**When the owner reports a problem, he is describing LIVE PRODUCTION** — not the repo, not a worktree. Diagnose against prod first, read code second. And **never merge "to tidy up"**, because merging is releasing.

Stated in `CLAUDE.md` (loaded every session), `CONTRIBUTING.md` (owns the merge gate), and `docs/DEPLOY.md`.

Docs-only, no code touched. **Gate PASS.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpxEMPz2ZWG9Qed5BsFHvg