### PR TITLE
fix(auth): the audit log now names WHO logged out

### DIFF
--- a/backend/src/api/routes/auth.py
+++ b/backend/src/api/routes/auth.py
@@ -282,9 +282,27 @@ async def logout(
     request: Request,
     job360_session: Optional[str] = Cookie(default=None, alias=SESSION_COOKIE_NAME),
 ) -> Response:
+    # Capture WHO is logging out. This route deliberately takes the raw cookie
+    # rather than `require_user` (an expired or forged cookie must still clear
+    # the browser's, not 401), so the user is not otherwise in scope — and the
+    # audit line was being written without one. `revoke_session` now returns the
+    # owner it just signed out, which is the only place that identity exists.
+    user_id = None
     if job360_session:
-        await auth_sessions.revoke_session(str(DB_PATH), job360_session, secret=_secret())
-    get_audit_logger().info("auth", extra={"event": "logout", "status": "ok", **_client_meta(request)})
+        user_id = await auth_sessions.revoke_session(
+            str(DB_PATH), job360_session, secret=_secret()
+        )
+    get_audit_logger().info(
+        "auth",
+        extra={
+            "event": "logout",
+            "status": "ok",
+            # None when the cookie was already invalid — genuinely unknown, and
+            # honestly recorded as such rather than silently omitted.
+            "user_id": user_id,
+            **_client_meta(request),
+        },
+    )
     response.delete_cookie(SESSION_COOKIE_NAME)
     response.status_code = status.HTTP_204_NO_CONTENT
     return response

