### PR TITLE
fix(profile): stop the coverage metric from lying about good CVs

### DIFF
--- a/backend/src/services/profile/extraction_quality.py
+++ b/backend/src/services/profile/extraction_quality.py
@@ -22,6 +22,15 @@ WHAT IT MEASURES (all layout-agnostic, all rule-#28 safe — no skill vocabulary
   COVERAGE   Of the document's own signal terms — capitalised words, acronyms,
              dotted/slashed tech tokens — how many reached the profile? Low
              coverage means we read the file and understood little of it.
+
+             **Coverage is a RELATIVE signal, never a target.** Measured on 7 real
+             CVs, roughly half of what it counts as "missed" is not a skill at all:
+             the person's own name, Leeds, United Kingdom, former employers, the
+             word "Awards". A profile that captured 100% of signal terms would be
+             full of cities and company names and would match jobs WORSE, not
+             better. So: compare coverage against the same CV over time, or across
+             the deterministic/LLM passes. Never drive it toward 1.0, and never let
+             a loop optimise it — that is a metric begging to be gamed into junk.
   PRECISION  Of what we extracted, how much is junk? Bare lowercase words,
              glued-together tokens, near-duplicates. High junk means we are
              padding the profile with noise that flattens every match.
@@ -175,9 +184,13 @@ def score_extraction(
         missed = sorted(signals - hit, key=len, reverse=True)
         s.missed_examples = missed[:10]
         if s.coverage < 0.25:
+            # Deliberately NOT "most of what they wrote was not understood". About
+            # half of what this counts as missed is a place, an employer or the
+            # person's own name — saying otherwise tells someone their good CV was
+            # unreadable, which is both false and discouraging.
             s.problems.append(
-                f"only {s.coverage*100:.0f}% of the document's own specific terms "
-                "reached the profile — most of what this person wrote was not understood"
+                f"only {s.coverage*100:.0f}% of the specific terms in this document "
+                "reached the profile — likely whole sections were not read"
             )
     else:
         s.coverage = 0.0

--- a/backend/tests/test_extraction_quality.py
+++ b/backend/tests/test_extraction_quality.py
@@ -103,6 +103,45 @@ def test_missing_certifications_are_reported_when_the_cv_mentions_them():
     assert any("certification" in p.lower() for p in s.problems)
 
 
+def test_coverage_is_not_punished_for_places_employers_and_names():
+    """A CV thick with proper nouns must not be graded as a failed extraction.
+
+    MEASURED, on 7 real CVs: about half of what coverage counts as "missed" is
+    not a skill at all — the person's own name, Leeds, United Kingdom, General
+    Motors, the word "Awards". Coverage therefore has a practical ceiling well
+    below 1.0, and this test exists to stop anyone (a future session, or a loop
+    told to "improve extraction") from chasing it by stuffing employers and
+    cities into the skills list. That would raise the number and RUIN matching.
+
+    Here every genuine skill was captured. The verdict must not be "broken".
+    """
+    noun_heavy_cv = """
+    Priya Raman
+    London, United Kingdom
+    EXPERIENCE
+    Structural Engineer, Arup Group, Manchester
+    Previously at Balfour Beatty and Laing O'Rourke, Birmingham.
+    Chartered with the Institution of Civil Engineers.
+    Delivered designs in Revit and Tekla to Eurocode 2 and BS 5950.
+    EDUCATION
+    University of Leeds, Yorkshire
+    """
+    s = score_extraction(
+        noun_heavy_cv,
+        ["Revit", "Tekla", "Eurocode 2", "BS 5950", "Structural Design"],
+        job_titles=["Structural Engineer"],
+        summary="Chartered structural engineer.",
+        certifications=["Institution of Civil Engineers"],
+    )
+    # Every real skill in the document was extracted, so this must not read as a
+    # failure — even though coverage is dragged down by ~10 place/employer names.
+    assert s.verdict != "broken", (
+        f"a complete extraction was graded broken by proper-noun drag: {s.as_dict()}"
+    )
+    assert s.precision == 1.0, "no junk was extracted, precision must be perfect"
+    assert s.completeness == 1.0, "all four matcher-critical fields were filled"
+
+
 def test_empty_extraction_is_broken_not_merely_weak():
     s = score_extraction(NURSE_CV, [])
     assert s.verdict == "broken"


### PR DESCRIPTION
## What I measured

Investigating how to raise extraction coverage, I checked **what the missed terms actually are** on 7 real CVs. The answer changes the metric's meaning:

| Genuinely missed skills | Not skills at all |
|---|---|
| machine learning, NLP, LLM, data engineering, robotics, communication protocols | the person's own name, Leeds, Hertfordshire, United Kingdom, General Motors, Centific, "Awards", "work", "tools", "any" |

Coverage counts **every proper noun**. Roughly half of what it flags as missed is a place, an employer, or the person's own name.

## Why that is dangerous, not just imprecise

**A profile that captured 100% of signal terms would match jobs worse, not better** — it would be full of cities and company names diluting every comparison.

So coverage is a *relative* signal (this CV vs itself over time, or deterministic vs LLM pass). It is **not a target**. Anything told to "improve extraction" could raise the number by stuffing employers into the skills list — score up, product down. That is a metric begging to be gamed, and nothing in the code said so.

## Two fixes

1. **Wording.** The banner said *"most of what this person wrote was not understood"*. That can be plainly false for a good CV that names a lot of places. Now: *"likely whole sections were not read"* — which is what a low number actually evidences.
2. **Calibration recorded.** The docstring states the ceiling and forbids optimising toward it, so the next session or loop cannot rediscover this the expensive way.

## Test

New test builds a **civil-engineering** CV thick with proper nouns where every genuine skill *was* captured, and asserts the verdict is not `broken`. Different profession on purpose — same as the rest of this module, because a metric that only behaves on software CVs is overfitting with extra steps.

`126 passed` across `test_extraction_quality.py`, `test_profile.py`, `test_cv_parser*.py`, `test_two_pass*.py`. Gate: PASS.

No behaviour change to extraction itself — calibration and wording only.

## Negative result worth recording

I first hypothesised that **font-based section detection** (already built, currently fed only to the LLM as a hint) would fix heading detection universally. Measured: it adds **+1 skill for one person, +0.01 coverage**. After the earlier heading fixes, the text path already finds what font detection finds. **The union is not worth wiring.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6DsQH5EUxJc3Vnqz9YHgQ