### PR TITLE
feat(harness): the last mile — the loops can finally reach a human (closes #145)

### DIFF
--- a/.github/actions/alert/action.yml
+++ b/.github/actions/alert/action.yml
@@ -1,0 +1,110 @@
+name: "Alert the owner"
+description: >-
+  Send a harness alert to the owner by email via Resend. The last mile of the
+  escalation chain: without it the loops diagnose perfectly and tell nobody.
+
+# WHY THIS EXISTS (issue #145)
+#
+# The chain could detect, diagnose, route and even fix — and then it spoke only
+# on GitHub. A real outage at 03:00 would open an issue, label it correctly, and
+# wait until someone happened to look. Silence is the exact failure mode the
+# whole harness exists to prevent, so the harness having no voice was the last
+# hole in it.
+#
+# TWO RULES, both learned the hard way tonight:
+#
+#  1. NEVER fail the caller. An alert is a courtesy on top of the real work; if
+#     Resend is down, the detector must still finish and the issue must still be
+#     raised. Every failure path here ends in a ::warning::, never a non-zero
+#     exit. (The same choice is what made the 403 handoff bug survivable rather
+#     than silent — see absence.yml.)
+#  2. NEVER be quiet about being quiet. If the key is missing or the send fails,
+#     say so loudly in the job summary and the log. An alerting system that
+#     fails silently is worse than none, because it manufactures false
+#     confidence — you stop checking, believing you'd be told.
+
+inputs:
+  subject:
+    description: "Email subject line"
+    required: true
+  body:
+    description: "Plain-text email body"
+    required: true
+  resend_api_key:
+    description: "Resend API key. Pass secrets.RESEND_API_KEY. Blank = skip with a warning."
+    required: false
+    default: ""
+  to_email:
+    description: "Owner address. Pass secrets.OWNER_ALERT_EMAIL. Blank = skip with a warning."
+    required: false
+    default: ""
+  from_email:
+    description: "Sender. Must be on a Resend-verified domain (job360.uk is verified)."
+    required: false
+    default: "alerts@job360.uk"
+
+runs:
+  using: composite
+  steps:
+    - name: Send the alert
+      shell: bash
+      env:
+        RESEND_API_KEY: ${{ inputs.resend_api_key }}
+        TO_EMAIL: ${{ inputs.to_email }}
+        FROM_EMAIL: ${{ inputs.from_email }}
+        SUBJECT: ${{ inputs.subject }}
+        BODY: ${{ inputs.body }}
+      run: |
+        # No `set -e`: see rule 1 above. A failure to alert must never fail the
+        # thing that had something worth alerting about.
+        set +e
+
+        if [ -z "$RESEND_API_KEY" ] || [ -z "$TO_EMAIL" ]; then
+          echo "::warning::ALERT NOT SENT — RESEND_API_KEY and/or OWNER_ALERT_EMAIL is not set. The harness has no voice; you will only see this on GitHub."
+          {
+            echo "### ⚠️ Alert not sent"
+            echo
+            echo "\`RESEND_API_KEY\` and/or \`OWNER_ALERT_EMAIL\` are missing from repo secrets,"
+            echo "so this alert reached GitHub only. Add both under"
+            echo "**Settings → Secrets and variables → Actions** to receive it by email."
+            echo
+            echo "**Subject that would have been sent:** $SUBJECT"
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit 0
+        fi
+
+        # jq builds the JSON so a quote, newline or backtick anywhere in the
+        # body cannot break out of the payload. The body carries model output
+        # and scraped log text, so hand-rolled JSON here would be a real
+        # injection path, not a theoretical one.
+        payload=$(jq -n \
+          --arg from "$FROM_EMAIL" \
+          --arg to "$TO_EMAIL" \
+          --arg subject "$SUBJECT" \
+          --arg text "$BODY" \
+          '{from: $from, to: [$to], subject: $subject, text: $text}')
+
+        code=$(curl -sS -o /tmp/alert-resp.json -w '%{http_code}' \
+          -X POST https://api.resend.com/emails \
+          -H "Authorization: Bearer $RESEND_API_KEY" \
+          -H "Content-Type: application/json" \
+          -d "$payload")
+
+        if [ "$code" -ge 200 ] && [ "$code" -lt 300 ]; then
+          echo "alert sent (HTTP $code): $SUBJECT" >> "$GITHUB_STEP_SUMMARY"
+          echo "alert sent (HTTP $code)"
+        else
+          # Print the response so a bad key or an unverified sender domain is
+          # diagnosable from the run alone. Resend never echoes the API key back.
+          echo "::warning::ALERT SEND FAILED (HTTP $code) — you will only see this on GitHub. Response: $(head -c 300 /tmp/alert-resp.json)"
+          {
+            echo "### ⚠️ Alert send FAILED (HTTP $code)"
+            echo
+            echo "\`\`\`"
+            head -c 300 /tmp/alert-resp.json
+            echo
+            echo "\`\`\`"
+            echo "Common causes: bad \`RESEND_API_KEY\`, or \`$FROM_EMAIL\` is not on a Resend-verified domain."
+          } >> "$GITHUB_STEP_SUMMARY"
+        fi
+        exit 0

--- a/.github/workflows/absence.yml
+++ b/.github/workflows/absence.yml
@@ -111,6 +111,7 @@ jobs:
           echo "canary ok — the detector still fails when it should" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Open, update or close the tracking issue
+        id: raise
         if: always() && steps.check.outputs.stopped != ''
         env:
           GH_TOKEN: ${{ github.token }}
@@ -150,8 +151,17 @@ jobs:
               # itself: a raised-but-undiagnosed issue still reaches a human,
               # which is the whole point.
               n="${new##*/}"
-              gh workflow run triage.yml -f issue="$n" \
-                || echo "::warning::issue #$n was raised but triage could not be woken — diagnose it by hand"
+              echo "raised=$n" >> "$GITHUB_OUTPUT"
+              if gh workflow run triage.yml -f issue="$n"; then
+                echo "woken=yes" >> "$GITHUB_OUTPUT"
+              else
+                # Triage will not run, so it cannot send the alert either.
+                # Record that so the fallback step emails the owner directly:
+                # a broken handoff must never mean a silent alarm, which is
+                # the one outcome this entire chain exists to prevent.
+                echo "woken=no" >> "$GITHUB_OUTPUT"
+                echo "::warning::issue #$n was raised but triage could not be woken - diagnose it by hand"
+              fi
             else
               gh issue comment "$num" --body-file body.md
             fi
@@ -168,6 +178,26 @@ jobs:
   # can switch itself off with every dashboard still green.
   # Independent of the absence job on purpose: it needs no DB secret, so it keeps
   # working even if PROD_DATABASE_URL is missing or rotated.
+
+      # FALLBACK last mile: normally triage sends the email, because its alert
+      # carries the diagnosis. But if the handoff failed, triage never runs and
+      # never alerts — so the alarm would be silent. That is precisely the 403
+      # bug found on 2026-07-27, which stayed invisible because the failing call
+      # was the last thing the job did. Email directly in that case.
+      - name: Email the owner directly (only if triage could not be woken)
+        if: always() && steps.raise.outputs.woken == 'no'
+        uses: ./.github/actions/alert
+        with:
+          subject: "[job360 harness] #${{ steps.raise.outputs.raised }} raised - TRIAGE COULD NOT BE WOKEN"
+          body: |
+            The absence detector raised issue #${{ steps.raise.outputs.raised }}, but the handoff to
+            the triage loop FAILED, so nothing has diagnosed it. Go and look.
+
+            Issue: ${{ github.server_url }}/${{ github.repository }}/issues/${{ steps.raise.outputs.raised }}
+            Run:   ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          resend_api_key: ${{ secrets.RESEND_API_KEY }}
+          to_email: ${{ secrets.OWNER_ALERT_EMAIL }}
+
   watchdog:
     name: Are the watchers still running?
     runs-on: ubuntu-latest
@@ -194,6 +224,7 @@ jobs:
           [ "$code" -le 1 ] || exit "$code"
 
       - name: Open, update or close the tracking issue
+        id: wraise
         if: always() && steps.watch.outputs.stopped != ''
         env:
           GH_TOKEN: ${{ github.token }}
@@ -212,8 +243,17 @@ jobs:
             if [ -z "$num" ]; then
               new=$(gh issue create --title "$title" --body-file wbody.md --label harness)
               n="${new##*/}"   # same GITHUB_TOKEN recursion block as above
-              gh workflow run triage.yml -f issue="$n" \
-                || echo "::warning::issue #$n was raised but triage could not be woken — diagnose it by hand"
+              echo "raised=$n" >> "$GITHUB_OUTPUT"
+              if gh workflow run triage.yml -f issue="$n"; then
+                echo "woken=yes" >> "$GITHUB_OUTPUT"
+              else
+                # Triage will not run, so it cannot send the alert either.
+                # Record that so the fallback step emails the owner directly:
+                # a broken handoff must never mean a silent alarm, which is
+                # the one outcome this entire chain exists to prevent.
+                echo "woken=no" >> "$GITHUB_OUTPUT"
+                echo "::warning::issue #$n was raised but triage could not be woken - diagnose it by hand"
+              fi
             else
               gh issue comment "$num" --body-file wbody.md
             fi
@@ -221,3 +261,22 @@ jobs:
             gh issue close "$num" \
               --comment "All watchers reporting again as of run ${{ github.run_id }}. (auto-close)"
           fi
+
+      # FALLBACK last mile: normally triage sends the email, because its alert
+      # carries the diagnosis. But if the handoff failed, triage never runs and
+      # never alerts — so the alarm would be silent. That is precisely the 403
+      # bug found on 2026-07-27, which stayed invisible because the failing call
+      # was the last thing the job did. Email directly in that case.
+      - name: Email the owner directly (only if triage could not be woken)
+        if: always() && steps.wraise.outputs.woken == 'no'
+        uses: ./.github/actions/alert
+        with:
+          subject: "[job360 harness] #${{ steps.wraise.outputs.raised }} raised - TRIAGE COULD NOT BE WOKEN"
+          body: |
+            The watchdog raised issue #${{ steps.wraise.outputs.raised }}, but the handoff to
+            the triage loop FAILED, so nothing has diagnosed it. Go and look.
+
+            Issue: ${{ github.server_url }}/${{ github.repository }}/issues/${{ steps.wraise.outputs.raised }}
+            Run:   ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          resend_api_key: ${{ secrets.RESEND_API_KEY }}
+          to_email: ${{ secrets.OWNER_ALERT_EMAIL }}

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -191,6 +191,7 @@ jobs:
       # `agent:fix`, because nothing in this file can.
       - name: Post the diagnosis and apply ONE routing label
         if: steps.token.outputs.have == 'true'
+        id: route
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
@@ -221,6 +222,7 @@ jobs:
           } > comment.md
           gh issue comment "$num" --body-file comment.md
           gh issue edit "$num" --add-label "$label"
+          echo "label=$label" >> "$GITHUB_OUTPUT"
           echo "triaged #$num as $label" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Say so if triage is not configured
@@ -230,3 +232,44 @@ jobs:
         run: |
           gh issue comment "${{ steps.issue.outputs.num }}" \
             --body "Triage loop is installed but CLAUDE_CODE_OAUTH_TOKEN is not set, so this issue was not diagnosed."
+
+      # ── THE LAST MILE (issue #145) ────────────────────────────────────────
+      # Everything above speaks only on GitHub. This is where the chain finally
+      # reaches a human who is not looking at GitHub.
+      #
+      # `always()` is the whole point: the alert must fire when triage FAILED
+      # just as much as when it succeeded. A harness that only emails you about
+      # problems it understood is useless for the problems that matter most —
+      # and tonight's four breaks were all cases where a stage failed outright.
+      - name: Compose the alert
+        if: always()
+        id: compose
+        run: |
+          set -uo pipefail
+          num="${{ steps.issue.outputs.num }}"
+          d="EOF_${{ github.run_id }}"    # run-scoped delimiter: model output cannot close it
+          {
+            echo "body<<$d"
+            if [ -s triage.md ]; then
+              echo "Triage diagnosed issue #$num and routed it as: ${{ steps.route.outputs.label }}"
+              echo
+              cat triage.md
+            else
+              echo "Issue #$num was raised, but TRIAGE DID NOT PRODUCE A DIAGNOSIS."
+              echo "Something in the triage loop itself failed — go and look."
+            fi
+            echo
+            echo "-- "
+            echo "Issue: ${{ github.server_url }}/${{ github.repository }}/issues/$num"
+            echo "Run:   ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            echo "$d"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Email the owner
+        if: always()
+        uses: ./.github/actions/alert
+        with:
+          subject: "[job360 harness] #${{ steps.issue.outputs.num }} ${{ steps.route.outputs.label || 'TRIAGE FAILED' }}"
+          body: ${{ steps.compose.outputs.body }}
+          resend_api_key: ${{ secrets.RESEND_API_KEY }}
+          to_email: ${{ secrets.OWNER_ALERT_EMAIL }}


### PR DESCRIPTION
Closes #145.

## The harness had no voice

It could detect, diagnose, route and fix — and then it spoke **only on GitHub**. A real outage at 03:00 would open an issue, label it correctly, and wait until someone happened to look.

Silence is the exact failure this whole harness exists to prevent. Having no voice was the last hole in it.

## One action, every loop

`.github/actions/alert` sends via Resend's HTTP API — the same path the app already uses in production (`services/auth/email_sender.py:74`), on the verified `job360.uk` domain, because Railway blocks outbound SMTP.

### Two rules, both learned today

**1. Never fail the caller.** An alert is a courtesy on top of the real work. If Resend is down, the detector must still finish and the issue must still be raised. Every path exits 0.

**2. Never be quiet about being quiet.** Missing key, bad key, unverified sender — each writes a loud `::warning::` and a job-summary block naming the cause. *An alerting system that fails silently is worse than none: it manufactures the confidence that stops you checking.*

## Where it fires

**Normally triage sends it**, because triage is the only stage holding the *diagnosis* — so the email says **what broke and how it was routed**, not merely that something did.

It runs under `always()`, so a triage that **crashed** still emails you:

> `Issue #N was raised, but TRIAGE DID NOT PRODUCE A DIAGNOSIS. Something in the triage loop itself failed — go and look.`

A harness that only tells you about problems it understood is useless for the problems that matter most — and **all four breaks found today were stages failing outright.**

**If the hand-off itself fails**, triage never runs and cannot alert. Both issue-raising paths in `absence.yml` now record whether triage was actually woken, and fall back to emailing directly. That is the 403 bug from earlier today, which stayed invisible *precisely because* the failing call was the last thing the job did.

## Safety

- **`jq` builds the JSON**, so a quote, newline or backtick in the body cannot break out. The body carries model output and scraped log text — a real injection path, not a theoretical one. Escaping proven to round-trip byte-identical.
- The API key appears in **exactly one place**: the `curl` auth header. No code path echoes its value, and `curl -sS` never prints request headers.

## ⚠️ Needs two repo secrets to actually deliver

**Settings → Secrets and variables → Actions:**

| Secret | Value |
|---|---|
| `RESEND_API_KEY` | your Resend key (`re_…`) — the same one prod uses |
| `OWNER_ALERT_EMAIL` | where alerts should land |

Without them everything still works, and every run says loudly in the job summary that the alert went nowhere.

Gate: PASS.
