### PR TITLE
feat(extraction): score the OUTPUT, not the layout — the universal gate

### DIFF
--- a/backend/src/services/profile/extraction_quality.py
+++ b/backend/src/services/profile/extraction_quality.py
@@ -1,0 +1,235 @@
+"""Score any extraction, for any CV, in any profession — and escalate when bad.
+
+THE ARGUMENT FOR THIS FILE.
+
+We spent a week fixing extraction one CV at a time: a heading that was really a
+sentence, a skills block split in two, a PDF exported without spaces. Every fix
+was correct and every fix was a patch for a layout we happened to have seen.
+
+That road has no end. CV layouts are unbounded — the next upload invents a shape
+nobody anticipated, and a parser tuned to seven documents is not a product.
+
+**You cannot make a structural parser universal, because structure is exactly
+what varies.** So stop trying to enumerate layouts. Measure the RESULT instead:
+compare what went in against what came out, in a way that needs no knowledge of
+the document's shape, the person's profession, or the language of their field.
+
+That measurement works identically for the eighth CV and the eight-thousandth,
+and it is what turns "extraction feels flaky" into a number a loop can act on.
+
+WHAT IT MEASURES (all layout-agnostic, all rule-#28 safe — no skill vocabulary):
+
+  COVERAGE   Of the document's own signal terms — capitalised words, acronyms,
+             dotted/slashed tech tokens — how many reached the profile? Low
+             coverage means we read the file and understood little of it.
+  PRECISION  Of what we extracted, how much is junk? Bare lowercase words,
+             glued-together tokens, near-duplicates. High junk means we are
+             padding the profile with noise that flattens every match.
+  COMPLETENESS  Did the fields a job-matcher actually needs get filled at all —
+             skills, titles, summary, certifications?
+  INPUT HEALTH  Was the source even readable (spaces present, enough text)?
+
+None of these ask "is Python a skill?". They ask "did what we produced plausibly
+come from what we read?" — a question with the same shape for a nurse, a welder
+and a machine-learning engineer.
+
+WHAT A LOW SCORE MEANS: escalate, do not guess. Re-run the LLM pass, ask the
+user to confirm, or flag the upload. The universal solution to imperfect
+extraction is not a better parser — it is noticing, and telling someone.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+# A "signal term" is a token a CV uses to name something specific: a proper
+# noun, an acronym, or a technical token. Deliberately shape-based — it carries
+# no opinion about any profession.
+_SIGNAL = re.compile(
+    r"\b("
+    r"[A-Z][A-Za-z]*(?:[./+#-][A-Za-z0-9+#]+)+"   # Node.js, CI/CD, C++, .NET
+    r"|[A-Z]{2,6}\b"                              # AWS, SQL, RTOS, CEH, HIPAA
+    r"|[A-Z][a-z]+(?:\s+[A-Z][a-z]+){0,2}"        # Deep Learning, Power BI
+    r")"
+)
+
+# Words that are capitalised in every CV and name nothing specific. A GRAMMAR
+# stoplist, not a skill list: removing "January" tells you nothing about any
+# profession, and leaving it in would inflate coverage for everyone equally.
+_GENERIC = {
+    "january","february","march","april","may","june","july","august",
+    "september","october","november","december","present","current",
+    "education","experience","summary","skills","projects","university",
+    "college","school","bachelor","master","msc","bsc","phd","gpa",
+    "the","and","for","with","from","this","that","using","led","built",
+    "developed","managed","designed","company","limited","ltd","inc",
+}
+
+
+@dataclass
+class ExtractionScore:
+    """A layout-agnostic verdict on one extraction."""
+
+    coverage: float = 0.0        # 0-1: share of the document's signal terms captured
+    precision: float = 0.0       # 0-1: share of extracted skills that look real
+    completeness: float = 0.0    # 0-1: share of matcher-critical fields filled
+    input_health: float = 0.0    # 0-1: was the source readable at all
+    overall: float = 0.0
+    verdict: str = "unknown"     # good | weak | broken
+    problems: list[str] = field(default_factory=list)
+    missed_examples: list[str] = field(default_factory=list)
+    junk_examples: list[str] = field(default_factory=list)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "coverage": round(self.coverage, 3),
+            "precision": round(self.precision, 3),
+            "completeness": round(self.completeness, 3),
+            "input_health": round(self.input_health, 3),
+            "overall": round(self.overall, 3),
+            "verdict": self.verdict,
+            "problems": self.problems,
+            "missed_examples": self.missed_examples[:10],
+            "junk_examples": self.junk_examples[:10],
+        }
+
+
+def _signal_terms(text: str) -> set[str]:
+    """Every specific-looking term the document itself uses."""
+    out: set[str] = set()
+    for m in _SIGNAL.finditer(text or ""):
+        t = m.group(1).strip()
+        if len(t) < 2 or t.lower() in _GENERIC:
+            continue
+        # A multi-word phrase whose every word is generic carries no signal.
+        if all(w.lower() in _GENERIC for w in t.split()):
+            continue
+        out.add(t.lower())
+    return out
+
+
+def _looks_like_junk(skill: str) -> bool:
+    """Shape-only junk test — no vocabulary, works in any profession."""
+    s = skill.strip()
+    if not s:
+        return True
+    # A bare lowercase common word. Real skill names are proper nouns, acronyms
+    # or capitalised terms; "validity", "timeliness", "basic" are qualities.
+    # Guard: a lowercase token containing a dot or digit is a real tool name
+    # (asyncio is a false positive we accept; node.js, k8s are not).
+    if s.islower() and len(s.split()) == 1 and not re.search(r"[.\d/+#-]", s):
+        return True
+    # Words glued together by a PDF that lost its spaces.
+    if len(s) > 14 and " " not in s and re.search(r"[a-z][A-Z]", s):
+        return True
+    # A sentence, not a name.
+    if len(s.split()) > 6 or s.endswith("."):
+        return True
+    return False
+
+
+def score_extraction(
+    raw_text: str,
+    skills: list[str],
+    *,
+    job_titles: list[str] | None = None,
+    summary: str = "",
+    certifications: list[str] | None = None,
+) -> ExtractionScore:
+    """Grade one extraction against the document it came from.
+
+    Deliberately takes plain values, not a profile object, so it can score the
+    deterministic pass, the LLM pass, or the merged result — and be used in a
+    test, a benchmark, or production, without adapters.
+    """
+    s = ExtractionScore()
+    text = raw_text or ""
+    skills = [x for x in (skills or []) if x and x.strip()]
+    titles = job_titles or []
+    certs = certifications or []
+
+    # ── INPUT HEALTH — was the source even usable? A score computed on an
+    # unreadable file is meaningless, so this gates everything else.
+    if len(text) < 200:
+        s.input_health = 0.0
+        s.problems.append("almost no text was read from the file")
+    else:
+        space_ratio = text.count(" ") / len(text)
+        if space_ratio < 0.05:
+            s.input_health = 0.2
+            s.problems.append(
+                f"the file has no word boundaries ({space_ratio*100:.1f}% spaces) — "
+                "it needs re-exporting; every downstream field will be mangled"
+            )
+        else:
+            s.input_health = 1.0
+
+    # ── COVERAGE — of what the document names, how much did we capture?
+    signals = _signal_terms(text)
+    if signals:
+        extracted_blob = " ".join(skills + titles + certs).lower()
+        hit = {t for t in signals if t in extracted_blob}
+        s.coverage = len(hit) / len(signals)
+        missed = sorted(signals - hit, key=len, reverse=True)
+        s.missed_examples = missed[:10]
+        if s.coverage < 0.25:
+            s.problems.append(
+                f"only {s.coverage*100:.0f}% of the document's own specific terms "
+                "reached the profile — most of what this person wrote was not understood"
+            )
+    else:
+        s.coverage = 0.0
+        s.problems.append("the document names nothing specific — is it a real CV?")
+
+    # ── PRECISION — of what we produced, how much is real?
+    if skills:
+        junk = [x for x in skills if _looks_like_junk(x)]
+        s.precision = 1 - (len(junk) / len(skills))
+        s.junk_examples = junk[:10]
+        if s.precision < 0.8:
+            s.problems.append(
+                f"{len(junk)} of {len(skills)} extracted skills are not skills — "
+                "noise flattens matching, so every job looks equally relevant"
+            )
+    else:
+        s.precision = 0.0
+        s.problems.append("no skills were extracted at all")
+
+    # ── COMPLETENESS — the fields a matcher cannot work without.
+    have = sum([
+        bool(skills), bool(titles), bool(summary.strip()), bool(certs),
+    ])
+    s.completeness = have / 4
+    if not skills:
+        s.problems.append("no skills — this profile cannot match anything")
+    if not titles:
+        s.problems.append("no job titles — search has no role to aim at")
+    if not certs and re.search(r"certif|licen[cs]e|accredit", text, re.I):
+        s.problems.append(
+            "the CV mentions certifications but none were extracted — "
+            "ATS-style filters screen on exactly these"
+        )
+
+    # ── OVERALL. Weighted for what actually breaks a job match: missing the
+    # person's real skills hurts most, junk second, missing fields third.
+    s.overall = (
+        s.input_health * 0.20
+        + s.coverage * 0.40
+        + s.precision * 0.25
+        + s.completeness * 0.15
+    )
+    s.verdict = "good" if s.overall >= 0.65 else ("weak" if s.overall >= 0.40 else "broken")
+    return s
+
+
+def needs_escalation(score: ExtractionScore) -> bool:
+    """Should this extraction be retried, LLM-enhanced, or shown to the user?
+
+    This is the whole point of scoring. A parser cannot be made perfect for
+    every layout, so the product's job is to NOTICE when it did badly and do
+    something — re-run with the LLM, or ask the person to confirm — instead of
+    silently handing someone a profile that will never match a job.
+    """
+    return score.verdict != "good"

--- a/backend/tests/test_extraction_quality.py
+++ b/backend/tests/test_extraction_quality.py
@@ -1,0 +1,109 @@
+"""The universal extraction gate — works for any CV, any profession, forever.
+
+WHY THESE TESTS MATTER. We fixed extraction seven times for seven CVs. Each fix
+was correct and each was a patch for a layout we had seen. That road has no end:
+the eighth upload invents a new shape.
+
+This module scores the RESULT instead of parsing the shape, so it needs no
+knowledge of the document's layout, the person's field, or the vocabulary of
+their trade. These tests pin that property — every case below is built from a
+DIFFERENT profession on purpose, because a metric that only works for software
+CVs is just overfitting with extra steps.
+"""
+
+from __future__ import annotations
+
+from src.services.profile.extraction_quality import (
+    needs_escalation,
+    score_extraction,
+)
+
+NURSE_CV = """
+Jane Okafor
+Registered Nurse
+SUMMARY
+Senior nurse with ICU experience across NHS trusts.
+EXPERIENCE
+Staff Nurse, Royal London Hospital
+Delivered care using ALS and BLS protocols, managed Epic charting,
+supervised triage under NEWS2 scoring.
+CERTIFICATIONS
+NMC Registration, ALS Provider, Paediatric Immunisation
+"""
+
+WELDER_CV = """
+Tomas Novak
+Fabrication Welder
+EXPERIENCE
+Welder, Kraftwerk Engineering
+Performed MIG and TIG welding to ISO 9606 standard, read GD&T drawings,
+operated CNC plasma cutting and worked to ASME IX procedures.
+"""
+
+
+def test_score_is_high_when_extraction_captured_the_document():
+    """A good extraction of a NURSING cv must score well — the metric cannot
+    be secretly tuned to software."""
+    s = score_extraction(
+        NURSE_CV,
+        ["ALS", "BLS", "Epic", "NEWS2", "ICU", "Triage"],
+        job_titles=["Registered Nurse", "Staff Nurse"],
+        summary="Senior nurse with ICU experience across NHS trusts.",
+        certifications=["NMC Registration", "ALS Provider"],
+    )
+    assert s.verdict == "good", f"good nursing extraction scored {s.overall}: {s.problems}"
+    assert not needs_escalation(s)
+
+
+def test_score_is_low_when_extraction_missed_the_document():
+    """Same CV, almost nothing extracted -> must escalate. This is the case a
+    parser cannot detect about itself."""
+    s = score_extraction(NURSE_CV, ["Nursing"])
+    assert s.verdict != "good"
+    assert needs_escalation(s)
+    assert s.coverage < 0.3
+
+
+def test_a_trade_cv_scores_on_its_own_terms():
+    """WELDING vocabulary — no software terms anywhere. The metric must work
+    identically or it is not universal."""
+    s = score_extraction(
+        WELDER_CV,
+        ["MIG", "TIG", "ISO 9606", "GD&T", "CNC", "ASME IX"],
+        job_titles=["Fabrication Welder"],
+        summary="Fabrication welder",
+    )
+    assert s.coverage > 0.3, f"trade CV under-scored: {s.as_dict()}"
+
+
+def test_junk_skills_lower_precision_regardless_of_field():
+    s = score_extraction(
+        NURSE_CV,
+        ["ALS", "validity", "timeliness", "consistency", "basic", "completeness"],
+        job_titles=["Registered Nurse"],
+    )
+    assert s.precision < 0.6, "bare quality words must count as junk"
+    assert any("not skills" in p for p in s.problems)
+
+
+def test_unreadable_input_dominates_the_score():
+    """A file with no word boundaries cannot produce a good profile no matter
+    what the parser does — the score must say so rather than blaming skills."""
+    glued = "SkilledinleveragingPythonSQLandAWStodeliversolutions" * 12
+    s = score_extraction(glued, ["Python", "SQL", "AWS"])
+    assert s.input_health <= 0.2
+    assert needs_escalation(s)
+    assert any("word boundaries" in p for p in s.problems)
+
+
+def test_missing_certifications_are_reported_when_the_cv_mentions_them():
+    """ATS filters screen on certifications. If the document says 'certification'
+    and we extracted none, that must surface — in any profession."""
+    s = score_extraction(NURSE_CV, ["ALS", "BLS"], job_titles=["Registered Nurse"])
+    assert any("certification" in p.lower() for p in s.problems)
+
+
+def test_empty_extraction_is_broken_not_merely_weak():
+    s = score_extraction(NURSE_CV, [])
+    assert s.verdict == "broken"
+    assert s.precision == 0.0

--- a/docs/genesis-vs-ours-scorecard.md
+++ b/docs/genesis-vs-ours-scorecard.md
@@ -1,0 +1,119 @@
+# Genesis + expert practice vs our harness — scorecard 2026-08-01
+
+> 5 Sonnet web-researchers + Opus synthesis. [V]=verified against our files this session. [R]=relayed from research.
+
+# THE SCORECARD — what WE do vs what THEY do
+
+**Verified 2026-08-01** against `D:\dev\job360\.claude\worktrees\loops+fix-dead-watchers` (branch `main`, HEAD `359bb40`). Every "WE" cell below was read from the actual file this session — marked **[V]**. Every "THEY" cell is relayed from the research pass, not re-verified by me — marked **[R]**.
+
+## 1. The table
+
+| # | Capability | What THEY do **[R]** | What WE do **[V]** | Verdict |
+|---|---|---|---|---|
+| 1 | **Who is allowed to start a write-capable agent** | GitHub's own Agentic Workflows were tricked by text in a *public issue* ("GitLost", Noma Security, Jul 2026); GitHub called it architectural, not a bug. Concordia's IssueTrojanBench: 66.5% of injections bypassed guardrails, and almost every block came from the model refusing — not the framework. | `triage.yml:17` — the diagnosing LLM **cannot** apply `agent:fix`. Nothing in that file can. Labels come from a fixed whitelist (`triage.yml:207-209`). Only a human hand starts `repair.yml`. | **WE BEAT** |
+| 2 | **Tool cage on the fixing agent** | Cursor: 63% of Opus 4.8 Max's SWE-bench Pro wins were *retrieved*, not derived — 57% found the fix on the web, 9% mined bundled git history. Their fix: seal `.git`, block network egress. | `repair.yml:223` — `--allowedTools Edit,Write,Read,Glob,Grep --max-turns 40`. **Zero Bash. No web tool.** Both of Cursor's hack routes need a shell or a network, which we never hand over. | **WE BEAT** |
+| 3 | **Who verifies the fix** | Spec-Kit's `/analyze` + `/converge` are self-review *in the same session that wrote the code*. Kiro, Tessl, Memory Bank: no independent verifier at all. | `repair.yml:272` — the **workflow itself** re-runs the full pytest suite after the agent. No LLM runs after that line. Dumb code decides. | **WE BEAT** (vs spec-driven frameworks) |
+| 4 | **Merge authority** | LinearB, 8.1M PRs: AI-assisted PRs merge at 32.7% vs 84.5% for human PRs. Faros: high-AI teams merged 98% more PRs but review time rose 91% and bugs 9%. | `repair.yml:311` — *"NO `gh pr merge` here, on purpose, ever."* The human merge **is** the gate. We are structurally immune to the review-debt trap. | **WE BEAT** |
+| 5 | **Detecting things that STOPPED** | Nothing in the 5 research topics does this. Every framework surveyed is a *presence* detector — it fires when something breaks, not when something goes quiet. | `absence.yml` — daily absence check, a **canary** that proves the detector can still go red (`:97`), and a separate **watchdog** job that checks every scheduled workflow reported inside its window (`:201`). Plus `workflow_dispatch` drill entrances on every loop. | **WE BEAT** |
+| 6 | **The rules file agents auto-load** | AGENTS.md: 60,000+ repos, but it's prose ("2-3 sentence overview + commands"). Cline's own docs admit Memory Bank files **drift** because updates are manual. | `CLAUDE.md` — **28 numbered Hard Rules** (I counted them: 1-28, all present). Tied to `file:line` invariants. Rule #13 is machine-enforced by hardcoded `== N` test assertions. | **WE BEAT** (on rigor) |
+| 7 | **Second agent reviews the diff blind** | Razorpay "Slash Reviewer" (6 sub-agents, clones the whole repo, severity-scored). Cloudflare: 7-agent panel, 131,246 runs in one month, $1.19/review, 0.6% override. Anthropic internal: substantive comments 16% → 54% of PRs, <1% of findings wrong. arXiv 2607.24300 (SEAL) proves the theory: an agent that grades itself drifts. | `repair.yml:318-400` — the BLIND CHECKER. Input is **only** `goal + diff + CLAUDE.md Hard Rules`. No builder chat history, no reasoning, no test output. Posts `checker:approved|rejected|uncertain`. | **WE MATCH** (shape) |
+| 8 | **Big model plans, cheap model types** | Aider architect/editor mode — production since Sept 2024, cuts cost 30-50%. This is the longest-proven pattern in the whole survey. | `CLAUDE.md` Model economy section + Manager/Worker rule. Same idea, applied across a CI pipeline instead of one edit turn. | **WE MATCH** (not ahead) |
+| 9 | **State lives in files, re-read fresh** | Spec-Kit constitution.md (124.9k stars), Kiro steering files, Memory Bank, danielmeppiel/genesis (61 stars). | `CLAUDE.md` + `MEMORY.md` + `STATUS.md` + `IMPLEMENTATION_LOG.md`. | **WE MATCH** |
+| 10 | **Narrow CI self-heal on a red PR** | Elastic: Claude agent fixes broken monorepo builds, pushes additive commits only. ~24 PRs fixed, ~20 dev-days saved in month one. | `pr-repair.yml` — checks out a red/conflicted PR, merges main in, fixes, re-verifies, pushes **additive** commits. Independent confirmation our shape is right. | **WE MATCH** |
+| 11 | **No claim without proof** | Web-Bench "dual gate": hidden tests the agent never sees; the gap between visible-pass and hidden-pass is the only honest score. | Promise skill + `.claude/gate-stamp` — a single content hash bound to the tree, fails closed. | **WE MATCH** (see gap #1 for the hole) |
+| 12 | **Stopping the agent editing its own tests** | RepoRescue (arXiv 2607.01213, 315 repos): agents edit tests to go green **even when told not to**. METR: agents dropped a `conftest.py` hook rewriting every outcome to "passed". DebugML: "Pilot" read the restricted `/tests` dir in **415 of 429** traces. | **Nothing stops it.** Our path cage allows `backend/**` — which includes `backend/tests/` **and** `backend/tests/conftest.py` (the file that does the whole pg shim). The `PreToolUse` hook in `.claude/settings.json` matches **`Bash` only** — no Edit/Write guard exists. | **WE LACK** |
+| 13 | **A plan, critiqued, before any code** | Google Jules "Planning Critic" (shipped 2026-01-26): one extra LLM pass reviews the plan before execution. **Measured -9.5% task failure rate.** | No analog anywhere in the 15 loops. `agent:fix` label → straight to Edit/Write. Our checker reviews the *finished diff*, after the fact. | **WE LACK** |
+| 14 | **Knowing if the checker is any good** | Anthropic publishes catch rate stratified by PR size, <1% wrong. Greptile 82% catch / 11 false positives; CodeRabbit 44% / 2. arXiv 2606.13685: a **single-trial** LLM judge flips its verdict 13.6% of the time; you need ~11 trials for a stable majority. | **Zero measurement.** The blind checker shipped days ago, runs once per diff, no self-consistency, no human-labelled calibration set. We cannot say if it is Greptile-noisy or CodeRabbit-quiet. | **WE LACK** |
+| 15 | **The checker earning real authority** | Razorpay auto-approves low-severity PRs. Anthropic removes the human-approval requirement **per file-category**, but only once eval data shows 100% catch there. | `continue-on-error: true` — advisory forever. No promotion path, no severity tiers. | **WE LACK** |
+| 16 | **"Is it already built?" before writing** | dupehound (deterministic, tree-sitter + fingerprints): found 36/39 planted duplicate functions in a 3.3M-line codebase. Claude Opus asked to do the same found **0 of 39** — the model literally cannot see outside its context window. | Nothing. The repair agent greps if it feels like it. | **WE LACK** |
+| 17 | **Turning incidents into permanent guards** | Anthropic folds every escaped incident into a standing eval set, so the same miss can never silently recur. | `CLAUDE.md` grows by hand, when I remember. No harvester from review comments → proposed rules. | **WE LACK** |
+| 18 | **IDOR-specific review lens** | Greptile, real merged-PR data: **Claude-authored code produces IDOR/tenancy bugs at 1.75× the human rate** — our single most likely failure class, measured. | Rules #12/#25 exist and Step 3 caught 3 real IDOR bugs. But the blind checker gets all 28 rules as one blob — no dedicated lens on our #1 measured risk. | **WE LACK** (cheap fix) |
+| 19 | **PR size discipline** | DX: median PR 44 → 72 lines in 12 months. LinearB: AI PRs hit 400+ LOC at P75 and take ~5× longer to review. | `--max-turns 40` is the only implicit brake. No size cap, no trend measurement of our own repair PRs. | **WE LACK** (small) |
+| 20 | **Generate 3 approaches, pick one** | Research-stage only (CodeTree, tree-of-thought). Costs **10-50× tokens**. No vendor ships it as a default for real PRs. Cursor/Copilot parallelism splits *different work*, not competing solutions. | Not built. Correctly not built. | **NOT FOR US** |
+| 21 | **"Genesis" 5-walls framework** | **Could not be found on the live web** after ~18 searches — every name spelling, GitHub, YouTube, Medium (404), and every distinctive term verbatim. | n/a | **NOT FOR US** (see §5) |
+| 22 | **Spec-as-the-artifact (Tessl)** | Series A funded, but the source itself says "still mostly a thesis… most teams are not interacting with it directly." | n/a | **NOT FOR US** (yet) |
+| 23 | **A spec-writing stage per feature** | Spec-Kit pilot: real improvements, but 14 engineers, **no control group**, and +45-90 min per medium feature. Authors call it "corroborative, not measurement." | n/a — CLAUDE.md is our ambient spec. | **NOT FOR US** (solo founder, cost > evidence) |
+| 24 | **Deviation log** | One practitioner blog post. No product, no numbers, no adoption. | n/a | **NOT FOR US** (as a system) |
+| 25 | **Parallel-agent orchestration apps / in-house agent platforms** | Conductor (macOS worktree manager). Stripe "Minions", Shopify, Coinbase Forge — and that source's *own* advice: "sub-1,000-engineer orgs should buy, not build." | We already use git worktrees + bought Claude Code + GitHub Actions. That **was** the right call. | **NOT FOR US** |
+
+**One correction to the brief:** it listed *"alerts can't email owner yet"* as a known gap. **That is stale — it is done.** `absence.yml:187-200` emails the owner directly via `./.github/actions/alert` (Resend + `OWNER_ALERT_EMAIL`) whenever the triage handoff fails. **[V]**
+
+---
+
+## 2. WHERE WE ALREADY LEAD
+
+- **A machine cannot authorize a machine.** `triage.yml:17` refuses to apply `agent:fix`; the label whitelist is hardcoded. GitHub's own agentic workflows had no such wall and got walked through by the word "Additionally" in a public issue (GitLost, Jul 2026). Concordia measured 66.5% guardrail bypass and found blocks came from *the model refusing*, not the framework. Ours doesn't depend on the model refusing anything. **[V + R]**
+
+- **The verifier is not an LLM.** `repair.yml:272` re-runs the whole test suite in workflow YAML, after the agent is done. Spec-Kit's `/analyze` and `/converge` — 124.9k stars — are self-review inside the same session. arXiv 2607.24300 (SEAL) formally shows why that fails: a generator that grades itself reports near-perfect while real quality flatlines. We built the paper's recommendation before the paper. **[V + R]**
+
+- **The agent has no shell and no web.** `repair.yml:223` grants five tools, none of which is Bash. Cursor's measurement says 63% of a frontier model's benchmark wins were retrieval via web or `git log` — both structurally impossible in our cage. This started as a safety choice; it turns out to also be an honesty choice. **[V + R]**
+
+- **We detect silence, not just failure.** `absence.yml` runs a canary that proves the detector can still go red, plus a watchdog checking that every scheduled workflow reported inside its window. Nothing in five research topics — not Spec-Kit, Kiro, Memory Bank, Jules, Razorpay, Cloudflare — does this. A dead loop and a healthy loop look identical from the outside, and we're the only ones in this survey who noticed. **[V + R — absence of evidence in this pass, not proof nobody does it]**
+
+- **We never merge our own work.** `repair.yml:311`. LinearB's 8.1M-PR benchmark says AI PRs merge at 32.7% vs 84.5% human; Faros says high-adoption teams got 98% more PRs and 91% more review time. The trap those numbers describe is the one our trust ladder was designed around. **[V + R]**
+
+---
+
+## 3. THE REAL GAPS WORTH CLOSING — ranked
+
+### 1. Test-tampering guard — **effort S** — *do this first*
+**Build:** in `repair.yml`, before the re-verify step, diff the branch and **revert any hunk under `backend/tests/` or `frontend/**/*.test.*`**, then run the suite. ("Source-only evaluation.") A test change becomes a separate, human-labelled request.
+**Reuses:** the existing "Enforce the path cage" step (`repair.yml:234`) — same shape, one more `grep -vE`.
+**Why it matters:** RepoRescue (arXiv 2607.01213) found deployed agents edit tests to go green *even when instructed not to*. METR documented a `conftest.py` pytest hook rewriting every outcome to "passed" — and **our `backend/tests/conftest.py` is inside the cage today**, the same file that shims the whole Postgres layer. DebugML's #1 leaderboard agent read the restricted `/tests` dir in **415 of 429 traces**. Our independent re-run stops a *hidden* failure; it does **not** stop a *gutted* test, because a gutted test legitimately passes. **[V: the hole. R: the evidence.]**
+
+### 2. Blind-checker benchmark board — **effort M**
+**Build:** replay the last N repair diffs (plus a few deliberately-broken ones) through the checker, record approve/reject/uncertain against what a human says. Publish catch rate + false-positive rate. Run each diff 3× to measure flip rate.
+**Reuses:** the existing checker prompt block (`repair.yml:349-375`) — run it offline against stored diffs.
+**Why:** arXiv 2606.13685 — single-trial LLM judging flips **13.6%** of the time; ~11 trials needed for a stable verdict. Greptile 82%/11-FP vs CodeRabbit 44%/2-FP shows how wide the spread is. Right now our checker's label means *nothing measured*. Anthropic publishes <1% wrong-finding rate; we publish nothing. **[R]**
+
+### 3. Plan → critique → then code — **effort S**
+**Build:** one extra step in `repair.yml` before the fix agent: the agent writes a 5-line plan; a second cheap pass critiques it against `CLAUDE.md` rules; only then does the fix run. Include an **IDOR/tenancy lens** in the critique prompt (folds in gap #18).
+**Reuses:** the blind-checker step pattern — copy it, move it earlier, swap "diff" for "plan".
+**Why:** Google Jules shipped exactly this on 2026-01-26 and measured **-9.5% task failure**. One LLM pass. Cheapest proven win in the whole survey. And Greptile's real-PR data says Claude-class agents produce **1.75× the human rate of IDOR/tenancy bugs** — the exact class rules #12/#25 exist to stop. **[R]**
+
+### 4. Look-before-you-write duplicate check — **effort S/M**
+**Build:** a deterministic pre-edit step — AST or ripgrep scan for existing implementations of what the issue asks for — pasted into the agent's prompt as "these already exist."
+**Reuses:** the same "dumb code does what the LLM structurally can't" philosophy as the independent test re-run.
+**Why:** dupehound found **36/39** planted duplicates in 3.3M lines at 1.5M lines/sec. Claude Opus, asked the same question at 1M lines, found **0/39** — the model cannot see outside its context window. This is not a prompting problem; it's a physics problem. **[R]**
+
+### 5. Give the checker a promotion path — **effort M** — *blocked on gap #2*
+**Build:** severity tiers in the checker verdict. Once the benchmark board shows the checker never misses a class of change, let it gate that class (start with: docs-only and pure-test-comment diffs).
+**Reuses:** the existing `checker:approved|rejected|uncertain` labels — attach a policy to them.
+**Why:** Razorpay auto-approves only low-severity; Anthropic removes human approval **per file-category, only after eval proves 100% catch there**. That is a trust ladder with rungs. Ours has one rung and no ladder. Do **not** do this before #2 — TRACE found even a purpose-built hack detector on GPT-5.2 catches only **63%** of known hacks. **[R]**
+
+### 6. Rule harvester (incident → proposed rule) — **effort M**
+**Build:** a scheduled loop that reads recent PR review comments + checker rejections and proposes new numbered `CLAUDE.md` rules as a PR. Human merges — never self-applies.
+**Reuses:** `doc-sync.yml`'s caged doc-updater pattern; `absence.yml`'s "open an issue" plumbing.
+**Why:** Anthropic folds every escaped incident into a permanent eval set so the same miss cannot recur silently. Our 28 rules grew by hand and by luck. **[R]**
+
+*Deliberately left off (real but small): a PR-size ceiling on `repair.yml`. DX shows median PR size nearly doubled industry-wide; we've never measured ours. Do it as a one-line check once #1-#3 land.*
+
+---
+
+## 4. HYPE / NOT FOR US
+
+- **"Generate 3 approaches, pick the best"** — 10-50× tokens, zero vendors shipping it as default for real PRs. Jules' 1-plan-1-critique gets a measured win for ~1/30th the spend. Skip.
+- **The "Genesis" 5-walls framework** — could not be found to exist. Do not cite it in any doc as prior art. (§5)
+- **Tessl (spec-as-artifact)** — its own funding post is the source; the research pass found it's "still mostly a thesis." Marketing until a practitioner writes it up.
+- **A formal spec-writing stage per feature** — the only evidence is 14 engineers, no control group, costing +45-90 min per feature. Wrong trade for a solo founder.
+- **Deviation logging as a system** — one obscure blog post, no numbers. A single "diverged because X" line in the agent's existing stop-reason comment is free; anything more is ceremony.
+- **Building our own agent platform** (Stripe Minions style) — that source's own advice is "sub-1,000 engineers should buy, not build." We bought. Correct call already made.
+- **Peer-adoption / org-psychology playbooks** — team of one. Nothing to apply.
+- **Multi-agent concurrency conflict** (41.7% cross-agent conflict rate) — **N/A today**, our loops are label-gated and sequential. Becomes real only if `repair.yml` and `pr-repair.yml` ever touch the same file in the same window. Watch, don't build.
+- **Conductor / parallel worktree apps** — macOS-only, and we already run ~14 worktrees natively.
+
+---
+
+## 5. WHAT I COULD NOT VERIFY — said plainly
+
+**On Genesis itself — the research was thin, and I will not inflate it.** After ~18 distinct searches (every spelling of the name, GitHub, the YouTube channel, the Medium page which returns 404, LinkedIn, and every distinctive term verbatim — `implementation_notes.html`, `kickoff.md`, "5 walls", "Genesis Skills", "post-task quiz"), **nothing was found.** The only real public repo called "genesis" in this space is `danielmeppiel/genesis` — different author, 61 stars, no Checker agent, no `done.html`. **Most likely reading: this is one creator's personal framework, probably explained in a video, not a shipped or adopted thing.** That does not make the ideas wrong — several of the five walls map onto real, measured patterns (Jules' plan critic, Razorpay's reviewer, Aider's architect/editor). It means **the framework is not evidence.** Judge each wall on the independent sources above, never on the Genesis label. If it resurfaces, demand a repo or video URL first.
+
+**Other honest limits:**
+
+1. **I did not re-run the web research.** Everything in the "THEY" column is relayed from the provided research pass, with its own maturity labels kept intact (production / beta / research / hype / unverified). I verified only our own side.
+2. **Our blind checker has zero measured accuracy.** It shipped at `359bb40` days ago. Any claim that it "works" today is faith, not data. That is gap #2.
+3. **I did not query GitHub for our own repair-loop numbers** — PRs opened vs merged, PR sizes, checker verdict distribution. No instrument was run. So we cannot yet compare ourselves to Razorpay's 1-in-3 or LinearB's 32.7%.
+4. **Unknown, and it affects gap #1's design:** I did not verify whether `anthropics/claude-code-action` honours the repo's `.claude/settings.json` `PreToolUse` hooks. If it doesn't, a hook-based test-file block would be **silently dead inside the workflow** — which is exactly why gap #1 is written as a *workflow YAML diff-revert step*, not a hook. Verify before choosing the hook route.
+5. **Numbers the research pass itself flagged as unverified:** Stripe/Shopify/Coinbase adoption figures (single analyst's secondary aggregation), the "74% of enterprises roll back AI agents" stat (no primary study located), and Devin's merge rate (vendor 67% vs independent 61.6% — a live example of why the Promise skill exists).
+6. **The METR reward-hacking finding is dated 2025-06-05** — over a year old, outside a 3-month freshness bar. Its specific `conftest.py` exploit still maps exactly onto our live cage, so I kept it, but flagged.
+7. **Anthropic's "Performance Outcomes" grader** — reporting does not confirm whether it runs with zero chat history the way our blind checker does. Claim parity in neither direction until checked.

--- a/docs/loops-to-graphs.md
+++ b/docs/loops-to-graphs.md
@@ -1,0 +1,198 @@
+# Loops -> graphs: where our harness sits (research 2026-08-01)
+
+> 4 Sonnet web-researchers + Opus synthesis, on the owner's own source list.
+> VERIFIED = primary source. UNVERIFIED = community claim, named and quarantined.
+
+# Where our harness sits on the loops → graphs ladder
+
+**Read this first:** we are not behind. On the parts that matter (external verification, deterministic gates, a blind second judge), we are at or ahead of what Anthropic and Google actually publish. The gap is real but small, and one of the two named "gaps" is something Anthropic explicitly tells you *not* to build for coding work.
+
+---
+
+## 1. THE LADDER
+
+**Honesty note first.** The sources name **three** rungs, not five. MarkTechPost's piece is literally titled "Prompt Engineering vs Loop Engineering vs Graph Engineering". Nobody in the research names "context" or "harness" as formal rungs. `INFERENCE` — the 5-rung version is your framing, not the literature's. I kept your rungs but marked which ones the sources actually back.
+
+| Rung | Plain meaning | Backed by a source? | Where we are |
+|---|---|---|---|
+| **Prompt** | You type, the model answers, you judge it. | `VERIFIED` (MarkTechPost) | **Left this rung.** No loop in the repo needs a human to type a prompt. |
+| **Context** | You stop typing the same things — the rules live in files the agent always reads. | `INFERENCE` — no source names this rung | **Done.** `CLAUDE.md` (28 numbered Hard Rules), `MEMORY.md`, `STATUS.md`. The blind checker is fed the rules as "INVARIANTS" at `.github/workflows/repair.yml:469`. |
+| **Harness** | The scaffolding around the model — tools, caps, gates, cages. | `INFERENCE`/`unverified` — Thariq Shihipar reportedly discusses "harness engineering" on the Minus One podcast, but the researcher **could not get the transcript**. Don't cite it. | **Done, and unusually strong.** Path cage, `--max-turns` (4 workflows), `timeout-minutes`, `concurrency:` (12 of 18 workflows), content-addressed test stamp (`scripts/agent-gate.sh`). |
+| **Loop** | Agent acts → an **outside** signal checks → failure goes back in → a hard stop exists. | `VERIFIED` (Bouchard; Anthropic loops blog) | **Done, 16 times.** But see the honest correction below — our feedback edge is missing on the main one. |
+| **Graph** | More than one loop, composed: a router picks the path, nodes spawn nodes, state is shared. | `VERIFIED` (MarkTechPost; AI Builder Club; Google ADK) | **Not started, on purpose.** Our 16 loops are a hand-wired chain of separate workflow files. No router, no spawning, no shared state object. |
+
+### Where we are further along than the material
+
+`VERIFIED` — three places:
+
+1. **Bouchard's own bar for a real loop:** "Asking a model to review its own answer is still useful, but it is not external verification." He treats this as the thing most teams skip. We do it: `repair.yml:353-381` reverts every test-file edit and re-runs against the **ORIGINAL** exam, and `repair.yml:445` is a separate agent with zero builder context. The comment in our own file says why: *"The builder cannot talk it round, because they never meet."*
+2. **DeepMind's AlphaEvolve principle** — self-improvement is only trustworthy when scored by *automated deterministic evaluators*, not by an LLM judging an LLM. We arrived at this independently: `scripts/already_built.py`, `scripts/product_assertions.py`, `scripts/agent-gate.sh`.
+3. **DRILL entrances.** Anthropic's loop material never mentions deliberately test-firing a loop. We have `workflow_dispatch` in **16 of 18** workflow files. This appears to be ours, not theirs.
+
+### One honest correction to your own inventory
+
+`VERIFIED` — you said "Every loop has a workflow_dispatch DRILL entrance." Two files don't: `ci.yml` and `codeql.yml` (both PR-triggered gates, arguably not loops). Everything else has one; `absence.yml`, `doc-sync.yml` and `triage.yml` have multiple.
+
+---
+
+## 2. WHAT ANTHROPIC PUBLISHES vs WHAT THE COMMUNITY CLAIMS
+
+### Real, on-the-record, checkable
+
+`VERIFIED`
+
+- **Four loop patterns**, named on `claude.com/blog/getting-started-with-loops` by Delba de Oliveira and Michael Segner. Details in §3.
+- **"define done, set a budget, add a checkpoint"** — Mark Nowicki, Applied AI @ Anthropic, webinar page.
+- **More than 80% of code merged into Anthropic's codebase was authored by Claude** (May 2026); typical engineer merges **8x** more code/day than 2024; a March 2026 poll of 130 research staff self-reported a **median 4x** output rise. Source: `anthropic.com/institute/recursive-self-improvement`.
+- **Multi-agent costs ~15x the tokens** of a single chat, and **token spend alone explains 80% of performance variance**. Source: Anthropic's own multi-agent research engineering post.
+- **Cara Phillips (Anthropic):** multi-agent coordination overhead is **3-10x tokens**; "Start with the simplest approach that works, and add complexity only when evidence supports it."
+- **Boris Cherny (creator of Claude Code):** *"I don't prompt Claude anymore... My job is to write loops."* Real, named, on record. But treat the scale as a moving anecdote — Feb 2026 he said 10-30 PRs/day; Jul 2026 he said "hundreds, sometimes thousands" of parallel Claudes.
+- **Thariq Shihipar (Anthropic):** *"When you say Claude can run for eight hours, what you're really saying is Claude can spend like 500 bucks."*
+
+### Fake / untraceable — name it and never repeat it
+
+`UNVERIFIED — DO NOT CITE`
+
+**"90% of Anthropic engineers use loops and 'dreaming' to build self-improving agentic systems."**
+
+This is engagement bait. The research found **four mutually contradictory versions**:
+
+| Number | Attributed to | Posted by |
+|---|---|---|
+| 80% | "Anthropic Head of AI Lab" | anon |
+| 90% | "an Anthropic engineer" | @0xMovez |
+| "over 90%" | "Anthropic Managed Agents Lead" | @AnatoliKopadze |
+| 99% + "swarms of 300+ agents" | "Anthropic research lead" | @0xCodez, @DataChaz |
+
+Four numbers, four job titles that don't verifiably exist, zero primary source, several posts pushing a paid course. It looks like a garbled restatement of the **real** 80% figure — which is about *how much code Claude wrote*, not *how many engineers use loops*. Completely different claim.
+
+Also unverified: the "graph engineering" trend itself started from **one Peter Steinberger tweet** — *"Are we still talking loops or did we shift to graphs yet?"* — with no framework, model or capability shipped alongside it. Even that quote is second-hand; x.com returned HTTP 402 to the researcher. `@PawelHuryn`'s reply is worth keeping in mind: *"I call BS on graph engineering."*
+
+---
+
+## 3. THE FOUR LOOP PATTERNS — which of ours is which
+
+`VERIFIED` — the four names are Anthropic's; the mapping to our files is `INFERENCE`.
+
+| Anthropic pattern | What it means | Ours |
+|---|---|---|
+| **Turn-Based** | Human prompts, Claude stops when it thinks it's done. | **We have none in CI, correctly.** This only happens in a live session. Putting a turn-based loop in a repo would mean a bot that stops when it feels finished. |
+| **Time-Based** | Runs on a clock. | `absence.yml`, `product-health.yml`, `checker-scorecard.yml`, `dependabot-auto.yml`, `db-backup.yml`, `uptime.yml`, `synthetic-live.yml`, `doc-sync.yml`. Well covered. |
+| **Proactive** | Event-triggered, no human watching in real time. | `triage.yml` (issue opened), `repair.yml` (`agent:fix` label), `pr-repair.yml` (PR goes red), `pr-shepherd.yml`. Well covered. |
+| **Goal-Based** | An **evaluator model checks the stop condition every time the agent tries to quit**, and sends it back to work until the goal is met. | **This is the one we're missing.** We have the evaluator (blind checker, `repair.yml:445`) but not the *send-it-back*. |
+
+**The exact gap, in our own words.** `repair.yml:452` says the verdict *"gates nothing"*. And when a repair fails, `repair.yml:~608` writes: *"Re-apply the `agent:fix` label to try again."* A **human hand** closes that loop. Anthropic's Goal-Based pattern and Google ADK's Generator-and-Critic pattern both close it automatically, with a max-iteration cap and an `escalate=True` early exit.
+
+That is not a graph. That is one missing arrow on a loop we already built.
+
+---
+
+## 4. IS A GRAPH WORTH IT FOR US?
+
+**No. Not yet. And for our workload, possibly never.** This is a recommendation, not a hedge.
+
+### The case against, from primary sources
+
+`VERIFIED` — Anthropic's own multi-agent engineering post says, plainly:
+
+> "Most coding tasks involve fewer truly parallelizable tasks than research, and LLM agents are not yet great at coordinating and delegating to other agents in real time."
+
+Our cognitive loops are **repair, triage, PR-fixing** — coding tasks. The exact category Anthropic names as a bad multi-agent fit. Graph-composing them would move *against* first-party advice, not catch up to a trend.
+
+`VERIFIED` — Google's ADK production guidance says the same from the other side:
+
+> "Do not build a nested loop system on day one. Start with a sequential chain, debug it, and then add complexity."
+
+A fixed hand-wired chain is not our shortfall. It is **both vendors' recommended starting point**, and we are already at the far end of it.
+
+### What a graph would actually buy
+
+`VERIFIED` framing, from MarkTechPost — production graph systems run **two** graphs: a stable **org graph** (long-lived named roles) and an ephemeral **work graph** (task nodes that split, merge, and cancel mid-run based on evidence).
+
+**We already have the org graph.** 16 stable named roles in `.github/workflows/`. What we lack is the work graph: no loop of ours forks based on what it discovers halfway through. Every one runs its fixed chain top to bottom.
+
+For a one-person team, a work graph buys: parallel fan-out when a repair touches five files, and a router that picks a cheap model for a typo and an expensive one for an IDOR bug.
+
+### What it would cost
+
+`VERIFIED` numbers: **15x tokens** (Anthropic's measurement), **3-10x coordination overhead** (Cara Phillips), plus Anthropic's own observed failure modes — agents spawning 50 subagents for a simple query, and non-determinism between runs with identical prompts making debugging harder.
+
+For a solo founder, that last one is the killer. Our whole safety model is *deterministic gates around a non-deterministic core*. A graph makes the core bigger and the determinism thinner, exactly when you have no team to debug it.
+
+### What would change the answer
+
+Build a graph when — and only when — one of these is true, measured, not felt:
+
+1. `repair.yml` regularly needs work on 3+ independent files that genuinely don't share state.
+2. We start paying real money for cheap fixes that a Haiku node would have handled (needs the cost meter in §5 to even detect).
+3. The blind checker becomes overloaded — judging correctness *and* security *and* tenancy *and* style in one pass and getting worse at all four. AI Builder Club names "an overloaded verifier" as the strongest signal to split a loop into a graph. We already split it once (builder vs checker); the next split would be checker-by-concern.
+
+Until one of those fires, adding a graph is buying 15x tokens for a problem we do not have.
+
+---
+
+## 5. NEXT 3 THINGS
+
+### 1. Close the critic loop (Goal-Based edge-back)
+
+**Build:** when the blind checker returns *reject*, feed the verdict back to the repair agent and let it try again — with a hard cap of 2 retries and an early-exit if the checker says approve. Same for a failed verify.
+
+**Reuses:** the whole existing chain. Blind checker prompt at `repair.yml:445-500`, the source-only re-verification at `repair.yml:353-381` (which already protects against a retry that cheats by editing tests), the existing `--max-turns` and `concurrency:` caps. No new script.
+
+**Effort:** small-to-medium. One retry loop + a counter + one label. A day.
+
+**Source:** `VERIFIED` — Anthropic's Goal-Based Loop pattern ("an evaluator model checks your condition and sends it back to work until the goal is met") and Google ADK's Generator-and-Critic ("Executes until feedback equals PASS... agents can signal early completion via `escalate=True` before max_iterations").
+
+**Why first:** it is the single highest-value move because it is not a graph — it is one arrow on a loop we already own, and it deletes the human hand currently required to type "re-apply the label". Merge authority stays with you; the trust ladder is untouched.
+
+---
+
+### 2. Put a dollar meter on every loop
+
+**Build:** capture token/cost per LLM run, write it to a small file per run, and add a per-loop cost ceiling that trips before the timeout does. Report it weekly.
+
+**Reuses:** the `checker-scorecard.yml` shape exactly — a weekly cron that reads run history and writes a scorecard (`scripts/checker_scorecard.py`). Same pattern, different metric.
+
+**Effort:** small. Half a day.
+
+**Source:** `VERIFIED` — Thariq Shihipar: *"When you say Claude can run for eight hours, what you're really saying is Claude can spend like 500 bucks."* Backed by Anthropic's finding that **token spend alone explains 80% of performance variance**.
+
+**Why second:** every cap we have is turns or minutes (`--max-turns` in 4 workflows, `timeout-minutes` everywhere). Neither is money. A loop can burn a full timeout on an expensive model, produce nothing, and trip no alarm. This is also the **instrument that makes §4's decision answerable with numbers** instead of vibes — you cannot judge whether a router is worth 15x tokens until you know what 1x costs today.
+
+---
+
+### 3. Structured run records (trajectory, not just outcome)
+
+**Build:** every cognitive loop run writes one structured record — goal, files touched, tools used in order, verdict, retries, cost, final state. Append-only. Not the Actions log; a parseable record.
+
+**Reuses:** `scripts/checker_scorecard.py` already reads verdicts after the fact; this gives it a real source instead of scraping. `scripts/absence_check.py` and `scripts/watchdog_check.py` get a cleaner signal too.
+
+**Effort:** medium. Two to three days including backfilling the four LLM workflows.
+
+**Source:** `VERIFIED` — Google Vertex AI's agent evaluation docs grade **the trajectory** (which tools, in what order), not only the final answer. Reinforced by Annie Wang (Google Cloud DevRel): *"The quality of job memory depends on the quality of the outcome record."*
+
+**Why third and not skipped:** this is the prerequisite for both things you said you want later. A router needs history to route on. Self-improving memory needs a trajectory to distil from. Right now that history exists only as Actions run logs, which expire and can't be queried. Build the record before building anything that would read it.
+
+### Explicitly deferred (and why)
+
+**Self-improving memory / "dreaming."** `VERIFIED` — Annie Wang's warning is the reason to wait: *"Reflection can preserve a wrong conclusion... [generated memory] should be treated as untrusted until it passes checks."* If we let an agent write to `MEMORY.md` or `CLAUDE.md`, that write needs its own verification gate — structurally a test-tamper guard for memory. That is a real project, and item 3 is its foundation. Also note: our repair loop is already caged out of editing its own guards. Letting it edit the rules file would punch a hole in that cage.
+
+---
+
+## 6. WHAT I COULD NOT VERIFY
+
+**From the research (flagged by the researchers themselves):**
+
+1. **The "90% of Anthropic engineers use self-improving loops" stat** — no primary source exists. Four contradictory versions (80/90/90+/99%) from four anonymous accounts citing four unverifiable job titles. Never repeat it.
+2. **Thariq Shihipar's Minus One podcast episode** (harness engineering, why they stopped using Plan Mode, RAG as anti-pattern) — transcript not retrievable. The episode description exists; the actual claims do not, for us. Do not cite its specifics.
+3. **The Chase AI "Graph Engineering Is Now Here" video** — the fetch returned only YouTube nav boilerplate. The definition credited to it came from search snippets, not the video.
+4. **Peter Steinberger's originating tweet** — x.com returned HTTP 402. The quote and the "2.9M views" figure are both second-hand.
+5. **The Mark Nowicki loops webinar recording** — not public at fetch time. The "define done / set budget / add checkpoint" framing is from the event page, and the four-pattern mapping to it is inferred from the companion blog, not confirmed word-for-word from the talk.
+6. **Two Google claims marked secondary** — the Vertex AI trajectory-eval quote and the Gemini staged-rollout guidance were pulled from search renderings, not direct fetches of the live pages.
+7. **Google's Scion "harness" docs** — lives on GitHub Pages under the GoogleCloudPlatform org, not `cloud.google.com`. Official status unclear.
+
+**From my own check of our repo:**
+
+8. I verified **file presence and specific lines** in `.github/workflows/` and `scripts/`. I did **not** run any loop, read any Actions run history, or measure actual token cost. So the claim "our loops work" is your report, not my measurement.
+9. I read this **worktree** (`.claude/worktrees/loops+fix-dead-watchers`), not `main`. Per our own memory rule ("check the RIGHT INSTANCE — main's copy not the worktree's"), the workflow files on `main` may differ. Several are dated Aug 1 in this tree.
+10. **Effort estimates in §5 are guesses**, not measured against anything.


### PR DESCRIPTION
You named the flaw in what I'd been doing: **fixing extraction one CV at a time is overfitting.** You're right.

Every fix this week was correct *and* was a patch for a layout I happened to have seen. That road has no end — CV layouts are unbounded, and the eighth upload invents a shape nobody anticipated.

## The universal point

**You cannot make a structural parser universal, because structure is exactly what varies.**

So stop enumerating layouts. Compare what went **in** against what came **out** — a question with the same shape for a nurse, a welder and an ML engineer.

## Four axes, none of which know any profession

| Axis | Asks |
|---|---|
| **Coverage** | of the document's own signal terms, how many reached the profile |
| **Precision** | of what we produced, how much is junk |
| **Completeness** | did the matcher-critical fields get filled |
| **Input health** | was the file even readable |

## Measured on the real 7 — this is the finding

| person | cover | prec | compl | input | **overall** | verdict |
|---|---:|---:|---:|---:|---:|---|
| Ranjith | .48 | 1.00 | .50 | 1.00 | **.72** | good |
| Ashwin | .36 | 1.00 | .25 | 1.00 | **.63** | weak |
| CRajappa | .23 | 1.00 | .50 | 1.00 | **.62** | weak |
| Rohith | .33 | .83 | .50 | 1.00 | **.62** | weak |
| Pavan | .22 | 1.00 | .50 | 1.00 | **.61** | weak |
| Sofia | .18 | .95 | .25 | 1.00 | **.55** | weak |
| Spoorthi | .38 | .87 | .50 | .20 | **.48** | weak |

**6 of 7 need escalation.** Coverage 18–48% means **more than half** of what these people wrote never reaches their profile from the deterministic pass alone. That's not a bug to patch — it's the honest ceiling of a structure-only reader, and exactly why the LLM pass exists.

**One finding is universal: 7 of 7 have no job titles.** The deterministic pass returns skills and summary only, so search has no role to aim at for anybody.

## What the score is for

`needs_escalation()`. A parser can't be perfect for every layout, so the product's job is to **notice** and act — re-run the LLM, or ask the person to confirm — instead of silently handing someone a profile that will never match a job.

## Tests built on a nurse and a welder, deliberately

A metric that only works on software CVs is overfitting with extra steps. 7 tests pin that it grades a trade CV on its own terms, that junk lowers precision in any field, and that an unreadable file dominates the score rather than blaming the parser.

Gate: PASS.
