### PR TITLE
fix(harness): triage refused its own detector — bot-initiated runs were blocked

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -124,6 +124,15 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          # The action refuses bot-initiated runs by default, and our escalation
+          # is bot-initiated BY DESIGN: a detector dispatches this loop. Without
+          # this, every automatic triage dies with "Workflow initiated by
+          # non-human actor" and only human-opened issues are ever diagnosed —
+          # the same shape of break as the GITHUB_TOKEN one, a layer further in.
+          # NOT '*': the action's own docs warn that on a PUBLIC repo that lets
+          # external Apps invoke it with prompts they control. Naming the one bot
+          # we actually dispatch from keeps that door shut.
+          allowed_bots: "github-actions"
           prompt: |
             You are the TRIAGE loop for Job360. Diagnose ONE freshly-opened
             issue and route it. You do not fix anything here.


### PR DESCRIPTION
## Fourth dead link, same shape as the other three, one layer further in

`claude-code-action` refuses to run when a bot started the workflow:

```
Workflow initiated by non-human actor: github-actions (type: Bot).
Add bot to allowed_bots list or use '*' to allow all bots.
```

That default is right for the common case and **wrong for ours**: our escalation is bot-initiated *by design* — a detector notices something and dispatches this loop.

So **every automatic triage died at the model step**, while every hand-opened issue sailed through. The loop worked perfectly for the only issues that never needed it — exactly how the previous three breaks presented.

## Fixed by naming the bot, not opening the gate

The action's own docs say why `'*'` is wrong here:

> "WARNING: On public repos with '\*', external Apps may be able to invoke this action with prompts they control."

This repo is public. `allowed_bots: "github-actions"` admits our own workflows and nothing else.

## How it was caught

Drill run `30309744075` → triage run `30309760421`, on main, minutes after the previous fix landed. **Every stage before the model was green** — issue raised, handoff dispatched, evidence gathered. Only firing it end to end showed the last stage refused.

Gate: PASS.