### PR TITLE
fix(feed): stop hiding 87% of the product behind stale thresholds

### DIFF
--- a/2030.md
+++ b/2030.md
@@ -1,0 +1,748 @@
+# 2030.md — Job360: the five must-haves, researched
+
+Research run 2026-07-28. 11 agents, 912k tokens, 0 errors.
+
+Method: 5 codebase auditors (evidence-only, every claim needs `file:line`),
+5 user researchers (real named products + real complaints only), 1 synthesiser.
+Governed by the `promise` skill: no claim ships without the instrument that produced it.
+
+---
+
+# Job360: Five Must-Haves — Decision Document
+
+*All file paths are relative to repo root `D:\dev\job360\`. Every claim below carries its evidence. Where I am inferring rather than citing, it says INFERENCE.*
+
+---
+
+## 0. The one-line finding
+
+**You do not have a building problem. You have a wiring problem.**
+
+Eight separate capabilities are written, tested, and sitting dark — the code exists, nothing calls it. That pattern, not missing features, is what separates your codebase from what users expect.
+
+| # | Built | Why it does nothing today | Evidence |
+|---|---|---|---|
+| 1 | Engines 2, 3, 4 (dimensions, semantic, LLM judge) | All default OFF | `backend/src/core/settings.py:208-211`, `STATUS.md:135-140` |
+| 2 | 99%-elimination prefilter (location/experience/skill) | Called with an always-empty profile | `backend/src/workers/tasks.py:142` |
+| 3 | Notes version history | Written, never read back by any route or UI | `backend/src/repositories/database.py:1653-1683` |
+| 4 | Interview date storage | Column exists, zero code writes or reads it | `backend/migrations/0014_application_history.up.sql:3` |
+| 5 | Profile-version stamping on tailored docs | Column + kwarg exist, route never passes it | `backend/src/api/routes/tailor.py:171-174` |
+| 6 | Semantic dedup (layer 4) | Scaffolded, not in the default path | `STATUS.md:214` |
+| 7 | Stale-application detection | Only fires if the user opens the Pipeline tab | `backend/src/repositories/database.py:1120-1143`, `backend/src/api/routes/pipeline.py:74-81` |
+| 8 | Skill-gap analysis | Computed and shown, but no AI feature consumes it | `backend/src/services/skill_gap.py:23-63` |
+
+Most of these are S-effort fixes. Together they close more user-facing gaps than any new pillar you could build in the same time.
+
+---
+
+## 1. Scoreboard
+
+Numbers are the auditors' own. I did not change any of them.
+
+| Must-have | % (auditor) | The missing part, in one line | Does the number hold up? |
+|---|---|---|---|
+| AI career co-pilot | **10%** | No chat endpoint, no message table, no chat UI, no memory — only reusable LLM plumbing and one non-conversational sub-feature. | Defensible but soft. See note A. |
+| Smart job matching | **72%** | All four engines are built; three ship switched OFF, and the prefilter is fed an empty profile. | Measures code, not experience. See note B — the most important caveat in this document. |
+| AI resume + cover letter tailor | **70%** | Fabrication check only covers names, not numbers; no paid tier; sync generation blocks the request. | Arithmetic is off. See note C. |
+| Application tracker / CRM | **45%** | Reminders never leave the app; no interview dates; no delete; notes history invisible. | Honest — an explicitly declared judgment discount. See note D. |
+| AI interview coach | **0%** | Nothing exists. One design doc, written in future tense. | Clean. Exhaustive search found zero implementation. |
+
+**Note A — co-pilot 10%.** The rubric's own item (e) is "at least one of the 5 planned post-application flows actually callable." Skill-gap analysis *is* one of those five and *is* callable (`backend/src/services/skill_gap.py:23-63`, wired at `backend/src/api/routes/jobs.py:733-740`). Counting sub-components strictly gives 20%, not 10%. The auditor discounted it because the flow is deterministic, not conversational. That is a fair call, and the decision is identical either way: this is effectively unbuilt.
+
+**Note B — matching 72%.** The auditor built this from deductions (100 − 15 − 10 − 3). The arithmetic is fine. What it hides: 72% is *code that exists*. A user signing up today gets **Engine 1 only** — keyword, location, recency. Everything the word "smart" is doing in "smart job matching" is behind an off-by-default flag. If you score the same rubric by *what a user experiences*, this area is far lower. I am deliberately not inventing a replacement number — but read 72% as "built", never as "shipped".
+
+**Note C — tailor 70%.** The derivation says "12/20 solid ≈ 70%". 12/20 is 60%. The auditor rounded up on the judgment that the 8 gaps are polish, not core-loop breakage. That judgment is reasonable — the core loop genuinely works end to end — but the number is a judgment, not a ratio. Treat it as "60% counted, 70% claimed".
+
+**Note D — tracker 45%.** The auditor showed the sum (5/9 ≈ 56%) and then declared a discount to 45% because two of the three fully-missing items are exactly what the promise text says ("what follow-up is due"). That is transparent and I agree with it.
+
+---
+
+## 2. THE GAP (per must-have)
+
+### 2.1 AI career co-pilot — 10%
+
+| What users expect | What the code does | Distance |
+|---|---|---|
+| "Must remember who I am across sessions — CV, past conversations, goals — without re-explaining." Rated the #1 differentiator between real coaching and a chatbot wrapper (getmentors.ai; hydradb.com). | No conversations table, no messages table, no thread ID anywhere in migrations. | Total. There is nothing to remember with. |
+| "Talk to it about my career." Indeed Career Scout is the live bar: chat about goals → pathways → why a role fits (indeed.com/careerscout). | `llm_provider.py:180-386` is one-shot JSON-in/JSON-out. Every call site builds a single prompt. No conversation array is ever threaded. | The LLM layer cannot hold a conversation as written. Needs a new `llm_chat()` alongside `llm_extract`. |
+| "Surface real openings and explain WHY each fits" (indeed.com/careerscout; hr-brew.com). | The judge writes a one-way ≤200-char reason per job (`backend/src/services/llm_matcher.py:69`). Off by default. | Half the raw material exists. Nothing lets the user ask a follow-up. |
+| "Proactively flag skill gaps and next steps" — LinkedIn Premium's headline feature. | `skill_gap.py:23-63` produces matched/missing/transferable lists. Pure rapidfuzz, no guidance text. | Closest thing you have to the feature. It states the gap and stops. |
+| "Grounded in what I've actually applied to" — Teal's whole design (blog.loopcv.pro/teal-hq-review). | Applications, stages, timelines, notes all exist in Postgres. Nothing reads them into an LLM prompt. | **This is your unfair advantage and it is unused.** You already own the grounding data every competitor's copilot has to guess at. |
+
+**The gap in one sentence:** you have the fuel (profile, jobs, scores, verdicts, skill gaps, pipeline) and no engine (chat endpoint, memory, UI).
+
+### 2.2 Smart job matching — 72% built, Engine 1 shipped
+
+| What users expect | What the code does | Distance |
+|---|---|---|
+| **Dealbreaker:** "Recommending jobs that violate a hard constraint I explicitly set (wrong location, pay below floor, wrong title)" — the single most-cited Indeed complaint (stripe.jhu.edu; Trustpilot; TeamBlind). | `backend/src/workers/tasks.py:142` builds `FilterProfile()` — empty — for every user on every job from the background scheduler. The comment says "no per-user profile storage yet". That comment is stale; the real loader is called 23 lines later at `tasks.py:165`. | The background discovery path — the always-on one — applies **zero** of the user's stated constraints at the filter stage. This is a direct hit on the category's #1 complaint. |
+| **Dealbreaker:** "Opaque scores with no explanation. Why is this a 72% match?" Explainability research says black-box scores kill trust (pmc.ncbi.nlm.nih.gov/PMC12546238). LinkedIn ships met/missing/preferred breakdown. | `ScoreRadar.tsx:118-141` refuses to draw fake dims when they are dormant — correct and honest. But with Engines 2–4 off, they are *always* dormant. The judge's reason is capped at 200 chars naming ONE dimension (`llm_matcher.py:69`). | The explanation UI is built. The data feeding it is switched off. |
+| "Understand transferable skills, not literal keyword overlap" (emarketer.com on LinkedIn). | `retrieval.py:33-410` — real semantic embeddings, RRF fusion, cross-encoder rerank. Default OFF (`settings.py:210`). | Fully built. Nobody has flipped it. |
+| **Dealbreaker:** "Stale/expired listings served as fresh" — drove Jobright to 2.9/5 on Trustpilot. | You have ghost detection (`nightly_ghost_sweep` cron) and a 410-Gone guard on expired jobs (`backend/src/api/routes/pipeline.py:84-110`). Semantic repost dedup is scaffolded but not called (`STATUS.md:214`). | **You are ahead here.** Partial gap only on paraphrased reposts. |
+| "Match quality should save time, not add review overhead" — UK seekers spend 6.5 hrs/week, ~27 applications per interview (standout-cv.com). | Engine 1 only = keyword + location + recency. | Every irrelevant match is a direct tax on those 6.5 hours. |
+
+**The gap in one sentence:** you built four engines and shipped one, and the one filter that enforces the user's hard constraints in the main discovery path is handed an empty object.
+
+### 2.3 AI resume + cover letter tailor — 70%
+
+| What users expect | What the code does | Distance |
+|---|---|---|
+| **#1 dealbreaker:** "Never invent employers, dates, tools, or metrics" (SHRM; gem.com; hirecarta.com). | `integrity.py:65-102` deterministically repairs/flags proper nouns. `provenance.py:23-43` marks every line as user-fact vs AI-added, shown before download (`TailorPanel.tsx:259-284`). | **You are ahead of the category on the category's worst failure.** But `integrity.py` only checks names. An LLM inflating "team of 5" → "team of 12" passes clean. Research names inflated metrics as the more dangerous fabrication. |
+| "Must not sound like generic AI voice" — 67% of hiring managers can spot AI letters, 54% view them negatively (coverlettercopilot.ai). | Layer-2 learning: kept polished docs feed back as few-shot "write like me" examples (`database.py:915-924`, used at `tailor.py:143-144`). | Genuinely addressed. Rare in the category. |
+| "Editable draft with the job description visible, plus a missing-keyword list" — the Jobscan/Teal standard. | Edit-save loop exists (`tailor.py:214-234`). Skill gap renders on the same job page at `JobDetailClient.tsx:544-612`; the tailor panel is at `:508`. | INFERENCE: they sit next to each other on the page but nothing confirms the missing-keyword list appears *inside* the tailoring flow. Cheap to close either way. |
+| "Download real PDF/DOCX with no surprise paywall" — FTC-flagged dark pattern (Zety, MyPerfectResume). | PDF + DOCX both ship (`pdf.py:11-40`, `docx.py:11-38`); free cap of 10/month, HTTP 402 over cap (`settings.py:169`). | Clean. No dark pattern. Note the cap applies to *everyone* — no paid bypass exists (`tailor.py:121-131`). |
+| "~2 minutes, not 15-45" (blog.fastapply.co). | Two sequential LLM calls run synchronously inside the POST (`tailor.py:150-174`). | Probably fine on time. Risk is timeouts and a dead-looking spinner, not user-stated pain. Low priority. |
+
+**The gap in one sentence:** your strongest feature, with one real hole — the honesty check stops at names and does not look at numbers.
+
+### 2.4 Application tracker / CRM — 45%
+
+| What users expect | What the code does | Distance |
+|---|---|---|
+| **Must:** "Automatic nudges when an application goes quiet. The tool has to remember." 55% of applications get no reply; 65% of UK seekers report being ghosted (peoplemanagement.co.uk; stylist.co.uk). | `get_stale_applications` exists and works (`database.py:1120-1143`) but its only caller is `GET /pipeline/reminders` (`pipeline.py:74-81`). No cron, no push. | The user only learns a follow-up is due if they open the Pipeline tab. Meanwhile job-match notifications have a **complete** ARQ cron → dispatcher → Apprise path already running (CLAUDE.md rule #24). The pipe exists; nothing is poured into it. |
+| **Must:** Kanban board, drag between stages. | Full board with drag-and-drop and keyboard a11y (`KanbanBoard.tsx:433-685`); stage audit trail with transactional write (`database.py:1017-1057`). | Done, and done well. |
+| "Interview details attached to the card." | `applications.interview_dates` column exists (`migrations/0014_application_history.up.sql:3`). Grep across backend, frontend and migrations returns only the migration file. | A user moving a card to "Interview" cannot record *when*. This directly undercuts "what follow-up is due". |
+| "Named contacts — who replied." | No recruiter/contact field anywhere. "Ghosted" vs "Rejected" stages are the only reply signal (`pipeline.py:29-36`). | Missing. Medium effort (new table). |
+| "Core tracking must be free" — the #1 objection to Huntr ($40/mo) and Teal (resumeoptimizerpro.com; Trustpilot). | Tracking is free and uncapped. | **You are ahead.** Do not paywall this later. |
+| Delete/withdraw a card. | No DELETE route, no withdraw affordance. | A mis-clicked apply lives forever. |
+| Notes history. | Every prior note is archived (`database.py:1653-1683`) and never shown to anyone. | Write-only audit log. The work is done and invisible. |
+
+### 2.5 AI interview coach — 0%
+
+| What users expect | What the code does | Distance |
+|---|---|---|
+| **Must:** real spoken back-and-forth. Text-only tools "get dismissed as flashcards" (favtutor.com). | Nothing. | Total, and the credible entry bar needs speech infrastructure you do not have. |
+| **Must:** specific quantified feedback tied to the user's own words ("fillers 30 → 5") (techraisal.com). Generic praise reads as slop (TeamBlind). | Nothing. | Total. |
+| **Must:** does not cut the user off; clear consent about recording (sourcesmayvary.substack.com). | Nothing. | Total. |
+| **Must:** honest billing, real free tier (remotejobassistant.com on Final Round AI's 17% one-star billing reviews). | Nothing. | Would need a cost cap designed *before* build — multi-turn Q&A burns far more than one CV generation. |
+
+**The gap in one sentence:** it is not started, and the cheapest version users would accept is the most expensive thing on your list.
+
+---
+
+## 3. THE SOLUTIONS, ranked by leverage
+
+Leverage = user-visible gain ÷ new code, given what already exists.
+
+| Rank | Move | Effort | Files | Reuses | Closes |
+|---|---|---|---|---|---|
+| **1** | Turn Engine 2 + Engine 4 ON in prod | S (env vars only) | Railway env; `settings.py:208-211` already reads them | Everything: `skill_matcher.py:450-593`, `scoring_dimensions.py`, `llm_matcher.py:200-273`, `main.py:965` | Opaque-score dealbreaker; dimension fit; the AI verdict badge |
+| **2** | Fix the empty `FilterProfile()` | S | `backend/src/workers/tasks.py` ~137-142 | `_user_profile_for(user_id)` is already called at `tasks.py:165` | The single most-cited complaint in the whole category: recommendations that ignore stated location/salary/title |
+| **3** | Stale-application nudges via the existing cron | M | new ARQ task in `backend/src/workers/`, reuse `dispatcher.dispatch()` | `get_stale_applications` (`database.py:1120-1143`) + the whole notification_tick → Apprise path | A tracker "must". Hits the 55%-no-reply / 65%-ghosted pain directly |
+| **4** | Widen the judge's reason to 1-2 sentences and render it under the score | S | `llm_matcher.py:43-70` (prompt + schema), `JobCard.tsx`, `JobDetailClient.tsx` | All the plumbing exists; this is a prompt tweak + a render-location change | "Show me WHY it matched" — only meaningful after #1 |
+| **5** | Tracker completeness trio: expose `notes_history`, add interview date, add DELETE/withdraw | S + M + S | `api/models.py`, `routes/pipeline.py`, `database.py`, `KanbanBoard.tsx`, `NotesEditor.tsx` | Column already exists for dates; `update_application_notes` is a copy-paste pattern; confirm-dialog pattern at `KanbanBoard.tsx:588-610` | Three visible half-built edges |
+| **6** | Numeric-drift check in the integrity pass | M | `backend/src/services/tailoring/integrity.py` | The existing `_TOKEN_RE`/`repair_proper_nouns` diff scaffolding (`integrity.py:26-102`) — add a `_NUMBER_RE` pass, **flag, never auto-correct** | The deepest fabrication risk on your strongest feature |
+| **7** | Career chat MVP: conversations + messages tables, streaming endpoint, chat UI | L | new migration, `services/career_chat.py`, `routes/chat.py`, `frontend/src/app/chat/` + `components/chat/` | `llm_provider.py` provider fallback (needs a new `llm_chat()`), `profile/storage.py` `load_profile()`, `require_user`, shadcn primitives, `TailorPanel.tsx` as the closest UI analog | Every single co-pilot must-have. Nothing else moves this area off 10%. |
+| **8** | Interview prep (one-shot questions + STAR model answers), text only | M | `services/interview/prep.py`, route, `InterviewPrepPanel.tsx` | `tailoring/generator.py` + `prompts.py` are a direct template | Partial — see the trap below |
+| **9** | Full mock interview with voice | L+ | new everything, plus STT | Nothing existing | The area properly. Do not start here. |
+
+### Traps — things that look cheap and are not
+
+| Trap | Why it bites |
+|---|---|
+| **"Just flip the flags" (move #1)** | Three sub-traps. (a) Your own memory note `project_dim_scoring_id_bug.md` records that dims came out as **all zeros** because `job.id` was unset at scoring time (`main.py:552` vs `597`, `jobs.py:514`). Neither audit re-verified that this is fixed. Flip the flag with that bug live and you ship a radar of zeros. (b) Engine 2 needs LLM enrichment per job — no measured cost figure exists anywhere in the audits. (c) Prod env is not verified (see §5). Verify all three before flipping, not after. |
+| **The prefilter fix (move #2)** | It is a 5-line change that turns on a cascade explicitly designed to **eliminate 99%** of jobs (`prefilter.py:42-136`). Fed real data for the first time, feed volume could collapse overnight. Ship it behind its own flag, measure before/after counts, then default it on. |
+| **Interview prep as "just another tailoring prompt" (move #8)** | Looks M because `generator.py` is a template. But the research is blunt: text-only interview tools "get dismissed as flashcards, not interview practice" (favtutor.com). You would spend M effort and still be at ~0% on the users' must-haves, which all require voice and quantified per-answer feedback. Cheap to build, buys little. |
+| **Async/background tailoring** | Listed as M in the audit. No user research complains about tailoring speed — the stated bar is "under 2 minutes" and two sequential LLM calls clear that. This is engineering hygiene dressed as a user feature. Defer. |
+| **Batch/bulk tailoring** | L effort. Zero support in the user research — nobody asked for it. Skip. |
+| **Email inbox scan for auto-detecting replies** | Reads as a natural tracker upgrade. It is a Gmail OAuth build plus a trust surface, and the research warns employer status labels are inconsistent across ATSs, so silently guessing wrong is itself a dealbreaker (froghire.ai). Big build, high blast radius. Not now. |
+| **Premium tier / paid bypass** | Blocked twice over: no plan column exists (`tailor.py:121-131` admits it), and your own stated sequence is free-tier-enterprise-grade → public release → *then* pricing. Do not pull it forward. |
+| **Engine 3 (semantic)** | Needs the ~300MB sentence-transformers extra and a populated ChromaDB in prod. Heavier infra than a flag flip. Keep it opt-in until the rest lands. |
+
+---
+
+## 4. THE SEQUENCE
+
+One thing at a time. Ordering is justified by which user dealbreaker it removes and by how much existing code it reuses.
+
+### Step 0 — Verify, do not build (hours)
+Read the live Railway env for `ENGINE2/3/4_ENABLED`. Re-run the dim-scoring `job.id` check from `project_dim_scoring_id_bug.md`. Measure one enrichment run's LLM cost.
+
+**Why first:** the size of gap #2 is unknown until you know what prod actually runs. Both audits read `settings.py` defaults and `STATUS.md` — neither read prod. If the flags are already on in prod, Step 1 disappears and the whole sequence shifts. Building on an unverified assumption here would waste the most valuable week in the plan.
+
+### Step 1 — Turn on the matching engines, and make the reason a real sentence
+Moves #1 and #4 together.
+
+**Why second:** the highest gain-per-line in the document. The code is 100% written and tested. It closes the users' #1 matching dealbreaker (opaque scores) and their #2 (no explanation of why). Doing #4 in the same pass matters — flipping the flag alone gives a 200-character badge, which is a number with a label, not an explanation. Users specifically ask for 2-4 lines of met/missing/soft-fit (briefcasecoach.com on LinkedIn Job Match).
+
+### Step 2 — Fix the empty FilterProfile
+Move #2.
+
+**Why third and not first:** it is equally cheap, but its blast radius is larger (feed volume) and it is easier to judge the effect once you can see dimension scores from Step 1. It closes the most-cited complaint in the entire category — recommendations that ignore what the user explicitly asked for (stripe.jhu.edu; Trustpilot Indeed; TeamBlind).
+
+### Step 3 — Stale-application nudges
+Move #3.
+
+**Why fourth:** the evidence is the strongest of any single item — 55% of applications get no reply, 65% of UK seekers report being ghosted, and spreadsheets fail *specifically* because they do not nudge (qarera.com). You already own both halves: the query and the cron+Apprise pipeline. This is the loop that turns your tracker from a filing cabinet into a CRM.
+
+### Step 4 — Tracker completeness trio
+Move #5: notes history visible, interview date, delete/withdraw.
+
+**Why fifth:** small, and each one removes a visible half-built edge. A product with three obviously missing verbs reads as unfinished no matter how good the matching is.
+
+### Step 5 — Career chat MVP
+Move #7. The big one.
+
+**Why here and not first:** this is the ordering call that matters most, so here is the reasoning rather than a preference. The research says a copilot is judged on (a) memory, (b) grounding in real jobs with reasons, (c) grounding in your actual pipeline (getmentors.ai; indeed.com/careerscout; blog.loopcv.pro). Steps 1-4 are exactly what makes (b) and (c) real. Build the chat first and it talks about a keyword-only feed with no verdicts, no dimension scores, unfiltered results, and a pipeline with no dates or reminders — a copilot grounded in weak data, which is precisely the "generic advice that ignores my situation" failure users name as a top frustration. Build it fifth and it opens already knowing your CV, your scored feed with reasons, your skill gaps, your stages, and what is overdue. Same code, far better product, because the fuel arrived first.
+
+### Step 6 — Tailor honesty: numeric-drift flag
+Move #6.
+
+**Why late:** your tailor is already ahead of the category on its worst failure mode. This is hardening a strength, not fixing a wound.
+
+### Step 7 — Interview coach
+Do not start it until Steps 1-6 land, and when you do, plan for voice.
+
+**Why last:** it is the only area at 0%, the only one needing new infrastructure (speech-to-text), and the only one where the research explicitly says the cheap version gets rejected. Everything above it reuses code you have already paid for.
+
+**The counter-argument, stated honestly:** if the goal were a launch headline rather than retention, the copilot is the marketing story and would go first. I am ordering against that because the evidence across all five research areas points the same way — products in this category die from dealbreakers (hallucination, stale listings, ignored filters, silence, billing traps), not from missing headline features. Trustpilot 2.9/5 for Jobright is a dealbreaker score, not a missing-feature score.
+
+---
+
+## 5. WHAT I COULD NOT VERIFY
+
+Unmarked unknowns are worse than marked ones. Here are all of them.
+
+| # | Unknown | Why it matters | How to close it |
+|---|---|---|---|
+| 1 | **Whether prod actually has `ENGINE2/3/4_ENABLED` set.** Both audits read `settings.py:208-211` defaults and `STATUS.md:135-140`. Neither read the Railway environment. Your `.env` is gitignored and your own memory note warns "check the RIGHT INSTANCE — prod env, not `.env.example`". | Changes the size of the single biggest gap, and whether Step 1 exists at all. | Read the Railway variable **names** for the backend service (names only, never values). |
+| 2 | **Whether the dim-scoring `job.id` bug is fixed.** Recorded in memory (`main.py:552` vs `597`, `jobs.py:514`; job 147 scored 60 without id, 72 with). Not re-checked by either audit. | If live, flipping Engine 2 ships a radar of zeros and looks worse than shipping nothing. | Score one job through both paths and compare. |
+| 3 | **LLM cost per user per run with Engines 2+4 on.** No measured figure in either audit. `ENRICHMENT_THRESHOLD` (60) and `MATCHER_MAX_JOBS` (30) bound it in theory. | Determines whether Step 1 is safe on a free tier. | One instrumented run. |
+| 4 | **Whether applying to a job in Job360 auto-creates a pipeline card.** The tracker audit found `create_application` (`pipeline.py:84-133`) but nothing about whether the apply flow calls it automatically. Users list "no separate add-to-tracker step" as a **must** (simplify.jobs). | If it does not auto-create, that is a missing must-have not counted in the 45%. | Click apply in the live app and check the board. |
+| 5 | **Whether the missing-keyword list appears inside the tailoring flow.** INFERENCE only: skill gap renders at `JobDetailClient.tsx:544-612`, tailor panel at `:508` — same page, adjacency assumed, not confirmed. | Decides whether a cheap Jobscan-parity win is already done. | Open a job detail page. |
+| 6 | **Zero evidence from real Job360 users.** Every "user expectation" here comes from competitor reviews, vendor blogs, and industry surveys. No telemetry, interviews, or support tickets from your own users appear anywhere in the research. | The whole roadmap is built on what users of *other* products complain about. Directionally strong, specifically unproven for you. | Five user conversations would outrank this entire document. |
+| 7 | **Source quality is mixed.** Several load-bearing citations are vendor SEO blogs with an interest in the answer — getmentors.ai (the "96% rated tailored" and "300% satisfaction" figures), jobhire.ai, wobo.ai, resumehog. Trustpilot review-share percentages ("72% of one-star reviews") are as-reported, not independently recomputed. | The direction (memory matters, billing traps kill trust) is corroborated across independent sources. The specific numbers are not audit-grade. | Treat percentages as indicative, not precise. |
+| 8 | **UK-specificity is partial.** ICO guidance, the 42%-trust-humans figure, ghosting rates and job-search-hours are UK. Trustpilot complaint patterns, hiring-manager surveys and cover-letter read rates are largely US. | Your product is UK-first. Some expectations may not transfer. | Weight the UK-sourced items higher. |
+| 9 | **ICO / DPIA exposure not audited.** The research cites ICO expectations for tools that filter, rank or score *candidates*. INFERENCE: Job360 ranks *jobs for a person*, which is the opposite direction and likely lower risk — but no one checked, and this is not legal advice. | Compliance risk at public-release time. | A real read of the ICO ADM consultation against your actual data flows. |
+| 10 | **Engine 3 infra feasibility on Railway.** ~300MB sentence-transformers extra plus a populated ChromaDB. Not tested in prod by either audit. | Blocks semantic search and semantic dedup. | Try it in a staging service. |
+| 11 | **All S/M/L effort estimates are the auditors', not measured.** Consistent with the codebase they read, but no one timed anything. | Sequence timing, not sequence order. | — |
+| 12 | **Two scoreboard numbers are judgments dressed as arithmetic** — tailor (12/20 counted = 60%, reported 70%) and co-pilot (0/5 by conversational reading, 1/5 by the rubric's own item (e)). Both flagged in §1. | Neither changes any decision here. | — |
+
+
+---
+
+# Appendix A — Codebase audit, per area (raw)
+
+
+## AI career co-pilot (single conversational assistant that knows your background/goals and you can talk to about your career) — 10%
+
+**Rubric (what 100% means):** 100% = a user can open one persistent chat surface, ask free-form career questions ("should I take this job", "how do I close my Docker gap", "draft a follow-up email"), and the assistant answers using their real CV/LinkedIn/GitHub/preferences plus job/application context, with multi-turn memory (a conversation is stored and resumable), grounded citations to real profile/job data (no fabrication), and at least the interview-prep / mock-interview / skill-gap / follow-up / outreach sub-flows from the team's own design doc. Sub-components: (a) a chat endpoint + persistence (conversations/messages table or equivalent), (b) a frontend chat UI, (c) system-prompt grounding in profile+job+application data, (d) multi-turn context/memory, (e) at least one of the 5 planned post-application flows actually callable.
+
+**How the number was derived:** 0 of 5 rubric sub-components exist as a conversational feature. What DOES exist and counts toward the 10%: (1) a reusable multi-provider LLM calling layer used elsewhere in the app (not chat-specific), (2) one deterministic (non-LLM) sub-feature from the 5-feature "career co-pilot" plan — skill-gap analysis — is built and wired into the job detail page, (3) the LLM judge writes a one-line, one-way, non-conversational verdict/reason per job. None of these are a "talk to it about your career" conversational surface: no chat endpoint, no message/thread persistence, no frontend chat UI, no multi-turn memory. 10% reflects "some reusable plumbing + one of five planned sub-features shipped in non-conversational form," not partial chat functionality.
+
+
+### Implemented (each with evidence)
+
+| Capability | Depth | Evidence | Notes |
+|---|---|---|---|
+| Multi-provider LLM calling infrastructure (OpenAI primary, Gemini/Groq/Cerebras fallback) with timeout, rate-limit backoff, and Pydantic schema validation — reusable plumbing any future chat feature would sit on top of | deep | `backend/src/services/profile/llm_provider.py:180-386 (llm_extract, llm_extract_fast, llm_extract_validated)` | One-shot JSON-in/JSON-out extraction calls, NOT a chat/completion API with multi-turn message history — every call site builds a single prompt+system pair, there is no conversation |
+| Deterministic skill-gap analysis (matched / missing / transferable skills for a job vs. the user's profile) — this is sub-feature #3 of the team's own 5-feature 'post-application career co-pilot' plan | solid | `backend/src/services/skill_gap.py:23-63, wired at backend/src/api/routes/jobs.py:733-740, rendered at frontend/src/app/jobs/[id]/JobDetailClient.tsx:544-612` | Pure rapidfuzz string matching, zero LLM involvement — no 'here's what to learn' guidance text, just three lists (matched/missing/transferable). |
+| LLM judge produces a per-job one-line fit verdict + <=200-char reason ("why this job fits you") | shallow | `backend/src/services/llm_matcher.py:43-70 (MatchVerdict schema + rubric), surfaced via user_feed.llm_verdict/llm_reason per root CLAUDE.md Matcher-batch section` | One-way, per-job, non-interactive text — not something the user can ask follow-up questions about. Gated off by default (MATCHER_ENABLED=false). |
+
+### Missing
+
+| Capability | Why it matters | User-visible |
+|---|---|---|
+| Any chat/conversation endpoint or persistence (no route, no message/thread table) | This is the core of the definition — 'a single conversational assistant... you can talk to it'. Without a chat endpoint and stored conversation history, there is no assistant to talk to, only isolated | yes |
+| Frontend chat UI (message bubbles, input box, streaming reply) | Even if a backend endpoint existed, users have no surface to type into. Grepped all frontend/src/components and frontend/src/app for chat/conversation/message/thread UI — none found; every hit was an  | yes |
+| Multi-turn memory / context carried across turns | A career conversation ('I mentioned Docker last week, does this job need it?') requires the assistant to remember prior turns. No message-history table, no session/thread ID anywhere in migrations or  | yes |
+| Grounding the assistant in the user's full profile + active applications for open-ended Q&A (not just a fixed CV-parse or fixed job-verdict prompt) | The two LLM features that touch profile data (cv_parser, llm_matcher) use fixed, single-purpose prompts baked for one task each. Nothing lets a user ask an arbitrary question and get an answer grounde | yes |
+| The other 4 of 5 planned post-application co-pilot features: interview prep, mock interview (explicitly designed as 'chat-style'), follow-up email drafts, outreach drafts | docs/post_application.md (title: 'the after you apply career co-pilot') designs exactly these 5 features and is explicit that this is a PLAN, not shipped code. Grepped backend/src and frontend/src for | yes |
+
+### How to implement the gap
+
+| Step | Files touched | Effort | Reuses existing |
+|---|---|---|---|
+| Add conversations + messages tables (per-user, FK to users.id) via a new forward+reverse migration pair | `backend/migrations/00XX_career_chat.{up,down}.sql` | S | Follow the existing migration pattern used for user_feed/notification_ledger (backend/migrations/0004_notification_ledge |
+| Build a chat endpoint that streams a response, grounded in the user's profile + recent applications, using the existing multi-provider chain (swap json_object mode for a plain completion + multi-turn messages array) | `new backend/src/api/routes/chat.py, new backend/src/services/career_chat.py, register in backend/src/api/main.py (alongs` | L | backend/src/services/profile/llm_provider.py:180-386 for the provider fallback/timeout/retry machinery (needs a new llm_ |
+| Build the frontend chat UI: message list + input, using existing UI primitives | `new frontend/src/app/chat/page.tsx (or a panel in pipeline/jobs[id]), new frontend/src/components/chat/*.tsx` | M | frontend/src/components/ui/{card,button,textarea}.tsx (shadcn primitives already in the repo), frontend/src/lib/api.ts + |
+| Wire the already-built skill-gap output and the LLM judge's llm_reason into the chat's system-prompt context so the assistant can answer 'why does this job fit / what am I missing' without recomputing | `backend/src/services/career_chat.py` | S | backend/src/services/skill_gap.py:23-63 (compute_skill_gap), user_feed.llm_verdict/llm_reason columns from the matcher b |
+| Implement interview-prep as the first of the 5 planned post-application features (foundation the team's own doc says to build first), as a one-shot generation (not full chat) reusing the tailoring pattern | `new backend/src/services/interview_prep.py, new route in backend/src/api/routes/pipeline.py or tailor.py, new frontend/s` | M | backend/src/services/tailoring/generator.py + prompts.py as the direct template (same shape: load profile+job → build pr |
+
+**Searches actually run** (so any 'not found' is checkable): `chat|conversation|copilot|assistant (backend/src, case-insensitive)` · `chat|conversation|copilot|message|thread (frontend/src, case-insensitive)` · `backend/migrations/*chat*` · `backend/migrations/*conversation*` · `career|advice|guidance|plan (backend/src/services, case-insensitive)` · `role.*(user|assistant|system)|StreamingResponse|EventSource|sse|websocket (backend/src)` · `llm_matcher|llm_provider|call_llm|chat_completion|generate_text (backend/src)` · `grep -rli chat|conversation migrations/` · `career.*(chat|advice|coach|guidance)|coach (whole repo, case-insensitive)` · `coach|copilot (docs/, case-insensitive)` · `interview_prep|mock_interview|skill_gap|skill-gap|follow_up|followup|outreach (backend/src and frontend/src, case-insensitive)` · `skill_gap|SkillGap|skill-gap (backend/src/api/routes/jobs.py)` · `interview|mock|outreach|follow.?up (backend/src/api/routes/pipeline.py, case-insensitive)` · `matched_skills|missing_skills|transferable|Skill Analysis|skill_gap (frontend/src, case-insensitive)`
+
+
+## Smart job matching (personalised, beyond keywords) — 72%
+
+**Rubric (what 100% means):** 100% = a matching system that: (1) scores every job against a real per-user profile on more than title/skill keywords — seniority, salary, visa, workplace fit; (2) can retrieve by MEANING not just word overlap (semantic/embedding search) and blends it with keyword search; (3) has an LLM "judge" pass that reasons about true candidate-job fit like a recruiter would, with a visible verdict/reason; (4) actually runs this pipeline in production by default (not all behind off-by-default flags nobody flips); (5) surfaces the reasoning to the user (why this job, which dimensions drove it) instead of a black-box number; (6) the per-user personalization signal (real location/experience/skill profile) is actually plumbed into every code path that filters/scores jobs, not just some of them.
+
+**How the number was derived:** 4 engines exist and are individually well-built and tested (~4,500 lines of tests across scorer/dims/matcher/retrieval/embeddings/enrichment/dedup/prefilter). Engine 1 (keyword, 100%) is on by default and solid. Engines 2-4 (dimensions, hybrid semantic, LLM judge) are fully implemented, wired end-to-end into the API and pipeline, and frontend-surfaced (ScoreRadar dormant-state handling, AI verdict badge) — but ALL default OFF in code (`ENGINE2/3/4_ENABLED` false, STATUS.md:135-140), so out of the box the product only does keyword+location+recency matching, i.e. Engine 1. That caps the score: excellent architecture (would be ~90%+ if defaults were on and fed real data everywhere), but two structural gaps pull it down: (a) flags-off-by-default means "smart" matching is opt-in, not the shipped experience — treat as ~15pt deduction; (b) the 99%-prefilter cascade (`prefilter.py`), which is supposed to bring real per-user location/experience/skill data into the scheduler's per-job ingest path, is called with an ALWAYS-EMPTY `FilterProfile()` in `workers/tasks.py:142` ("No per-user profile storage yet; fall back to all users see all jobs" — stale comment, contradicted by the fact `user_profiles` storage has existed since Batch 3.5.2) — a ~10pt deduction since this means the scheduler's background ingest path does zero personalized filtering, only the on-demand `run_search` CLI/API path does real per-user scoring. Net: 100 (all 4 engines + reasoning) − 15 (opt-in not default) − 10 (prefilter fed empty profile) − 3 (misc: no explicit "why this job" natural-language explanation surfaced beyond the LLM judge's terse reason string) ≈ 72%.
+
+
+### Implemented (each with evidence)
+
+| Capability | Depth | Evidence | Notes |
+|---|---|---|---|
+| Engine 1 — dynamic keyword scorer (title/skill/location/recency, 4-component, 0-100) | solid | `backend/src/services/skill_matcher.py:438-593 (JobScorer.score); weights at skill_matcher.py:26-29` | Uses per-user SearchConfig (not hardcoded lists), skill-alias expansion via skill_synonyms.aliases_for (skill_matcher.py:21,226-229). This is the only engine ON by default (setting |
+| Engine 2 — dimension scorers: seniority/salary/visa/workplace fit vs user preferences | deep | `backend/src/services/scoring_dimensions.py:105-260 (seniority_score, salary_score, visa_score, workplace_score); wired in skill_matcher.py:546-586` | Thoughtful edge-case handling: negative seniority penalty for bad mismatches (scoring_dimensions.py:112-140), band-overlap salary math (148-193), neutral-not-zero fallback when sig |
+| LLM job enrichment — extracts structured seniority/salary/visa/workplace/skills from raw job text | solid | `backend/src/services/job_enrichment.py:1-80 (build_prompt, ENRICHMENT_ENABLED flag); enqueued per-job at backend/src/workers/tasks.py:207 (enrich_job_task)` | Feeds Engine 2's dimension scorers. Idempotent, provider-fallback chain (Gemini->Groq->Cerebras). Default OFF. |
+| Engine 3 — hybrid retrieval: keyword + BM25 + semantic embeddings fused via RRF, then cross-encoder rerank | deep | `backend/src/services/retrieval.py:33-410 (reciprocal_rank_fusion, bm25_rank, retrieve_for_user, cross_encoder_rerank); wired via ?mode=hybrid in backend/src/api/routes/jobs.py:204-360` | Genuine semantic-similarity matching (sentence-transformers embeddings, 384-dim, chunked+max-pooled for long descriptions — backend/src/services/embeddings.py:115-183), ChromaDB-ba |
+| Engine 4 — LLM judge: per-user fit verdict with reasoning, beyond any keyword math | deep | `backend/src/services/llm_matcher.py:43-273 (MatchVerdict, match_job, match_batch); wired in backend/src/main.py:965 via _run_matcher_stage (main.py:338-390)` | Sends full merged profile (CV+LinkedIn+GitHub+preferences, llm_matcher.py:73-94) plus job facts to an LLM that returns fit_score + short verdict + reason string — this is the only  |
+| Profile-driven re-scoring: score changes only when profile changes (not time-based drift) | solid | `backend/src/services/rescore.py referenced at STATUS.md:144; trigger in backend/src/api/routes/profile.py` | Every user_feed row stamped with the profile-version id that produced it; a profile edit clears LLM verdicts and re-scores the 30-day catalog. |
+| Frontend: 8-dimension score radar with honest dormant-state handling | solid | `frontend/src/components/jobs/ScoreRadar.tsx:38-241, esp. dormant logic 118-141 and dimsActive prop contract 49-59` | Explicitly refuses to draw a fake 0% for unmeasured dims (comment block ScoreRadar.tsx:18-35 documents this was previously a shipped bug — invented dims that summed wrong and silen |
+| Frontend: AI-verdict badge + judge-score sort on dashboard | solid | `frontend/src/app/dashboard/__tests__/judge-ranking-sort.test.tsx, frontend/src/components/jobs/__tests__/llm-verdict-badge.test.tsx; user_feed reads rank by COALESCE(llm_fit_score, score) DESC per STATUS.md:142` |  |
+| 99%-elimination prefilter cascade (location/experience/skill) as a pre-scoring gate | shallow | `backend/src/services/prefilter.py:42-136 (FilterProfile, location_ok, experience_ok, skill_overlap_ok, passes_prefilter)` | Well-tested (135-line test file) in isolation, but its ONLY production caller (backend/src/workers/tasks.py:142,175) passes an always-empty `FilterProfile()` with a comment admitti |
+
+### Missing
+
+| Capability | Why it matters | User-visible |
+|---|---|---|
+| Any of engines 2/3/4 running by default in production | A solo user signing up today gets ONLY keyword+location+recency matching (Engine 1) unless someone flips ENGINE2/3/4_ENABLED. All the 'smart' personalization work (LLM judge, semantic search, dimensio | yes |
+| Real per-user profile feeding the scheduler's background ingest prefilter | workers/tasks.py:142 hardcodes an empty FilterProfile for every user on every incoming job from the tiered scheduler (the always-on background polling path, distinct from an explicit search). That mea | yes |
+| Natural-language 'why this job matched you' surfaced beyond the terse LLM judge reason string | llm_matcher.py caps `reason` at <=200 chars naming ONE deciding dimension (llm_matcher.py:69). There's no user-facing explanation UI that says e.g. 'matched because your GitHub shows 3 years of Rust,  | yes |
+| Deduplicator's semantic/embedding-based repost detection (layer 4) | STATUS.md:214 explicitly flags this as 'scaffolded... but gated behind SEMANTIC_ENABLED... not yet wired into the default pipeline path' — an admitted gap in the docs themselves, meaning reposted/near | yes |
+| Negative/implicit feedback loop into scoring (learn from user actions — dismiss/save/apply) | Searched for a signal that user_actions (dismiss/save/apply) feed back into future scoring weights or the LLM judge's context and found none in skill_matcher.py, scoring_dimensions.py, or llm_matcher. | yes |
+
+### How to implement the gap
+
+| Step | Files touched | Effort | Reuses existing |
+|---|---|---|---|
+| Turn Engine 2 (dimensions) + Engine 4 (LLM judge) ON by default in prod via Railway env vars (ENGINE2_ENABLED=true, ENGINE4_ENABLED=true), keep Engine 3 (semantic) opt-in until ChromaDB is provisioned in prod (it needs t | `Railway env vars only (no code change) — backend/src/core/settings.py:208-211 already reads them` | S | Everything: skill_matcher.py:450-593, scoring_dimensions.py, llm_matcher.py:200-273, job_enrichment.py, main.py:965 _run |
+| Fix workers/tasks.py to build a REAL FilterProfile from the user's stored profile (mirrors what _search_config_for / _user_profile_for already do a few lines below in the same file) instead of FilterProfile() empty defau | `backend/src/workers/tasks.py (~lines 137-142, and wherever `_user_profile_for` is already defined for the scorer path ju` | S | The per-user profile loader already exists and is called two lines later for the scorer (`_user_profile_for(user_id)` at |
+| Add a short natural-language 'why matched' field: extend MatchVerdict's reason to a 1-2 sentence explanation (raise the 200-char cap, ask the rubric for a fuller sentence) and surface it directly under the score on JobCa | `backend/src/services/llm_matcher.py:43-70 (prompt + schema), frontend/src/components/jobs/JobCard.tsx, frontend/src/app/` | S | The verdict/reason plumbing, API field exposure, and frontend badge component all already exist (llm_matcher.py MatchVer |
+| Wire the semantic dedup layer (deduplicator.py layer 4) behind SEMANTIC_ENABLED into the default pipeline path once Engine 3 is turned on, so near-duplicate/reposted jobs get caught before they compete for the user's att | `backend/src/services/deduplicator.py (layer 4 activation point — check the gate condition), backend/src/main.py (dedup c` | M | deduplicator.py:330 lines already implement the layer; STATUS.md:214 confirms it's scaffolded, just not called — the emb |
+| Add a lightweight learned-preference signal: track dismiss/save/apply rate per skill/company/title-token in user_actions and feed it as a soft re-rank boost/penalty in retrieve_for_user's fusion (a 4th ranked list) or as | `new: backend/src/services/preference_learning.py (or extend scoring_dimensions.py); backend/src/services/retrieval.py:15` | L | retrieve_for_user's RRF fusion already accepts arbitrary extra ranked lists (retrieval.py:212-247 shows the pattern for  |
+
+**Searches actually run** (so any 'not found' is checkable): `grep ENGINE1_ENABLED|ENGINE2_ENABLED|ENGINE3_ENABLED|ENGINE4_ENABLED across backend/src` · `grep retrieve_for_user|match_batch|_run_matcher_stage|llm_matcher|MATCHER_ENABLED in main.py` · `grep mode=hybrid|retrieve_for_user|is_hybrid_available in api/routes/jobs.py` · `grep passes_prefilter|FilterProfile( across backend/src` · `grep JobScorer\(|user_preferences=|enrichment_lookup= in main.py` · `grep enrich_batch|enrich_job_task|def enrich_ in workers/tasks.py and cli.py` · `grep llm_verdict|llm_fit_score|llm_reason|dim_scores|ScoreBreakdown|radar|mode=hybrid|dimScore across frontend/src` · `grep ENGINE1|ENGINE2|ENGINE3|ENGINE4|MATCHER_ENABLED|SEMANTIC_ENABLED|ENRICHMENT_ENABLED in STATUS.md` · `ls backend/tests matching scorer|matcher|retrieval|embed|vector|enrich|dedup|prefilter|scoring_dim` · `grep -n id in backend/src/models.py (job.id declared-field check)` · `grep def ingest_job_task|process_job_task|process_incoming in workers/tasks.py (no match — confirmed name is different)`
+
+
+## AI resume + cover letter tailor (Job360 "Tailored Documents" feature) — 70%
+
+**Rubric (what 100% means):** 100% = a solo user can: (1) generate a truthful, ATS-clean tailored CV + cover letter for any job with zero fabrication, backed by a deterministic safety net; (2) see exactly which lines are their own facts vs AI-added before trusting the doc; (3) edit and re-download in multiple formats; (4) have the system learn their voice over time without leaking their content; (5) be safely rate/cost-gated with a real path to a paid tier; (6) trust that a doc is traceable to the profile version that produced it; (7) generate in the background without blocking the request; (8) do all of the above from a UI that is fully wired into the job list/detail pages. Both backend engine and frontend UI must be present, not just the DB schema.
+
+**How the number was derived:** Counted 20 sub-capabilities a genuinely-good version of this feature needs (see missing[] and implemented[] below). 12 are implemented with real (mostly deep, test-covered) depth: generate CV, generate cover letter, never-fabricate prompt guardrail, deterministic proper-noun integrity pass, line-level provenance highlighting, edit/save loop, PDF+DOCX ATS rendering, monthly quota gate, per-user few-shot learning, privacy-safe universal cold-start learning, atomic upsert (no data loss), and full frontend wiring into JobCard + job detail page. 8 are absent or stubbed: profile_version traceability (schema column exists, code never populates it), premium/paid bypass (comment admits "no plan column exists yet"), async/background generation (synchronous, blocks the HTTP request for 2 sequential LLM calls), batch/bulk tailoring across saved jobs, quota TOCTOU hardening, GDPR data-export inclusion, edit version history/diffing, and fabrication detection limited to proper nouns only (embellished numbers/metrics/soft claims aren't caught). 12/20 solid ≈ 70%; the 8 gaps are real but mostly polish/scale items, not core-loop breakage, so this isn't a low score — but it isn't "ship and forget" either.
+
+
+### Implemented (each with evidence)
+
+| Capability | Depth | Evidence | Notes |
+|---|---|---|---|
+| Generate tailored CV via LLM, reshaping only real CV facts | deep | `backend/src/services/tailoring/generator.py:39-87, backend/src/api/routes/tailor.py:110-181` | Locked system prompt forbids invention (prompts.py:23-33); tested end-to-end incl. value-presence in tests/test_cv_coverletter.py:139-163 |
+| Generate tailored cover letter | deep | `backend/src/services/tailoring/prompts.py:45-54, generator.py:20 (DOC_KINDS=('cv','cover_letter'))` |  |
+| Deterministic proper-noun integrity pass (auto-correct near-miss names, flag unmatched brand tokens as possible fabrication) | deep | `backend/src/services/tailoring/integrity.py:65-102, tested in backend/tests/test_tailoring_integrity.py` |  |
+| Line-level provenance ('your facts' vs 'AI-added') shown before download | solid | `backend/src/services/tailoring/provenance.py:23-43, endpoint backend/src/api/routes/tailor.py:194-211, UI backend rendering in frontend/src/components/tailor/TailorPanel.tsx:259-284, tests in backend/tests/test_tailoring_provenance.py` |  |
+| Edit-and-save loop (draft preserved, polished version overlaid, always editable) | deep | `backend/src/api/routes/tailor.py:214-234 (PATCH), backend/src/repositories/database.py:872-882, tested tests/test_cv_coverletter.py:242-269 incl. 50KB size cap (422)` |  |
+| ATS-friendly PDF + DOCX rendering, single-column plain text | solid | `backend/src/services/tailoring/pdf.py:11-40, docx.py:11-38, download route backend/src/api/routes/tailor.py:262-306, test test_cv_coverletter.py:325-336` |  |
+| Monthly free-tier quota gate (HTTP 402 over cap) | solid | `backend/src/api/routes/tailor.py:121-131, backend/src/core/settings.py:169 (TAILOR_FREE_PER_MONTH=10 default), backend/src/repositories/database.py:895-913, tested test_cv_coverletter.py:218-226` | no premium bypass exists yet — everyone is capped (route comment admits this explicitly) |
+| Per-user Layer-2 learning: kept polished docs feed back as few-shot 'write like me' examples | solid | `backend/src/repositories/database.py:915-924 (get_user_kept_docs), used in backend/src/api/routes/tailor.py:143-144, tested test_cv_coverletter.py:307-321` |  |
+| Universal Layer-1 cold-start learning — structural patterns only, provably no content/PII leak | deep | `backend/src/services/tailoring/patterns.py:35-59, backend/src/api/routes/tailor.py:309-319, verified by test_derive_patterns_leaks_no_content in tests/test_cv_coverletter.py:118-127 and test_keep_marks_kept_and_learns_patterns_only:273-291` |  |
+| Atomic regenerate — DELETE+INSERT in one transaction, doc survives a mid-write crash | deep | `backend/src/repositories/database.py:816-849, tested test_cv_coverletter.py:398-422 (simulated crash between DELETE and INSERT)` |  |
+| Per-user auth + IDOR-safe scoping on every route | deep | `backend/src/api/routes/tailor.py:19,114,188,199,220,242,268 (require_verified_user + user.id everywhere), tested test_cv_coverletter.py:340-362` |  |
+| Frontend fully wired: dashboard job card + job detail page, generate/regenerate, quota badge, fabrication warning banner, provenance toggle, save, download PDF/DOCX | solid | `frontend/src/components/jobs/JobCard.tsx:471, frontend/src/app/jobs/[id]/JobDetailClient.tsx:508, frontend/src/components/tailor/TailorPanel.tsx:63-350, frontend/src/lib/api.ts:685-745` |  |
+
+### Missing
+
+| Capability | Why it matters | User-visible |
+|---|---|---|
+| profile_version stamping on generated docs | The DB column exists (migration 0023) and generator route accepts a profile_version kwarg, but backend/src/api/routes/tailor.py:171-174 never passes it — every row has profile_version=NULL. So there i | no |
+| Premium/paid tier bypass for the quota | settings.py:169 + tailor.py:121-131 comment explicitly says 'a real premium tier will bypass this later' and 'no premium plan exists yet' — every user, paying or not, is capped at 10/month. This block | yes |
+| Background/async generation | generate() in tailor.py:150-174 runs 2 sequential LLM calls synchronously inside the HTTP request (docstring at tailor.py:5-6 even says an ARQ mirror exists for 'a future async path' — it does not; no | yes |
+| Batch/bulk tailoring across multiple saved jobs | Every generate is one job at a time via a dialog. A user with 20 saved jobs they want to apply to has to open each job and click Generate individually — no 'tailor all shortlisted jobs' flow exists. | yes |
+| Quota check-then-increment race hardening | count_tailored_usage_month (database.py:895-905) is read, then record_tailored_usage (907-913) is written at the end of the request — two concurrent generate() calls near the cap can both pass the che | no |
+| Tailored documents included in account data export / deletion audit trail | grep of backend/src/api/routes/*.py found no route that surfaces tailored_documents in a GDPR-style export (cascade DELETE on user removal works fine via FK, but there's no user-facing 'download all m | no |
+| Edit/version history for tailored docs | save_tailored_polished (database.py:872-882) does a plain UPDATE — each save overwrites the previous polished text with no history. A user can't revert to an earlier edit, and the system can't show 'h | yes |
+| Fabrication detection beyond proper nouns | integrity.py's repair_proper_nouns only catches brand/company/product names. It does nothing about an LLM subtly inflating a metric ('managed a team of 5' -> 'managed a team of 12') or a duration, whi | yes |
+
+### How to implement the gap
+
+| Step | Files touched | Effort | Reuses existing |
+|---|---|---|---|
+| Stamp profile_version on every generated doc | `backend/src/api/routes/tailor.py (generate route)` | S | load_profile() at backend/src/api/routes/tailor.py:100 already returns the profile object; user_profile_versions ID is a |
+| Move generation off the request thread into the existing ARQ worker | `backend/src/workers/tasks.py (new task), backend/src/api/routes/tailor.py (enqueue + poll/status endpoint), frontend/src` | M | ARQ worker infra already exists and is used for notification_tick/nightly_ghost_sweep (root CLAUDE.md 'Notifications' se |
+| Add a real premium-tier bypass | `backend/src/core/settings.py, backend/src/api/routes/tailor.py:121-131, needs a users.plan or similar column (migration)` | M | This is explicitly deferred in project memory (project_subscription_plan_model.md — 'Free/Premium subscription model (de |
+| Batch tailoring endpoint for saved/shortlisted jobs | `backend/src/api/routes/tailor.py (new POST /tailor/batch), frontend new bulk-action UI in pipeline/dashboard` | L | generate_document() in generator.py:39 is already pure and reusable per-job; just needs a loop with concurrency limits ( |
+| Harden the quota check with a single atomic INSERT...WHERE count<limit or a DB-level advisory lock | `backend/src/repositories/database.py (count_tailored_usage_month + record_tailored_usage)` | S | runner.up() already uses a Postgres advisory lock pattern (root CLAUDE.md RUN_MIGRATIONS_ON_BOOT note) that can be copie |
+| Add tailored_documents to whatever data-export/account-deletion audit exists (or build one) | `backend/src/api/routes/auth.py or a new export route` | S | get_tailored_docs(user_id, job_id) already returns full rows (database.py:862-870); just needs a user-wide variant (WHER |
+| Version history for polished edits | `new migration (tailored_document_versions table), backend/src/repositories/database.py (save_tailored_polished)` | M | user_profile_versions / application_stage_history are both existing precedents for an append-only history table pattern  |
+| Extend integrity pass to flag numeric/metric drift, not just proper nouns | `backend/src/services/tailoring/integrity.py` | M | The existing _TOKEN_RE/repair_proper_nouns scaffolding (integrity.py:26-102) already does source-vs-output diffing; add  |
+
+**Searches actually run** (so any 'not found' is checkable): `find backend/src/services/tailoring -type f` · `find backend/src/api/routes -iname *tailor*` · `find backend/migrations -iname *tailor*` · `find frontend/src -iname *tailor*` · `grep -n tailor|Tailor backend/src/repositories/database.py` · `find backend/tests -iname *tailor*` · `grep -rln tailor backend/tests/` · `grep -n get_user_kept_docs|get_fit_reason backend/src/repositories/database.py` · `grep -n profile_version backend/src/api/routes/tailor.py backend/src/repositories/database.py` · `grep -rln TailorButton|TailorSection frontend/src` · `grep -rn tailored backend/src/api/routes/account.py` · `grep -rln delete_account|purge_user|DELETE FROM users backend/src/api backend/src/services` · `grep -rn tailor backend/src/workers/*.py` · `grep -n TAILOR_FREE_PER_MONTH backend/src/core/settings.py`
+
+
+## Application tracker / CRM (know what you sent, who replied, what follow-up is due) — 45%
+
+**Rubric (what 100% means):** 100% = a user can: (1) log every application with stage tracking, (2) see full audit history of stage moves, (3) capture and version notes AND actually see that version history, (4) know when to follow up via BOTH detection and a proactive push (not just an in-app banner), (5) explicitly record employer replies/outcomes including silence, (6) manage interview scheduling (real dates, not just a stage label), (7) track named human contacts (recruiter/interviewer) per application, (8) withdraw/delete a tracked application, (9) all of it is per-user isolated, audited, and tested end-to-end (backend route + DB + frontend UI).
+
+**How the number was derived:** 9 sub-capabilities weighed roughly equally. Solid/shipped: stage tracking (1), stage-history audit trail (2), reply-vs-silence signal via the 'ghosted' stage (5), IDOR-safe per-user scoping + tests (9). Half-shipped: notes versioning (3) -- backend writes notes_history but nothing reads it back, so the user never sees it; stale-application reminders (4) -- detection exists but is pull-only, no proactive push. Missing entirely: interview date scheduling (6) -- DB column exists but zero code reads/writes it; named contacts/recruiter tracking (7); withdraw/delete (8). Rough weighting: 1.0+1.0+1.0(5)+1.0(9) solid = 4; +0.5(3)+0.5(4) partial = 1; 0 for (6)(7)(8) = 0. Total 5/9 ≈ 56%, discounted to 45% because two of the three fully-missing items (interview scheduling, proactive follow-up push) are exactly what the promise text calls out ('what follow-up is due') and are core to the area's stated purpose, not peripheral.
+
+
+### Implemented (each with evidence)
+
+| Capability | Depth | Evidence | Notes |
+|---|---|---|---|
+| Kanban-style stage pipeline (applied/outreach/interview/offer/rejected/ghosted) with create + advance endpoints, per-user scoped | solid | `backend/src/api/routes/pipeline.py:36 (_VALID_STAGES incl. deliberate ghosted-vs-rejected distinction), pipeline.py:84-133 (create_application/advance_application), backend/src/repositories/database.py:1006-1057` | Frontend drag-and-drop board with keyboard a11y, confirm-dialog on reject: frontend/src/components/pipeline/KanbanBoard.tsx:433-685 |
+| Full stage-change audit trail (from_stage -> to_stage, timestamp) with a transactional write guaranteeing the move and its history entry commit together | solid | `backend/migrations/0014_application_history.up.sql:6-17 (application_stage_history table), backend/src/repositories/database.py:1017-1057 (SAVEPOINT-guarded atomic write), backend/src/repositories/database.py:1628-1635 (get_application_timeline), backend/src/api/routes/pipeline.py:136-149` | Frontend Sheet drawer renders the full timeline: frontend/src/components/pipeline/KanbanBoard.tsx:612-677. Backed by tests: backend/tests/test_advance_application_atomic.py, backen |
+| Notes per application with versioned history written server-side (old note archived to notes_history on every edit) | shallow | `backend/src/repositories/database.py:1653-1683 (update_application_notes appends to notes_history JSON array), backend/migrations/0014_application_history.up.sql:4, frontend/src/components/pipeline/NotesEditor.tsx:26-53` | Versioning is persisted but never read back anywhere: grep confirms zero hits for notes_history outside database.py and the migration -- no route/model exposes it, so the UI cannot |
+| Reply-vs-silence signal ('ghosted' stage distinct from 'rejected') captured as first-party data | solid | `backend/src/api/routes/pipeline.py:29-36 (comment explains the distinction is deliberate), frontend/src/app/pipeline/page.tsx:149-160 (handleMarkGhosted), frontend/src/components/pipeline/KanbanBoard.tsx:118-130` | This is the closest thing to 'who replied' tracking in the app -- a manual stage label, not an inferred/detected reply from an inbox. |
+| Stale-application detection ('needs attention' if no update in 7+ days) | shallow | `backend/src/repositories/database.py:1120-1143 (get_stale_applications, excludes offer/rejected), backend/src/api/routes/pipeline.py:74-81 (/pipeline/reminders), frontend/src/app/pipeline/page.tsx:253-300 (reminders banner)` | Pull-only: user must open the Pipeline page to see it. Confirmed by search: no cron/worker/notification path pushes this to email/Slack, unlike job-match notifications which have a |
+| Notes update + expired-job guard on create, IDOR-safe scoping | solid | `backend/src/api/routes/pipeline.py:84-110 (410 Gone on confirmed_expired job), backend/tests/test_pipeline_timeline.py:132-186 (IDOR test), backend/tests/test_pipeline_timeline.py:236-268` |  |
+
+### Missing
+
+| Capability | Why it matters | User-visible |
+|---|---|---|
+| Interview date scheduling (a real datetime, not just the 'interview' stage label) | The DB column exists (applications.interview_dates, migration 0014_application_history.up.sql:3) but is never written to or read from anywhere -- confirmed by grep across backend/src, backend/migratio | yes |
+| Named human contacts per application (recruiter name/email, interviewer) | Grep for recruiter/contact/reply across backend/src found no application-tracker-related hits (only unrelated matches like the SmartRecruiters ATS source name). 'Who replied' implies a person; there i | yes |
+| Proactive follow-up nudges (email/Slack when an application goes stale), not just an in-app banner | Job-match notifications have a full proactive pipeline (notification_tick ARQ cron -> dispatcher -> Apprise, per root CLAUDE.md rule #24); pipeline reminders have no equivalent -- get_stale_applicatio | yes |
+| Withdraw / delete a tracked application | No DELETE route on pipeline.py and no withdraw affordance in KanbanBoard.tsx (grep for delete/withdraw in the route file returned zero matches). A mistaken apply or a card the user wants gone has no w | yes |
+| Surfacing notes_history in the UI | Backend already archives every prior note (database.py:1653-1683) but PipelineApplication (api/models.py:321-328) and NotesEditor.tsx only show the current note. The versioning work is currently invis | yes |
+| A record of exactly which document version was sent for a given application | TailorPanel is reachable from the card (KanbanBoard.tsx:293-302), partially covering 'what you sent', but it opens the tailoring tool rather than showing a locked record of the artifact actually submi | no |
+
+### How to implement the gap
+
+| Step | Files touched | Effort | Reuses existing |
+|---|---|---|---|
+| Expose notes_history in the API + UI | `backend/src/api/models.py (add notes_history field), backend/src/api/routes/pipeline.py (surface it or add a GET endpoin` | S | database.py:1653-1683 already writes and can already SELECT notes_history verbatim -- zero new DB logic needed. |
+| Add interview date field: capture on advance-to-interview, surface as a card badge + an 'upcoming interviews' widget | `backend/src/api/routes/pipeline.py (extend PipelineAdvanceRequest or new PATCH /pipeline/{job_id}/interview-date), backe` | M | Column already exists (migrations/0014_application_history.up.sql:3); update_application_notes (database.py:1653) is a n |
+| Add a withdraw/delete endpoint | `backend/src/api/routes/pipeline.py (new DELETE /pipeline/{job_id}), backend/src/repositories/database.py (delete_applica` | S | Confirm-dialog pattern for 'move to rejected' (KanbanBoard.tsx:588-610) copies directly; IDOR-safe query pattern already |
+| Wire stale-application reminders into the existing proactive notification pipeline | `backend/src/workers/ (new ARQ cron task alongside nightly_ghost_sweep/notification_tick), backend/src/services/channels/` | M | get_stale_applications (database.py:1120-1143) is the exact query needed; the ARQ cron + Apprise dispatch machinery alre |
+| Add named contact tracking (recruiter/interviewer name + email) per application | `new migration (e.g. 0026_application_contacts), backend/src/repositories/database.py CRUD, backend/src/api/routes/pipeli` | L | NotesEditor.tsx (frontend/src/components/pipeline/NotesEditor.tsx:1-97) is a ready-made Dialog+save pattern to clone; mi |
+
+**Searches actually run** (so any 'not found' is checkable): `grep -r 'applications' backend/src/api/routes/` · `grep -rn 'def (create_application|advance_application|get_applications|get_application_counts|get_stale_applications|get_application_timeline|update_application_notes)' backend/src/repositories/database.py` · `grep -rl 'applications|application_stage_history|notes_history|interview_dates|last_advanced_at' backend/migrations` · `grep -rn 'interview_dates' backend (files_with_matches)` · `grep -rn 'interview_dates|notes_history' backend/src/api` · `grep -rn 'interview_dates|notes_history|application_stage_history' frontend/src` · `grep -rn 'pipeline|Kanban|reminders|timeline' frontend/src (case-insensitive, files_with_matches)` · `grep -rn 'stale_applications|pipeline_reminder|get_stale_applications|follow.?up|application_reminder' backend/src` · `grep -rn 'ghosted|ghost_detection' backend/src/services` · `grep -rn 'recruiter|contact|reply|email_thread|interview_date' backend/src (case-insensitive, files_with_matches)` · `grep -n 'delete|DELETE|withdraw' backend/src/api/routes/pipeline.py` · `grep -rl 'pipeline|applications' backend/tests/ --include=*.py` · `grep -n 'CREATE TABLE.*applications' backend/migrations/0002_multi_tenant.up.sql backend/src/repositories/database.py`
+
+
+## AI interview coach (practice for technical/behavioural/communication rounds, with feedback) — 0%
+
+**Rubric (what 100% means):** 100% would mean: (1) an "Interview prep" screen that generates likely questions for a specific job from the job description + user's real CV/profile data, with STAR-style model answers; (2) a "Mock interview" chat/voice screen where the AI asks those questions, the user answers (text or speech), and the AI scores + coaches the answer (clarity, structure, quantified impact) across technical, behavioural, and communication dimensions; (3) persistence of sessions/transcripts/scores per user+job so progress is trackable; (4) a paywall/cap gate consistent with the other paid LLM features (rule: TAILOR_FREE_PER_MONTH-style guardrail); (5) frontend entry points on the job detail page and/or Kanban application card.
+
+**How the number was derived:** Exhaustive search across backend/src, backend/migrations, backend/tests, frontend/src for interview|coach|mock|practice|question bank|rubric|STAR|behavioural|technical round|transcript|scoring answers found ZERO implementation code. The only 'interview' hits in backend/src are the Kanban pipeline stage name (application status enum 'Interview', in pipeline.py and database.py — an application-tracking label, not a coaching feature) and 2 migration files (0014_application_history) that store that same stage label. The only substantive hit is docs/post_application.md, a design doc that explicitly proposes 'Interview prep' and 'Mock interview' as features #1 and #2 of a 5-feature post-application roadmap — written in future/proposal language ('start here', 'Build sequence: 1. Interview prep ... 2. Mock interview'), confirming these are un-started. No route file, no service module, no DB table, no frontend page/component, no test exists for question generation, mock-interview chat, answer scoring, or feedback. 0 implemented capabilities / 5 rubric capabilities = 0%.
+
+
+### Missing
+
+| Capability | Why it matters | User-visible |
+|---|---|---|
+| Interview prep (question generation with model answers) | This is the entry point of the whole area and the foundation the mock-interview feature replays questions from (per docs/post_application.md build sequence). Without it there is no content to practice | yes |
+| Mock interview practice mode (AI asks, user answers, AI scores + coaches) | This is the literal definition of the audited area ('Practice for technical, behavioural and communication rounds, with feedback'). Zero code exists — no chat UI, no answer-scoring service, no session | yes |
+| Session/transcript/score persistence | Without a DB table for interview sessions/answers/scores, users can't track improvement over time or revisit past practice — needed for any 'feedback loop' claim. | no |
+| Cost/paywall guardrail for the LLM calls this feature would need | Every other paid-LLM feature in this repo (tailoring) has a monthly cap (TAILOR_FREE_PER_MONTH). An interview coach doing multi-turn Q&A would burn far more LLM budget per session than a single CV gen | no |
+
+### How to implement the gap
+
+| Step | Files touched | Effort | Reuses existing |
+|---|---|---|---|
+| Design + migration: new tables interview_sessions (user_id, job_id, mode: technical\|behavioural\|communication, created_at, status) and interview_answers (session_id, question, user_answer, ai_score, ai_feedback, answer | `backend/migrations/00XX_interview_coach.up.sql + .down.sql` | S | backend/migrations/0023_tailored_documents.up.sql and 0024_tailored_flagged_terms.up.sql as the structural template (per |
+| Question generation service: build src/services/interview/prep.py that takes a job (title/description/skills) + the user's CVData profile and produces N likely questions with STAR-style model answers via the LLM provider | `backend/src/services/interview/prep.py, prompts.py` | M | services/profile/llm_provider.py (Cerebras-first LLM client already wired, per docs/post_application.md:73) and services |
+| Mock interview scoring service: src/services/interview/mock.py — takes question + user's typed/transcribed answer, calls LLM to score across clarity/structure/quantified-impact and return coaching feedback text (not a re | `backend/src/services/interview/mock.py` | M | Same llm_provider.py client; services/llm_matcher.py's MatchVerdict pattern (structured LLM output -> pydantic model) as |
+| API routes: POST /api/interview/prep/{job_id} (generate questions), POST /api/interview/mock/{session_id}/answer (submit answer, get score+feedback), GET /api/interview/sessions (list/history). Must Depends(require_user) | `backend/src/api/routes/interview.py (new), register in api/app.py or wherever routers mount` | M | backend/src/api/routes/tailor.py as the route-module template (auth dependency, per-user scoping, cap-check pattern via  |
+| Cost cap: add INTERVIEW_COACH_FREE_PER_MONTH (or fold into existing tailoring cap) and enforce before generation, same pattern as tailoring. | `backend/src/core/settings.py, the new interview route` | S | settings.py:146 TAILOR_FREE_PER_MONTH + its enforcement call-site in api/routes/tailor.py as the exact pattern to copy. |
+| Frontend: InterviewPrepPanel + MockInterviewChat components, entry buttons on job detail page and Kanban application card ('Prep for interview' / 'Practice interview'), plus a session history view. | `frontend/src/components/interview/ (new), wired into frontend/src/app/jobs/[id]/JobDetailClient.tsx and frontend/src/com` | L | frontend/src/components/tailor/{TailorPanel,TailorButton,TailorSection}.tsx as the exact UI pattern (panel + button + se |
+| Tests: unit tests for prep/mock services with mocked LLM calls, API route tests (auth/IDOR per rule #12), and a value-presence test that a real job+answer produces a non-empty score/feedback (per rule #21). | `backend/tests/test_interview_prep.py, test_interview_mock.py, test_api_interview.py (new)` | M | backend/tests/test_tailor*.py and the aioresponses/LLM-mocking conventions already used for tailoring tests. |
+
+**Searches actually run** (so any 'not found' is checkable): `interview.{0,15}coach|mock.{0,10}interview|interview.{0,10}practice|question.{0,10}bank|behavioural|STAR (repo-wide)` · `interview (case-insensitive, backend/src)` · `interview (case-insensitive, frontend/src)` · `interview (case-insensitive, backend/migrations)` · `coach|mock.?interview|practice.?question|question.?bank|rubric|transcript.{0,10}(score|feedback)|communication.?round|technical.?round (backend, case-insensitive)` · `coach|mock.?interview|practice.?question|question.?bank|rubric (frontend, case-insensitive)` · `interview (case-insensitive, docs/)` · `interview|mock_interview|prep_question|question_bank (backend/src/services/tailoring)` · `interview|mock (backend/src/api/routes)` · `ls backend/migrations | grep -i interview|mock|coach`
+
+
+
+---
+
+# Appendix B — What users expect, per area (raw)
+
+
+## AI career co-pilot — a single conversational assistant that knows a UK job seeker's background and goals, and can be talked to about their career
+
+**How it should feel:** Fast, remembers-you, and grounded — concretely: (1) it opens already knowing your CV and last conversation, no re-onboarding; (2) when you ask 'find me something,' it comes back with actual live UK roles plus a one-line reason each one fits your specific background, not a generic list; (3) any text it drafts for you (CV bullet, cover letter line) reads like your own voice when you skim it, not a template with your name swapped in; (4) if it doesn't know something (does this company sponsor visas, is this listing still open), it says so instead of guessing; (5) cancelling or seeing what it costs takes one click, no hunting; (6) the tone is like a calm, competent friend who has your file open — plainspoken, specific, never a wall of hedging or corporate-speak. The opposite feeling to avoid: talking to a stranger who forgot you, handing you a form-letter, and burying the 'unsubscribe' button.
+
+
+| Priority | Expectation | Evidence |
+|---|---|---|
+| must | It must remember who I am across sessions — my CV, past conversations, goals, preferences — without me re-explaining every time. | https://getmentors.ai/blog/ai-career-coaching-app ; https://hydradb.com/blog/ai-chatbot-forgets-users-fix |
+| must | Job/course/salary suggestions must be current and locally grounded, not generic template advice that ignores the actual UK market or my situation. | https://getmentors.ai/blog/ai-career-coaching-app |
+| must | It must not fabricate — skills I don't have, job listings that no longer exist, salary figures, or 'facts' about a role/company. | https://www.trustpilot.com/review/jobright.ai ; https://www.training.nih.gov/oite-careers-blog/minimizing-ai-risks-in-your-job-search |
+| must | It should surface real job openings that match my profile and explain WHY each one fits, not just list generic titles. | https://www.indeed.com/careerscout ; https://www.hr-brew.com/stories/2025/09/10/indeed-releases-two-ai-agents-to-improve-hiring-process-for-ta-and-job-seekers |
+| must | Any generated CV bullet, cover letter, or answer should sound like ME, not like every other AI-assisted applicant. | https://doppelwriter.com/blog/ai-cover-letter-generator ; https://www.inc.com/kit-eaton/how-ai-slop-is-ruining-hiring/91229018 |
+| must | Pricing, cancellation, and what's included must be transparent up front — no surprise auto-renewal or hidden gating between 'free' and 'paid' tiers. | https://www.trustpilot.com/review/jobright.ai ; https://jobhire.ai/blog/aiapply-reviews |
+| must | It must be explicit about what it will and won't do with my CV/personal data, and give me control/visibility (UK GDPR-grade), especially if it screens, scores, or ranks anything about me. | https://ico.org.uk/about-the-ico/media-centre/news-and-blogs/2024/11/ico-intervention-into-ai-recruitment-tools-leads-to-better-data-protection-for-job-seekers/ ; https://itbrief.co.uk/story/uk-jobsee |
+| strong | It should proactively flag skill gaps and suggest concrete next steps (courses, certifications, projects) tied to my actual target roles. | https://m.umu.com/ask/q11122301573854539964 |
+| strong | It should track my applications/pipeline in one place so the copilot's advice is grounded in what I've actually done, not asked cold every time. | https://blog.loopcv.pro/teal-hq-review/ ; https://hiredradar.com/teal-hq-review/ |
+| strong | Support/help must be responsive when something goes wrong (a bad application sent, a billing issue, a broken feature) — not email-only with no SLA. | https://jobhire.ai/blog/jobright-ai-review-and-decision-guide-2026 |
+| nice | It should feel like a coach with a supportive tone that builds confidence, not a cold, jargon-heavy chatbot that just dumps advice. | https://getmentors.ai/blog/ai-career-coaching-app |
+
+**Dealbreakers — what makes people abandon this:**
+
+- Amnesia between sessions — having to re-explain your CV, goals, and constraints every single conversation reads as 'not real AI coaching' and drives users back to plain ChatGPT, which they then also abandon for the same reason (evidence: getmentors.ai, hydradb.com).
+- Hallucinated content — invented skills on your CV, fabricated metrics, expired/fake job listings, wrong salary numbers. Documented across Jobright and multiple AI resume tools; this is the fastest way to lose trust because it's discovered AFTER the user already acted on it (evidence: Trustpilot Jobright reviews, NIH careers blog).
+- Output that reads as generic 'AI slop' — recruiters and the market at large are now actively penalizing applications that sound templated; users who realize their copilot made them sound like everyone else stop using it (evidence: Inc.com, doppelwriter.com).
+- Billing/cancellation traps — silent auto-renewal, buried cancel buttons, charges continuing after cancellation. This is the #1 documented complaint pattern in the category (72% of Jobright's 1-star reviews) and converts a product problem into a trust catastrophe (evidence: Trustpilot).
+- Advertised automation that doesn't actually work as claimed (e.g., 'auto-apply' requiring a second paid tool, 'AI Agent... 90% automation' treated by reviewers as marketing spin) — users specifically call out the gap between the pitch and reality as why they distrust the whole category (evidence: BBB complaint via jobhire.ai, wobo.ai on Jobright's 90% claim).
+- No human escape hatch / no way to challenge a bad AI decision or get real support when something breaks — compounded in the UK by ICO's finding that most AI recruitment tools lack meaningful human review, which is exactly what erodes the 42% of UK job seekers who already trust humans over AI more.
+- Feeling screened/judged by a black box — UK job seekers specifically report low confidence in AI-led processes; a copilot that feels like it's silently scoring/gatekeeping rather than helping you triggers the same distrust as AI recruiter screening tools.
+
+**Who does this today:** Indeed Career Scout, LinkedIn AI Career Coach (Premium), Teal HQ, Jobright AI, Simplify Copilot, Careerflow, AiApply, FutureFit AI Career Copilot
+
+
+**Sources:**
+
+- https://jobhire.ai/blog/jobright-ai-review-and-decision-guide-2026
+- https://www.wobo.ai/blog/jobright-review
+- https://enhancv.com/blog/ai-hiring-statistics/
+- https://jobhire.ai/blog/aiapply-reviews
+- https://m.umu.com/ask/q11122301573854539964
+- https://en.ai-pedias.com/blog/ai-career-coaching-2026
+- https://www.trustpilot.com/review/jobright.ai
+- https://www.trustpilot.com/review/jobright.ai?page=4
+- https://zplatform.ai/ai-reviews/jobright-ai/
+- https://pitchhired.com/blog/is-jobright-legit
+- https://blog.loopcv.pro/teal-hq-review/
+- https://hiredradar.com/teal-hq-review/
+
+## Smart job matching (personalised, beyond keywords)
+
+**How it should feel:** "Open a job and the fit judgment is already there — no extra click, no waiting for a report to generate (this is the bar LinkedIn's Job Match sets: it appears automatically the instant you view a listing). The score is never a bare number alone; next to it sits a short breakdown — 2-4 lines: which required quals you clearly meet, which ones you're missing, and one line on the soft stuff (remote/hybrid, seniority, company stage) that a keyword search would never catch. If something in your history overlaps a requirement without using the exact same word (e.g. 'led a small team' vs 'management experience'), the copy should acknowledge that instead of silently scoring it zero. When the system is unsure, it says so in plain words rather than dressing up a shaky guess as 92% confidence. Every match respects the hard limits the person actually set (place, pay, title) — a violated filter should never appear disguised as a good match. And the person can always drop into a plain search/filter view instead of the curated feed, so a wrong guess by the algorithm costs them one click, not a dead end."
+
+
+| Priority | Expectation | Evidence |
+|---|---|---|
+| must | Show WHY a job matched — which specific skills/quals it hit and which it missed — not just a bare percentage or score. | https://pmc.ncbi.nlm.nih.gov/articles/PMC12546238/ ; https://www.briefcasecoach.com/how-to-use-linkedins-new-job-match-feature/ ; https://brainforge.ai/blog/how-linkedin-uses-ai-to-match-you-with-jobs |
+| must | Respect hard filters the person actually set (location, salary floor, job title) — don't recommend things that fail an explicit constraint. | https://stripe.jhu.edu/news/the-frustrating-reality-of-indeeds-irrelevant-job-suggestions ; https://www.trustpilot.com/review/www.indeed.com ; https://www.teamblind.com/post/job-search-site-marol3q1 |
+| must | Keep listings fresh and real — dead/expired postings shown as fresh matches destroy trust fast. | https://www.adzuna.co.uk/blog/jobright-review-better-alternative-in-2025/ ; https://stripe.jhu.edu/news/the-case-against-indeeds-frustrating-job-recommendations |
+| must | Match quality should visibly save real time, not add review overhead — every irrelevant match is a tax on an already time-poor search. | https://standout-cv.com/stats/job-search-statistics-uk ; https://stripe.jhu.edu/news/the-frustrating-reality-of-indeeds-irrelevant-job-suggestions |
+| strong | Understand transferable/adjacent skills, not literal keyword overlap — someone pivoting fields shouldn't get filtered out just because the exact term isn't on their CV. | https://www.emarketer.com/content/linkedin-s-shift-toward-ai-job-matching-recruitment-could-risk-oversimplifying-hiring-process |
+| strong | Match on soft/contextual preferences too — remote/hybrid, company stage, culture/values — not just title and skill overlap. | https://sprounix.com/blog/otta-job-search-insights ; https://scoutify.com/blog/otta-review/ ; https://www.emarketer.com/content/linkedin-s-shift-toward-ai-job-matching-recruitment-could-risk-oversimpl |
+| strong | Let the person see and correct what the algorithm believes about them — a curated-only feed with no manual search/filter path feels controlling when the model gets it wrong. | https://scoutify.com/blog/otta-review/ |
+| strong | Don't let AI-generated match copy read as generic slop or overclaim confidence the model doesn't have — mixed accuracy above ~85% scores was 'generally accurate but not infallible.' | https://www.wobo.ai/blog/jobright-review ; https://resumehog.com/blog/posts/jobright-ai-review-2026-is-this-job-search-copilot-worth-it.html ; https://www.peoplemanagement.co.uk/article/1957338/employ |
+| nice | Surface the match instantly, inline, at the point of viewing a job — not as a separate report you have to go generate. | https://blog.theinterviewguys.com/linkedins-new-ai-job-match-tool/ ; https://www.briefcasecoach.com/how-to-use-linkedins-new-job-match-feature/ |
+| nice | Be honest about billing/cost transparency around AI matching features — hidden paywalls or no-refund policies on a 'smart matching' pitch actively burn trust. | https://www.adzuna.co.uk/blog/jobright-review-better-alternative-in-2025/ |
+
+**Dealbreakers — what makes people abandon this:**
+
+- Recommending jobs that violate a hard constraint the user explicitly set (wrong location, pay below stated floor, wrong job title/level) — the single most-cited Indeed complaint found.
+- Stale/expired/ghost listings served as if current — directly tanked Jobright's Trustpilot score to 2.9/5 and is a named Indeed complaint too.
+- Opaque scores with no explanation ('why is this a 72% match?') — research on explainable recommenders shows black-box scores are the trust-killer; users disengage when they can't scrutinize the logic.
+- Pure keyword overlap that misses obviously transferable skills, pushing career-pivoters out of relevant matches — named directly as a risk of AI job matching in press coverage of LinkedIn's rollout.
+- Curated feed with no escape hatch to search/filter manually when the algorithm is wrong — Otta reviewers cite this as the real cost of a matching-only UX.
+- Billing dishonesty layered on top of an AI-matching pitch (hidden paywalls, no refunds) — compounds distrust of the AI claims themselves, per Jobright's review pattern.
+
+**Who does this today:** LinkedIn Job Match, Indeed (match score / recommendation engine), Otta / Welcome to the Jungle (fit score, work-style + culture matching), Jobright.ai (AI match score, 85%+ threshold), Jobscan (ATS/keyword match scoring), Adzuna (UK job market aggregator, publishes own market-quality commentary)
+
+
+**Sources:**
+
+- https://www.quora.com/LinkedIn-s-AI-job-Match-tool-recommends-terrible-fits-Why-are-top-hires-failing-on-purpose-to-get-noticed
+- https://www.emarketer.com/content/linkedin-s-shift-toward-ai-job-matching-recruitment-could-risk-oversimplifying-hiring-process
+- https://stripe.jhu.edu/news/the-frustrating-reality-of-indeeds-irrelevant-job-suggestions
+- https://stripe.jhu.edu/news/the-case-against-indeeds-frustrating-job-recommendations
+- https://www.trustpilot.com/review/www.indeed.com
+- https://www.teamblind.com/post/job-search-site-marol3q1
+- https://sprounix.com/blog/otta-job-search-insights
+- https://scoutify.com/blog/otta-review/
+- https://www.adzuna.co.uk/blog/jobright-review-better-alternative-in-2025/
+- https://www.wobo.ai/blog/jobright-review
+- https://resumehog.com/blog/posts/jobright-ai-review-2026-is-this-job-search-copilot-worth-it.html
+- https://pmc.ncbi.nlm.nih.gov/articles/PMC12546238/
+
+## AI resume + cover letter tailor — each application tuned to the specific job (UK-focused job-search product, individual job seekers)
+
+**How it should feel:** Concretely: the user pastes or picks a job posting, and within roughly 1-2 minutes (not 15-45 like manual tailoring) sees a live match score/percentage next to the job description with a short, specific list of missing keywords. The tailored CV and cover letter appear in an editable pane, side-by-side with the original job description, so the user can scan every changed line against their own memory of what actually happened in their career — nothing appears that they don't recognize as true. Edits are one click away, not a re-generation from scratch. The final document downloads instantly as a clean PDF/DOCX with no paywall surprise. Nothing in the wording feels swappable with another candidate's letter — it should reference the actual company/role specifics the user's profile and the job posting share. The whole loop should feel like a fast, honest second pair of eyes tightening what's already true — not a black box writing fiction on the user's behalf.
+
+
+| Priority | Expectation | Evidence |
+|---|---|---|
+| must | Paste/select a job description and get a per-job match score PLUS a specific list of missing/matched keywords (hard skills + soft skills), not just a vague 'tailored' label. | https://www.jobscan.co/blog/jobscan-vs-teal/ ; https://www.tealhq.com/tools/resume-builder |
+| must | The tailored draft must never invent employers, dates, tools, or metrics the user never had — it can only rephrase/reorder/emphasize real experience against the job description. | https://www.shrm.org/topics-tools/news/technology/how-to-spot-ai-generated-lies-on-a-resume ; https://www.gem.com/blog/detect-ai-generated-resumes ; https://hirecarta.com/blog/why-ai-resume-writers-li |
+| must | Output must not sound like generic 'AI voice' — no interchangeable buzzwords, no five-paragraph template every applicant to that ATS has seen, no phrase that could apply to any candidate. | https://coverlettercopilot.ai/blog/are-ai-cover-letters-detectable-by-recruiters ; https://www.teamblind.com/post/generic-reusable-cover-letter-abyeyot8 |
+| must | User can see and edit the tailored output before it's used/downloaded — an editable draft with the job description still visible, not a locked black-box generation. | https://www.tealhq.com/tools/resume-builder ; https://www.rezi.ai/posts/how-to-tailor-your-resume |
+| must | Download as a real, ATS-parseable file format (PDF and/or DOCX with clean formatting) — not locked behind a plain-text-only free tier or a late-stage paywall after the user already invested time. | https://pitchmeai.com/blog/zety-resume-builder-download-paywall ; https://resufit.com/blog/actually-free-resume-builders-no-hidden-paywalls/ |
+| must | No keyword-stuffing or hidden-text tricks to game the ATS score — matched keywords should appear inside real, context-rich achievement bullets. | https://www.jobscan.co/blog/resume-keyword-stuffing/ ; https://hireflow.net/blog/semantic-matching-ats-2026 |
+| strong | Fast turnaround — a tailored draft should be produced in roughly under 2 minutes of tool time, collapsing what used to be 15-45 minutes of manual tailoring per application. | https://blog.fastapply.co/how-to-tailor-resume-each-job-ai-2026 ; https://jd2cv.uk/blog/how-to-tailor-cv-to-job-description-ats-uk |
+| strong | Cover letter generation should be genuinely optional / low-friction, not force every application through a long-letter workflow. | https://resumegenius.com/blog/cover-letter-help/cover-letter-statistics |
+| strong | Company/role-specific detail (why THIS company, why THIS role) should be woven in automatically where the source data supports it, not left as a '[Company Name]' template blank. | https://coverlettercopilot.ai/blog/are-ai-cover-letters-detectable-by-recruiters |
+| nice | Score/keyword feedback should adapt to which ATS/company the job is likely posted through (Workday, Greenhouse, Taleo, iCIMS, or UK boards like Reed/CV-Library/Totaljobs) rather than one generic ATS m | https://www.jobscan.co/blog/jobscan-vs-teal/ ; https://www.wobo.ai/blog/simplify-review ; https://cv-scout.com/blog/what-is-ats-and-how-to-beat-it-uk |
+| nice | A visible diff / 'what changed and why' between the master CV/base letter and the tailored version, so the user can sanity-check every AI edit against their own memory of their real experience before  | LOW-CONFIDENCE — inferred from https://hirecarta.com/blog/why-ai-resume-writers-lie and https://www.tealhq.com/tools/resume-builder ; no source found describing a shipped 'diff view' feature specifica |
+
+**Dealbreakers — what makes people abandon this:**
+
+- Output reads as generic AI slop — buzzword-heavy, five-paragraph boilerplate that could apply to any candidate at any company; 67% of hiring managers say they can spot it and 54% view it negatively.
+- The tool fabricates or 'conflates' experience — adds a tool/skill/employer the user never had, or blends two real facts into one false-sounding claim; this is not just an annoyance, it can fail a technical interview or count as resume fraud.
+- Keyword-stuffed output that reads as obviously gamed — hidden text, repeated role titles, tool lists with no supporting achievement — gets caught by modern semantic ATS parsing or a human pasting the text and reads as 'someone trying to trick me,' an instant emotional no from the recruiter.
+- Paywall sprung AFTER the user has already spent 20-30 minutes building/tailoring, locking the finished PDF/DOCX behind a surprise auto-renewing trial — a documented, FTC-flagged dark pattern (Zety, MyPerfectResume) that burns trust immediately.
+- Slow or unreliable generation / autofill that breaks on the harder ATS platforms — documented autofill accuracy on Simplify Copilot dropped to ~40% on Taleo and ~50% on iCIMS, and general complaints include freezes and unreliable profile connections on the paid tier.
+- No user control over the final text — a locked/black-box generation the user can't edit before it goes out under their name is a trust-breaker for something as consequential as a job application.
+
+**Who does this today:** Jobscan, Teal, Rezi, Kickresume, Simplify Copilot, LazyApply, Zety, MyPerfectResume, Resume Genius
+
+
+**Sources:**
+
+- https://coverlettercopilot.ai/blog/are-ai-cover-letters-detectable-by-recruiters
+- https://www.teamblind.com/post/generic-reusable-cover-letter-abyeyot8
+- https://www.jobscan.co/blog/jobscan-vs-teal/
+- https://www.tealhq.com/tools/resume-builder
+- https://www.rezi.ai/posts/how-to-tailor-your-resume
+- https://www.shrm.org/topics-tools/news/technology/how-to-spot-ai-generated-lies-on-a-resume
+- https://www.gem.com/blog/detect-ai-generated-resumes
+- https://hirecarta.com/blog/why-ai-resume-writers-lie
+- https://www.jobscan.co/blog/resume-keyword-stuffing/
+- https://hireflow.net/blog/semantic-matching-ats-2026
+- https://blog.fastapply.co/how-to-tailor-resume-each-job-ai-2026
+- https://jd2cv.uk/blog/how-to-tailor-cv-to-job-description-ats-uk
+
+## Application tracker / CRM — for a UK-focused AI job-search product, aimed at individual job seekers who want to know what they sent, who replied, and what follow-up is due
+
+**How it should feel:** Adding a job takes one click if it came through the product's own search (auto-filled, no form) or under 30 seconds if pasted in manually — never a multi-field spreadsheet row. The main screen is a Kanban board (Saved → Applied → Interviewing → Offer → Rejected) you drag cards across, not a table. When a week passes with no reply on an 'Applied' card, a quiet badge or nudge appears on its own — the user never has to check a calendar or remember to chase anyone. If email sync is on, a rejection or interview invite auto-fills the card's status, but the original employer wording stays visible in the notes and low-confidence changes wait for a one-tap confirm, so the user never wonders 'did it just guess that wrong?'. Basic tracking (log, board, reminders) never hits a paywall mid-search — nothing about staying organized costs money, only optional AI extras do.
+
+
+| Priority | Expectation | Evidence |
+|---|---|---|
+| must | A single place to log every application (company, role, date applied, link, status) that replaces a spreadsheet, updated with near-zero manual typing per entry | https://www.qarera.com/blog/job-application-tracker-vs-spreadsheet ; https://medium.com/@shreya.nadkarni1998/why-linkedin-job-tracker-is-invisible-and-how-can-we-fix-it-d722f34eedad |
+| must | A visual pipeline/Kanban view with stages like Bookmarked/Saved → Applied → Interviewing → Offer → Rejected, that you can drag between | https://www.tealhq.com/tools/job-tracker (Bookmarked→Applied→Interviewing→Negotiating kanban) ; https://huntr.co/product/job-tracker (Kanban board named as the most credible feature in reviews) |
+| must | Automatic follow-up nudges when an application has gone quiet for N days — the tool has to remember, the user shouldn't have to | https://www.qarera.com/blog/job-application-tracker-vs-spreadsheet ; https://www.peoplemanagement.co.uk/article/1872244/the-hiring-process-broken-nine-10-workers-say-theyve-ghosted-recruiters-pm-poll- |
+| must | The tracker fills itself when a job is applied to through the product's own search/apply flow — no separate manual 'add to tracker' step required for jobs sourced inside the app | https://simplify.jobs/job-application-tracker ; https://help.simplify.jobs/articles/2415391-using-copilot-to-autofill-applications ; https://www.teamblind.com/post/linkedin-why-is-the-job-search-sudde |
+| must | Core tracking (log, pipeline, reminders) must be free/unlimited — do not paywall the basic job of tracking behind a subscription, only paywall AI extras (autofill, tailoring, resume scoring) | https://resumeoptimizerpro.com/blog/huntr-alternative ; https://www.trustpilot.com/review/huntr.co ; https://jobhire.ai/blog/jobright-ai-review-and-decision-guide-2026 |
+| strong | Optional email inbox scan to auto-detect rejections/interview invites, but only auto-apply high-confidence changes and ask for confirmation on the rest — never silently overwrite the user's record | https://www.ourskillstory.com/features/email-sync ; https://www.trackrjobs.com/ ; https://www.froghire.ai/blog/how-to-read-job-application-status-meanings |
+| strong | One unified view that captures applications regardless of source — job boards, company career portals, referrals, LinkedIn Easy Apply — not just the ones made inside the product | https://www.teamblind.com/post/linkedin-why-is-the-job-search-suddenly-so-broken-y8xj6drg |
+| strong | Per-application notes, recruiter/contact info, and interview details attached to the card, not a separate tool | https://www.tealhq.com/tools/job-tracker ; https://simplify.jobs/job-application-tracker |
+| strong | Logging a new application manually (for jobs found outside the product) should take under ~30 seconds — a couple of fields, not a full form | https://www.qarera.com/blog/job-application-tracker-vs-spreadsheet |
+| nice | Simple response-rate / funnel stats (applied vs interviewed vs offers) surfaced passively, not as a separate analytics module | https://enhancv.com/features/job-application-tracker/ (marketing claim, not user complaint — low confidence) |
+
+**Dealbreakers — what makes people abandon this:**
+
+- Paywalling the basic tracking function (not just AI extras) — Huntr's $40/mo Pro plan and Teal's free-tier keyword/match-score limits are the #1 and most-debated user objections found in reviews.
+- Manual data entry that doesn't shrink with volume — this is the exact, documented reason people abandon spreadsheets once past ~15-20 active applications (4-5 hrs/week of copy-paste admin).
+- Auto-detected statuses that are silently wrong or overwrite the user's own record — employer status labels vary wildly by ATS, and a tool that reinterprets them without letting the user confirm will lose trust fast (this is the core 'anxious, sceptical of AI slop' risk named in the brief).
+- A tracker that lives disconnected from where the user actually applies, forcing them to re-enter data across LinkedIn, job boards, and portals — the most concrete user complaint found ('everything starts to feel fragmented').
+- A feature nobody discovers — LinkedIn's own job tracker is a cautionary tale: 56% of surveyed job seekers didn't even know it existed, so it lost to spreadsheets and memory purely on visibility, not on missing capability.
+- Silence/no feedback loop mirroring the exact anxiety the product is meant to relieve — 55-75% of applications get no employer response and 65% of UK job seekers report being ghosted; a tracker that just sits there without proactively surfacing 'this one's gone quiet' fails the core promise.
+
+**Who does this today:** Huntr, Teal (Teal HQ), Simplify / Simplify Copilot, LinkedIn Job Tracker / My Jobs, Jobright.ai, Careerflow.ai, Trackr (trackrjobs.com), SkillStory (email status sync), JobTrack (jobtracks.co.uk — UK public sector / NHS / Civil Service specific)
+
+
+**Sources:**
+
+- https://huntr.co/product/job-tracker
+- https://www.wobo.ai/blog/huntr-review/
+- https://resumeoptimizerpro.com/blog/huntr-alternative
+- https://www.trustpilot.com/review/huntr.co
+- https://www.tealhq.com/tools/job-tracker
+- https://jobcopilot.com/teal-review/
+- https://resumehog.com/blog/posts/teal-hq-review-2026-is-this-job-search-tool-worth-it.html
+- https://www.wobo.ai/blog/teal-review/
+- https://simplify.jobs/job-application-tracker
+- https://simplify.jobs/copilot
+- https://help.simplify.jobs/articles/2415391-using-copilot-to-autofill-applications
+- https://blog.theinterviewguys.com/why-75-of-job-applications-vanish-into-a-black-hole/
+
+## AI interview coach — practice for technical, behavioural and communication rounds, with feedback (UK job-search product, individual job seekers)
+
+**How it should feel:** "It should feel like a real conversation, not a form. The user talks (voice, not typing), the AI actually waits for them to finish a thought before responding — no mid-sentence interruptions. Right after each answer (or at the end of the session), a feedback panel appears within seconds and it quotes the user's own words back at them — e.g. 'you said \"I helped the team\" — try \"I cut deploy time 35% by...\"' — plus hard numbers (filler-word count, pace, STAR-coverage checklist), never a vague 'good job.' Across sessions there's a simple trend line (fillers per minute, STAR completeness) so the user can SEE themselves improving week to week — that's what earns trust from someone who applies to a lot of roles and is short on time. It should never pretend to be human (no fake face/voice mimicry), it should say plainly if/how a session is recorded, and the free tier should be generous enough that a sceptical user can judge the feedback quality before paying anything."
+
+
+| Priority | Expectation | Evidence |
+|---|---|---|
+| must | Real, spoken back-and-forth practice (voice in, voice or structured feedback out) — not a text quiz. | HiredKit praised for 'genuine two-way spoken mock' (favtutor.com/best-ai-mock-interview-tools-2026); Yoodli and interviewing.io are both voice-based (g2.com/products/yoodli-inc-yoodli/reviews; intervi |
+| must | Feedback must be specific and quantified, tied to the user's actual words — not generic praise or cookie-cutter phrasing. | Yoodli's 'feedback is specific and quantified rather than vague... filler words drop from 30 to 5' (techraisal.com/blog/yoodli-ai-review-a-practical-look); Blind/geekempowered users called generic AI  |
+| must | It must feel like it's actually listening — no cutting the user off mid-thought, no rushing to the next question. | Substack review: 'The AI cut off responses mid-thought and moved quickly to the next question without genuine engagement' — described the whole experience as 'officially creeped out' / impersonal (sou |
+| must | No avatar/deepfake of the user's own face or voice, and no ambiguity about whether the session is recorded or how it's evaluated, without explicit consent. | 'A video avatar tool that looked and sounded like them without their consent... officially creeped out'; 'unclear if interactions were being recorded or fairly evaluated' (sourcesmayvary.substack.com/ |
+| must | Structured behavioural feedback against a known framework (STAR: situation/task/action/result) with a concrete rewrite suggestion, not just a score. | 'AI highlights what worked, what was missing, and how to refine responses'; example given: 'Increased team productivity by 35%...' is flagged as stronger than 'I helped the team work better' (Adobe: a |
+| must | Honest marketing and clean billing — no fake testimonials, no non-refundable traps or hidden session caps. | Final Round AI: '17% one-star reviews cite billing issues... non-refundable monthly plan and 5-session monthly cap' (remotejobassistant.com/blog/final-round-ai-review); Blind thread on Superinterviews |
+| strong | Accurate speech recognition and fair scoring across accents. | Accent-related transcription accuracy issues flagged in speech-tool reviews (g2.com/products/sonix-sonix-ai/reviews); general concern that 'AI interview feedback tools can rate responses differently b |
+| strong | A real free tier or free first session, not a paywall before the user can judge quality. | 'HiredKit leads here on ethical live-voice practice... free first stage'; Yoodli 'free Starter plan includes 5 lifetime roleplay sessions' (favtutor.com/best-ai-mock-interview-tools-2026; g2.com/produ |
+| strong | Progress tracking across sessions (trend, not just a one-off score). | Yoodli's headline feature is watching a metric move over repeated sessions, e.g. filler-word count trending down (techraisal.com/blog/yoodli-ai-review-a-practical-look) |
+| strong | Coverage of both technical/coding rounds and behavioural rounds in one place, so the user isn't stitching together three tools. | 'The best AI mock interview setup... is a small stack: PracHub for questions, Interviewing.io for live human mocks, Pramp/Exponent for peer practice, and a delivery coach like Yoodli' (favtutor.com/be |
+| nice | Recently-asked, role-specific questions rather than a generic static bank. | PracHub recommended specifically 'for real, recently-asked interview questions' as distinct from generic mock tools (favtutor.com/best-ai-mock-interview-tools-2026) |
+| nice | Option to redo/retry a single answer immediately rather than restart the whole mock. | Low-confidence inference from interview-anxiety research showing most candidates are nervous hours before an interview and want low-risk rehearsal (standout-cv.com/stats/job-interview-statistics) |
+
+**Dealbreakers — what makes people abandon this:**
+
+- Deepfake-style avatar of the user's own face/voice without explicit consent — reads as an ethical violation, not a feature ('officially creeped out').
+- Generic, cookie-cutter feedback that could apply to any answer — instantly signals AI slop to sceptical users and they say so publicly.
+- AI cuts the user off mid-answer or rushes through questions — breaks the illusion of a real interview and feels disrespectful of the user's effort.
+- Opaque recording/evaluation — user can't tell if the session is being recorded or how it's judged.
+- Billing traps: non-refundable plans, hidden session caps, subscription pressure before value is proven.
+- Fake or unverifiable testimonials/marketing claims — once caught, users warn whole communities off the product (Blind threads exist specifically for this).
+- Misheard answers or biased scoring tied to accent/speech pattern — feels unfair, not just inaccurate.
+- Live 'copilot that whispers answers during a real interview' framing — a meaningfully large share of users (and likely employers) call this cheating, which is reputationally toxic even if some users want it; keep the product firmly in the practice/rehearsal lane, not real-time assistance during an actual interview.
+
+**Who does this today:** Yoodli, Final Round AI, Huru, interviewing.io, Pramp / Exponent (tryexponent.com), HiredKit, Google Interview Warmup (retired ~April 2026), Big Interview, MockWin, AiApply, AceRound
+
+
+**Sources:**
+
+- https://jobhire.ai/blog/aiapply-reviews
+- https://ophyai.com/blog/interview-tips/ai-interview-assistant-reddit
+- https://www.aceround.app/blog/ai-interview-assistant-reddit/
+- https://www.remotejobassistant.com/blog/final-round-ai-review
+- https://favtutor.com/best-ai-mock-interview-tools-2026/
+- https://interviewsidekick.com/blog/best-ai-interview-software
+- https://www.hiredkit.ai/blog/best-ai-interview-prep-tools-2026
+- https://prachub.com/resources/7-best-ai-mock-interview-platforms-in-2026-ranked-by-real-engineers
+- https://ophyai.com/best-ai-mock-interview
+- https://www.teamblind.com/post/anyone-tried-superinterviews-interview-preparation-site-2wqwwmy5
+- https://sourcesmayvary.substack.com/p/i-just-did-a-job-interview-with-an
+- https://www.teamblind.com/post/built-an-ai-tool-to-prep-for-interviews-after-blowing-35-sharing-in-case-it-helps-others-u1bvpfjb
+---
+
+# Fix shipped 2026-07-28 — the feed was hiding itself
+
+Found while verifying the research above. Both numbers below are **measured in
+prod**, not estimated.
+
+## What was wrong
+
+| Gate | Set to | Reality | Effect |
+|---|---|---|---|
+| `DEFAULT_MIN_SCORE` (frontend) | 20 | score p50=**10**, p90=**26** | floor sat above the 90th percentile → **87.5% of the feed hidden** (3,236 rows → 406 shown) |
+| `ENRICHMENT_THRESHOLD` (backend) | 60 | **max score in the entire feed = 58** | stage had **never run once**; `job_enrichment` held **0 rows** |
+
+Measured across 3,342 feed rows / 3,688 catalog jobs, 2026-07-28.
+
+```
+score histogram      0-10:    35
+                    10-20: 2,795   <- 84% of the whole feed
+                    20-30:   254
+                    30-40:   197
+                    40-50:    47
+                    50-60:    14
+                    60+  :     0   <- the enrichment gate lives up here
+```
+
+**Root cause:** `merge_cv_and_preferences` used to copy the entire CV into
+preferences, inflating every score. Removing that (correctly) dropped scores to
+normal. Neither gate was re-tuned. The scores moved; the goalposts did not.
+
+**Why nobody noticed the enrichment one:** 0 rows selected produces no error, no
+log and no empty state. *A filter tuned past your maximum is indistinguishable
+from a feature that was never built.* The 20-floor at least left a short list;
+the 60-gate left nothing to see at all.
+
+**Corroborating evidence it is a threshold problem, not an engine problem:** the
+LLM judge (engine 4) was running fine in the same prod — 80 verdicts, max
+`llm_fit_score` 90, and in 44 rows it scored a job *higher* than the keyword
+engine. Engine 4 uses `MATCHER_MAX_JOBS` (a budget). Engine 2 used a threshold.
+Same product, same data, opposite outcome.
+
+## The fix
+
+**Rank, never hide.** `DEFAULT_MIN_SCORE` → **0**. Sorting already puts the best
+first and users stop scrolling when quality drops, so the floor bought nothing
+the sort did not already give — while risking an empty product. The slider still
+works for anyone who wants a floor; it is just no longer imposed.
+
+**Budget, never threshold.** `ENRICHMENT_THRESHOLD` → `ENRICHMENT_MAX_JOBS=20` +
+`ENRICHMENT_MIN_SCORE=10`. A threshold is a *claim about the score
+distribution*, and distributions move. A budget makes no such claim — it works
+whether the top score is 58 or 95 — and doubles as a hard cost ceiling, which a
+threshold never was.
+
+**Never hide silently.** `JobListResponse` gained `total_unfiltered`, so the UI
+can say "N hidden by filters · show all". Any future mis-tuned filter announces
+itself instead of looking like an empty feed.
+
+**Alarm on zero.** If the enrichment budget ever selects nothing, it now logs a
+warning naming the best score it saw and the floor in force.
+
+## Verified
+
+- 4 new backend tests pin the budget property at any distribution scale, incl.
+  the exact prod histogram (`tests/test_job_enrichment.py`)
+- 2 new Playwright specs drive the real browser: every job renders by default,
+  no request may impose a floor, and hidden rows are announced with a way back
+  (`tests/e2e/feed-visibility.spec.ts`)
+- `tests/test_api.py` + `tests/test_main.py`: 43 passed
+
+## Side-finding: the e2e suite was testing Grafana
+
+`playwright.config.ts` had `reuseExistingServer: !CI` against a hardcoded port
+3000 — and Grafana owns 3000 on this machine. Playwright silently ran the whole
+suite against Grafana; every spec failed with "element not found" and looked
+like a real regression. The page snapshot said `<title>Grafana</title>`. Port is
+now configurable via `E2E_PORT`, so a busy 3000 is a non-event.

--- a/backend/src/api/models.py
+++ b/backend/src/api/models.py
@@ -138,6 +138,12 @@ class JobResponse(BaseModel):
 class JobListResponse(BaseModel):
     jobs: list[JobResponse]
     total: int
+    # Rows before min_score was applied. `total - total_unfiltered` is what the
+    # filter removed, which the UI shows as "N hidden by filters". Without it a
+    # filter tuned above the score distribution looks identical to an empty feed —
+    # exactly how 2,830 of one user's 3,236 jobs vanished with nothing on screen
+    # to say so. Defaults to 0 for back-compat with older clients.
+    total_unfiltered: int = 0
     filters_applied: dict[Any, Any]
 
 

--- a/backend/src/api/routes/jobs.py
+++ b/backend/src/api/routes/jobs.py
@@ -460,10 +460,20 @@ async def list_jobs(
     # callers (sitemap / unfurl bots) get the shared catalog. No fallback: an
     # empty feed shows the empty dashboard, never another user's jobs.
     # Step-1 B6: single LEFT JOIN avoids per-job enrichment lookups (N+1).
+    # Fetch UNFILTERED, then apply min_score in Python, so we can report how many
+    # rows the filter removed. Without that number the UI cannot say "N hidden",
+    # and a filter that hides everything is indistinguishable from an empty feed —
+    # measured 2026-07-28: 3,236 rows -> 406 visible at the old default of 20,
+    # with nothing on screen explaining the missing 2,830.
+    # No extra cost: this route already loads every row and paginates in Python.
     if user is not None:
-        all_rows = await db.get_user_feed_jobs(user.id, days=days, min_score=min_score or 0)
+        all_rows = await db.get_user_feed_jobs(user.id, days=days, min_score=0)
     else:
-        all_rows = await db.get_recent_jobs_with_enrichment(days=days, min_score=min_score or 0)
+        all_rows = await db.get_recent_jobs_with_enrichment(days=days, min_score=0)
+
+    total_unfiltered = len(all_rows)
+    if min_score:
+        all_rows = [r for r in all_rows if (r["match_score"] or 0) >= min_score]
 
     if mode == "hybrid":
         # Rank semantically against the caller's OWN profile (not the top job).
@@ -543,7 +553,12 @@ async def list_jobs(
     if visa_only:
         filters_applied["visa_only"] = visa_only
 
-    return JobListResponse(jobs=jobs, total=total, filters_applied=filters_applied)
+    return JobListResponse(
+        jobs=jobs,
+        total=total,
+        total_unfiltered=total_unfiltered,
+        filters_applied=filters_applied,
+    )
 
 
 @router.get("/jobs/{job_id}/duplicates")

--- a/backend/src/core/settings.py
+++ b/backend/src/core/settings.py
@@ -114,10 +114,29 @@ MIN_STORE_SCORE = int(os.getenv("MIN_STORE_SCORE", "1"))
 MAX_RESULTS_PER_SOURCE = 100
 MAX_DAYS_OLD = 7
 
-# Step-1 B7 — gate the LLM enrichment pipeline by score. Only jobs whose
-# match_score >= ENRICHMENT_THRESHOLD get sent to the LLM. Default 60 cuts
-# noise-floor traffic and keeps free-tier provider quotas usable.
-ENRICHMENT_THRESHOLD = int(os.getenv("ENRICHMENT_THRESHOLD", "60"))
+# Step-1 B7 — gate the LLM enrichment pipeline.
+#
+# WAS a hard threshold of 60. Measured in prod 2026-07-28: the maximum
+# match_score across the entire 3,342-row feed was 58 and `job_enrichment` held
+# 0 rows. The gate sat ABOVE the highest score the scorer can produce, so this
+# stage had never run once — and produced no error, no log and no empty state
+# while doing so. A filter tuned past your maximum is indistinguishable from a
+# feature that was never built.
+#
+# Cause: the distribution moved. `merge_cv_and_preferences` used to copy the
+# whole CV into preferences, inflating every score; removing that dropped scores
+# to normal, and this constant was never re-tuned.
+#
+# Now a BUDGET: enrich the best N per run, above a low sanity floor. A budget
+# makes no claim about the distribution, so it cannot go stale — and it doubles
+# as a hard cost ceiling, which a threshold never was. Same pattern as
+# MATCHER_MAX_JOBS (engine 4), which is precisely why the LLM judge was running
+# in prod while enrichment was dark.
+ENRICHMENT_MAX_JOBS = int(os.getenv("ENRICHMENT_MAX_JOBS", "20"))
+ENRICHMENT_MIN_SCORE = int(os.getenv("ENRICHMENT_MIN_SCORE", "10"))
+# Back-compat: some call sites / .env files still reference the old name. Kept as
+# an alias of the floor so nothing breaks, but it is no longer the gate.
+ENRICHMENT_THRESHOLD = int(os.getenv("ENRICHMENT_THRESHOLD", str(ENRICHMENT_MIN_SCORE)))
 
 # Step-1 B12 — per-user concurrent search cap. POST /search refuses with
 # HTTP 429 once a user already has this many runs in `pending`/`running`

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -14,7 +14,8 @@ from src.core.settings import (
     CAREERJET_AFFID,
     DB_PATH,
     DFE_APPRENTICESHIPS_API_KEY,
-    ENRICHMENT_THRESHOLD,
+    ENRICHMENT_MAX_JOBS,
+    ENRICHMENT_MIN_SCORE,
     EXPORTS_DIR,
     FINDWORK_API_KEY,
     JOOBLE_API_KEY,
@@ -851,18 +852,52 @@ async def run_search(
             from src.core.settings import ENGINE2_ENABLED  # noqa: PLC0415
 
             if ENGINE2_ENABLED or ENRICHMENT_ENABLED:
-                high_scored = [
+                # BUDGET, not a threshold. Measured in prod 2026-07-28: the highest
+                # match_score in the entire 3,342-row feed was 58, against a
+                # threshold of 60 — so this stage had NEVER run, and job_enrichment
+                # held 0 rows. It could not have run: the gate sat above the
+                # maximum the scorer can currently produce.
+                #
+                # A threshold is a claim about the score distribution. That
+                # distribution moved when the CV-copy merge was removed from
+                # merge_cv_and_preferences (scores fell to normal), and the gate
+                # was never re-tuned. Worse, the failure is SILENT: zero rows
+                # selected logs nothing, raises nothing, and looks exactly like a
+                # feature that was never built.
+                #
+                # "Best N per run" makes no claim about the distribution at all. It
+                # works whether the top score is 58 or 95, self-adjusts as scoring
+                # changes, and doubles as a hard cost ceiling — the same pattern
+                # MATCHER_MAX_JOBS already uses for the LLM judge (engine 4), which
+                # is why THAT engine was running (80 verdicts in prod) while this
+                # one was dark.
+                eligible = [
                     j
                     for j in unique_jobs
                     if getattr(j, "id", None) is not None
                     and j.match_score is not None
-                    and j.match_score >= ENRICHMENT_THRESHOLD
+                    and j.match_score >= ENRICHMENT_MIN_SCORE
                 ]
+                eligible.sort(key=lambda j: j.match_score or 0, reverse=True)
+                high_scored = eligible[:ENRICHMENT_MAX_JOBS]
                 if high_scored:
                     logger.info(
-                        "Enriching %s jobs with match_score >= %s",
+                        "Enriching top %s of %s eligible jobs (budget=%s, floor=%s, best score=%s)",
                         len(high_scored),
-                        ENRICHMENT_THRESHOLD,
+                        len(eligible),
+                        ENRICHMENT_MAX_JOBS,
+                        ENRICHMENT_MIN_SCORE,
+                        high_scored[0].match_score,
+                    )
+                elif unique_jobs:
+                    # Never fail silently again: if the budget selected nothing,
+                    # say why. This log is the alarm the old threshold lacked.
+                    best = max((j.match_score or 0) for j in unique_jobs)
+                    logger.warning(
+                        "Enrichment selected 0 jobs — %s scored, best was %s, floor is %s",
+                        len(unique_jobs),
+                        best,
+                        ENRICHMENT_MIN_SCORE,
                     )
                     # Concurrency 3 (not 10): free-tier LLMs cap at ~30 requests/min
                     # (Cerebras) and small token/min budgets (Groq). A burst of 10

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -880,6 +880,17 @@ async def run_search(
                 ]
                 eligible.sort(key=lambda j: j.match_score or 0, reverse=True)
                 high_scored = eligible[:ENRICHMENT_MAX_JOBS]
+                if not high_scored and unique_jobs:
+                    # Never fail silently again: if the budget selected nothing,
+                    # say why. This log is the alarm the old threshold lacked —
+                    # a stage that selects 0 rows otherwise looks identical to a
+                    # stage that was never built.
+                    logger.warning(
+                        "Enrichment selected 0 jobs — %s scored, best was %s, floor is %s",
+                        len(unique_jobs),
+                        max((j.match_score or 0) for j in unique_jobs),
+                        ENRICHMENT_MIN_SCORE,
+                    )
                 if high_scored:
                     logger.info(
                         "Enriching top %s of %s eligible jobs (budget=%s, floor=%s, best score=%s)",
@@ -888,16 +899,6 @@ async def run_search(
                         ENRICHMENT_MAX_JOBS,
                         ENRICHMENT_MIN_SCORE,
                         high_scored[0].match_score,
-                    )
-                elif unique_jobs:
-                    # Never fail silently again: if the budget selected nothing,
-                    # say why. This log is the alarm the old threshold lacked.
-                    best = max((j.match_score or 0) for j in unique_jobs)
-                    logger.warning(
-                        "Enrichment selected 0 jobs — %s scored, best was %s, floor is %s",
-                        len(unique_jobs),
-                        best,
-                        ENRICHMENT_MIN_SCORE,
                     )
                     # Concurrency 3 (not 10): free-tier LLMs cap at ~30 requests/min
                     # (Cerebras) and small token/min budgets (Groq). A burst of 10

--- a/backend/tests/test_job_enrichment.py
+++ b/backend/tests/test_job_enrichment.py
@@ -648,3 +648,55 @@ async def test_enrich_batch_persists_results_to_db(db_with_schema):
         loaded = await load_enrichment(conn, job.id)
         assert loaded is not None
         assert loaded.title_canonical == valid.title_canonical
+
+
+# ---------------------------------------------------------------------------
+# Enrichment BUDGET (replaces the old absolute ENRICHMENT_THRESHOLD)
+#
+# Regression guard for a silent, total failure measured in prod 2026-07-28:
+# the gate was `match_score >= 60`, the highest score in the entire 3,342-row
+# feed was 58, and `job_enrichment` held 0 rows. The stage had never run once
+# and said nothing while not running.
+#
+# A threshold is a claim about the score distribution; the distribution moved
+# and the claim went stale. A budget makes no such claim. These tests pin that
+# property: selection must work at ANY scale of scores.
+# ---------------------------------------------------------------------------
+
+
+def _pick(scores, budget, floor):
+    """Mirror of the selection in src/main.py's enrichment stage."""
+    jobs = [type("J", (), {"id": i, "match_score": s})() for i, s in enumerate(scores)]
+    eligible = [j for j in jobs if j.id is not None and j.match_score is not None and j.match_score >= floor]
+    eligible.sort(key=lambda j: j.match_score or 0, reverse=True)
+    return [j.match_score for j in eligible[:budget]]
+
+
+def test_budget_selects_best_jobs_when_all_scores_are_below_the_old_threshold():
+    """THE bug. Real prod distribution: nothing above 58, old gate was 60."""
+    prod_like = [10] * 2795 + [25] * 254 + [35] * 197 + [45] * 47 + [55] * 14
+    picked = _pick(prod_like, budget=20, floor=10)
+    assert len(picked) == 20, "budget must fill even though no score reaches 60"
+    # Best-first: only 14 jobs score 55, so the budget takes all of those and
+    # then drops to the next band. It must never take the FIRST 20 it walks past.
+    assert picked == [55] * 14 + [45] * 6
+    assert picked == sorted(picked, reverse=True), "selection must be best-first"
+    # The old behaviour, for contrast: an absolute floor of 60 selects nothing.
+    assert _pick(prod_like, budget=20, floor=60) == []
+
+
+def test_budget_is_a_hard_cost_ceiling():
+    """Even if every job scores perfectly, we never exceed the budget."""
+    assert len(_pick([100] * 500, budget=20, floor=10)) == 20
+
+
+def test_budget_survives_a_distribution_shift_in_either_direction():
+    """The property a threshold lacks: correct at any scale, no re-tuning."""
+    for top in (12, 58, 95):
+        picked = _pick([top - 2, top - 1, top], budget=2, floor=10)
+        assert picked == [top, top - 1], f"failed at distribution topping out at {top}"
+
+
+def test_floor_still_drops_true_noise():
+    """A budget is not 'enrich everything' — the sanity floor still applies."""
+    assert _pick([1, 2, 3], budget=20, floor=10) == []

--- a/backend/tests/test_main_scheduler_wiring.py
+++ b/backend/tests/test_main_scheduler_wiring.py
@@ -290,8 +290,13 @@ async def test_enrichment_runs_after_insert_so_jobs_have_db_ids(tmp_db_path, mon
     )
 
     # Turn enrichment ON and enrich everything that clears the score filter.
+    # The absolute ENRICHMENT_THRESHOLD was replaced by a budget (max jobs) plus
+    # a low sanity floor — the old constant sat above the maximum score the
+    # scorer could produce, so the stage never ran. Floor 0 + a generous budget
+    # keeps this test's intent: "enrich everything, then check the DB ids".
     monkeypatch.setattr(main_mod, "ENRICHMENT_ENABLED", True)
-    monkeypatch.setattr(main_mod, "ENRICHMENT_THRESHOLD", 0)
+    monkeypatch.setattr(main_mod, "ENRICHMENT_MIN_SCORE", 0)
+    monkeypatch.setattr(main_mod, "ENRICHMENT_MAX_JOBS", 1000)
 
     # Capture the jobs handed to enrich_batch (no live LLM — rule #4).
     captured: dict = {}

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -482,6 +482,11 @@
           "total": {
             "title": "Total",
             "type": "integer"
+          },
+          "total_unfiltered": {
+            "default": 0,
+            "title": "Total Unfiltered",
+            "type": "integer"
           }
         },
         "required": [

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,5 +1,14 @@
 import { defineConfig, devices } from "@playwright/test";
 
+// Port is configurable because 3000 is the most contested port on any dev box.
+// If something else already owns it (Grafana, another Next app), Playwright's
+// `reuseExistingServer` silently runs the whole suite AGAINST THAT APP: every
+// spec fails with "element not found" and looks like a real regression. That
+// cost a debugging cycle on 2026-07-28 — the page snapshot said "Grafana".
+// `E2E_PORT=3011 npm run test:e2e` now sidesteps it without killing anything.
+const PORT = process.env.E2E_PORT ?? "3000";
+const BASE_URL = `http://localhost:${PORT}`;
+
 export default defineConfig({
   testDir: "./tests/e2e",
   fullyParallel: true,
@@ -14,7 +23,7 @@ export default defineConfig({
   timeout: process.env.CI ? 90_000 : 30_000,
   expect: { timeout: process.env.CI ? 20_000 : 5_000 },
   use: {
-    baseURL: "http://localhost:3000",
+    baseURL: BASE_URL,
     trace: "on-first-retry",
   },
   projects: [
@@ -30,8 +39,10 @@ export default defineConfig({
     // specs fail (even after 2 retries). A prebuilt server navigates instantly —
     // verified locally: 7 specs 1.9m (dev) -> 32s (start). Locally we still reuse a
     // running `npm run dev` for fast iteration.
-    command: process.env.CI ? "npm run build && npm run start" : "npm run dev",
-    url: "http://localhost:3000",
+    command: process.env.CI
+      ? `npm run build && npm run start -- --port ${PORT}`
+      : `npm run dev -- --port ${PORT}`,
+    url: BASE_URL,
     reuseExistingServer: !process.env.CI,
     // Turn on the middleware's E2E auth bypass (src/middleware.ts) so the hermetic,
     // mocked specs pass the session guard without a live backend. Never set in prod.

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -145,6 +145,12 @@ export default function DashboardPage() {
     [jobsData?.jobs]
   );
   const total = jobsData?.total ?? 0;
+  // How many rows the min_score filter removed. A hidden job with nothing on
+  // screen saying it is hidden reads as "the product found nothing" — which is
+  // how 2,830 of one user's 3,236 jobs disappeared silently (measured
+  // 2026-07-28). Never hide without saying so.
+  const totalUnfiltered = jobsData?.total_unfiltered ?? 0;
+  const hiddenByFilters = Math.max(0, totalUnfiltered - total);
 
   // ---------------------------------------------------------------------------
   // TanStack Query — unfiltered list for accurate bucket counts
@@ -422,6 +428,22 @@ export default function DashboardPage() {
                 <>
                   <span className="font-mono text-foreground">{total}</span> jobs
                   matched your profile
+                  {hiddenByFilters > 0 && (
+                    <>
+                      {" · "}
+                      <span className="font-mono text-foreground">{hiddenByFilters}</span>{" "}
+                      hidden by filters{" "}
+                      <button
+                        type="button"
+                        onClick={() =>
+                          setFilters((f) => ({ ...f, min_score: 0 }))
+                        }
+                        className="underline hover:no-underline"
+                      >
+                        show all
+                      </button>
+                    </>
+                  )}
                 </>
               ) : isLoading ? (
                 "Loading jobs..."

--- a/frontend/src/components/jobs/FilterPanel.tsx
+++ b/frontend/src/components/jobs/FilterPanel.tsx
@@ -44,8 +44,23 @@ import type { JobFilters } from "@/lib/types";
  * So a 30 default hides 87% of the feed from every NEW user — the product
  * looks empty on day one. 20 keeps a real filter (drops the weakest ~38%)
  * while leaving a populated feed. Change this one constant to re-tune.
+ *
+ * RE-MEASURED IN PROD 2026-07-28 — 20 is still far too high:
+ *   user 88e7d907: 3,236 feed rows -> 406 visible at >=20   (87.5% hidden)
+ *   whole feed:    3,342 rows      -> 512 visible at >=20
+ *   score p50 = 10, p90 = 26, max = 58
+ * A floor of 20 sits near the 90th percentile, so it hides nine jobs in ten.
+ *
+ * DEFAULT IS NOW 0 — rank, never hide.
+ *
+ * Any non-zero default is a claim about the score distribution, and that
+ * distribution moves every time scoring changes (it did when the CV-copy merge
+ * was removed from merge_cv_and_preferences). Sorting by score already puts the
+ * best first, and users stop scrolling when quality drops — so the filter buys
+ * nothing that the sort does not already give, while risking an empty product.
+ * The slider still works for anyone who wants a floor; it just is not imposed.
  */
-export const DEFAULT_MIN_SCORE = 20;
+export const DEFAULT_MIN_SCORE = 0;
 
 const DEFAULT_FILTERS: JobFilters = {
   min_score: DEFAULT_MIN_SCORE,

--- a/frontend/src/lib/api-types.ts
+++ b/frontend/src/lib/api-types.ts
@@ -1649,6 +1649,11 @@ export interface components {
             jobs: components["schemas"]["JobResponse"][];
             /** Total */
             total: number;
+            /**
+             * Total Unfiltered
+             * @default 0
+             */
+            total_unfiltered: number;
         };
         /** JobResponse */
         JobResponse: {

--- a/frontend/tests/e2e/feed-visibility.spec.ts
+++ b/frontend/tests/e2e/feed-visibility.spec.ts
@@ -1,0 +1,202 @@
+import { test, expect, type Page } from "@playwright/test";
+
+/**
+ * Feed visibility — the filter must never hide the product silently.
+ *
+ * THE BUG (measured in prod 2026-07-28, not hypothesised):
+ *   user 88e7d907 had 3,236 feed rows and saw 406 of them — 87.5% hidden —
+ *   because DEFAULT_MIN_SCORE was 20 while the score distribution was
+ *   p50=10, p90=26, max=58. The floor sat above the 90th percentile.
+ *   Nothing on screen said anything was hidden, so a heavily-filtered feed
+ *   looked exactly like a product that had found nothing.
+ *
+ * Two guarantees pinned here:
+ *   1. Out of the box, NOTHING is filtered out. Rank, never hide.
+ *   2. If the user does set a floor, the UI says how many that floor removed
+ *      and offers a way back. A hidden job with nothing announcing it is
+ *      indistinguishable from a job that does not exist.
+ *
+ * Hermetic (frontend-only), same pattern as dashboard-sort.spec.ts: fake the
+ * session cookie (middleware only checks presence) and mock the API.
+ */
+
+const SESSION_COOKIE = {
+  name: "job360_session",
+  value: "e2e-token",
+  domain: "localhost",
+  path: "/",
+};
+
+// Mirrors the real prod histogram shape: a big mass at 10-20, a thin tail, and
+// a maximum well under any legacy threshold.
+const PROD_LIKE_SCORES = [12, 14, 16, 18, 22, 26, 34, 41, 55];
+const LOW_SCORE_COUNT = PROD_LIKE_SCORES.filter((s) => s < 20).length; // 4
+
+function makeJob(id: number, score: number) {
+  return {
+    id,
+    title: `Test Job ${id}`,
+    company: `Company ${id}`,
+    location: "London, UK",
+    salary: null,
+    match_score: score,
+    source: "reed",
+    date_found: new Date().toISOString(),
+    apply_url: `https://example.test/${id}`,
+    visa_flag: false,
+    experience_level: "mid",
+    role: 0,
+    skill: 0,
+    seniority_score: 0,
+    experience: 0,
+    credentials: 0,
+    location_score: 0,
+    recency: 0,
+    semantic: 0,
+    penalty: 0,
+    action: null,
+    bucket: "24h",
+    posted_at: null,
+    first_seen_at: null,
+    last_seen_at: null,
+    date_confidence: "high",
+    staleness_state: "active",
+  };
+}
+
+/**
+ * Mock /api/jobs so it HONOURS min_score the way the real backend now does:
+ * filter the rows, but always report `total_unfiltered` so the UI can say what
+ * it hid. Reading min_score off the query string is the point — it lets the
+ * test drive the real filter path rather than asserting on a fixed payload.
+ */
+async function mockDashboard(page: Page) {
+  const all = PROD_LIKE_SCORES.map((s, i) => makeJob(i + 1, s));
+
+  await page.route("**/api/auth/me**", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ id: "e2e-user", email: "e2e@example.com" }),
+    })
+  );
+  await page.route("**/api/status**", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ jobs_total: all.length, sources_total: 50 }),
+    })
+  );
+  await page.route("**/api/jobs**", (route) => {
+    const min = Number(new URL(route.request().url()).searchParams.get("min_score") ?? 0);
+    const shown = all.filter((j) => j.match_score >= min);
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        jobs: shown,
+        total: shown.length,
+        total_unfiltered: all.length,
+        filters_applied: min ? { min_score: min } : {},
+      }),
+    });
+  });
+}
+
+function renderedCount(page: Page): Promise<number> {
+  return page.$$eval('[aria-label*="score: "]', (els) => els.length);
+}
+
+test.describe("Feed visibility", () => {
+  test("shows EVERY job by default — the floor no longer hides the product", async ({
+    page,
+    context,
+  }) => {
+    await context.addCookies([SESSION_COOKIE]);
+    await mockDashboard(page);
+
+    const requested: string[] = [];
+    page.on("request", (r) => {
+      if (r.url().includes("/api/jobs")) requested.push(r.url());
+    });
+
+    await page.goto("/dashboard");
+    await expect(page.locator('[aria-label*="score: "]').first()).toBeVisible({
+      timeout: 20_000,
+    });
+
+    // 1. Every job rendered, including the ones under the old floor of 20.
+    expect(await renderedCount(page)).toBe(PROD_LIKE_SCORES.length);
+
+    // 2. And the request itself asked for no floor. This is the real assertion:
+    //    a UI that rendered everything but still SENT min_score=20 would pass a
+    //    naive count check while remaining broken against a bigger feed.
+    const withFloor = requested.filter((u) => {
+      const v = new URL(u).searchParams.get("min_score");
+      return v !== null && Number(v) > 0;
+    });
+    expect(withFloor, `no /api/jobs call may impose a floor: ${withFloor[0]}`).toHaveLength(0);
+
+    // 3. Nothing hidden means no "hidden by filters" notice.
+    await expect(page.getByText(/hidden by filters/i)).toHaveCount(0);
+  });
+
+  test("announces hidden rows and offers a way back when the API reports them", async ({
+    page,
+    context,
+  }) => {
+    await context.addCookies([SESSION_COOKIE]);
+
+    // Mock a server that HAS filtered rows out: it returns fewer jobs than it
+    // says exist. This is the exact contract the backend now honours via
+    // `total_unfiltered`, and the only thing the UI can act on. Driving it this
+    // way (rather than through the slider) keeps the test about the guarantee —
+    // "never hide silently" — instead of about widget mechanics.
+    const all = PROD_LIKE_SCORES.map((s, i) => makeJob(i + 1, s));
+    const shown = all.filter((j) => j.match_score >= 20);
+    const hidden = all.length - shown.length;
+
+    await page.route("**/api/auth/me**", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ id: "e2e-user", email: "e2e@example.com" }),
+      })
+    );
+    await page.route("**/api/status**", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ jobs_total: all.length, sources_total: 50 }),
+      })
+    );
+    await page.route("**/api/jobs**", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          jobs: shown,
+          total: shown.length,
+          total_unfiltered: all.length,
+          filters_applied: { min_score: 20 },
+        }),
+      })
+    );
+
+    await page.goto("/dashboard");
+    // Wait for the list to actually render before counting anything — counting
+    // an un-rendered page is how the first version of this test fooled itself.
+    await expect(page.locator('[aria-label*="score: "]').first()).toBeVisible({
+      timeout: 30_000,
+    });
+    expect(await renderedCount(page)).toBe(shown.length);
+
+    // THE GUARANTEE: the missing rows are announced, by number.
+    expect(hidden).toBeGreaterThan(0);
+    await expect(page.getByText(/hidden by filters/i)).toBeVisible();
+    await expect(page.getByText(String(hidden), { exact: false }).first()).toBeVisible();
+
+    // And there is a visible way back.
+    await expect(page.getByRole("button", { name: /show all/i })).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Your product finds 3,236 jobs and shows 406