--- a/backend/src/services/auth/sessions.py
+++ b/backend/src/services/auth/sessions.py
@@ -93,14 +93,39 @@ async def resolve_session(
     return cast(Optional[str], row["user_id"])
 
 
-async def revoke_session(db_path: str, cookie: str, *, secret: str) -> None:
+async def revoke_session(db_path: str, cookie: str, *, secret: str) -> Optional[str]:
+    """Delete one session and return the user it belonged to (None if unknown).
+
+    Reads the owner BEFORE deleting so the audit trail can say *who* signed out.
+    It previously ran the DELETE alone, which meant the one fact worth recording
+    was thrown away: measured in production 2026-07-28, `audit_log` held 19 of 59
+    rows with no user_id, and while 10 were `magic_link_request` (legitimately
+    unattributed — no account exists yet at request time), 4 `logout` and 4
+    `session_revoked` had lost a user that was perfectly knowable. "Who logged
+    out?" was unanswerable from the table you reach for during an incident.
+
+    SELECT-then-DELETE rather than `DELETE ... RETURNING`: every statement here
+    goes through the psycopg shim's translate(), and SELECT + DELETE are already
+    exercised everywhere in this codebase, so this cannot depend on how the shim
+    handles a RETURNING clause.
+
+    Returns None for a forged, expired or already-revoked cookie — logout is
+    called with whatever the browser presents, so that path must degrade quietly.
+    """
     sid = _unsign(cookie, secret)
     if sid is None:
-        return
+        return None
     async with open_db(db_path) as db:
+        cur = await db.execute("SELECT user_id FROM sessions WHERE id = ?", (sid,))
+        row = await cur.fetchone()
+        user_id = cast(Optional[str], row["user_id"]) if row else None
         await db.execute("DELETE FROM sessions WHERE id = ?", (sid,))
         await db.commit()
-    get_audit_logger().info("session_revoked", extra={"event": "session_revoked", "session_id": sid[:8]})
+    get_audit_logger().info(
+        "session_revoked",
+        extra={"event": "session_revoked", "session_id": sid[:8], "user_id": user_id},
+    )
+    return user_id
 
 
 async def revoke_all_for_user(db_path: str, user_id: str) -> int:

--- a/backend/tests/test_auth_sessions.py
+++ b/backend/tests/test_auth_sessions.py
@@ -99,3 +99,58 @@ async def test_wrong_secret_rejected(session_db):
     assert await auth_sessions.resolve_session(
         session_db, cookie, secret="a-different-secret-that-is-long-enough"
     ) is None
+
+
+# ── Audit attribution: a revoked session must name WHOSE it was ───────────────
+
+
+@pytest.mark.asyncio
+async def test_revoke_session_returns_the_owner(session_db):
+    """`revoke_session` must report which user it just signed out.
+
+    Measured in production 2026-07-28: audit_log held 59 rows, 19 with no
+    user_id. Ten were `magic_link_request`, legitimately unattributed (no
+    account exists yet at request time) — but 4 `logout` and 4
+    `session_revoked` had lost a user that WAS knowable, because this function
+    only ever ran `DELETE FROM sessions WHERE id = ?` and never read the owner.
+
+    So "who logged out?" could not be answered from the audit trail — in the one
+    table you would reach for during an incident.
+    """
+    cookie = await auth_sessions.create_session(
+        session_db, user_id="user-42", secret=SESSION_SECRET
+    )
+    owner = await auth_sessions.revoke_session(
+        session_db, cookie, secret=SESSION_SECRET
+    )
+    assert owner == "user-42"
+
+
+@pytest.mark.asyncio
+async def test_revoke_session_returns_none_for_an_unknown_cookie(session_db):
+    """A forged or already-revoked cookie has no owner — and must not raise.
+
+    Logout is called with whatever cookie the browser presents, so this path is
+    reachable by anyone; it has to degrade quietly rather than 500.
+    """
+    assert await auth_sessions.revoke_session(
+        session_db, "not-a-real-cookie", secret=SESSION_SECRET
+    ) is None
+
+
+@pytest.mark.asyncio
+async def test_session_revoked_audit_event_carries_the_user(session_db, caplog):
+    """The audit line itself must be attributable, not just the return value."""
+    import logging
+
+    cookie = await auth_sessions.create_session(
+        session_db, user_id="user-99", secret=SESSION_SECRET
+    )
+    with caplog.at_level(logging.INFO):
+        await auth_sessions.revoke_session(session_db, cookie, secret=SESSION_SECRET)
+
+    revoked = [r for r in caplog.records if getattr(r, "event", None) == "session_revoked"]
+    assert revoked, "revoking a session must emit a session_revoked audit event"
+    assert getattr(revoked[0], "user_id", None) == "user-99", (
+        "the audit event must name the user whose session ended"
+    )


### PR DESCRIPTION
Found by the **new observation layer, unprompted**, against live production:

```
audit_log: 59 rows, 19 with no user_id
```

| event | NULL user | verdict |
|---|---|---|
| `magic_link_request` (10) | ✅ **legitimate** — fires before any account exists |
| `logout` (4), `session_revoked` (4), `magic_link_consume` (1) | ❌ **lost a knowable user** |

So **"who logged out?" was unanswerable** — in the one table you reach for during an incident.

## Cause

`revoke_session` ran `DELETE FROM sessions WHERE id = ?` and nothing else, so the owner was destroyed before it could be recorded.

`/logout` deliberately takes the **raw cookie** rather than `require_user` — an expired or forged cookie must still clear the browser's, not 401 — so the user isn't otherwise in scope there. The session row was the *only* place that identity existed, and the DELETE threw it away.

## Fix

`revoke_session` reads the owner before deleting, logs it on `session_revoked`, and **returns** it so `/logout` can attribute its own line too.

Compare `revoke_all_for_user`, which has always logged a `user_id` — only because it happens to be handed one. This closes that asymmetry.

**SELECT-then-DELETE, not `DELETE ... RETURNING`:** every statement here goes through the psycopg shim's `translate()`, and SELECT + DELETE are exercised everywhere in this codebase — correctness shouldn't hinge on how the shim handles a RETURNING clause.

`None` is still recorded, **honestly**, when the cookie was already invalid. That's a real *unknown*, and writing it explicitly beats omitting the field and leaving a reader to guess whether it was unknown or unrecorded.

## Tests (TDD — 2 red first)

- the owner is returned
- an unknown cookie returns `None` **without raising** — that path is reachable by anyone, so it must degrade quietly
- the emitted audit event itself names the user

**16 passed** (`test_auth_sessions` + `test_auth_routes`) · `ruff` clean · **gate PASS**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpxEMPz2ZWG9Qed5BsFHvg