### PR TITLE
test(e2e): prove two accounts in one browser stay isolated

### DIFF
--- a/frontend/tests/e2e/two-account-isolation.spec.ts
+++ b/frontend/tests/e2e/two-account-isolation.spec.ts
@@ -1,0 +1,213 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Two accounts, one browser — the isolation the whole ownership model rests on.
+ *
+ * The design being proven: a user_id owns everything, and two users share
+ * nothing. Verified in the database (production reports 0 orphans, 0 shared
+ * rows, and the same job scoring differently per user) — this spec proves the
+ * other half, that the isolation survives all the way to the screen.
+ *
+ * Two real failure modes are covered, and they are NOT the same bug:
+ *
+ *   1. SIDE BY SIDE — two browser contexts, two sessions. Each has its own
+ *      cookie jar, so this is the case that should trivially work. It is here
+ *      as the control: if this ever fails, the leak is server-side.
+ *
+ *   2. SEQUENTIAL, SAME JAR — one context, sign in as A, then a second account
+ *      signs in and REPLACES the session cookie (a browser profile has ONE
+ *      cookie jar, so this is what actually happens when you open a second tab
+ *      and log in as someone else). The stale page keeps rendering A's cached
+ *      jobs while the cookie underneath is B's — so a click there is sent as B
+ *      while the user is looking at A's data. That is the bug; this is the
+ *      regression pin.
+ *
+ * Self-contained by design, like the rest of the suite: fake session cookies +
+ * mocked API, so it needs no backend and cannot touch production.
+ */
+
+const ALICE_JOB = "AliceSecOps";
+const BOB_JOB = "BobMLOps";
+
+function jobPayload(title: string, id: number, score: number) {
+  return {
+    total: 1,
+    jobs: [
+      {
+        id,
+        title,
+        company: "Acme",
+        location: "London",
+        salary: null,
+        match_score: score,
+        source: "test",
+        date_found: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
+        apply_url: "https://example.com/apply",
+        visa_flag: false,
+        experience_level: "",
+        bucket: "24h",
+        action: null,
+        staleness_state: "fresh",
+        description: "A test role.",
+        first_seen: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
+        last_seen: new Date().toISOString(),
+      },
+    ],
+  };
+}
+
+/** Wire one page to look like a signed-in account with exactly one job. */
+async function serveAccount(
+  page: import("@playwright/test").Page,
+  opts: { userId: string; email: string; jobTitle: string; jobId: number; score: number }
+) {
+  await page.route("**/api/auth/me**", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ id: opts.userId, email: opts.email, email_verified: true }),
+    })
+  );
+  await page.route("**/api/jobs**", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(jobPayload(opts.jobTitle, opts.jobId, opts.score)),
+    })
+  );
+  await page.route("**/api/status**", (route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: "{}" })
+  );
+}
+
+test.describe("two accounts in one browser", () => {
+  test("side-by-side sessions never see each other's jobs", async ({ browser }) => {
+    const ctxA = await browser.newContext();
+    const ctxB = await browser.newContext();
+    try {
+      await ctxA.addCookies([
+        { name: "job360_session", value: "session-alice", domain: "localhost", path: "/" },
+      ]);
+      await ctxB.addCookies([
+        { name: "job360_session", value: "session-bob", domain: "localhost", path: "/" },
+      ]);
+
+      const pageA = await ctxA.newPage();
+      const pageB = await ctxB.newPage();
+      await serveAccount(pageA, {
+        userId: "user-alice", email: "alice@example.com",
+        jobTitle: ALICE_JOB, jobId: 101, score: 88,
+      });
+      await serveAccount(pageB, {
+        userId: "user-bob", email: "bob@example.com",
+        jobTitle: BOB_JOB, jobId: 202, score: 42,
+      });
+
+      await pageA.goto("/dashboard");
+      await pageB.goto("/dashboard");
+
+      await expect(pageA.getByText(new RegExp(ALICE_JOB))).toBeVisible({ timeout: 15_000 });
+      await expect(pageB.getByText(new RegExp(BOB_JOB))).toBeVisible({ timeout: 15_000 });
+
+      // The load-bearing assertions: neither page contains the other's job.
+      await expect(pageA.getByText(new RegExp(BOB_JOB))).toHaveCount(0);
+      await expect(pageB.getByText(new RegExp(ALICE_JOB))).toHaveCount(0);
+    } finally {
+      await ctxA.close();
+      await ctxB.close();
+    }
+  });
+
+  // ---------------------------------------------------------------------------
+  // The two SEQUENTIAL cases below are marked fixme deliberately, not abandoned.
+  //
+  // They fail for a reason that is about the HARNESS, not the app: a Playwright
+  // route handler is keyed on URL, not on the request's cookie. So "the second
+  // account signs in and the API now answers as them" can only be simulated by
+  // swapping the handler mid-test, which races the app's own refetch — the page
+  // snapshot at timeout still shows the first account's job and never the
+  // second's, whether or not the identity-change cache clear is present. A test
+  // that fails identically with and without the fix proves nothing about the fix.
+  //
+  // That behaviour IS covered, deterministically, one layer down:
+  // AuthProvider.test.tsx asserts the cache is wiped when a DIFFERENT account
+  // resolves, wiped when the session ends, and KEPT when the same account
+  // re-validates. Component tests can drive identity directly; the browser
+  // cannot, without a real second backend session.
+  //
+  // Same convention this repo already uses for tailor-cv (fixme: Server-Component
+  // fetch unmockable). To finish these properly they need two REAL sessions
+  // against a live backend, which is a live-e2e job, not a hermetic one.
+  // ---------------------------------------------------------------------------
+
+  test.fixme("a second account signing in replaces the first — no stale data survives", async ({
+    browser,
+  }) => {
+    // ONE context = one cookie jar, exactly like a real browser profile.
+    const ctx = await browser.newContext();
+    try {
+      await ctx.addCookies([
+        { name: "job360_session", value: "session-alice", domain: "localhost", path: "/" },
+      ]);
+      const page = await ctx.newPage();
+
+      await serveAccount(page, {
+        userId: "user-alice", email: "alice@example.com",
+        jobTitle: ALICE_JOB, jobId: 101, score: 88,
+      });
+      await page.goto("/dashboard");
+      await expect(page.getByText(new RegExp(ALICE_JOB))).toBeVisible({ timeout: 15_000 });
+
+      // Bob signs in elsewhere: the cookie is REPLACED for the whole jar, and
+      // every subsequent API call now answers as Bob.
+      await ctx.clearCookies();
+      await ctx.addCookies([
+        { name: "job360_session", value: "session-bob", domain: "localhost", path: "/" },
+      ]);
+      await page.unrouteAll({ behavior: "ignoreErrors" });
+      await serveAccount(page, {
+        userId: "user-bob", email: "bob@example.com",
+        jobTitle: BOB_JOB, jobId: 202, score: 42,
+      });
+
+      // Focus is the app's re-validation trigger (AuthProvider listens for it).
+      // Without the identity-change cache clear, Alice's cached jobs stay on
+      // screen under Bob's cookie — and a click would be recorded as Bob.
+      await page.evaluate(() => window.dispatchEvent(new Event("focus")));
+
+      await expect(page.getByText(new RegExp(BOB_JOB))).toBeVisible({ timeout: 15_000 });
+      await expect(page.getByText(new RegExp(ALICE_JOB))).toHaveCount(0);
+    } finally {
+      await ctx.close();
+    }
+  });
+
+  test.fixme("signing out leaves nothing of the previous account behind", async ({ browser }) => {
+    const ctx = await browser.newContext();
+    try {
+      await ctx.addCookies([
+        { name: "job360_session", value: "session-alice", domain: "localhost", path: "/" },
+      ]);
+      const page = await ctx.newPage();
+      await serveAccount(page, {
+        userId: "user-alice", email: "alice@example.com",
+        jobTitle: ALICE_JOB, jobId: 101, score: 88,
+      });
+      await page.goto("/dashboard");
+      await expect(page.getByText(new RegExp(ALICE_JOB))).toBeVisible({ timeout: 15_000 });
+
+      // Session ends (expired, or revoked from another device).
+      await ctx.clearCookies();
+      await page.unrouteAll({ behavior: "ignoreErrors" });
+      await page.route("**/api/auth/me**", (route) =>
+        route.fulfill({ status: 401, contentType: "application/json", body: "{}" })
+      );
+      await page.evaluate(() => window.dispatchEvent(new Event("focus")));
+
+      // Whatever the app decides to show, it must not still be Alice's jobs.
+      await expect(page.getByText(new RegExp(ALICE_JOB))).toHaveCount(0, { timeout: 15_000 });
+    } finally {
+      await ctx.close();
+    }
+  });
+});


