### PR TITLE
fix: the catalog cron had no keywords to fetch with — issue #170, layer two

### DIFF
--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -542,6 +542,7 @@ async def run_search(
     no_notify: bool = False,
     user_id: str | None = None,
     enqueue: Callable[..., Any] | None = None,
+    search_config: SearchConfig | None = None,
 ) -> dict[str, Any]:
     # SI1 — ``enqueue`` is the notification fan-out hook. The per-user feed-write
     # path historically wrote user_feed but NEVER triggered a notification, so no
@@ -578,8 +579,16 @@ async def run_search(
     # profile; otherwise fall back to the single-tenant CLI path
     # (DEFAULT_TENANT_ID). See docs/plans/batch-3.5.2-plan.md Deliverable E.
     # Without this, the web "New Search" ran profile-less (E2E_TEST_REPORT #1).
-    profile = load_profile(user_id or DEFAULT_TENANT_ID)
-    if not profile or not profile.is_complete:
+    #
+    # A caller may instead hand us a ready-made `search_config` — the shared
+    # catalog refresh does: it fetches for EVERYONE (union of all users'
+    # configs), so no single profile is "the" profile, and the worker container
+    # has no legacy user_profile.json to fall back to. Found live 2026-07-30:
+    # the 04:00 cron loaded DEFAULT_TENANT_ID, got nothing, and aborted with
+    # sources_queried=0 — the second of two independent reasons the catalog
+    # cron had never once fetched a job.
+    profile = None if search_config is not None else load_profile(user_id or DEFAULT_TENANT_ID)
+    if search_config is None and (not profile or not profile.is_complete):
         logger.error("=" * 60)
         logger.error("No user profile found. Job360 requires a CV or preferences.")
         logger.error("")
@@ -598,8 +607,15 @@ async def run_search(
             "error": "no_profile",
         }
 
-    search_config = generate_search_config(profile)
-    logger.info("  Using dynamic keywords from user profile")
+    if search_config is None:
+        search_config = generate_search_config(profile)
+        logger.info("  Using dynamic keywords from user profile")
+    else:
+        logger.info(
+            "  Using caller-provided search config (%s titles, %s keywords)",
+            len(search_config.job_titles),
+            len(search_config.relevance_keywords),
+        )
     logger.info("=" * 60)
 
     # Init database

--- a/backend/src/services/profile/storage.py
+++ b/backend/src/services/profile/storage.py
@@ -318,6 +318,19 @@ def load_profile(user_id: str) -> Optional[UserProfile]:
     )
 
 
