### PR TITLE
feat(profile): show the user how much of their CV we actually understood

### DIFF
--- a/backend/src/api/models.py
+++ b/backend/src/api/models.py
@@ -192,6 +192,11 @@ class CVDetail(BaseModel):
     # Aggregated highlights for the CV viewer — merges skills + titles +
     # companies + achievements + name/headline/location for in-text highlighting
     highlights: list[str] = []
+    # The universal extraction gate's verdict, so the USER can see how well we
+    # understood their CV. A score computed and logged but never shown is a dead
+    # artifact — the person whose profile it is has no way to know we only
+    # understood a fraction of their document, and no way to correct it.
+    extraction_score: dict[str, Any] = {}
 
 
 class ProfileResponse(BaseModel):

--- a/backend/src/api/routes/profile.py
+++ b/backend/src/api/routes/profile.py
@@ -114,6 +114,7 @@ def _build_profile_response(profile: UserProfile) -> ProfileResponse:
     )
     cv = profile.cv_data
     cv_detail = CVDetail(
+        extraction_score=getattr(cv, "extraction_score", {}) or {},
         raw_text=cv.raw_text,
         skills=cv.skills,
         job_titles=cv.job_titles,

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -201,6 +201,12 @@
             "title": "Experience Text",
             "type": "string"
           },
