### PR TITLE
fix(profile): a new CV replaces the old one instead of blending with it

### DIFF
--- a/backend/src/api/routes/profile.py
+++ b/backend/src/api/routes/profile.py
@@ -43,7 +43,7 @@ from src.services.profile.storage import (
     restore_profile_version,
     save_profile,
 )
-from src.services.profile.two_pass import run_two_pass_extraction
+from src.services.profile.two_pass import reset_cv_owned_fields, run_two_pass_extraction
 
 router = APIRouter(tags=["profile"])
 
@@ -285,6 +285,21 @@ def _capture_cv_raw(content: bytes, filename: str | None, profile: UserProfile) 
                 status_code=503,
                 detail="Could not extract any text from the CV file",
             )
+        # A NEW CV replaces the old one — it does not merge with it.
+        #
+        # This used to set raw_text alone, leaving every extracted field from the
+        # PREVIOUS CV in place. The enhance merge then fills empty scalars only
+        # and unions the lists, so uploading a different person's CV produced one
+        # profile carrying the FIRST person's name/headline/location/summary and
+        # BOTH people's skills (measured in prod: 104 skills -> 152, name
+        # unchanged). Tailored CVs are generated from this profile, so that put
+        # the wrong name on a document headed to an employer.
+        #
+        # ORDER IS THE SAFETY GUARD: every rejection above (413/415/503) raises
+        # BEFORE this line, so an unreadable or oversized upload leaves the
+        # existing profile completely untouched. We only discard the old CV once
+        # the new one is known to be readable.
+        reset_cv_owned_fields(profile.cv_data)
         profile.cv_data.raw_text = raw_text
     finally:
         try:

--- a/backend/src/services/profile/two_pass.py
+++ b/backend/src/services/profile/two_pass.py
@@ -138,6 +138,61 @@ def dedup_fuzzy(items: list[str], threshold: int = 85) -> list[str]:
     return kept
 
 