+def list_profile_user_ids() -> list[str]:
+    """Return every user_id that has a stored profile.
+
+    Exists for the shared-catalog refresh: the catalog serves ALL users, so
+    the fetch keywords must be the union of all users' configs — no single
+    profile is "the" profile there, and the worker container has no legacy
+    JSON fallback.
+    """
+    with pgsync.connect(str(DB_PATH)) as conn:
+        cur = conn.execute("SELECT user_id FROM user_profiles ORDER BY user_id")
+        return [r[0] for r in cur.fetchall()]
+
+
 def profile_exists(user_id: str) -> bool:
     """Return True if ``user_id`` has a profile row.
 

--- a/backend/src/workers/tasks.py
+++ b/backend/src/workers/tasks.py
@@ -982,8 +982,62 @@ async def refresh_catalog(ctx: dict[str, Any]) -> dict[str, Any]:
     import logging  # noqa: PLC0415
 
     from src.main import run_search  # noqa: PLC0415 — lazy (rule #11): heavy import
+    from src.services.profile.keyword_generator import generate_search_config  # noqa: PLC0415
+    from src.services.profile.models import SearchConfig  # noqa: PLC0415
+    from src.services.profile.storage import list_profile_user_ids, load_profile  # noqa: PLC0415
 
-    stats = await run_search(user_id=None, no_notify=True)
+    # The shared catalog serves EVERYONE, so fetch with the UNION of every
+    # user's search config. Passing user_id=None alone was not enough — found
+    # live 2026-07-30: run_search then fell back to DEFAULT_TENANT_ID, which
+    # has no profile row in prod, and aborted with sources_queried=0. Combined
+    # with the read-only-disk crash it masked, this cron had never fetched a
+    # single job. Cost safety is unchanged: user_id stays None, so the
+    # per-user stages (user_feed write, the paid LLM judge) remain
+    # structurally unreachable.
+    union = SearchConfig()
+    profiles_used = 0
+    for uid in list_profile_user_ids():
+        profile = load_profile(uid)
+        if not profile or not profile.is_complete:
+            continue
+        cfg = generate_search_config(profile)
+        profiles_used += 1
+        for attr in (
+            "job_titles",
+            "primary_skills",
+            "secondary_skills",
+            "tertiary_skills",
+            "relevance_keywords",
+            "locations",
+            "visa_keywords",
+            "search_queries",
+        ):
+            merged = getattr(union, attr)
+            for item in getattr(cfg, attr):
+                if item not in merged:
+                    merged.append(item)
+        union.core_domain_words |= cfg.core_domain_words
+        union.supporting_role_words |= cfg.supporting_role_words
+        # Deliberately NOT unioned: negative_title_keywords. One user's "not
+        # for me" (e.g. an engineer excluding "sales") must not hide jobs from
+        # a user who wants exactly those — exclusions are personal, and the
+        # shared catalog must over-collect, not under-collect.
+
+    if profiles_used == 0:
+        # Say it loudly rather than abort quietly inside run_search — an empty
+        # union means an empty fetch, which is this cron failing its one job.
+        logging.getLogger(__name__).warning(
+            "catalog refresh skipped: no complete user profiles found — nothing to fetch for"
+        )
+        return {"sources_queried": 0, "total_found": 0, "new_jobs": 0, "profiles_used": 0}
+
+    logging.getLogger(__name__).info(
+        "catalog refresh: union of %s profile(s) — %s titles, %s keywords",
+        profiles_used,
+        len(union.job_titles),
+        len(union.relevance_keywords),
+    )
+    stats = await run_search(user_id=None, no_notify=True, search_config=union)
     logging.getLogger(__name__).info(
         "catalog refresh: sources=%s found=%s new=%s",
         stats.get("sources_queried"),

--- a/backend/tests/test_worker_tasks.py
+++ b/backend/tests/test_worker_tasks.py
@@ -550,7 +550,20 @@ def test_refresh_catalog_is_shared_only_so_the_paid_llm_stages_cannot_run():
     import asyncio
     from unittest.mock import patch
 
+    from src.services.profile.models import CVData, UserPreferences, UserProfile
+    from src.services.profile.storage import save_profile
     from src.workers import tasks as tasks_mod
+
+    # The union-config redesign (issue #170 layer two) skips the fetch entirely
+    # when no complete profiles exist — seed one so run_search is reached and
+    # this test keeps exercising its actual contract (user_id=None).
+    save_profile(
+        UserProfile(
+            cv_data=CVData(raw_text="x", skills=["python"], job_titles=["Engineer"]),
+            preferences=UserPreferences(target_job_titles=["Engineer"], additional_skills=["python"]),
+        ),
+        user_id="cost-safety-user",
+    )
 
     captured: dict = {}
 

--- a/backend/tests/test_worker_tasks.py
+++ b/backend/tests/test_worker_tasks.py
@@ -570,3 +570,68 @@ def test_refresh_catalog_is_shared_only_so_the_paid_llm_stages_cannot_run():
     )
     assert captured.get("no_notify") is True
     assert result["new_jobs"] == 7
+
+
+def test_refresh_catalog_fetches_with_the_union_of_all_user_configs():
+    """Issue #170, second root cause: passing user_id=None made run_search fall
+    back to DEFAULT_TENANT_ID, which has no profile row in prod — so the cron
+    aborted with sources_queried=0 every night (once the read-only-disk crash
+    in front of it was fixed). The shared catalog serves EVERYONE, so the fetch
+    must use the UNION of every user's search config, while user_id stays None
+    to keep the paid per-user stages structurally unreachable.
+    """
+    import asyncio
+    from unittest.mock import patch
+
+    from src.services.profile.models import CVData, UserPreferences, UserProfile
+    from src.services.profile.storage import save_profile
+    from src.workers import tasks as tasks_mod
+
+    # Two users with clearly different interests — and one personal exclusion.
+    save_profile(
+        UserProfile(
+            cv_data=CVData(raw_text="x", skills=["python"], job_titles=["Data Engineer"]),
+            preferences=UserPreferences(
+                target_job_titles=["Data Engineer"],
+                additional_skills=["python"],
+                excluded_skills=["sales"],
+            ),
+        ),
+        user_id="union-user-a",
+    )
+    save_profile(
+        UserProfile(
+            cv_data=CVData(raw_text="y", skills=["selling"], job_titles=["Sales Manager"]),
+            preferences=UserPreferences(
+                target_job_titles=["Sales Manager"], additional_skills=["selling"]
+            ),
+        ),
+        user_id="union-user-b",
+    )
+
+    captured: dict = {}
+
+    async def _fake_run_search(**kwargs):
+        captured.update(kwargs)
+        return {"total_found": 10, "new_jobs": 2, "sources_queried": 5}
+
+    async def _go():
+        with patch("src.main.run_search", _fake_run_search):
+            return await tasks_mod.refresh_catalog({})
+
+    result = asyncio.run(_go())
+
+    assert result["new_jobs"] == 2
+    cfg = captured.get("search_config")
+    assert cfg is not None, "refresh_catalog must hand run_search a union config"
+    # Both users' worlds are represented — the catalog over-collects on purpose.
+    assert "Data Engineer" in cfg.job_titles
+    assert "Sales Manager" in cfg.job_titles
+    # Cost safety unchanged.
+    assert captured.get("user_id") is None
+    # One user's personal exclusion must NOT hide jobs from the other: user A
+    # excluded "sales" while user B wants exactly that. Exclusions are applied
+    # per-user at scoring time, never at shared-catalog fetch time.
+    assert not cfg.negative_title_keywords, (
+        f"personal exclusions leaked into the shared fetch: {cfg.negative_title_keywords}"
+    )


### PR DESCRIPTION
## Found live, minutes after #176 deployed

The 04:00 cron finally survived startup — and returned `sources_queried: 0`:

```
[ERROR] No user profile found. Job360 requires a CV or preferences.
0.09s <- refresh_catalog . {'sources_queried': 0, 'total_found': 0, 'new_jobs': 0}
```

`run_search(user_id=None)` falls back to `DEFAULT_TENANT_ID` — no profile row in prod. Without a profile the keyword lists are empty **by design**. So the shared-catalog cron, which belongs to no single user, had nothing to fetch with and aborted.

**Two independent faults were stacked** — the read-only-disk crash (#176) sat in front of this one and hid it completely. The cron has never fetched a job since it shipped.

## The fix: fetch for everyone

The shared catalog serves all users, so it fetches with the **union of every user's search config**:

- `storage.list_profile_user_ids()` — every user with a stored profile
- `refresh_catalog` unions their generated configs (titles, skills, keywords, locations, queries)
- `run_search` grows an optional `search_config=` parameter that skips the profile load

**Cost safety unchanged** and still pinned by the existing test: `user_id` stays `None`, so the per-user stages — the `user_feed` write and the **paid LLM judge** — remain structurally unreachable.

## One judgment call, explicit in code and test

`negative_title_keywords` are **not** unioned. One user's *"not for me"* (an engineer excluding "sales") must not hide jobs from the user who wants exactly those. Exclusions are personal, applied at scoring time; the shared catalog **over-collects on purpose**.

If no complete profiles exist, the cron warns loudly and returns zeros instead of aborting deep inside `run_search`.

## Tests

17 worker-task tests green, including a new one: two seeded users with different worlds → both reach the fetch config, `user_id` stays `None`, personal exclusions don't leak.

Gate: PASS.