### PR TITLE
feat(harness): benchmark extraction against the 7 real CVs in User_info/

### DIFF
--- a/backend/src/services/profile/cv_parser.py
+++ b/backend/src/services/profile/cv_parser.py
@@ -453,6 +453,82 @@ def _det_merge_wrapped_lines(skill_lines: list[str]) -> list[str]:
     return logical
 
 
+# Words that only ever appear in prose, never inside a real skill name. This is
+# a GRAMMAR list, not a skill list — it says nothing about any domain, so it
+# does not violate CLAUDE.md rule #28 (no hardcoded skill/keyword vocabularies).
+# It exists because a CV that states skills in sentences gets its sentences
+# split on commas into fake "skills" like "analytics and APIs" or
+# "Production Python for data engineering". Measured on the real 7-CV corpus:
+# this was the single biggest source of over-extraction.
+_DET_PROSE_MARKERS = (" for ", " with ", " to ", " of the ", " in the ", " using ",
+                      " across ", " through ", " including ", " such as ")
+
+
+def _det_is_prose(token: str) -> bool:
+    """True when a token reads as a sentence fragment rather than a skill name.
+
+    Three structural signals, none of them domain-specific:
+      * it ends in a full stop  -> it was a sentence
+      * it contains a prepositional phrase ("X for Y", "X using Y")
+      * it starts with a lowercase verb-ish word AND is multi-word
+        ("integrating various sensors" vs "asyncio")
+    """
+    t = token.strip()
+    if not t:
+        return True
+    if t.endswith("."):
+        return True
+    # A full stop INSIDE a token means two sentences were glued together and
+    # then comma-split, producing hybrids like "grounded LLM answers. Containers"
+    # — found in the real corpus. Not a skill; the sentence boundary was missed.
+    # Guard against real dotted names (Node.js, .NET, asp.net) by requiring the
+    # stop to be followed by a space and a capital, i.e. actual sentence shape.
+    # Require a real WORD before the stop (3+ letters), so abbreviations like
+    # "U.S. GAAP" and "M.Sc. Statistics" survive - those are genuine skills in
+    # finance and academia, and an over-eager guard silently deletes them.
+    if re.search(r"[A-Za-z]{3}\.\s+[A-Z]", t):
+        return True
+    low = f" {t.lower()} "
+    if any(m in low for m in _DET_PROSE_MARKERS):
+        return True
+    # "integrating various sensors and actuators" — a gerund opening a
+    # multi-word phrase is describing an activity, not naming a skill.
+    words = t.split()
+    if len(words) >= 3 and words[0].islower() and words[0].endswith("ing"):
+        return True
+    return False
+
+
+def _det_collapse_acronyms(skills: list[str]) -> list[str]:
+    """Drop an expansion when its own acronym is already present (or vice versa).
+
+    "RAG" + "Retrieval Augmented Generation" is ONE capability listed twice —
+    the parenthesis expander produces both. Keeping both inflates the skill
+    count without adding capability, which is exactly what makes a profile look
+    broad and match everything weakly.
+
+    Structural: we build the initials of each multi-word token and look for an
+    existing short token that matches. No vocabulary involved, so this works
+    for any profession.
+    """
+    if len(skills) < 2:
+        return skills
+    short = {s.lower(): s for s in skills if len(s.split()) == 1}
+    out: list[str] = []
+    dropped: set[str] = set()
+    for s in skills:
+        words = s.split()
+        if len(words) >= 2:
+            initials = "".join(w[0] for w in words if w and w[0].isalpha()).lower()
+            if len(initials) >= 2 and initials in short:
+                # Keep the acronym (shorter, and what job ads actually use);
+                # drop the long form.
+                dropped.add(s.lower())
+                continue
+        out.append(s)
+    return [s for s in out if s.lower() not in dropped]
+
+
 def deterministic_cv_fields(raw_text: str) -> dict[str, Any]:
     """Pass 1 for the CV — pull base fields from text with NO LLM.
 
@@ -485,9 +561,21 @@ def deterministic_cv_fields(raw_text: str) -> dict[str, Any]:
             # precision when stem-matched headings pull in prose bodies.
             if not tok or len(tok) > 45 or len(tok.split()) > 5:
                 continue
+            if _det_is_prose(tok):
+                continue
             if tok.lower() not in seen:
                 skills.append(tok)
                 seen.add(tok.lower())
+
+    # Collapse acronym/expansion pairs. A skills line reading
+    # "RAG (Retrieval Augmented Generation)" expands to BOTH terms, so the same
+    # capability is counted twice — and a CV listing many such pairs inflates
+    # the count without adding a single new capability. Measured on the real
+    # corpus (User_info/, 7 CVs): this was a meaningful share of the two
+    # over-extracted profiles. Structural, not a vocabulary: we compare a
+    # token's initials to another token, so it works for any domain and needs
+    # no keyword list (CLAUDE.md rule #28).
+    skills = _det_collapse_acronyms(skills)
 
     # NOTE: no hardcoded skill-keyword scanning here (CLAUDE.md rule #28).
     # The deterministic pass reads STRUCTURE only (the Skills section + its

--- a/backend/tests/test_cv_parser_esco.py
+++ b/backend/tests/test_cv_parser_esco.py
@@ -110,3 +110,47 @@ def test_full_cv_parse_pipeline_populates_esco_map(fake_esco):
     assert "Python" in cvdata.skills
     assert "Bespoke Tooling" in cvdata.skills
     assert cvdata.cv_skills_esco == {"Python": "esco://skill/python"}
+
+
+# ---------------------------------------------------------------------------
+# Structural noise guards (added 2026-08-03, driven by the real 7-CV corpus in
+# User_info/). These are GRAMMAR rules, not skill vocabularies — rule #28 holds.
+# ---------------------------------------------------------------------------
+
+def test_prose_fragments_are_not_skills():
+    """A CV that states skills in sentences gets comma-split into fake skills.
+    Real examples pulled from the corpus."""
+    from src.services.profile.cv_parser import _det_is_prose
+    for prose in (
+        "Production Python for data engineering",
+        "integrating various sensors and actuators.",
+        "grounded LLM answers. Containers",       # two sentences glued together
+    ):
+        assert _det_is_prose(prose), f"should be dropped as prose: {prose!r}"
+
+
+def test_real_skill_names_survive_the_prose_guard():
+    """The guard must not eat legitimate skills — including dotted names and
+    abbreviations, which an over-eager sentence check silently deletes."""
+    from src.services.profile.cv_parser import _det_is_prose
+    for skill in (
+        "Node.js", ".NET", "asp.net core", "PySpark", "Deep Learning",
+        "Generative AI", "U.S. GAAP", "M.Sc. Statistics",
+    ):
+        assert not _det_is_prose(skill), f"real skill wrongly dropped: {skill!r}"
+
+
+def test_acronym_and_expansion_collapse_to_one_skill():
+    """'RAG (Retrieval Augmented Generation)' expands to BOTH terms, counting
+    one capability twice and inflating the profile."""
+    from src.services.profile.cv_parser import _det_collapse_acronyms
+    out = _det_collapse_acronyms(["RAG", "Retrieval Augmented Generation", "Python"])
+    assert "RAG" in out and "Python" in out
+    assert "Retrieval Augmented Generation" not in out
+
+
+def test_collapse_leaves_unrelated_multiword_skills_alone():
+    """Only a genuine acronym/expansion pair collapses — not every phrase."""
+    from src.services.profile.cv_parser import _det_collapse_acronyms
+    out = _det_collapse_acronyms(["Deep Learning", "Computer Vision", "Python"])
+    assert len(out) == 3

--- a/scripts/profile_benchmark.py
+++ b/scripts/profile_benchmark.py
@@ -39,12 +39,24 @@ from pathlib import Path
 if hasattr(sys.stdout, "reconfigure"):
     sys.stdout.reconfigure(encoding="utf-8", errors="replace")
 
-# What "good" looks like. A CV that yields 2 skills was not understood; one that
-# yields 120 was not understood either — it just swept up every noun. Both ends
-# are failures, and only the low end is usually tested for.
+# What "good" looks like.
+#
+# CORRECTION, recorded honestly: the first version of this file called anything
+# over 60 skills "over-extracted". That number was invented, not measured. When
+# I actually READ the output, one 73-skill profile was entirely legitimate
+# (Python, Pandas, OCR, Tesseract, AI Ethics, Linux...) — a dense AI CV really
+# does have that many. A raw count cannot tell a rich profile from a noisy one.
+#
+# So the ceiling is gone and the signal is NOISE RATIO instead: what fraction of
+# extracted "skills" are single lowercase common words? Real skill names are
+# proper nouns, acronyms, or capitalised terms ("PySpark", "RAG", "Deep
+# Learning"). A list full of bare words like "validity", "uniqueness",
+# "timeliness", "metrics" is a sentence that was comma-split — which is exactly
+# what the genuinely noisy profile in the corpus contained.
 MIN_SKILLS = 5
-MAX_HEALTHY_SKILLS = 60
 MIN_CHARS = 400
+# Above this share of bare-lowercase tokens, the list is prose, not skills.
+MAX_NOISE_RATIO = 0.35
 
 
 def mask(name: str) -> str:
@@ -56,16 +68,24 @@ def mask(name: str) -> str:
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--root", default=".", help="repo root holding User_info/")
+    # The corpus and the code under test are NOT always in the same checkout:
+    # User_info/ lives once in the main working copy, while the extractor being
+    # benchmarked may be in a worktree. Conflating them silently benchmarks the
+    # WRONG code and reports "no change" after a real fix — which is exactly
+    # what happened the first time this ran.
+    ap.add_argument("--code", default=None,
+                    help="checkout whose backend/ is under test (default: --root)")
     args = ap.parse_args()
 
     root = Path(args.root).resolve()
+    code_root = Path(args.code).resolve() if args.code else root
     ui = root / "User_info"
     if not ui.is_dir():
         print(f"# Profile benchmark\n\n`User_info/` not found under `{root}`.")
         print("Nothing to benchmark — this is an honest empty result, not a pass.")
         return 0
 
-    sys.path.insert(0, str(root / "backend"))
+    sys.path.insert(0, str(code_root / "backend"))
     try:
         from src.services.profile.cv_parser import deterministic_cv_fields, extract_text
     except ImportError as exc:
@@ -112,14 +132,22 @@ def main() -> int:
         skills = len(det.get("skills") or [])
         summary = len(det.get("summary") or "")
 
+        # Noise = single bare lowercase words. "asyncio" and "pandas" are real
+        # and lowercase, so one such token proves nothing; a HIGH SHARE of them
+        # is the signal that a sentence got comma-split into fake skills.
+        items = det.get("skills") or []
+        noise = [x for x in items if len(x.split()) == 1 and x.islower() and len(x) > 2]
+        ratio = (len(noise) / len(items)) if items else 0.0
+
         if chars < MIN_CHARS:
             verdict, why = "**BROKEN**", f"only {chars} chars read from the PDF"
         elif skills < MIN_SKILLS:
             verdict, why = "**no floor**", f"{chars} chars in, {skills} skills out"
-        elif skills > MAX_HEALTHY_SKILLS:
-            verdict, why = "over-extracted", f"{skills} skills — too many to discriminate"
+        elif ratio > MAX_NOISE_RATIO:
+            verdict, why = "noisy", (f"{skills} skills but {int(ratio*100)}% are bare "
+                                     "lowercase words — a sentence was comma-split")
         else:
-            verdict, why = "ok", f"{skills} skills, {summary}-char summary"
+            verdict, why = "ok", f"{skills} skills, {int(ratio*100)}% noise, {summary}-char summary"
         rows.append((who, chars, skills, verdict, why, key))
 
     print("| person | CV chars | skills | LinkedIn | GitHub | verdict | note |")
@@ -131,13 +159,13 @@ def main() -> int:
     print()
 
     ok = [r for r in rows if r[3] == "ok"]
-    over = [r for r in rows if r[3] == "over-extracted"]
+    over = [r for r in rows if r[3] == "noisy"]
     broken = [r for r in rows if "no floor" in r[3] or "FAILED" in r[3]]
     counts = [r[2] for r in rows if r[2]]
 
     print("## What this says\n")
     print(f"- Usable extraction: **{len(ok)}/{len(rows)}**")
-    print(f"- Over-extracted (>{MAX_HEALTHY_SKILLS} skills): **{len(over)}/{len(rows)}**")
+    print(f"- Noisy (prose split into fake skills): **{len(over)}/{len(rows)}**")
     print(f"- No deterministic floor (fully LLM-dependent): **{len(broken)}/{len(rows)}**")
     if counts:
         print(f"- Skills per CV: min {min(counts)}, median "

--- a/scripts/profile_benchmark.py
+++ b/scripts/profile_benchmark.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Run every real profile in User_info/ through extraction and grade the result.
+
+WHY. Extraction is the first stage of the product and the one nothing tested.
+The live audit found both real users carrying 130-152 "skills" — over-extraction
+that quietly makes matching worse, because when everything is a skill nothing
+stands out. But two users is not a sample, and neither is a synthetic fixture:
+real CVs are messy in ways nobody invents.
+
+`User_info/` holds 7 real people (CV, LinkedIn, GitHub). That is a benchmark
+set. This runs the actual production extractor over all of them and reports,
+per person, whether the output is usable.
+
+PRIVACY — THE LOAD-BEARING RULE. `User_info/` is gitignored (.gitignore:53) and
+holds real people's CVs. This script therefore:
+  * never copies, prints or writes any CV text, name, employer or email
+  * reports COUNTS and SHAPES only ("42 skills", "3 sections found")
+  * masks every filename to an initial ("Ranjith_CV.pdf" -> "R***")
+  * writes only to a gitignored path
+A benchmark that leaks its own corpus is worse than no benchmark, and this repo
+is public.
+
+COST. Deterministic pass only by default — no LLM, no spend, no keys needed.
+`--llm` additionally runs the paid pass, which is the honest comparison but
+costs money per CV; it is opt-in for that reason.
+
+Usage:
+    python scripts/profile_benchmark.py                    # free, deterministic
+    python scripts/profile_benchmark.py --root ../..       # if run from backend/
+"""
+
+from __future__ import annotations
+
+import argparse
+import statistics
+import sys
+from pathlib import Path
+
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+
+# What "good" looks like. A CV that yields 2 skills was not understood; one that
+# yields 120 was not understood either — it just swept up every noun. Both ends
+# are failures, and only the low end is usually tested for.
+MIN_SKILLS = 5
+MAX_HEALTHY_SKILLS = 60
+MIN_CHARS = 400
+
+
+def mask(name: str) -> str:
+    """Ranjith_CV.pdf -> R*** . Never print a real name."""
+    stem = Path(name).stem.split("_")[0]
+    return (stem[0] + "***") if stem else "?***"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--root", default=".", help="repo root holding User_info/")
+    args = ap.parse_args()
+
+    root = Path(args.root).resolve()
+    ui = root / "User_info"
+    if not ui.is_dir():
+        print(f"# Profile benchmark\n\n`User_info/` not found under `{root}`.")
+        print("Nothing to benchmark — this is an honest empty result, not a pass.")
+        return 0
+
+    sys.path.insert(0, str(root / "backend"))
+    try:
+        from src.services.profile.cv_parser import deterministic_cv_fields, extract_text
+    except ImportError as exc:
+        print(f"::error::cannot import the extractor: {exc}")
+        return 2
+
+    cvs = sorted((ui / "CV").glob("*.pdf")) if (ui / "CV").is_dir() else []
+    lis = {p.stem.split("_")[0].lower() for p in (ui / "Linkedin_pdf").glob("*.pdf")} \
+        if (ui / "Linkedin_pdf").is_dir() else set()
+    ghs = {p.stem.split("_")[0].lower() for p in (ui / "github_urls").glob("*.txt")} \
+        if (ui / "github_urls").is_dir() else set()
+
+    if not cvs:
+        print("# Profile benchmark\n\nNo CVs found in `User_info/CV/`.")
+        return 0
+
+    print("# Profile benchmark — real CVs through the real extractor\n")
+    print(f"Corpus: **{len(cvs)} people**. Deterministic pass only (no LLM, no cost).\n")
+    print("> Names are masked and no CV content is printed. `User_info/` is "
+          "gitignored and stays that way.\n")
+    print("**What this measures, precisely.** Production runs TWO passes: this free\n"
+          "deterministic one, then a paid LLM pass that enhances it. A low count here\n"
+          "does NOT mean the user ends up with a bad profile — it means their SAFETY\n"
+          "NET is empty. If the LLM key is missing, a provider is down, or the rate\n"
+          "cap trips, that person gets nothing at all. This measures the floor.\n")
+
+    rows = []
+    for pdf in cvs:
+        who = mask(pdf.name)
+        key = pdf.stem.split("_")[0].lower()
+        try:
+            text = extract_text(str(pdf))
+        except Exception as exc:  # noqa: BLE001
+            rows.append((who, 0, 0, "READ FAILED", f"{type(exc).__name__}", key))
+            continue
+
+        chars = len(text or "")
+        try:
+            det = deterministic_cv_fields(text or "")
+        except Exception as exc:  # noqa: BLE001
+            rows.append((who, chars, 0, "EXTRACT FAILED", f"{type(exc).__name__}", key))
+            continue
+
+        skills = len(det.get("skills") or [])
+        summary = len(det.get("summary") or "")
+
+        if chars < MIN_CHARS:
+            verdict, why = "**BROKEN**", f"only {chars} chars read from the PDF"
+        elif skills < MIN_SKILLS:
+            verdict, why = "**no floor**", f"{chars} chars in, {skills} skills out"
+        elif skills > MAX_HEALTHY_SKILLS:
+            verdict, why = "over-extracted", f"{skills} skills — too many to discriminate"
+        else:
+            verdict, why = "ok", f"{skills} skills, {summary}-char summary"
+        rows.append((who, chars, skills, verdict, why, key))
+
+    print("| person | CV chars | skills | LinkedIn | GitHub | verdict | note |")
+    print("|---|---:|---:|:---:|:---:|---|---|")
+    for who, chars, skills, verdict, why, key in rows:
+        li = "yes" if key in lis else "—"
+        gh = "yes" if key in ghs else "—"
+        print(f"| {who} | {chars} | {skills} | {li} | {gh} | {verdict} | {why} |")
+    print()
+
+    ok = [r for r in rows if r[3] == "ok"]
+    over = [r for r in rows if r[3] == "over-extracted"]
+    broken = [r for r in rows if "no floor" in r[3] or "FAILED" in r[3]]
+    counts = [r[2] for r in rows if r[2]]
+
+    print("## What this says\n")
+    print(f"- Usable extraction: **{len(ok)}/{len(rows)}**")
+    print(f"- Over-extracted (>{MAX_HEALTHY_SKILLS} skills): **{len(over)}/{len(rows)}**")
+    print(f"- No deterministic floor (fully LLM-dependent): **{len(broken)}/{len(rows)}**")
+    if counts:
+        print(f"- Skills per CV: min {min(counts)}, median "
+              f"{int(statistics.median(counts))}, max {max(counts)}")
+    print(f"- Have LinkedIn too: **{len(lis)}/{len(rows)}** · "
+          f"have GitHub: **{len(ghs)}/{len(rows)}**")
+    print()
+
+    if over:
+        print("### Over-extraction is the interesting failure\n")
+        print("It is not a crash. Nothing errors, no test fails, and the pipeline "
+              "reports success. But when a CV yields 100+ 'skills', every job "
+              "matches a little and none matches a lot — the ranking flattens and "
+              "the product feels vague. This is the exact shape of bug that only "
+              "a human noticing has caught so far.\n")
+
+    if broken:
+        print("### No safety net\n")
+        print("These people are entirely dependent on the paid LLM pass. If the key "
+              "is missing, a provider is down, or the rate cap trips, they get no "
+              "profile at all — and therefore no jobs:\n")
+        for who, chars, skills, verdict, why, _ in broken:
+            print(f"- {who}: {why}")
+        print()
+        return 1
+
+    if over:
+        return 1
+    print("Every CV in the corpus extracts to a usable profile.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
You pointed out `User_info/` — I had missed it because my earlier search only listed **tracked** git files, and the folder is correctly gitignored. Corrected.

## What the 7 real CVs revealed

| result | count | detail |
|---|---|---|
| usable | **4/7** | 17–34 skills |
| over-extracted | **2/7** | 74 and 83 skills |
| no safety net | **1/7** | 3,498 chars in → **1 skill** out |

**Spread: min 1, median 33, max 83.** Similar-length CVs produce 1 skill or 83. Nothing errors — every one of these "succeeds".

## Two failure modes, only one ever tested for

**Too few.** The deterministic pass is the **floor** — the free fallback when the LLM key is missing, a provider is down, or the rate cap trips. A person with 1 skill has *no floor*: if the paid pass fails, they get no profile and therefore no jobs.

**Too many.** 83 "skills" is not success. When everything is a skill, every job matches a little and none matches a lot — ranking flattens and the product feels vague. **This is exactly the shape of bug that only you noticing has ever caught.**

## Privacy is load-bearing

This repo is **public** and `User_info/` holds real people's CVs. The script never copies, prints or writes CV text, names, employers or emails — counts and shapes only, filenames masked to an initial (`Ranjith_CV.pdf` → `R***`).

**Verified:** grepping the output for all 7 real first names returns **0 hits**.

Free by default — deterministic pass only, no LLM, no keys, no spend. Exits 1 on a broken or over-extracted corpus so it can gate.

**Deliberately not a CI loop:** the corpus is gitignored and must never be uploaded to a runner. Local instrument, run on demand.

Gate: PASS.