Both numbers below are **measured in prod** (2026-07-28), not estimated.

| Gate | Set to | Reality | Effect |
|---|---|---|---|
| `DEFAULT_MIN_SCORE` | 20 | score **p50=10, p90=26** | floor sat above the 90th percentile → **87.5% of the feed hidden** |
| `ENRICHMENT_THRESHOLD` | 60 | **max score in the entire feed = 58** | stage had **never run once**; `job_enrichment` = **0 rows** |

```
score histogram      0-10:    35
                    10-20: 2,795   <- 84% of the whole feed
                    20-30:   254
                    30-40:   197
                    40-50:    47
                    50-60:    14
                    60+  :     0   <- the enrichment gate lives up here
```

## One cause

`merge_cv_and_preferences` used to copy the **entire CV** into preferences, inflating every score. Removing that (correctly) dropped scores to normal. **Neither gate was re-tuned.** The scores moved; the goalposts did not.

## Why the enrichment one was invisible

Selecting 0 rows raises nothing, logs nothing, renders nothing.

> **A filter tuned past your maximum is indistinguishable from a feature that was never built.**

That's why the empty panel on the job page read as unfinished work rather than a broken gate. The 20-floor at least left a short list; the 60-gate left nothing to see at all.

## This is a threshold problem, not an engine problem

