### PR TITLE
feat(extraction): the quality gate now RUNS on every extraction

### DIFF
--- a/backend/src/services/profile/models.py
+++ b/backend/src/services/profile/models.py
@@ -22,6 +22,12 @@ class CVData:
     headline: str = ""
     location: str = ""
     achievements: list[str] = field(default_factory=list)
+    # The universal extraction gate's verdict on THIS profile (coverage,
+    # precision, completeness, input health, overall, problems). Written by
+    # run_two_pass_extraction after both passes merge. Advisory: it never
+    # blocks a save, it tells the product when a profile is too thin to match
+    # anything so it can escalate instead of failing silently.
+    extraction_score: dict[str, Any] = field(default_factory=dict)
     # LinkedIn-sourced data
     linkedin_positions: list[dict[str, Any]] = field(default_factory=list)
     linkedin_skills: list[str] = field(default_factory=list)

--- a/backend/src/services/profile/two_pass.py
+++ b/backend/src/services/profile/two_pass.py
@@ -25,6 +25,10 @@ from src.services.profile.cv_parser import (
     deterministic_cv_fields,
     llm_cv_fields_from_text,
 )
+from src.services.profile.extraction_quality import (
+    needs_escalation,
+    score_extraction,
+)
 from src.services.profile.github_enricher import (
     deterministic_github_fields,
     llm_infer_github_skills,
@@ -343,5 +347,40 @@ async def run_two_pass_extraction(profile: UserProfile) -> UserProfile:
         profile.preferences = merge_cv_and_preferences(
             cv.skills, cv.job_titles, prefs
         )
+
+    # ── THE UNIVERSAL GATE ────────────────────────────────────────────────
+    # Grade what we just produced against the document it came from. This is
+    # deliberately the LAST thing the extractor does, after BOTH passes and the
+    # merge, because it judges the finished profile — not any one parser.
+    #
+    # Why it exists: extraction was being fixed one CV at a time, and every fix
+    # was a patch for a layout we happened to have seen. Layouts are unbounded;
+    # that road has no end. A parser cannot be made perfect for every document,
+    # so the product's job is to NOTICE when it did badly rather than silently
+    # hand someone a profile that will never match a job.
+    #
+    # Never raises and never blocks a save: a scoring failure must not cost a
+    # user their upload. The score is advisory — it is carried on the profile so
+    # the API can show it, and logged loudly so a low score is visible in prod.
+    try:
+        score = score_extraction(
+            cv.raw_text or "",
+            list(cv.skills or []),
+            job_titles=list(cv.job_titles or []),
+            summary=cv.summary or "",
+            certifications=list(cv.certifications or []),
+        )
+        cv.extraction_score = score.as_dict()
+        if needs_escalation(score):
+            logger.warning(
+                "extraction scored %s (%.2f) for this profile - coverage %.0f%%, "
+                "precision %.0f%%. Problems: %s",
+                score.verdict, score.overall, score.coverage * 100,
+                score.precision * 100, "; ".join(score.problems[:3]),
+            )
+        else:
+            logger.info("extraction scored %s (%.2f)", score.verdict, score.overall)
+    except Exception as exc:  # noqa: BLE001 - scoring must never cost an upload
+        logger.warning("extraction scoring failed (non-fatal): %s", exc)
 
     return profile

--- a/backend/tests/test_extraction_quality.py
+++ b/backend/tests/test_extraction_quality.py
@@ -107,3 +107,94 @@ def test_empty_extraction_is_broken_not_merely_weak():
     s = score_extraction(NURSE_CV, [])
     assert s.verdict == "broken"
     assert s.precision == 0.0
+
+
+# ---------------------------------------------------------------------------
+# The gate must actually FIRE in the pipeline, not just exist as a function.
+# A scorer nobody calls is the same as no scorer — and this repo has been
+# burned by exactly that shape before (a telemetry file nothing wrote, a
+# detector nothing woke).
+# ---------------------------------------------------------------------------
+
+def test_two_pass_writes_the_score_onto_the_profile():
+    """run_two_pass_extraction must leave its verdict on cv_data, so the API
+    and the UI can act on a thin profile instead of shipping it silently."""
+    import asyncio
+    from unittest.mock import patch
+
+    from src.services.profile import two_pass as tp
+    from src.services.profile.models import CVData, UserPreferences, UserProfile
+
+    profile = UserProfile(
+        cv_data=CVData(
+            raw_text=NURSE_CV,
+            skills=["ALS", "BLS", "Epic"],
+            job_titles=["Registered Nurse"],
+            summary="Senior nurse with ICU experience.",
+        ),
+        preferences=UserPreferences(target_job_titles=["Nurse"]),
+    )
+
+    # Neutralise every paid/network pass — we are testing the GATE, not the LLM.
+    # llm_cv_fields_from_text returns a CVData (not a dict), and the merge that
+    # follows reads .skills off it, so the stub must keep that shape.
+    async def _noop(*a, **kw):
+        return CVData()
+
+    async def _noop_list(*a, **kw):
+        return []
+
+    # llm_curate is imported INSIDE run_two_pass_extraction, so it must be
+    # patched at its SOURCE module — patching a two_pass attribute misses it.
+    # The LinkedIn/GitHub passes no-op on their own here: this profile carries
+    # no LinkedIn text and no GitHub data, which is the documented behaviour.
+    from src.services.profile import llm_curate
+
+    with patch.object(tp, "llm_cv_fields_from_text", _noop), \
+         patch.object(tp, "llm_infer_github_skills", _noop_list), \
+         patch.object(tp, "llm_infer_from_about_me", _noop_list), \
+         patch.object(llm_curate, "llm_suggest_adjacent_skills", _noop_list), \
+         patch.object(llm_curate, "llm_merge_duplicates", _noop_list):
+        out = asyncio.run(tp.run_two_pass_extraction(profile))
+
+    score = out.cv_data.extraction_score
+    assert score, "the gate did not run — a scorer nobody calls is no scorer"
+    assert "overall" in score and "verdict" in score
+    assert 0.0 <= score["overall"] <= 1.0
+
+
+def test_scoring_failure_never_costs_the_user_their_upload():
+    """If scoring itself breaks, extraction must still return a profile. A
+    quality check that can destroy the thing it measures is worse than none."""
+    import asyncio
+    from unittest.mock import patch
+
+    from src.services.profile import two_pass as tp
+    from src.services.profile.models import CVData, UserPreferences, UserProfile
+
+    profile = UserProfile(
+        cv_data=CVData(raw_text=NURSE_CV, skills=["ALS"]),
+        preferences=UserPreferences(),
+    )
+
+    async def _noop(*a, **kw):
+        return CVData()
+
+    async def _noop_list(*a, **kw):
+        return []
+
+    def _boom(*a, **kw):
+        raise RuntimeError("scorer exploded")
+
+    from src.services.profile import llm_curate
+
+    with patch.object(tp, "llm_cv_fields_from_text", _noop), \
+         patch.object(tp, "llm_infer_github_skills", _noop_list), \
+         patch.object(tp, "llm_infer_from_about_me", _noop_list), \
+         patch.object(llm_curate, "llm_suggest_adjacent_skills", _noop_list), \
+         patch.object(llm_curate, "llm_merge_duplicates", _noop_list), \
+         patch.object(tp, "score_extraction", _boom):
+        out = asyncio.run(tp.run_two_pass_extraction(profile))
+
+    assert out is profile, "a scoring crash must not lose the extraction"
+    assert out.cv_data.skills == ["ALS"], "the extracted data must survive"


### PR DESCRIPTION
The scorer existed but **nothing called it**. This repo has been burned by that exact shape twice — a telemetry file nothing wrote, a detector nothing woke. **A scorer nobody calls is the same as no scorer.**

## What changed

`run_two_pass_extraction` now grades what it produced, as its **last** act — after both passes and the merge. It judges the *finished profile*, not any one parser, which is the whole point: a structure-only reader can't be made universal, so the product's job is to **notice** when it did badly.

- `cv.extraction_score` — coverage / precision / completeness / input_health / overall / verdict / problems
- `needs_escalation()` — logged at **WARNING** with real numbers, so a bad extraction is visible in prod logs rather than only in a test

## Two safety properties, both tested

1. **The gate must fire** — a test drives the real `run_two_pass_extraction` with every paid pass stubbed, and asserts the score lands on `cv_data`.
2. **The gate must never cost an upload** — a second test makes the scorer *raise*, and asserts extraction still returns the profile with its data intact. A quality check that can destroy the thing it measures is worse than none.

## Two pipeline facts those tests exposed

- `llm_cv_fields_from_text` returns a **CVData**, not a dict — the merge reads `.skills` off it
- `llm_curate` is imported **inside** the function, so patching a `two_pass` attribute silently misses it

Both now documented in the test so the next person doesn't relearn them.

**346 extraction/profile tests pass.** Gate: PASS.