### PR DESCRIPTION
The database side of the ownership model is already **measured** (production: 0 orphans, 0 shared rows, the same job scoring differently per user). This proves the other half — that the isolation survives **all the way to the screen**.

## Passing

**Side-by-side sessions never see each other's jobs.** Two browser contexts, two cookie jars, two mocked accounts; each page shows only its own job and asserts the other's is *absent*. If this ever goes red, the leak is server-side — which makes it a useful alarm rather than a formality.

## Fixme — deliberately, with the reason recorded in the spec

The two **sequential** cases (a second account signing in; a session ending) fail for a reason about the **harness, not the app**: a Playwright route handler is keyed on **URL, not cookie**, so *"the API now answers as the other account"* can only be simulated by swapping the handler mid-test, which races the app's own refetch.

**I checked this properly rather than assuming.** I applied the identity-change cache clear from the account-switch branch and re-ran — **same failure**, and the page snapshot at timeout still showed the first account's job.

> A test that fails identically **with and without** the fix proves nothing about the fix. Shipping it green would have been worse than shipping it skipped.

That behaviour **is** covered deterministically one layer down, where identity can be driven directly: `AuthProvider.test.tsx` asserts the cache is wiped when a different account resolves, wiped when the session ends, and **kept** when the same account re-validates. Finishing the browser versions needs two *real* backend sessions — a live-e2e job, not a hermetic one.

Same convention this repo already uses for `tailor-cv` (fixme: Server-Component fetch unmockable).

## A detour worth recording

Every spec in the suite failed locally — **including `job-render.spec.ts`, which is green in CI**. That control experiment moved the fault off my spec immediately: another session's dev server owns `:3000` and serves 404, and `playwright.config.ts` sets `reuseExistingServer: !CI`, so Playwright adopts it and no spec can pass.

Ran against an isolated server on `:3100` with `E2E_TEST_MODE=1` via a temporary local-only config, since deleted. **The shared config is untouched**, so CI and other worktrees are unaffected.

**1 passed, 2 skipped** · **gate PASS**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpxEMPz2ZWG9Qed5BsFHvg