### PR TITLE
fix: one poison row killed the whole catalog insert — issue #170, layer three

### DIFF
--- a/backend/src/models.py
+++ b/backend/src/models.py
@@ -3,6 +3,9 @@ import re
 from dataclasses import dataclass
 from typing import Optional
 
+# Max chars per normalized-key component — see normalized_key() for the why.
+_KEY_COMPONENT_MAX = 300
+
 _COMPANY_SUFFIXES = re.compile(
     r"\s+(ltd|limited|inc|plc|corporation|corp|group|llc|gmbh|ag|sa|co|company|holdings|solutions|technologies|services|systems|pty)\.?\s*$",
     re.IGNORECASE,
@@ -110,4 +113,15 @@ class Job:
         # (stripping punctuation risks over-merging distinct roles).
         company = re.sub(r"\s+", " ", company)
         title = re.sub(r"\s+", " ", self.title.strip().lower())
-        return (company, title)
+        # Cap each component. Found live 2026-07-30: one scraped job carried a
+        # title so long that (normalized_company, normalized_title) blew
+        # Postgres's btree index-row limit — "index row size 3128 exceeds
+        # maximum 2704" on jobs' UNIQUE(normalized_company, normalized_title) —
+        # and that ONE poison row aborted the whole catalog insert. No real
+        # company or title approaches 300 chars; anything longer is scraped
+        # garbage whose first 300 chars identify it just as well for dedup.
+        # 300+300 chars stays under the ~2704-byte limit even fully multibyte.
+        # Rule #1 holds because BOTH consumers of the key — the in-memory
+        # deduplicator and the DB UNIQUE constraint — flow through this one
+        # function, so they keep agreeing after truncation.
+        return (company[:_KEY_COMPONENT_MAX], title[:_KEY_COMPONENT_MAX])

--- a/backend/tests/test_models.py
+++ b/backend/tests/test_models.py
@@ -263,3 +263,44 @@ def test_normalized_key_does_not_strip_seniority():
     j1 = Job(title="Senior AI Engineer", company="DeepMind", apply_url="x", source="a", date_found="x")
     j2 = Job(title="AI Engineer", company="DeepMind", apply_url="x", source="a", date_found="x")
     assert j1.normalized_key() != j2.normalized_key(), "Seniority should NOT be stripped by normalized_key"
+
+
+def test_normalized_key_caps_component_length():
+    """Live failure 2026-07-30: one scraped job's title blew Postgres's btree
+    index-row limit ("index row size 3128 exceeds maximum 2704" on the jobs
+    UNIQUE(normalized_company, normalized_title)) and that single poison row
+    aborted the ENTIRE catalog insert — the whole 257s fetch thrown away.
+
+    Rule #1 safety: dedup layer 1 and the DB constraint both consume this one
+    function, so capping here keeps them agreeing.
+    """
+    monster = Job(
+        title="Senior Engineer " * 300,  # ~4,800 chars of scraped garbage
+        company="Acme " * 300,
+        apply_url="https://x.test/1",
+        source="test",
+        date_found="2026-07-30",
+    )
+    company, title = monster.normalized_key()
+    assert len(company) <= 300
+    assert len(title) <= 300
+    # Two monsters that share their first 300 chars must still collide — that
+    # is the dedup working, not a loss: page-of-text titles differing only
+    # after char 300 are the same scraped listing.
+    monster2 = Job(
+        title="Senior Engineer " * 300 + "different tail",
+        company="Acme " * 300,
+        apply_url="https://x.test/2",
+        source="test",
+        date_found="2026-07-30",
+    )
+    assert monster.normalized_key() == monster2.normalized_key()
+    # And sane keys are untouched.
+    normal = Job(
+        title="Software Engineer",
+        company="Acme Ltd",
+        apply_url="https://x.test/3",
+        source="test",
+        date_found="2026-07-30",
+    )
+    assert normal.normalized_key() == ("acme", "software engineer")


### PR DESCRIPTION
## Third and final layer under #170

With the read-only disk (#176) and the missing fetch keywords (#177) fixed, the catalog cron finally fetched for real — **257 seconds**: Lever 155, Greenhouse 1,432, Workday 345, more. Then the DB write died:

```
ProgramLimitExceeded: index row size 3128 exceeds btree version 4 maximum 2704
for index "jobs_normalized_company_normalized_title_key"
```

**One** scraped job carried a title long enough that its normalized key blew Postgres's index-row limit — and that single poison row aborted the **entire batch**. The whole fetch thrown away, and still no `run_log` row for the absence detector.

## Fix

`normalized_key()` caps each component at 300 chars. No real company or title approaches that; anything longer is scraped garbage whose first 300 chars identify it just as well for dedup. 300+300 stays under the ~2,704-byte limit even fully multibyte.

**Rule #1 is why the cap lives here** and not at the insert: both consumers of the key — in-memory dedup layer 1 and the DB UNIQUE constraint — flow through this one function, so they keep agreeing after truncation.

## Verified with exactly rule #1's suites

`test_models` + `test_deduplicator` + `test_database` → **75 passed**, including a new regression test:
- monster keys cap at 300
- twins differing only after char 300 still collide — that's dedup *working*; a page-of-text title differing at char 301 is the same scraped listing
- sane keys byte-identical to before

Gate: PASS.