### PR TITLE
fix(tailor): stamp generated documents with the profile version that produced them

### DIFF
--- a/backend/src/api/routes/tailor.py
+++ b/backend/src/api/routes/tailor.py
@@ -21,7 +21,7 @@ from src.api.dependencies import get_request_db
 from src.core.settings import TAILOR_FREE_PER_MONTH
 from src.repositories.database import JobDatabase
 from src.services.profile.llm_provider import llm_extract
-from src.services.profile.storage import load_profile
+from src.services.profile.storage import current_profile_version_id, load_profile
 from src.services.tailoring import DOC_KINDS, generate_document
 from src.services.tailoring.docx import render_docx
 from src.services.tailoring.generator import EmptyCVError
@@ -139,6 +139,24 @@ async def generate(
 
     fit_reason = await db.get_fit_reason(user.id, job_id)
 
+    # PROVENANCE — which profile snapshot produced these documents.
+    #
+    # `tailored_documents.profile_version` has existed since migration 0023
+    # ("which user_profile_versions snapshot fed the draft") and
+    # `upsert_tailored_doc` has always accepted it, but this — the only caller —
+    # never passed it. Production therefore held tailored documents with no
+    # provenance at all.
+    #
+    # It matters because this is the most expensive and most personal artifact
+    # the product makes: a paid LLM call, sent to a real employer. Without the
+    # stamp there is no way to answer "which version of my profile wrote this?",
+    # and no way to find the documents generated from a profile later discovered
+    # to be wrong — the CV-blend bug produced exactly such profiles.
+    #
+    # Resolved ONCE, outside the loop, so the CV and the cover letter can never
+    # be attributed to different versions of the same profile.
+    profile_version = current_profile_version_id(user.id)
+
     for kind in DOC_KINDS:
         # Layer 2 (per-user): the user's own past KEPT docs → 'write like me'.
         examples = await db.get_user_kept_docs(user.id, kind, limit=3)
@@ -171,6 +189,7 @@ async def generate(
         await db.upsert_tailored_doc(
             user.id, job_id, kind, doc.document,
             model=doc.model, flagged_terms=doc.flagged_terms,
+            profile_version=profile_version,
         )
 
     await db.record_tailored_usage(user.id, job_id)

--- a/backend/tests/test_cv_coverletter.py
+++ b/backend/tests/test_cv_coverletter.py
@@ -420,3 +420,76 @@ async def test_upsert_insert_failure_does_not_lose_existing_doc(fixture_user_id,
     row = await db.get_tailored_doc(fixture_user_id, job_id, "cv")
     assert row is not None, "original doc was lost — DELETE was not rolled back"
     assert row["ai_draft"] == "precious original draft"
+
+
+# ── Provenance: a tailored doc must name the profile snapshot that wrote it ────
+
+
+@pytest.mark.asyncio
+async def test_generated_docs_are_stamped_with_the_profile_version(
+    authenticated_async_context, fixture_user_id, monkeypatch
+):
+    """A tailored CV must record WHICH profile version produced it.
+
+    `tailored_documents.profile_version` has existed since migration 0023
+    ("which user_profile_versions snapshot fed the draft") and
+    `upsert_tailored_doc` has always accepted it — but the one caller never
+    passed it, so production held 4 tailored documents with 0 versions between
+    them.
+
+    That is the most expensive, most personal artifact this product makes: a
+    paid LLM call, sent to a real employer. Without the stamp there is no way to
+    answer "which version of my profile wrote this?" — and no way to find the
+    documents generated from a profile that was later found to be wrong (the
+    CV-blend bug produced exactly such profiles).
+    """
+    import src.services.profile.storage as storage
+
+    captured: list = []
+    _patch_route(monkeypatch, captured)
+    # Pin the version the route should stamp, so the assertion is exact rather
+    # than "some integer".
+    monkeypatch.setattr(
+        "src.api.routes.tailor.current_profile_version_id", lambda _uid: 4242
+    )
+    assert hasattr(storage, "current_profile_version_id")
+
+    db = await api_deps.get_db()
+    job_id = await _insert_job(db)
+
+    async with authenticated_async_context() as client:
+        resp = await client.post(f"/api/tailor/{job_id}/generate")
+    assert resp.status_code == 200, resp.text
+
+    # BOTH documents — the cover letter is generated from the same profile.
+    for kind in ("cv", "cover_letter"):
+        row = await db.get_tailored_doc(fixture_user_id, job_id, kind)
+        assert row is not None, f"{kind} was not stored"
+        assert row["profile_version"] == 4242, (
+            f"{kind} must record the profile snapshot that produced it, "
+            f"got {row.get('profile_version')!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_missing_profile_version_does_not_block_generation(
+    authenticated_async_context, fixture_user_id, monkeypatch
+):
+    """No version available (fresh account, or the versions table is empty) must
+    still produce documents — provenance is a record, never a gate."""
+    captured: list = []
+    _patch_route(monkeypatch, captured)
+    monkeypatch.setattr(
+        "src.api.routes.tailor.current_profile_version_id", lambda _uid: None
+    )
+
+    db = await api_deps.get_db()
+    job_id = await _insert_job(db)
+
+    async with authenticated_async_context() as client:
+        resp = await client.post(f"/api/tailor/{job_id}/generate")
+
+    assert resp.status_code == 200, resp.text
+    row = await db.get_tailored_doc(fixture_user_id, job_id, "cv")
+    assert row["ai_draft"], "the document must still be generated and stored"
+    assert row["profile_version"] is None


### PR DESCRIPTION
Found by an identity-linkage audit against **live production**:

```sql
SELECT count(*), count(profile_version) FROM tailored_documents;  -- (4, 0)
```

**Every tailored CV and cover letter in production has no provenance at all.**

## Everything needed already existed

| piece | where |
|---|---|
| the column | `migrations/0023:21` — `profile_version INTEGER -- which user_profile_versions snapshot fed the draft` |
| the parameter | `database.py:818` — `upsert_tailored_doc(..., profile_version: int \| None = None)` |
| the helper | `storage.py:235` — `current_profile_version_id(user_id)` |

The one caller (`routes/tailor.py`) simply never passed it. **A column, a parameter and a helper — all correct, connected by nothing.**

## Why it matters

A tailored CV is the most expensive and most personal artifact this product makes: a paid LLM call, sent to a real employer.

Without the stamp there's no way to answer *"which version of my profile wrote this?"* — and, concretely, **no way to find the documents generated from a profile later found to be wrong.** The CV-blend bug (#153) produced exactly such profiles — one person's name, two people's skills — and without provenance the poisoned drafts are indistinguishable from clean ones.

The same mechanism already works where it *is* wired: `user_feed.profile_version` is **3342/3342** populated in prod with zero orphans. That's what makes this fix shape proven rather than novel.

## Design notes

- Resolved **once, outside** the `DOC_KINDS` loop — so the CV and the cover letter can never be attributed to different versions of the same profile.
- **Provenance is a record, never a gate.** With no version available (fresh account, empty versions table) generation still succeeds and stores `NULL`. A test pins that, because the tempting stricter version would break new users on their very first document.
- The 4 existing prod rows stay `NULL` — read `NULL` as "pre-provenance".

## Tests

Two route-level tests: both documents carry the exact pinned version, and a missing version doesn't block generation.

**39 passed** across all three tailoring suites · `ruff` clean · **gate PASS**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpxEMPz2ZWG9Qed5BsFHvg