### PR TITLE
fix(harness): the alarm handoff 403'd — absence needs actions: write

### DIFF
--- a/.github/workflows/absence.yml
+++ b/.github/workflows/absence.yml
@@ -27,6 +27,12 @@ on:
 permissions:
   contents: read
   issues: write
+  # actions: write is what lets `gh workflow run triage.yml` hand an alarm to the
+  # triage loop. Without it the dispatch 403s and the issue is raised into silence
+  # — exactly the break this handoff exists to fix, one layer down. Found by drill
+  # run 30309508655: issue #162 was raised, the dispatch failed, and only the
+  # `|| warn` fallback made it visible.
+  actions: write
 
 concurrency:
   group: absence-check


### PR DESCRIPTION
## Third dead link found by drilling — and the first caught *after* the fix meant to close this gap

PR #154 made escalation an explicit `gh workflow run triage.yml` handoff, because GitHub refuses to start a workflow from an `issues` event raised with the automatic `GITHUB_TOKEN`. Correct and necessary. **Not sufficient.**

Dispatching a workflow needs `actions: write`. This job had only `contents: read` + `issues: write`, so the dispatch returned:

```
HTTP 403: Resource not accessible by integration
```

The issue was raised **into silence** — the exact failure the handoff exists to prevent, moved one layer down.

## How it was caught

Drill run `30309508655`, on main, minutes after #154 landed. It raised issue #162, then warned:

> `issue #162 was raised but triage could not be woken — diagnose it by hand`

Two design choices are the only reason this was visible rather than silent:

- the dispatch is `|| warn`, **never fatal** — so the alarm still reached a human even though its diagnosis did not
- the warning **names the issue number** and says plainly what did not happen

A `set -e` here would have failed the whole absence job instead, turning a *degraded handoff* into a *lost alarm*.

## The generalisable lesson

A permission block looks identical to a healthy run when the failing call is the **last thing a job does**. Only firing it on purpose revealed it — the third time that has been true today.

Gate: PASS.