+          "extraction_score": {
+            "additionalProperties": true,
+            "default": {},
+            "title": "Extraction Score",
+            "type": "object"
+          },
           "headline": {
             "default": "",
             "title": "Headline",

--- a/frontend/src/components/profile/CVUpload.tsx
+++ b/frontend/src/components/profile/CVUpload.tsx
@@ -275,6 +275,54 @@ export function CVUpload({
           )}
         </div>
 
+        {/* ── HOW MUCH OF THIS CV DID WE ACTUALLY UNDERSTAND? ───────────────
+            Measured on 7 real CVs, the parser captured 18-48% of what people
+            had written. Nothing on screen said so, so nobody could know their
+            profile was thin — they just quietly got worse matches forever.
+
+            Deliberately lives HERE and not in CVViewer: CVViewer is rendered
+            nowhere (a Playwright run proved it), and a warning in a dead
+            component is the same as no warning at all.
+
+            Silent on a good extraction. A banner that appears every time is a
+            banner nobody reads. */}
+        {(() => {
+          const q = (cvDetail as { extraction_score?: {
+            verdict?: string; coverage?: number; problems?: string[];
+          } } | null | undefined)?.extraction_score;
+          if (!q?.verdict || q.verdict === "good") return null;
+          const pct = Math.round((q.coverage ?? 0) * 100);
+          const broken = q.verdict === "broken";
+          return (
+            <div
+              role="status"
+              data-testid="extraction-quality-warning"
+              className={`mt-3 rounded-md border p-3 text-xs ${
+                broken
+                  ? "border-destructive/40 bg-destructive/5"
+                  : "border-amber-500/40 bg-amber-500/5"
+              }`}
+            >
+              <p className="font-semibold mb-1">
+                {broken
+                  ? "We could not read much of this CV"
+                  : `We understood about ${pct}% of this CV`}
+              </p>
+              <p className="text-muted-foreground mb-2">
+                Anything we missed will not be matched against jobs. Add what is
+                missing in your preferences on the right.
+              </p>
+              {q.problems?.length ? (
+                <ul className="list-disc pl-4 space-y-0.5 text-muted-foreground">
+                  {q.problems.slice(0, 3).map((p) => (
+                    <li key={p}>{p}</li>
+                  ))}
+                </ul>
+              ) : null}
+            </div>
+          );
+        })()}
+
         {/* V-04 upload validation error */}
         {uploadError && (
           <p className="mb-3 text-sm text-red-400" role="alert">{uploadError}</p>

--- a/frontend/src/lib/api-types.ts
+++ b/frontend/src/lib/api-types.ts
@@ -1522,6 +1522,13 @@ export interface components {
              */
             experience_text: string;
             /**
+             * Extraction Score
+             * @default {}
+             */
+            extraction_score: {
+                [key: string]: unknown;
+            };
+            /**
              * Headline
              * @default
              */

--- a/frontend/tests/e2e/extraction-quality-visible.spec.ts
+++ b/frontend/tests/e2e/extraction-quality-visible.spec.ts
@@ -1,0 +1,169 @@
+import { test, expect, type Page } from "@playwright/test";
+
+/**
+ * Can the user SEE how well we read their CV?
+ *
+ * WHY THIS EXISTS. We built a gate that scores every extraction — coverage,
+ * precision, completeness — and for a while it only wrote to a log file. That
+ * is the shape that has burned this repo twice already: a value computed,
+ * stored, and shown to nobody.
+ *
+ * It matters most here of all. Measured on 7 real CVs, the deterministic pass
+ * captured 18-48% of what people had written. The person whose profile it is
+ * had no way to know that, and therefore no way to fix it — they just quietly
+ * got worse job matches forever.
+ *
+ * So these specs check the thing a unit test cannot: that the warning reaches
+ * a real browser, in words a person understands, and that it STAYS QUIET when
+ * extraction went well. A banner that appears every time is a banner nobody
+ * reads.
+ *
+ * Hermetic, same pattern as the other specs: fake the session cookie
+ * (middleware only checks presence) and mock the API.
+ */
+
+const SESSION_COOKIE = {
+  name: "job360_session",
+  value: "e2e-token",
+  domain: "localhost",
+  path: "/",
+};
+
+const RAW_CV = `Jane Okafor
+Registered Nurse
+SUMMARY
+Senior nurse with ICU experience across NHS trusts.
+EXPERIENCE
+Staff Nurse, Royal London Hospital
+Delivered care using ALS and BLS protocols and Epic charting.`;
+
+function profilePayload(score: Record<string, unknown> | undefined, skills: string[]) {
+  return {
+    summary: {
+      is_complete: true,
+      job_titles: ["Registered Nurse"],
+      skills_count: skills.length,
+      cv_length: RAW_CV.length,
+      has_linkedin: false,
+      has_github: false,
+      education: [],
+      experience_level: "senior",
+    },
+    preferences: { target_job_titles: ["Nurse"], additional_skills: [] },
+    cv_detail: {
+      raw_text: RAW_CV,
+      skills,
+      job_titles: ["Registered Nurse"],
+      companies: [],
+      education: [],
+      certifications: [],
+      summary_text: "Senior nurse with ICU experience.",
+      experience_text: "",
+      name: "Jane Okafor",
+      headline: "Registered Nurse",
+      location: "London",
+      achievements: [],
+      highlights: skills,
+      ...(score ? { extraction_score: score } : {}),
+    },
+    skill_tiers: {},
+  };
+}
+
+async function mockProfile(
+  page: Page,
+  score: Record<string, unknown> | undefined,
+  skills: string[]
+) {
+  await page.route("**/api/auth/me**", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ id: "e2e-user", email: "e2e@example.com" }),
+    })
+  );
+  await page.route("**/api/profile**", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(profilePayload(score, skills)),
+    })
+  );
+}
+
+test.describe("Extraction quality is visible to the user", () => {
+  test("a weak extraction warns the person, in their own words", async ({
+    page,
+    context,
+  }) => {
+    await context.addCookies([SESSION_COOKIE]);
+    await mockProfile(
+      page,
+      {
+        verdict: "weak",
+        overall: 0.55,
+        coverage: 0.18,
+        precision: 0.95,
+        problems: [
+          "only 18% of the document's own specific terms reached the profile — most of what this person wrote was not understood",
+          "no job titles — search has no role to aim at",
+        ],
+      },
+      ["ALS", "BLS"]
+    );
+
+    await page.goto("/profile");
+
+    const warning = page.getByTestId("extraction-quality-warning");
+    await expect(warning).toBeVisible({ timeout: 30_000 });
+
+    // The number must be in PLAIN words. "coverage 0.18" means nothing to the
+    // person whose CV it is; "about 18%" does.
+    await expect(warning).toContainText("18%");
+    await expect(warning).toContainText(/understood/i);
+    // And it must say what it COSTS them, not just that a number is low.
+    await expect(warning).toContainText(/will not be matched/i);
+    // The specific problems are shown so the warning is actionable.
+    await expect(warning).toContainText(/no job titles/i);
+  });
+
+  test("a good extraction says nothing at all", async ({ page, context }) => {
+    await context.addCookies([SESSION_COOKIE]);
+    await mockProfile(
+      page,
+      { verdict: "good", overall: 0.82, coverage: 0.71, precision: 1.0, problems: [] },
+      ["ALS", "BLS", "Epic", "NEWS2"]
+    );
+
+    await page.goto("/profile");
+    // Wait for the page to actually render before asserting an ABSENCE —
+    // asserting "not visible" on a blank page passes for the wrong reason.
+    await expect(page.getByText(/CV Uploaded/i)).toBeVisible({ timeout: 30_000 });
+    await expect(page.getByTestId("extraction-quality-warning")).toHaveCount(0);
+  });
+
+  test("a profile saved before the gate existed does not break the page", async ({
+    page,
+    context,
+  }) => {
+    await context.addCookies([SESSION_COOKIE]);
+    // No extraction_score key at all — every profile stored before this shipped.
+    await mockProfile(page, undefined, ["ALS", "BLS"]);
+
+    await page.goto("/profile");
+    await expect(page.getByText(/CV Uploaded/i)).toBeVisible({ timeout: 30_000 });
+    await expect(page.getByTestId("extraction-quality-warning")).toHaveCount(0);
+  });
+
+  test("the CV panel confirms the upload was parsed", async ({ page, context }) => {
+    await context.addCookies([SESSION_COOKIE]);
+    await mockProfile(
+      page,
+      { verdict: "good", overall: 0.8, coverage: 0.7, precision: 1.0, problems: [] },
+      ["ALS", "BLS", "Epic"]
+    );
+
+    await page.goto("/profile");
+    await expect(page.getByText(/CV Uploaded/i)).toBeVisible({ timeout: 30_000 });
+  });
+});


