### PR TITLE
feat(harness): walk every user down the pipeline, find where it breaks for THEM

### DIFF
--- a/.github/workflows/user-journey.yml
+++ b/.github/workflows/user-journey.yml
@@ -1,0 +1,167 @@
+name: User journey (walk every user, find where it breaks for them)
+
+# THE GAP THIS CLOSES, in the owner's words: "run one user by one user and
+# check if the search is doing good, if the extraction is doing good, if the
+# dashboard looks good."
+#
+# Every other detector we have looks at AGGREGATES — total feed rows, max
+# score, catalog size. An aggregate hides the only thing that matters to a
+# person: the product can be perfectly healthy on average and completely
+# useless for them.
+#
+# Proven on the first real run (2026-08-03), against live prod:
+#   user 7edd5b59  has a profile and ZERO feed rows        -> BROKEN at 'feed'
+#   user 88e7d907  has 152 skills and ZERO target titles   -> degraded
+#   both real users have 130-152 extracted skills          -> over-extraction
+# Aggregate checks said the product was fine. It was fine on average.
+#
+# WHAT IT DOES: walks each user down the real pipeline —
+#   signup -> profile -> extraction -> search keywords -> feed -> scoring
+#          -> visible on the dashboard
+# — and reports the FIRST stage that breaks FOR THEM. That turns "the product
+# feels off" into "extraction works, search config is empty, so the feed is
+# empty" — a sentence the repair loop can act on.
+#
+# It also reports DEGRADED users separately: nobody is blocked, but the product
+# is worse than we think we are shipping. Those never become alarms on their
+# own — a nag that fires every night is a nag nobody reads.
+#
+# Read-only SQL. No model. Which is why it is trusted to raise an alarm itself.
+
+on:
+  schedule:
+    - cron: "0 9 * * *" # 09:00 UTC, after absence (08:00) and product-health (08:30)
+  workflow_dispatch:
+    inputs:
+      drill:
+        description: "FIRE DRILL — force a break to prove the chain still works"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  issues: write
+  actions: write # to wake the triage loop
+
+concurrency:
+  group: user-journey
+  cancel-in-progress: false
+
+jobs:
+  walk:
+    name: Walk every user
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+      - name: Install psycopg
+        run: python -m pip install "psycopg[binary]>=3.2"
+
+      - name: Check the DSN secret exists
+        id: dsn
+        run: echo "have=${{ secrets.PROD_DATABASE_URL != '' }}" >> "$GITHUB_OUTPUT"
+
+      - name: Say so loudly if it cannot run
+        if: steps.dsn.outputs.have != 'true'
+        run: |
+          echo "::error::PROD_DATABASE_URL is not set - the user journey audit cannot run."
+          echo "A silent skip recreates the exact failure this loop exists to catch."
+          exit 1
+
+      - name: Walk each user down the pipeline
+        id: walk
+        env:
+          PROD_DATABASE_URL: ${{ secrets.PROD_DATABASE_URL }}
+          DRILL: ${{ inputs.drill }}
+        run: |
+          # A drill forces a break so the whole downstream chain - issue,
+          # triage, repair - is exercised on purpose rather than only during a
+          # real incident, which is the worst time to discover it is broken.
+          if [ "$DRILL" = "true" ]; then
+            echo "::warning::FIRE DRILL - forcing a break. Users are fine."
+            export UJ_MIN_FEED=999999999
+          fi
+          set +e
+          python scripts/user_journey_audit.py > journey.md 2>&1
+          code=$?
+          set -e
+          cat journey.md
+          cat journey.md >> "$GITHUB_STEP_SUMMARY"
+          echo "broken=$code" >> "$GITHUB_OUTPUT"
+          # exit 2 = the audit itself broke -> fail LOUD, never silently pass
+          [ "$code" -le 1 ] || exit "$code"
+
+      # CANARY: a detector nobody has seen fail is not known to work. "All
+      # users healthy" might just mean the audit is blind.
+      - name: Canary - prove the audit can still fail
+        env:
+          PROD_DATABASE_URL: ${{ secrets.PROD_DATABASE_URL }}
+          UJ_MIN_SKILLS: "999999999"
+        run: |
+          set +e
+          python scripts/user_journey_audit.py > canary.md 2>&1
+          code=$?
+          set -e
+          if [ "$code" -ne 1 ]; then
+            echo "::error::CANARY FAILED - the audit did NOT go red against an impossible floor (exit $code). Today's green means nothing."
+            cat canary.md
+            exit 1
+          fi
+          echo "canary ok - the audit still fails when it should" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Raise it, and hand it to triage
+        if: always() && steps.walk.outputs.broken != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          if [ "${{ inputs.drill }}" = "true" ]; then
+            title="DRILL: user journey test - not a real problem"
+          else
+            # The "PRODUCT: " prefix is deliberate - triage's trusted-origin
+            # whitelist keys on it, so a real break here can auto-authorise a
+            # repair without the owner hand-relaying the message.
+            title="PRODUCT: the pipeline is broken for at least one user"
+          fi
+          num=$(gh issue list --state open --json number,title \
+                  --jq ".[] | select(.title==\"$title\") | .number" | head -1)
+
+          if [ "${{ steps.walk.outputs.broken }}" = "1" ]; then
+            {
+              if [ "${{ inputs.drill }}" = "true" ]; then
+                echo "> **This is a FIRE DRILL. Users are fine.**"
+                echo ">"
+                echo "> A break was forced to prove the chain still works:"
+                echo "> audit -> issue -> triage -> fix. Close when observed."
+                echo
+              fi
+              cat journey.md
+              echo
+              echo "Aggregate checks cannot see this. The product can look healthy"
+              echo "on average while being completely useless for one person."
+              echo
+              echo "- Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            } > body.md
+            if [ -z "$num" ]; then
+              new=$(gh issue create --title "$title" --body-file body.md --label harness)
+              n="${new##*/}"
+              # Explicit handoff: an issue opened with GITHUB_TOKEN raises no
+              # `issues` run (GitHub blocks that recursion), so relying on the
+              # event would leave every user-journey alarm undiagnosed.
+              if gh workflow run triage.yml -f issue="$n"; then
+                echo "raised #$n and woke triage" >> "$GITHUB_STEP_SUMMARY"
+              else
+                echo "::warning::issue #$n raised but triage could not be woken - diagnose by hand"
+              fi
+            else
+              gh issue comment "$num" --body-file body.md
+              echo "commented on existing #$num" >> "$GITHUB_STEP_SUMMARY"
+            fi
+          elif [ -n "$num" ]; then
+            gh issue close "$num" \
+              --comment "Every onboarded user reaches the dashboard again as of run ${{ github.run_id }}. (auto-close)"
+          fi

--- a/scripts/user_journey_audit.py
+++ b/scripts/user_journey_audit.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""Walk EVERY user through the whole pipeline and find where it breaks for them.
+
+WHY THIS EXISTS. Our other detectors look at aggregates: total feed rows, max
+score, catalog size. An aggregate hides the thing that actually matters — that
+the product can be perfectly healthy on average and completely broken for one
+person. Found live 2026-08-03 by the first run of this script:
+
+    user 7edd5b59  has a profile, and ZERO feed rows.  Aggregates said fine.
+    user 88e7d907  has 152 extracted skills and ZERO target job titles.
+
+Neither throws an error. Neither fails a test. Both are somebody's product
+being quietly useless.
+
+THE IDEA: the pipeline is a chain of stages. For each user, walk the chain and
+report the FIRST stage that broke. That turns "the product feels off" into
+"extraction works for this user, search config is empty, so the feed is empty" —
+a sentence a repair loop can act on.
+
+    signup -> profile input -> extraction -> search keywords -> feed
+           -> scoring -> visible on the dashboard
+
+Read-only SQL. No LLM. No writes.
+
+Exit codes:  0 = every onboarded user is healthy
+             1 = at least one user is broken at some stage
+             2 = the audit itself failed (fail LOUD, never silently pass)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+
+# A user who never uploaded anything is not a bug — they just never started.
+# Everything below applies only to users who DID give us input.
+MIN_SKILLS = int(os.getenv("UJ_MIN_SKILLS", "3"))
+MIN_FEED = int(os.getenv("UJ_MIN_FEED", "10"))
+DISPLAY_FLOOR = int(os.getenv("UJ_DISPLAY_FLOOR", "0"))
+
+
+def mask(email: str | None) -> str:
+    if not email or "@" not in email:
+        return "<none>"
+    return f"{email[0]}***@{email.split('@')[-1]}"
+
+
+def audit_user(cur, uid, email) -> tuple[str, str, dict]:
+    """Return (stage_reached, verdict, facts) for one user.
+
+    verdict is 'ok', 'broken', or 'not-started'.
+    """
+    f: dict = {}
+
+    def one(q, default=0):
+        cur.execute(q, (uid,))
+        row = cur.fetchone()
+        return row[0] if row and row[0] is not None else default
+
+    f["profile_rows"] = one("SELECT count(*) FROM user_profiles WHERE user_id=%s")
+
+    # STAGE 1 — did they give us anything at all?
+    if not f["profile_rows"]:
+        return "signup", "not-started", f
+
+    cur.execute("SELECT cv_data, preferences FROM user_profiles WHERE user_id=%s", (uid,))
+    row = cur.fetchone()
+    cv = json.loads(row[0]) if row and row[0] else {}
+    pref = json.loads(row[1]) if row and row[1] else {}
+
+    f["cv_chars"] = len(cv.get("raw_text") or "")
+    f["skills"] = len(cv.get("skills") or [])
+    f["cv_titles"] = len(cv.get("job_titles") or [])
+    f["target_titles"] = len(pref.get("target_job_titles") or [])
+    f["extra_skills"] = len(pref.get("additional_skills") or [])
+    f["has_linkedin"] = bool(cv.get("linkedin_raw_text"))
+    f["has_github"] = bool(cv.get("github_repos_brief"))
+
+    # STAGE 2 — extraction. Input went in; did anything come out?
+    if f["cv_chars"] and f["skills"] < MIN_SKILLS:
+        return "extraction", "broken", f
+
+    # STAGE 3 — search keywords. Extraction can succeed and still produce
+    # nothing to search WITH, which is the same as having no product.
+    if f["skills"] == 0 and f["cv_titles"] == 0 and f["target_titles"] == 0:
+        return "search-keywords", "broken", f
+
+    # STAGE 4 — the feed. Keywords existed; did any job reach this person?
+    f["feed_rows"] = one("SELECT count(*) FROM user_feed WHERE user_id=%s")
+    if f["feed_rows"] < MIN_FEED:
+        return "feed", "broken", f
+
+    # STAGE 5 — scoring. Rows exist; are the scores meaningful, or all one value?
+    f["max_score"] = one("SELECT coalesce(max(score),0) FROM user_feed WHERE user_id=%s")
+    f["distinct_scores"] = one(
+        "SELECT count(DISTINCT score) FROM user_feed WHERE user_id=%s"
+    )
+    if f["max_score"] == 0 or f["distinct_scores"] < 2:
+        return "scoring", "broken", f
+
+    # STAGE 6 — the dashboard. Scored rows exist; do any survive the filter?
+    cur.execute(
+        "SELECT count(*) FROM user_feed WHERE user_id=%s AND score >= %s",
+        (uid, DISPLAY_FLOOR),
+    )
+    f["visible"] = cur.fetchone()[0]
+    f["visible_pct"] = round(f["visible"] / f["feed_rows"] * 100) if f["feed_rows"] else 0
+    if f["visible"] == 0:
+        return "dashboard", "broken", f
+
+    # Quality signals that are NOT failures — worth reporting, not blocking.
+    f["llm_verdicts"] = one(
+        "SELECT count(*) FROM user_feed WHERE user_id=%s AND llm_fit_score IS NOT NULL"
+    )
+    return "complete", "ok", f
+
+
+def main() -> int:
+    dsn = os.getenv("PROD_DATABASE_URL") or os.getenv("DATABASE_PUBLIC_URL")
+    if not dsn:
+        print("::error::no PROD_DATABASE_URL - the user journey audit cannot run")
+        return 2
+    try:
+        import psycopg
+    except ImportError:
+        print("::error::psycopg not installed")
+        return 2
+
+    STAGES = [
+        "signup", "extraction", "search-keywords", "feed", "scoring",
+        "dashboard", "complete",
+    ]
+
+    try:
+        with psycopg.connect(dsn, connect_timeout=25) as conn, conn.cursor() as cur:
+            cur.execute("SELECT id, email FROM users ORDER BY created_at")
+            users = cur.fetchall()
+            results = [(uid, email, *audit_user(cur, uid, email)) for uid, email in users]
+    except Exception as exc:  # noqa: BLE001
+        print(f"::error::user journey audit could not run: {exc}")
+        return 2
+
+    onboarded = [r for r in results if r[3] != "not-started"]
+    broken = [r for r in onboarded if r[3] == "broken"]
+
+    print("# User journey audit - where does the pipeline break, per person?\n")
+    print(f"- Users total: **{len(results)}**")
+    print(f"- Onboarded (gave us input): **{len(onboarded)}**")
+    print(f"- Broken somewhere: **{len(broken)}**\n")
+
+    if not onboarded:
+        print("No onboarded users yet. Nothing to audit - an honest empty result.")
+        return 0
+
+    # Funnel: how far does each stage carry people?
+    print("## The funnel\n")
+    print("| stage | users who got this far |")
+    print("|---|---|")
+    for i, st in enumerate(STAGES):
+        got_here = sum(1 for r in onboarded if STAGES.index(r[2]) >= i)
+        bar = "#" * min(got_here, 30)
+        print(f"| {st} | {got_here} {bar} |")
+    print()
+
+    print("## Per user\n")
+    print("| user | verdict | reached | evidence |")
+    print("|---|---|---|---|")
+    for uid, email, stage, verdict, f in results:
+        tag = {"ok": "OK", "broken": "**BROKEN**", "not-started": "-"}[verdict]
+        if verdict == "not-started":
+            ev = "never uploaded a CV or set preferences"
+        elif verdict == "broken":
+            ev = {
+                "extraction": f"CV has {f.get('cv_chars',0)} chars but only "
+                              f"{f.get('skills',0)} skills came out",
+                "search-keywords": "nothing to search with: no skills, no CV titles, "
+                                   "no target titles",
+                "feed": f"only {f.get('feed_rows',0)} jobs reached this user",
+                "scoring": f"max score {f.get('max_score',0)}, "
+                           f"{f.get('distinct_scores',0)} distinct values - "
+                           "scoring is not discriminating",
+                "dashboard": f"{f.get('feed_rows',0)} scored jobs, "
+                             f"{f.get('visible',0)} visible - the filter hides everything",
+            }.get(stage, stage)
+        else:
+            ev = (f"{f.get('skills',0)} skills, {f.get('feed_rows',0)} jobs, "
+                  f"{f.get('visible_pct',0)}% visible, "
+                  f"{f.get('llm_verdicts',0)} AI verdicts")
+        print(f"| `{str(uid)[:8]}` {mask(email)} | {tag} | {stage} | {ev} |")
+    print()
+
+    # Quality warnings: healthy users can still have a degraded experience.
+    warnings = []
+    for uid, email, stage, verdict, f in results:
+        if verdict != "ok":
+            continue
+        who = f"`{str(uid)[:8]}`"
+        if f.get("target_titles", 0) == 0:
+            warnings.append(
+                f"{who} has NO target job titles - search runs on the CV alone, so "
+                "the user's own stated goal is not steering their results")
+        if f.get("skills", 0) > 100:
+            warnings.append(
+                f"{who} has {f['skills']} extracted skills - suspiciously many. "
+                "Over-extraction dilutes matching: everything looks like a partial fit")
+        if not f.get("has_linkedin") and not f.get("has_github"):
+            warnings.append(f"{who} has CV only - no LinkedIn or GitHub signal")
+        if f.get("llm_verdicts", 0) == 0:
+            warnings.append(f"{who} has no AI verdicts - the judge never ran for them")
+
+    if warnings:
+        print("## Working, but degraded\n")
+        print("Not failures - nobody is blocked. But this is a worse product than "
+              "we think we are shipping:\n")
+        for w in warnings:
+            print(f"- {w}")
+        print()
+
+    if broken:
+        print("## Broken\n")
+        for uid, email, stage, verdict, f in broken:
+            print(f"- `{str(uid)[:8]}` breaks at **{stage}**")
+        print("\nAggregate checks miss all of these: the product can look healthy "
+              "on average while being completely useless for one person.")
+        return 1
+
+    print("Every onboarded user reaches the dashboard with visible, scored jobs.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## The gap

Every detector we had looks at **aggregates** — total feed rows, max score, catalog size. An aggregate hides the only thing that matters to a person: **the product can be perfectly healthy on average and completely useless for them.**

## Found on the first real run, before this shipped

**BROKEN**
- `7edd5b59` — has a profile and **zero feed rows**. Breaks at `feed`.

**DEGRADED** *(nobody blocked, but worse than we think we're shipping)*
- `88e7d907` — **no target job titles**. Search runs on the CV alone, so the user's own stated goal never steers their results.
- `88e7d907` **152 skills**, `ad13c75d` **131** — over-extraction dilutes matching until everything looks like a partial fit.
- `ad13c75d` — CV only, no LinkedIn or GitHub signal.

None throws an error. None fails a test. Aggregates said fine — and on average, they were right.

## How it works

```
signup → profile → extraction → search keywords → feed → scoring → dashboard
```

For each user it walks the chain and reports **the first stage that broke for them**. That turns *"the product feels off"* into *"extraction works, the search config is empty, so the feed is empty"* — a sentence the repair loop can act on. Plus a funnel showing how far each stage carries people.

Degraded findings are reported but **never raise an alarm on their own** — a nag that fires nightly is a nag nobody reads.

The issue title uses the `PRODUCT: ` prefix deliberately: triage's trusted-origin whitelist keys on it, so a real break **auto-authorises a repair** instead of waiting for you to relay the message.

Read-only SQL, no model, canary + drill entrance. Exit code verified — 1 when a user is broken, and the canary proves it can still go red.

Gate: PASS.