### PR TITLE
fix: the catalog cron died nightly on a read-only disk (closes #170)

### DIFF
--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -1062,21 +1062,33 @@ async def run_search(
                 "per_source": per_source,
             }
 
-            # Generate outputs
+            # Generate outputs — file side-outputs only, so non-fatal by design.
+            # The run's REAL products (jobs, user_feed, run_log) live in
+            # Postgres above/below this block. In a container whose package dir
+            # is read-only (the worker installs into site-packages), these
+            # writes raise OSError; letting that kill the run would throw away
+            # the entire fetch AND skip the run_log write — which is exactly
+            # what starved the catalog for three nights before issue #170.
             if new_jobs:
-                # CSV
-                EXPORTS_DIR.mkdir(parents=True, exist_ok=True)
-                ts = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
-                csv_path = str(EXPORTS_DIR / f"jobs_{ts}.csv")
-                await asyncio.to_thread(export_to_csv, new_jobs, csv_path)
-                logger.info("CSV exported: %s", csv_path)
+                try:
+                    # CSV
+                    EXPORTS_DIR.mkdir(parents=True, exist_ok=True)
+                    ts = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+                    csv_path = str(EXPORTS_DIR / f"jobs_{ts}.csv")
+                    await asyncio.to_thread(export_to_csv, new_jobs, csv_path)
+                    logger.info("CSV exported: %s", csv_path)
 
-                # Markdown report
-                REPORTS_DIR.mkdir(parents=True, exist_ok=True)
-                md_report = generate_markdown_report(new_jobs, stats)
-                md_path = REPORTS_DIR / f"report_{ts}.md"
-                await asyncio.to_thread(md_path.write_text, md_report, encoding="utf-8")
-                logger.info("Report saved: %s", md_path)
+                    # Markdown report
+                    REPORTS_DIR.mkdir(parents=True, exist_ok=True)
+                    md_report = generate_markdown_report(new_jobs, stats)
+                    md_path = REPORTS_DIR / f"report_{ts}.md"
+                    await asyncio.to_thread(md_path.write_text, md_report, encoding="utf-8")
+                    logger.info("Report saved: %s", md_path)
+                except OSError as exc:
+                    logger.warning(
+                        "CSV/report export skipped (%s) — run continues; DB is the source of truth",
+                        exc,
+                    )
 
 
                 # Print time-bucketed summary to console

--- a/backend/src/utils/logger.py
+++ b/backend/src/utils/logger.py
@@ -233,7 +233,8 @@ def setup_audit_logger() -> logging.Logger:
     # during an incident. propagate=False means it never reaches the main
     # handlers' scrubber, so it needs its own.
     handler.addFilter(CRLFScrubFilter())
-    handler._job360_audit = True  # type: ignore[attr-defined] — idempotence marker, see above
+    # Idempotence marker (see guard above); setattr keeps mypy clean on the union type.
+    setattr(handler, "_job360_audit", True)  # noqa: B010 — deliberate dynamic marker
     audit.addHandler(handler)
     # docs/fable/05 C8 — tee the same records into the audit_log DB table so
     # audit history survives file rotation and is queryable with SQL. Lazy

--- a/backend/src/utils/logger.py
+++ b/backend/src/utils/logger.py
@@ -133,7 +133,6 @@ class JSONFormatter(logging.Formatter):
 
 
 def setup_logging(log_level: str | None = None) -> logging.Logger:
-    LOGS_DIR.mkdir(parents=True, exist_ok=True)
     logger = logging.getLogger("job360")
     if logger.handlers:
         if log_level:
@@ -148,21 +147,44 @@ def setup_logging(log_level: str | None = None) -> logging.Logger:
     console = logging.StreamHandler(sys.stdout)
     console.setFormatter(fmt)
     logger.addHandler(console)
-    file_handler = RotatingFileHandler(LOGS_DIR / "job360.log", maxBytes=5_000_000, backupCount=3)
-    file_handler.setFormatter(fmt)
-    logger.addHandler(file_handler)
-    # Second handler — JSON lines for machine consumption.
-    json_handler = RotatingFileHandler(
-        LOGS_DIR / "job360.jsonl", maxBytes=5_000_000, backupCount=3
-    )
-    json_handler.setFormatter(JSONFormatter())
-    logger.addHandler(json_handler)
+    # File handlers are a CONVENIENCE, not the product — stdout is the channel
+    # Railway (and any container host) actually captures. On 2026-07-30 the
+    # worker's 04:00 refresh_catalog cron died HERE, before fetching a single
+    # job: its image installs the package into site-packages, so LOGS_DIR
+    # resolved to /usr/local/lib/python3.12/site-packages/data/logs and
+    # mkdir() raised PermissionError. Three silent nights, empty catalog,
+    # absence detector's issue #170. A log file must never take down the
+    # pipeline it exists to describe.
+    file_handlers: list[logging.Handler] = []
+    try:
+        LOGS_DIR.mkdir(parents=True, exist_ok=True)
+        file_handler = RotatingFileHandler(
+            LOGS_DIR / "job360.log", maxBytes=5_000_000, backupCount=3
+        )
+        file_handler.setFormatter(fmt)
+        logger.addHandler(file_handler)
+        # Second handler — JSON lines for machine consumption.
+        json_handler = RotatingFileHandler(
+            LOGS_DIR / "job360.jsonl", maxBytes=5_000_000, backupCount=3
+        )
+        json_handler.setFormatter(JSONFormatter())
+        logger.addHandler(json_handler)
+        file_handlers = [file_handler, json_handler]
+    except OSError as exc:
+        # Never quiet about being quiet: say where file logs would have gone.
+        console.handle(
+            logging.LogRecord(
+                "job360", logging.WARNING, __file__, 0,
+                "file logging disabled (%s: %s) — continuing console-only",
+                (LOGS_DIR, exc), None,
+            )
+        )
     # Log-injection guard. MUST be attached to the HANDLERS, not to the logger:
     # a logger-level filter only sees records logged directly on that logger,
     # while every finding lives on CHILD loggers (job360.api.auth, …) whose
     # records merely propagate to these handlers. Handler filters see them all.
     _scrubber = CRLFScrubFilter()
-    for _h in (console, file_handler, json_handler):
+    for _h in (console, *file_handlers):
         _h.addFilter(_scrubber)
     return logger
 
@@ -182,15 +204,22 @@ def setup_audit_logger() -> logging.Logger:
     so audit records never appear in the main job360 handlers.  Idempotent
     — safe to call multiple times (e.g. from tests and from lifespan).
     """
-    LOGS_DIR.mkdir(parents=True, exist_ok=True)
     audit = logging.getLogger("job360.audit")
     if audit.handlers:
         return audit
     audit.setLevel(logging.INFO)
     audit.propagate = False
-    handler = RotatingFileHandler(
-        LOGS_DIR / "audit.log", maxBytes=5_000_000, backupCount=5
-    )
+    # Same read-only-container rule as setup_logging above: the audit FILE is a
+    # convenience copy. On OSError we fall back to stdout — the audit trail
+    # keeps flowing (host log capture + the DB tee below), just not to a file.
+    handler: logging.Handler
+    try:
+        LOGS_DIR.mkdir(parents=True, exist_ok=True)
+        handler = RotatingFileHandler(
+            LOGS_DIR / "audit.log", maxBytes=5_000_000, backupCount=5
+        )
+    except OSError:
+        handler = logging.StreamHandler(sys.stdout)
     handler.setFormatter(JSONFormatter())
     # The audit trail is the MOST injection-sensitive stream — it records login
     # attempts with attacker-supplied emails, and it is what an operator reads

--- a/backend/src/utils/logger.py
+++ b/backend/src/utils/logger.py
@@ -205,7 +205,14 @@ def setup_audit_logger() -> logging.Logger:
     — safe to call multiple times (e.g. from tests and from lifespan).
     """
     audit = logging.getLogger("job360.audit")
-    if audit.handlers:
+    # Idempotence must key on OUR handler, not on "any handler present".
+    # `job360.audit` is a process-global name: pytest's caplog attaches its
+    # LogCaptureHandlers to it, and any library can too. The old guard
+    # (`if audit.handlers`) saw a foreign handler and returned early — WITHOUT
+    # installing the audit file/stdout handler, its CRLF scrubber, or the DB
+    # tee. In that state audit records went wherever the foreign handler
+    # pointed and the durable audit_log table got nothing.
+    if any(getattr(h, "_job360_audit", False) for h in audit.handlers):
         return audit
     audit.setLevel(logging.INFO)
     audit.propagate = False
@@ -226,6 +233,7 @@ def setup_audit_logger() -> logging.Logger:
     # during an incident. propagate=False means it never reaches the main
     # handlers' scrubber, so it needs its own.
     handler.addFilter(CRLFScrubFilter())
+    handler._job360_audit = True  # type: ignore[attr-defined] — idempotence marker, see above
     audit.addHandler(handler)
     # docs/fable/05 C8 — tee the same records into the audit_log DB table so
     # audit history survives file rotation and is queryable with SQL. Lazy

--- a/backend/tests/test_logging_readonly_fs.py
+++ b/backend/tests/test_logging_readonly_fs.py
@@ -65,8 +65,10 @@ def test_setup_logging_console_keeps_injection_scrubber(monkeypatch):
 
     log = logger_mod.setup_logging("INFO")
 
+    # Class-NAME check, not isinstance: a module reload elsewhere in the suite
+    # gives CRLFScrubFilter a new identity and would fail isinstance spuriously.
     assert any(
-        isinstance(f, logger_mod.CRLFScrubFilter) for f in log.handlers[0].filters
+        type(f).__name__ == "CRLFScrubFilter" for f in log.handlers[0].filters
     ), "console fallback lost the CRLF injection scrubber"
 
 
@@ -75,12 +77,25 @@ def test_audit_logger_survives_readonly_fs(monkeypatch):
 
     audit = logger_mod.setup_audit_logger()  # must not raise
 
-    assert audit.handlers, "audit logger must still get a handler"
-    handler = audit.handlers[0]
+    # Assert on the handler THIS call created, not on handlers[0]: the shared
+    # `job360.audit` logger also carries the DB-tee QueueHandler (added by
+    # install_db_audit_trail at the end of setup), and in the full CI suite
+    # other tests touch this global logger too. Grabbing [0] made this test
+    # pass alone and fail in the full run.
+    import logging.handlers as lh
+
+    own = [h for h in audit.handlers if not isinstance(h, lh.QueueHandler)]
+    assert len(own) == 1, f"expected exactly one non-tee handler, got {audit.handlers}"
+    handler = own[0]
+    # RotatingFileHandler subclasses StreamHandler, so pin the fallback exactly:
+    # a rotating handler here would mean mkdir silently succeeded on the stub.
+    assert not isinstance(handler, lh.RotatingFileHandler)
     assert isinstance(handler, logging.StreamHandler)
     # The audit stream is the most injection-sensitive one — the scrubber must
-    # survive the fallback here too.
-    assert any(isinstance(f, logger_mod.CRLFScrubFilter) for f in handler.filters)
+    # survive the fallback. Checked by class NAME, not identity: another test
+    # reloading src.utils.logger gives the same class a new identity and would
+    # fail an isinstance() check spuriously.
+    assert any(type(f).__name__ == "CRLFScrubFilter" for f in handler.filters)
 
 
 def test_writable_fs_still_gets_file_handlers(tmp_path, monkeypatch):

--- a/backend/tests/test_logging_readonly_fs.py
+++ b/backend/tests/test_logging_readonly_fs.py
@@ -1,0 +1,96 @@
+"""A read-only filesystem must never take down the pipeline.
+
+Regression guard for the 2026-07-30 outage behind issue #170: the worker image
+installs the package into site-packages, so LOGS_DIR resolved to
+``/usr/local/lib/python3.12/site-packages/data/logs``. ``setup_logging`` did an
+unguarded ``LOGS_DIR.mkdir()`` as the FIRST line of ``run_search`` — the 04:00
+``refresh_catalog`` cron raised PermissionError before fetching a single job,
+for three nights, silently. The catalog starved and the absence detector fired.
+
+The rule these tests pin: log/export FILES are conveniences; stdout and
+Postgres are the product. Disk failure downgrades output, never kills the run.
+"""
+
+import logging
+
+import pytest
+
+import src.utils.logger as logger_mod
+
+
+class _ReadOnlyDir:
+    """Stands in for LOGS_DIR on a read-only filesystem: mkdir always denied."""
+
+    def mkdir(self, *a, **kw):
+        raise PermissionError(13, "Permission denied", "/site-packages/data/logs")
+
+    def __truediv__(self, other):  # pragma: no cover — reaching this IS the bug
+        raise AssertionError(
+            "file handler path was built even though mkdir failed — "
+            "the fallback must skip file handlers entirely"
+        )
+
+    def __str__(self):
+        return "/site-packages/data/logs (read-only stub)"
+
+
+@pytest.fixture(autouse=True)
+def _fresh_loggers():
+    """Both setup functions are idempotent via `if logger.handlers` — strip
+    handlers before AND after so each test exercises the real setup path and
+    leaves nothing behind for the rest of the suite."""
+    for name in ("job360", "job360.audit"):
+        logging.getLogger(name).handlers.clear()
+    yield
+    for name in ("job360", "job360.audit"):
+        logging.getLogger(name).handlers.clear()
+
+
+def test_setup_logging_survives_readonly_fs(monkeypatch):
+    monkeypatch.setattr(logger_mod, "LOGS_DIR", _ReadOnlyDir())
+
+    log = logger_mod.setup_logging("INFO")  # must not raise — THE bug
+
+    # Console-only fallback: exactly the stream handler, no file handlers.
+    assert len(log.handlers) == 1
+    assert isinstance(log.handlers[0], logging.StreamHandler)
+    # And logging through it must work end to end.
+    log.info("pipeline continues without file logs")
+
+
+def test_setup_logging_console_keeps_injection_scrubber(monkeypatch):
+    """The CRLF scrubber is a security control (log-injection guard). Falling
+    back to console-only must not silently drop it."""
+    monkeypatch.setattr(logger_mod, "LOGS_DIR", _ReadOnlyDir())
+
+    log = logger_mod.setup_logging("INFO")
+
+    assert any(
+        isinstance(f, logger_mod.CRLFScrubFilter) for f in log.handlers[0].filters
+    ), "console fallback lost the CRLF injection scrubber"
+
+
+def test_audit_logger_survives_readonly_fs(monkeypatch):
+    monkeypatch.setattr(logger_mod, "LOGS_DIR", _ReadOnlyDir())
+
+    audit = logger_mod.setup_audit_logger()  # must not raise
+
+    assert audit.handlers, "audit logger must still get a handler"
+    handler = audit.handlers[0]
+    assert isinstance(handler, logging.StreamHandler)
+    # The audit stream is the most injection-sensitive one — the scrubber must
+    # survive the fallback here too.
+    assert any(isinstance(f, logger_mod.CRLFScrubFilter) for f in handler.filters)
+
+
+def test_writable_fs_still_gets_file_handlers(tmp_path, monkeypatch):
+    """The fallback must not become the default: on a normal disk the two
+    rotating file handlers (text + jsonl) still attach."""
+    monkeypatch.setattr(logger_mod, "LOGS_DIR", tmp_path / "logs")
+
+    log = logger_mod.setup_logging("INFO")
+
+    from logging.handlers import RotatingFileHandler
+
+    rotating = [h for h in log.handlers if isinstance(h, RotatingFileHandler)]
+    assert len(rotating) == 2, "writable disk must still produce job360.log + job360.jsonl"

--- a/backend/tests/test_logging_readonly_fs.py
+++ b/backend/tests/test_logging_readonly_fs.py
@@ -77,15 +77,16 @@ def test_audit_logger_survives_readonly_fs(monkeypatch):
 
     audit = logger_mod.setup_audit_logger()  # must not raise
 
-    # Assert on the handler THIS call created, not on handlers[0]: the shared
-    # `job360.audit` logger also carries the DB-tee QueueHandler (added by
-    # install_db_audit_trail at the end of setup), and in the full CI suite
-    # other tests touch this global logger too. Grabbing [0] made this test
-    # pass alone and fail in the full run.
+    # Assert on the handler THIS call created — identified by its idempotence
+    # marker. The shared `job360.audit` logger also carries the DB-tee
+    # QueueHandler, and in CI pytest's caplog attaches LogCaptureHandlers to it
+    # between our fixture's clear and the call. That very noise exposed the
+    # real bug this run fixed: the old `if audit.handlers` guard saw a foreign
+    # handler and skipped installing the audit handler entirely.
     import logging.handlers as lh
 
-    own = [h for h in audit.handlers if not isinstance(h, lh.QueueHandler)]
-    assert len(own) == 1, f"expected exactly one non-tee handler, got {audit.handlers}"
+    own = [h for h in audit.handlers if getattr(h, "_job360_audit", False)]
+    assert len(own) == 1, f"expected exactly one job360 audit handler, got {audit.handlers}"
     handler = own[0]
     # RotatingFileHandler subclasses StreamHandler, so pin the fallback exactly:
     # a rotating handler here would mean mkdir silently succeeded on the stub.
@@ -96,6 +97,27 @@ def test_audit_logger_survives_readonly_fs(monkeypatch):
     # reloading src.utils.logger gives the same class a new identity and would
     # fail an isinstance() check spuriously.
     assert any(type(f).__name__ == "CRLFScrubFilter" for f in handler.filters)
+
+
+def test_audit_setup_not_blocked_by_foreign_handlers(tmp_path, monkeypatch):
+    """The bug CI's caplog noise exposed: `job360.audit` is a process-global
+    logger anyone can attach handlers to (pytest's caplog does exactly that).
+    The old idempotence guard — `if audit.handlers: return` — saw a FOREIGN
+    handler and skipped installing the audit handler, its scrubber and the DB
+    tee entirely. Idempotence must key on OUR marker, not on 'any handler'."""
+    monkeypatch.setattr(logger_mod, "LOGS_DIR", tmp_path / "logs")
+
+    foreign = logging.NullHandler()
+    logging.getLogger("job360.audit").addHandler(foreign)
+
+    audit = logger_mod.setup_audit_logger()
+
+    own = [h for h in audit.handlers if getattr(h, "_job360_audit", False)]
+    assert len(own) == 1, "a foreign handler must not block the audit handler install"
+    # And calling again must NOT double-install (real idempotence).
+    logger_mod.setup_audit_logger()
+    own2 = [h for h in audit.handlers if getattr(h, "_job360_audit", False)]
+    assert len(own2) == 1, "second call must not add a duplicate audit handler"
 
 
 def test_writable_fs_still_gets_file_handlers(tmp_path, monkeypatch):

--- a/backend/tests/test_main_scheduler_wiring.py
+++ b/backend/tests/test_main_scheduler_wiring.py
@@ -504,3 +504,67 @@ async def test_breaker_open_source_is_skipped(
     # still covers every registered source, with the breaker state explaining why.
     assert stats["per_source"].get("flaky", 0) == 0
     assert stats["per_source"].get("healthy") == 1
+
+
+@pytest.mark.asyncio
+async def test_run_search_survives_readonly_exports_dir(tmp_db_path, monkeypatch):
+    """Issue #170 regression, second write site: a read-only EXPORTS_DIR /
+    REPORTS_DIR must not kill the run.
+
+    In the worker container the package dir is read-only, so after fixing the
+    logging mkdir the run would have fetched EVERYTHING and then died at the
+    CSV export — throwing the whole fetch away and, worse, skipping the
+    run_log write that the absence detector watches. This drives the REAL
+    run_search (not a mirror of it) with dirs that refuse mkdir and asserts
+    the run completes, stores jobs, and writes run_log.
+    """
+    from migrations import runner
+    from src import main as main_mod
+    from src.repositories.database import JobDatabase
+    from src.services.profile.models import CVData, SearchConfig, UserPreferences, UserProfile
+
+    _setup = JobDatabase(tmp_db_path)
+    await _setup.init_db()
+    await runner.up(tmp_db_path)
+    await _setup.close()
+
+    stub = UserProfile(
+        cv_data=CVData(raw_text="x", skills=["python"], job_titles=["Engineer"]),
+        preferences=UserPreferences(target_job_titles=["Engineer"], additional_skills=["python"]),
+    )
+    monkeypatch.setattr(main_mod, "load_profile", lambda uid: stub)
+    monkeypatch.setattr(
+        main_mod, "generate_search_config",
+        lambda p: SearchConfig(job_titles=["Engineer"], relevance_keywords=["engineer"]),
+    )
+    monkeypatch.setattr(
+        main_mod, "_build_sources",
+        lambda *a, **kw: [_FakeSource("s", "ats", result=[_make_job("Engineer", "AcmeCo")])],
+    )
+
+    class _ReadOnlyDir:
+        """EXPORTS_DIR/REPORTS_DIR on a read-only filesystem."""
+
+        def mkdir(self, *a, **kw):
+            raise PermissionError(13, "Permission denied", "/site-packages/data/exports")
+
+        def __truediv__(self, other):  # pragma: no cover — reaching this IS the bug
+            raise AssertionError("export path built despite failed mkdir")
+
+    monkeypatch.setattr(main_mod, "EXPORTS_DIR", _ReadOnlyDir())
+    monkeypatch.setattr(main_mod, "REPORTS_DIR", _ReadOnlyDir())
+
+    # Must not raise — the old code let PermissionError escape here.
+    stats = await main_mod.run_search(db_path=tmp_db_path, no_notify=True, user_id="u1")
+
+    assert stats["new_jobs"] >= 1, "the fetched job must still be stored"
+
+    # run_log is what the absence detector reads — it MUST exist even though
+    # every file side-output was refused.
+    db = JobDatabase(tmp_db_path)
+    await db.init_db()
+    try:
+        runs = await db.get_run_logs(limit=5)
+    finally:
+        await db.close()
+    assert len(runs) >= 1, "run_log row must be written despite read-only export dirs"


### PR DESCRIPTION
## The absence detector's first real catch

Issue #170: no pipeline run for 36+ hours, catalog starving, every other instrument green.

## Root cause — verified from the live worker traceback

```
2026-07-30T04:00:03  cron:refresh_catalog failed, PermissionError: [Errno 13]
Permission denied: '/usr/local/lib/python3.12/site-packages/data'
  File ".../src/main.py", line 556, in run_search
```

`settings.py` anchors `BASE_DIR` on `__file__`. The API container runs from `/app` — writable, fine. The **worker** image installs the package into **site-packages** — read-only. `run_search`'s first act is `setup_logging()`, whose first act was an unguarded `LOGS_DIR.mkdir()`. The 04:00 cron died before fetching a single job, **every night, silently** — the API kept serving, so nothing looked wrong until the absence check compared `run_log` age against its limit.

## The rule this encodes

**Log and export files are conveniences. Stdout and Postgres are the product.** A disk problem may downgrade output; it must never kill the pipeline it describes.

## Three write sites fixed

A logging-only fix would have moved the crash to the CSV step at the **end** of the run — after all the fetching, and still before the `run_log` write the absence detector watches.

| Site | Now |
|---|---|
| `setup_logging` | file handlers under `try/OSError`; console-only fallback that **says where file logs would have gone**; CRLF injection scrubber survives the fallback (tested) |
| `setup_audit_logger` | stdout fallback; scrubber kept; DB tee still records |
| `run_search` CSV/report block | `try/OSError` + warning; run continues to the `run_log` write |
| metrics export | already guarded — verified, untouched |

## Tests — 13 passing

Per the lesson from #172's inverted-branch bug, the export guard is proven through the **real `run_search` path**, not a mirror: read-only exports dir → run completes, stores the job, **and writes `run_log`**. Plus: writable disk still gets both rotating file handlers (the fallback must not become the default).

Once deployed, tomorrow's 04:00 cron closes the loop: the absence detector auto-closes #170 when `run_log` goes fresh.

Closes #170.