+def reset_cv_owned_fields(cv: CVData) -> None:
+    """Clear everything the CV owns, so a NEW upload cannot inherit the old one.
+
+    Call this the moment a DIFFERENT CV replaces the current one — before the
+    new ``raw_text`` is parsed.
+
+    WHY THIS EXISTS. The upload route only replaces ``cv_data.raw_text``; every
+    other field stays. ``_merge_cv_llm_into`` (below) then fills empty scalars
+    ONLY and UNIONS the lists — both correct when RE-RUNNING extraction over the
+    same CV, both wrong when the CV has been swapped. Together they produced, in
+    production, a single profile holding the FIRST person's name/headline/
+    location/summary and BOTH people's skills, roles, companies and education. A
+    real profile went 104 skills -> 152 after a different person's CV was
+    uploaded, while ``name`` still read the original owner. Tailored CVs and
+    cover letters are generated from this profile, so the wrong name reaches an
+    employer.
+
+    Mutates IN PLACE: the route holds ``profile.cv_data``, so rebinding a new
+    object here would be silently discarded.
+
+    The field list below must stay in lockstep with ``_merge_cv_llm_into`` —
+    they are two halves of one contract: "what the CV owns". Deliberately NOT
+    cleared: ``raw_text`` (the caller is about to overwrite it), and everything
+    sourced from a DIFFERENT input the user did not re-upload — ``linkedin_*``,
+    ``github_*`` and ``about_me_inferred_skills``. Wiping those would silently
+    delete work, which is the opposite failure.
+    """
+    # Scoring-semantic — these reach SearchConfig and change what matches.
+    cv.skills.clear()
+    cv.job_titles.clear()
+    cv.companies.clear()
+    cv.education.clear()
+    cv.certifications.clear()
+    cv.industries.clear()
+    cv.cv_languages.clear()
+    cv.cv_skills_esco.clear()
+    cv.summary = ""
+    cv.experience_text = ""
+
+    # Identity / display — the fields that put the wrong name on a tailored CV.
+    cv.name = ""
+    cv.headline = ""
+    cv.location = ""
+    cv.achievements.clear()
+
+    # Classified FROM the CV, so it belongs to the CV. ``None`` (not "") is the
+    # documented "not classified" sentinel on CVData.
+    cv.career_domain = None
+
+    # Regenerated wholesale from the merged skill set on every two-pass run, but
+    # cleared so a failed re-extract cannot leave suggestions computed from a
+    # different person's skills.
+    cv.suggested_skills.clear()
+
+
 def _merge_cv_llm_into(cv: CVData, llm_cv: CVData) -> None:
     """Merge the CV-OWNED fields of an LLM result into the live ``cv``.
 

--- a/backend/tests/test_profile_upload.py
+++ b/backend/tests/test_profile_upload.py
@@ -420,3 +420,96 @@ def test_profile_route_logger_is_under_job360_namespace():
     import src.api.routes.profile as profile_route
 
     assert profile_route.logger.name == "job360.api.profile"
+
+
+# ---------------------------------------------------------------------------
+# CV REPLACEMENT — the route must reset CV-owned fields, and must NOT reset
+# them when the upload is rejected.
+# ---------------------------------------------------------------------------
+
+
+class TestCapturedCvReplacesRatherThanBlends:
+    """`_capture_cv_raw` is the single choke point for every CV upload route.
+
+    Unit tests cover `reset_cv_owned_fields` itself; these prove the ROUTE
+    actually calls it, and — just as important — that a REJECTED upload leaves
+    the existing profile untouched. Without the second half, a user who
+    accidentally picks a .txt file would have their whole profile wiped.
+    """
+
+    def _seeded_profile(self):
+        from src.services.profile.models import CVData, UserProfile
+
+        return UserProfile(
+            cv_data=CVData(
+                raw_text="ORIGINAL CV TEXT",
+                name="Alice Anderson",
+                skills=["Airflow", "Spark"],
+                job_titles=["Data Engineer"],
+                github_llm_skills=["LangChain"],
+            )
+        )
+
+    def test_successful_upload_drops_the_previous_cvs_data(self):
+        from unittest.mock import patch
+
+        from src.api.routes.profile import _capture_cv_raw
+
+        profile = self._seeded_profile()
+        with patch("src.api.routes.profile.extract_text", return_value="BRAND NEW CV TEXT"):
+            _capture_cv_raw(b"%PDF-1.4 fake", "new_cv.pdf", profile)
+
+        assert profile.cv_data.raw_text == "BRAND NEW CV TEXT"
+        # The previous CV's extracted data must be GONE, not waiting to be
+        # unioned with the new extraction.
+        assert profile.cv_data.name == ""
+        assert profile.cv_data.skills == []
+        assert profile.cv_data.job_titles == []
+        # A different input the user did NOT re-upload must survive.
+        assert profile.cv_data.github_llm_skills == ["LangChain"]
+
+    def test_oversized_upload_leaves_the_profile_completely_intact(self):
+        from fastapi import HTTPException
+
+        from src.api.routes.profile import _capture_cv_raw
+
+        profile = self._seeded_profile()
+        with pytest.raises(HTTPException) as exc:
+            _capture_cv_raw(b"x" * (10 * 1024 * 1024 + 1), "huge.pdf", profile)
+
+        assert exc.value.status_code == 413
+        assert profile.cv_data.raw_text == "ORIGINAL CV TEXT"
+        assert profile.cv_data.name == "Alice Anderson"
+        assert profile.cv_data.skills == ["Airflow", "Spark"]
+
+    def test_wrong_filetype_leaves_the_profile_completely_intact(self):
+        from fastapi import HTTPException
+
+        from src.api.routes.profile import _capture_cv_raw
+
+        profile = self._seeded_profile()
+        with pytest.raises(HTTPException) as exc:
+            _capture_cv_raw(b"hello", "notes.txt", profile)
+
+        assert exc.value.status_code == 415
+        assert profile.cv_data.raw_text == "ORIGINAL CV TEXT"
+        assert profile.cv_data.name == "Alice Anderson"
+        assert profile.cv_data.skills == ["Airflow", "Spark"]
+
+    def test_unreadable_file_leaves_the_profile_intact(self):
+        """A readable-looking PDF that yields no text must not wipe the profile."""
+        from unittest.mock import patch
+
+        from fastapi import HTTPException
+
+        from src.api.routes.profile import _capture_cv_raw
+
+        profile = self._seeded_profile()
+        with patch("src.api.routes.profile.extract_text", return_value="   "):
+            with pytest.raises(HTTPException) as exc:
+                _capture_cv_raw(b"%PDF-1.4 fake", "empty.pdf", profile)
+
+        assert exc.value.status_code == 503
+        assert profile.cv_data.raw_text == "ORIGINAL CV TEXT"
+        assert profile.cv_data.name == "Alice Anderson"
+        assert profile.cv_data.skills == ["Airflow", "Spark"]

--- a/backend/tests/test_two_pass.py
+++ b/backend/tests/test_two_pass.py
@@ -698,3 +698,141 @@ class TestTwoPassOrchestrator:
         out = await two_pass.run_two_pass_extraction(prof)
         assert "Existing LI Skill" in out.cv_data.linkedin_skills
         assert "Existing GH Skill" in out.cv_data.github_skills_inferred
+
+
+# ── CV REPLACEMENT — a new upload must not inherit the previous CV ──────────
+
+
+class TestCvReplacementResetsCvOwnedFields:
+    """Uploading a DIFFERENT CV must replace the CV-derived profile, not blend it.
+
+    Found in production 2026-07-27. The upload route sets only
+    ``profile.cv_data.raw_text`` and leaves every other field in place; the
+    enhance merge then fills empty scalars ONLY (`two_pass.py`
+    "never overwrite a value the user already has") and UNIONS the lists. So a
+    second CV produced one profile holding:
+
+        * the FIRST person's name / headline / location / summary
+        * BOTH people's skills, roles, companies, education
+
+    Measured: a real profile went from 104 skills to 152 after a different
+    person's CV was uploaded, while `name` still read the original owner.
+
+    That matters beyond tidiness — tailored CVs and cover letters are generated
+    from this profile, so the wrong name goes out to an employer.
+    """
+
+    def _cv_from_first_upload(self) -> CVData:
+        cv = CVData(
+            raw_text="OLD CV TEXT",
+            name="Alice Anderson",
+            headline="Staff Data Engineer",
+            location="Manchester, UK",
+            summary="Ten years of data platform work.",
+            experience_text="Built pipelines at OldCorp.",
+            skills=["Airflow", "Spark", "Python"],
+            job_titles=["Data Engineer"],
+            companies=["OldCorp"],
+            education=["BSc Computer Science"],
+            certifications=["AWS Solutions Architect"],
+            achievements=["Cut pipeline cost 40%"],
+            industries=["Energy"],
+            cv_languages=["English"],
+            cv_skills_esco={"Airflow": "http://esco/airflow"},
+            career_domain="data",
+            # NOT CV-owned — these come from other inputs and must SURVIVE.
+            linkedin_skills=["Public Speaking"],
+            linkedin_industry="Utilities",
+            linkedin_raw_text="LINKEDIN TEXT",
+            github_languages={"Python": 900},
+            github_llm_skills=["LangChain"],
+            github_repos_brief=[{"name": "etl-tools"}],
+            about_me_inferred_skills=["Mentoring"],
+        )
+        return cv
+
+    def test_reset_clears_every_cv_derived_field(self):
+        from src.services.profile.two_pass import reset_cv_owned_fields
+
+        cv = self._cv_from_first_upload()
+        reset_cv_owned_fields(cv)
+
+        # Identity must not survive — this is the bug that put the wrong name
+        # on someone else's tailored CV.
+        assert cv.name == ""
+        assert cv.headline == ""
+        assert cv.location == ""
+        assert cv.summary == ""
+        assert cv.experience_text == ""
+
+        # Nor may the previous CV's substance survive to be UNIONED with the new
+        # one. This is the assertion a "name updated" check would have missed.
+        assert cv.skills == []
+        assert cv.job_titles == []
+        assert cv.companies == []
+        assert cv.education == []
+        assert cv.certifications == []
+        assert cv.achievements == []
+        assert cv.industries == []
+        assert cv.cv_languages == []
+        assert cv.cv_skills_esco == {}
+        assert cv.career_domain is None
+
+    def test_reset_preserves_everything_the_cv_does_not_own(self):
+        """LinkedIn / GitHub / about-me are separate inputs the user did not re-upload.
+
+        Wiping them would silently delete work — the opposite failure.
+        """
+        from src.services.profile.two_pass import reset_cv_owned_fields
+
+        cv = self._cv_from_first_upload()
+        reset_cv_owned_fields(cv)
+
+        assert cv.linkedin_skills == ["Public Speaking"]
+        assert cv.linkedin_industry == "Utilities"
+        assert cv.linkedin_raw_text == "LINKEDIN TEXT"
+        assert cv.github_languages == {"Python": 900}
+        assert cv.github_llm_skills == ["LangChain"]
+        assert cv.github_repos_brief == [{"name": "etl-tools"}]
+        assert cv.about_me_inferred_skills == ["Mentoring"]
+
+    def test_reset_mutates_in_place_so_the_profile_keeps_its_object(self):
+        """The route holds `profile.cv_data`; a rebind would be silently lost."""
+        from src.services.profile.two_pass import reset_cv_owned_fields
+
+        cv = self._cv_from_first_upload()
+        skills_obj = cv.skills
+        reset_cv_owned_fields(cv)
+        assert cv.skills is skills_obj, "must clear the list, not rebind it"
+
+    def test_after_reset_the_merge_can_write_the_new_cvs_identity(self):
+        """End-to-end of the actual defect: reset + merge must yield ONLY person B.
+
+        Without the reset, `_merge_cv_llm_into` refuses to overwrite `name`
+        (fill-if-empty) and unions the skills — producing the two-person blend.
+        """
+        from src.services.profile.two_pass import (
+            _merge_cv_llm_into,
+            reset_cv_owned_fields,
+        )
+
+        cv = self._cv_from_first_upload()
+        cv.raw_text = "NEW CV TEXT"
+        reset_cv_owned_fields(cv)
+
+        newly_extracted = CVData(
+            name="Bob Brown",
+            headline="Frontend Engineer",
+            summary="Six years of React.",
+            skills=["React", "TypeScript"],
+            job_titles=["Frontend Engineer"],
+        )
+        _merge_cv_llm_into(cv, newly_extracted)
+
+        assert cv.name == "Bob Brown", "the new CV must own the identity"
+        assert cv.headline == "Frontend Engineer"
+        assert sorted(cv.skills) == ["React", "TypeScript"]
+        assert "Airflow" not in cv.skills, "person A's skills must be GONE, not unioned"
+        assert cv.job_titles == ["Frontend Engineer"]
+        # Other inputs still intact after the full round-trip.
+        assert cv.github_llm_skills == ["LangChain"]


### PR DESCRIPTION
Found in **live production** by reading `user_profile_versions`: a profile whose CV text was person B's still carried **person A's name**.

## What was happening

Two correct-looking pieces combining into a wrong one:

1. `_capture_cv_raw` (`profile.py`) set **only** `cv_data.raw_text`. Every other extracted field stayed as the previous CV left it.
2. `_merge_cv_llm_into` (`two_pass.py`) fills empty scalars **only** — *"never overwrite a value the user already has"* — and **unions** the lists.

Both are right when **re-running** extraction over the same CV. Both are wrong when the CV was **swapped**.

| field type | behaviour | result |
|---|---|---|
| `name`, `headline`, `location`, `summary` | fill-if-empty → old wins | **person A's identity** |
| `skills`, `job_titles`, `companies`, `education` | union | **both people's data** |

**Measured on the real profile:** 104 skills → **152** after a different person's CV was uploaded, `name` unchanged across versions 8–10 while `raw_text` went 5676 → 4017 bytes. The inflated skill set is also why that account's match scores jumped — a two-person skill union matches far more jobs.

**Not cosmetic:** `services/tailoring/` generates CVs and cover letters **from this profile**, so the wrong name goes onto a document headed to an employer.

## The fix

`reset_cv_owned_fields(cv)` clears exactly what the CV owns, called from `_capture_cv_raw` — the single choke point every upload route already funnels through, so it can't drift per-route. Fill-if-empty is then correct again, because the slate is genuinely empty.

**Deliberately NOT cleared:** `linkedin_*`, `github_*`, `about_me_inferred_skills`. Those come from inputs the user didn't re-upload — wiping them would silently delete work, the opposite failure.

### Order is the safety guard

Every rejection (**413** oversized / **415** wrong type / **503** unreadable) raises **before** the reset, so a bad upload leaves the existing profile completely untouched. Three tests pin exactly that — the naive version of this fix would let a mistyped filename wipe someone's profile.

## Tests (TDD — 4 red, then green)

- reset clears every CV-owned field
- reset **preserves** every non-CV field
- reset mutates **in place** (the route holds the object; a rebind would be silently lost)
- reset + merge yields **only person B** — asserting person A's skill is **absent**, which is the assertion a "name updated" check would have missed

Plus 4 route-level tests proving the wiring and all three rejection paths.

**119 passed** · `ruff` clean · **gate PASS**

## Not fixed here

Profiles **already** blended in prod stay blended — this stops recurrence, it doesn't rewrite stored data. Re-uploading the CV once rebuilds that profile cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpxEMPz2ZWG9Qed5BsFHvg