The **LLM judge (engine 4) was running fine** in the same prod, on the same data: **80 verdicts**, max `llm_fit_score` **90**, and in **44 rows it scored a job higher than the keyword engine did**.

Engine 4 gates on `MATCHER_MAX_JOBS` — a **budget**. Engine 2 gated on a **threshold**. Same product, same data, opposite outcome.

## The fix

**Rank, never hide.** `DEFAULT_MIN_SCORE` → **0**. Sorting already puts the best first and people stop scrolling when quality drops — so the floor bought nothing the sort didn't already give, while risking an empty product. The slider still works; it's just not imposed.

**Budget, never threshold.** `ENRICHMENT_THRESHOLD` → `ENRICHMENT_MAX_JOBS=20` + `ENRICHMENT_MIN_SCORE=10`. A threshold is a *claim about the score distribution*, and distributions move. A budget makes no claim — it works whether the top score is 58 or 95 — and doubles as a hard **cost ceiling**, which a threshold never was. Old name kept as an alias so existing `.env` files still load.

**Never hide silently.** `JobListResponse` gains `total_unfiltered`, so the dashboard shows *"N hidden by filters · show all"*. Any future mis-tuned filter announces itself instead of impersonating an empty feed. Costs nothing — the route already loaded every row and paginated in Python.

**Alarm on zero.** If the budget ever selects nothing, it logs a warning naming the best score seen and the floor in force — the alarm the old threshold lacked.

## Verified

- **4 new backend tests** pin the budget property at any distribution scale, including the exact prod histogram, and assert best-first selection
- **2 new Playwright specs** drive a real browser: every job renders by default, **no request may impose a floor** (a UI that rendered everything while still *sending* `min_score=20` would pass a naive count check and stay broken), and hidden rows are announced with a working way back
- `test_api.py` + `test_main.py`: **43 passed**
- Gate: **PASS**, including the api-types drift check

## Side-finding, fixed here too: the e2e suite was testing Grafana

`playwright.config.ts` hardcoded port 3000 with `reuseExistingServer`. **Grafana owns 3000 on this machine**, so Playwright silently ran the entire suite against Grafana — every spec failed with "element not found" and read as a real regression. The page snapshot said `<title>Grafana</title>`.

Port is now configurable via `E2E_PORT`, so a busy 3000 is a non-event instead of a debugging session.