### PR DESCRIPTION
The gate scored every extraction and **told nobody**. Same dead-artifact shape this repo has been burned by twice — and it matters most here: measured on 7 real CVs, the parser captured **18–48%** of what people had written, and the person whose profile it is had no way to know. They just quietly got worse matches forever.

## What ships

- `CVDetail` carries `extraction_score` through the API (schema-generated, so the frontend type follows automatically)
- `CVUpload` shows a banner when the verdict is **weak** or **broken** — in plain words (*"We understood about 18% of this CV"*), what it **costs** them (*"anything we missed will not be matched against jobs"*), and the specific problems so it's actionable
- **Silent on a good extraction.** A banner that appears every time is a banner nobody reads.

## What Playwright caught that no unit test could

I first put the banner in `CVViewer` — the component that renders *"Skills Extracted (N)"* and looked like the obvious home. **The browser run failed because that text never appears on the page.**

`CVViewer` is imported **nowhere**. It's dead code.

So the warning would have shipped into a component no user ever sees — **a dead warning about dead artifacts.** Moved to `CVUpload`, which the profile page actually renders.

This is exactly why *"it compiles"* and *"the unit test passes"* are not verification.

## 4 browser specs, all passing

- weak case warns with the real percentage and names the cost
- a good extraction stays silent
- a profile saved **before** the gate existed (no `extraction_score` key) doesn't break the page
- the CV panel confirms the upload

The silent-case specs wait for the panel to render before asserting an absence — asserting *"not visible"* on a blank page passes for the wrong reason.

Gate: PASS.
