### PR TITLE
perf(profile): stop paying twice to read a CV that has not changed

### DIFF
--- a/backend/src/services/profile/models.py
+++ b/backend/src/services/profile/models.py
@@ -28,6 +28,21 @@ class CVData:
     # blocks a save, it tells the product when a profile is too thin to match
     # anything so it can escalate instead of failing silently.
     extraction_score: dict[str, Any] = field(default_factory=dict)
+    # Which inputs the paid LLM passes have ALREADY read, as {input: sha256}.
+    # Keys: "cv", "linkedin", "github", "about_me".
+    #
+    # WHY. Every profile change re-runs the whole extraction, and each run makes
+    # a paid LLM call per input. Change one preference and we re-read an
+    # unchanged CV, again, at full price. The only guard was a blunt
+    # PROFILE_EXTRACT_MAX_PER_HOUR rate limit, which caps the bleeding rather
+    # than stopping it — and punishes the user with a 429 for our waste.
+    #
+    # We store the input's hash, NOT the LLM's output, because the output is
+    # already here: every pass merges into this same CVData. So an unchanged
+    # hash means "that call's result is already in these fields" and the call
+    # can simply be skipped. A hash is only recorded after a pass SUCCEEDS —
+    # otherwise one provider outage would permanently skip that input.
+    llm_input_hashes: dict[str, str] = field(default_factory=dict)
     # LinkedIn-sourced data
     linkedin_positions: list[dict[str, Any]] = field(default_factory=list)
     linkedin_skills: list[str] = field(default_factory=list)

--- a/backend/src/services/profile/two_pass.py
+++ b/backend/src/services/profile/two_pass.py
@@ -17,6 +17,8 @@ imported at module top so tests can monkeypatch them by name.
 from __future__ import annotations
 
 import asyncio
+import hashlib
+import json
 import logging
 import re
 from typing import Any
@@ -56,6 +58,30 @@ async def _none() -> None:
     this keeps the call site readable instead of building the list conditionally.
     """
     return None
+
+
+def _input_hash(raw: Any) -> str:
+    """Stable fingerprint of one extraction input.
+
+    Accepts whatever the four inputs actually are — CV/LinkedIn text are strings,
+    ``github_repos_brief`` may be a list of dicts — so a non-string is serialised
+    with sorted keys to keep the digest stable across runs (Python dict order is
+    insertion-ordered, and a re-fetch could reorder it without the content
+    changing, which would look like a change and re-bill the user).
+    """
+    if not isinstance(raw, str):
+        raw = json.dumps(raw, sort_keys=True, default=str)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _already_read(cv: CVData, key: str, raw: Any) -> bool:
+    """True when a paid LLM pass has already absorbed this exact input.
+
+    The result of that pass is merged into ``cv``, so skipping the call loses
+    nothing — the data is already in the fields. Returns False for empty input
+    so the "no input" path stays the caller's existing ``if raw`` check.
+    """
+    return bool(raw) and cv.llm_input_hashes.get(key) == _input_hash(raw)
 
 
 def _merge_str_list(dst: list[str], src: list[str]) -> None:
@@ -196,6 +222,15 @@ def reset_cv_owned_fields(cv: CVData) -> None:
     # different person's skills.
     cv.suggested_skills.clear()
 
+    # MUST be cleared with the fields it guards. The hash means "the LLM's
+    # reading of this input is already merged into the fields above" — and we
+    # just erased those fields. Leaving it would make re-uploading the SAME CV
+    # (a real thing users do after a bad parse) skip the LLM pass and keep the
+    # wiped, deterministic-only profile forever. Only the CV key: LinkedIn,
+    # GitHub and about_me data deliberately survives a CV swap, so their
+    # hashes must survive too.
+    cv.llm_input_hashes.pop("cv", None)
+
 
 def _merge_cv_llm_into(cv: CVData, llm_cv: CVData) -> None:
     """Merge the CV-OWNED fields of an LLM result into the live ``cv``.
@@ -265,12 +300,44 @@ async def run_two_pass_extraction(profile: UserProfile) -> UserProfile:
             logger.warning("two_pass: %s LLM pass skipped: %s", label, e)
             return None
 
+    # ── Skip any pass whose input we have already paid to read ─────────
+    # Changing ONE preference re-runs this whole function, so without this an
+    # untouched CV is sent to a paid model again on every edit. The hash says
+    # the previous result is already merged into `cv`, so the call adds cost
+    # and latency and returns what we already have.
+    _inputs = {
+        "cv": cv.raw_text,
+        "linkedin": cv.linkedin_raw_text,
+        "github": cv.github_repos_brief,
+        "about_me": prefs.about_me,
+    }
+    _cached = {k: _already_read(cv, k, v) for k, v in _inputs.items()}
+    if any(_cached.values()):
+        logger.info(
+            "two_pass: reusing unchanged input(s) %s - skipping those LLM calls",
+            ", ".join(sorted(k for k, v in _cached.items() if v)),
+        )
+
     _llm_cv_res, _llm_li_res, _llm_gh_res, _llm_pr_res = await asyncio.gather(
-        _safe(llm_cv_fields_from_text(cv.raw_text), "CV") if cv.raw_text else _none(),
-        _safe(llm_linkedin_fields(cv.linkedin_raw_text), "LinkedIn") if cv.linkedin_raw_text else _none(),
-        _safe(llm_infer_github_skills(cv.github_repos_brief), "GitHub") if cv.github_repos_brief else _none(),
-        _safe(llm_infer_from_about_me(prefs.about_me), "about_me") if prefs.about_me else _none(),
+        _safe(llm_cv_fields_from_text(cv.raw_text), "CV")
+        if cv.raw_text and not _cached["cv"] else _none(),
+        _safe(llm_linkedin_fields(cv.linkedin_raw_text), "LinkedIn")
+        if cv.linkedin_raw_text and not _cached["linkedin"] else _none(),
+        _safe(llm_infer_github_skills(cv.github_repos_brief), "GitHub")
+        if cv.github_repos_brief and not _cached["github"] else _none(),
+        _safe(llm_infer_from_about_me(prefs.about_me), "about_me")
+        if prefs.about_me and not _cached["about_me"] else _none(),
     )
+
+    # Record ONLY what actually succeeded. `_safe` returns None on failure, so a
+    # provider outage leaves the hash unset and the next run retries — the
+    # alternative would silently freeze a half-extracted profile forever.
+    for _key, _res in (
+        ("cv", _llm_cv_res), ("linkedin", _llm_li_res),
+        ("github", _llm_gh_res), ("about_me", _llm_pr_res),
+    ):
+        if _res is not None:
+            cv.llm_input_hashes[_key] = _input_hash(_inputs[_key])
 
     # ── ① CV ── raw = cv.raw_text ──────────────────────────────────────
     if cv.raw_text:

--- a/backend/tests/test_llm_input_cache.py
+++ b/backend/tests/test_llm_input_cache.py
@@ -1,0 +1,179 @@
+"""Don't pay twice to read the same CV.
+
+WHY THIS EXISTS. Every profile change re-runs the whole two-pass extraction, and
+each run makes a paid LLM call per input. So editing one preference re-sent an
+untouched CV to a paid model at full price. The only guard was
+PROFILE_EXTRACT_MAX_PER_HOUR — a rate limit, which caps the bleeding rather than
+stopping it, and pays for our waste with a 429 in the user's face.
+
+The fix stores the input's HASH, not the LLM's output, because the output is
+already merged into the same CVData. An unchanged hash means "that result is
+already in these fields", so the call can be skipped outright.
+
+That makes the risk obvious and worth pinning hard: a cache that skips a call it
+should have made silently ships a worse profile, and nobody finds out. Every test
+below is about that failure, not about the saving.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import patch
+
+from src.services.profile import llm_curate
+from src.services.profile import two_pass as tp
+from src.services.profile.models import CVData, UserPreferences, UserProfile
+
+CV_TEXT = """
+Jane Okafor
+Registered Nurse
+SUMMARY
+Senior nurse with ICU experience across NHS trusts.
+EXPERIENCE
+Staff Nurse, Royal London Hospital
+Delivered care using ALS and BLS protocols and Epic charting.
+"""
+
+
+class _Counter:
+    """Counts calls per input so a test can assert WHICH passes ran, not just
+    how many — per-input caching is the whole point and a total would hide a
+    pass that ran when it should not have."""
+
+    def __init__(self) -> None:
+        self.cv = self.linkedin = self.github = self.about_me = 0
+
+
+def _run(profile: UserProfile, counter: _Counter, *, cv_fails: bool = False) -> UserProfile:
+    """Run the real extractor with every paid call stubbed and counted."""
+
+    async def fake_cv(text, *a, **kw):
+        counter.cv += 1
+        if cv_fails:
+            raise RuntimeError("provider down")
+        return CVData(skills=["Epic"], job_titles=["Registered Nurse"])
+
+    async def fake_li(text, *a, **kw):
+        counter.linkedin += 1
+        return {}
+
+    async def fake_gh(brief, *a, **kw):
+        counter.github += 1
+        return ["Python"]
+
+    async def fake_about(text, *a, **kw):
+        counter.about_me += 1
+        return ["Teamwork"]
+
+    async def _noop_list(*a, **kw):
+        return []
+
+    async def _passthrough(items, *a, **kw):
+        return items
+
+    with patch.object(tp, "llm_cv_fields_from_text", fake_cv), \
+         patch.object(tp, "llm_linkedin_fields", fake_li), \
+         patch.object(tp, "llm_infer_github_skills", fake_gh), \
+         patch.object(tp, "llm_infer_from_about_me", fake_about), \
+         patch.object(llm_curate, "llm_suggest_adjacent_skills", _noop_list), \
+         patch.object(llm_curate, "llm_merge_duplicates", _passthrough):
+        return asyncio.run(tp.run_two_pass_extraction(profile))
+
+
+def _profile(**cv_kw) -> UserProfile:
+    return UserProfile(
+        cv_data=CVData(raw_text=CV_TEXT, **cv_kw),
+        preferences=UserPreferences(about_me="I like ICU work."),
+    )
+
+
+def test_an_unchanged_profile_costs_nothing_the_second_time():
+    """The saving itself. Re-extraction with nothing changed must make ZERO
+    paid calls — this is the case that fires whenever a user edits a setting."""
+    p = _profile()
+    c = _Counter()
+
+    _run(p, c)
+    assert (c.cv, c.about_me) == (1, 1), "first run must actually call the LLM"
+
+    _run(p, c)
+    assert (c.cv, c.about_me) == (1, 1), (
+        "an unchanged profile was sent to a paid model again"
+    )
+
+
+def test_changing_one_input_re_reads_only_that_input():
+    """Per-input, not all-or-nothing. Editing 'about me' must not re-bill the
+    user for re-reading a CV that did not change."""
+    p = _profile()
+    c = _Counter()
+    _run(p, c)
+
+    p.preferences.about_me = "Actually I want theatre work now."
+    _run(p, c)
+
+    assert c.about_me == 2, "the changed input must be re-read"
+    assert c.cv == 1, "an untouched CV was re-sent to a paid model"
+
+
+def test_a_failed_pass_is_retried_not_cached():
+    """A provider outage must NOT be remembered as 'already read'. Caching a
+    failure would freeze a half-extracted profile forever, and the user would
+    never learn why their matches are bad."""
+    p = _profile()
+    c = _Counter()
+
+    _run(p, c, cv_fails=True)
+    assert "cv" not in p.cv_data.llm_input_hashes, "a failure was cached"
+
+    _run(p, c)
+    assert c.cv == 2, "a failed CV pass was never retried"
+    assert "Epic" in p.cv_data.skills, "the retry's result never landed"
+
+
+def test_re_uploading_the_same_cv_after_a_reset_still_calls_the_llm():
+    """The dangerous case. reset_cv_owned_fields() wipes CV-derived fields; if
+    the hash survived, re-uploading the SAME file — exactly what someone does
+    after a bad parse — would skip the LLM and leave the wiped profile."""
+    p = _profile()
+    c = _Counter()
+    _run(p, c)
+    assert "Epic" in p.cv_data.skills
+
+    tp.reset_cv_owned_fields(p.cv_data)
+    assert "cv" not in p.cv_data.llm_input_hashes, (
+        "the hash outlived the fields it guards — a re-upload would be skipped"
+    )
+
+    _run(p, c)
+    assert c.cv == 2, "the re-uploaded CV was not re-read"
+    assert "Epic" in p.cv_data.skills, "the profile was not rebuilt"
+
+
+def test_a_reset_does_not_discard_linkedin_or_github_work():
+    """Only the CV's hash may be cleared. LinkedIn/GitHub data deliberately
+    survives a CV swap, so re-paying to re-read them would be pure waste."""
+    p = _profile(linkedin_raw_text="Top Skills\nTriage\n", github_repos_brief="repo: icu-tools")
+    c = _Counter()
+    _run(p, c)
+    assert c.linkedin == 1 and c.github == 1
+
+    tp.reset_cv_owned_fields(p.cv_data)
+    _run(p, c)
+
+    assert c.linkedin == 1, "LinkedIn was re-read because of a CV swap"
+    assert c.github == 1, "GitHub was re-read because of a CV swap"
+
+
+def test_reordered_github_data_is_not_mistaken_for_a_change():
+    """github_repos_brief can come back from a re-fetch in a different order
+    with identical content. Hashing raw repr would call that a change and
+    re-bill the user, so the digest is order-stable."""
+    a = tp._input_hash([{"name": "b", "lang": "Go"}, {"name": "a", "lang": "Py"}])
+    b = tp._input_hash([{"name": "a", "lang": "Py"}, {"name": "b", "lang": "Go"}])
+    assert a != b, "distinct list ORDER is still distinct content"
+
+    # But identical content with differently-ordered dict keys must match.
+    x = tp._input_hash([{"name": "a", "lang": "Py"}])
+    y = tp._input_hash([{"lang": "Py", "name": "a"}])
+    assert x == y, "dict key order must not read as a content change"


### PR DESCRIPTION
## Measured

| | paid LLM calls |
|---|---|
| First extraction | 8 |
| User edits one setting (before) | 8 |
| User edits one setting (after) | **4** |

**Half the repeat cost, gone.**

## The problem

Any profile change re-runs `run_two_pass_extraction`, and every run calls a paid model once per input (CV, LinkedIn, GitHub, about_me). Editing a single preference re-sent an **untouched CV** to a paid model at full price.

The only guard was `PROFILE_EXTRACT_MAX_PER_HOUR` — a rate limit. It caps the bleeding rather than stopping it, and it charges the *user* a 429 for our waste.

## The approach

Store the input's **hash, not the LLM's output**. Every pass merges into the same `CVData`, so the output is already sitting in the fields — an unchanged hash means *"that call's result is already here"*, so the call is skipped. Nothing to store, nothing to grow unbounded, nothing to go stale.

Per-input, so changing `about_me` doesn't re-bill for re-reading the CV.

## The risk, and what guards it

A cache that skips a call it *should* have made ships a worse profile and nobody finds out. Three guards, each with a test:

- **A hash is recorded only after a pass succeeds.** A provider outage leaves it unset so the next run retries, instead of freezing a half-extracted profile forever.
- **`reset_cv_owned_fields()` clears the `cv` hash.** It wipes CV-derived fields; a surviving hash would make re-uploading the *same file* — exactly what someone does after a bad parse — skip the LLM and keep the wiped profile. It clears only that key, because LinkedIn/GitHub data deliberately survives a CV swap.
- **The digest is order-stable.** `github_repos_brief` can return from a re-fetch with reordered keys and identical content, which would otherwise read as a change and re-bill the user.

## Compatibility

No migration. `CVData` is a JSON blob and `storage._filter_fields` drops unknown keys, so profiles saved before this load with an empty dict and simply pay once more, as they do today.

## Scope

The remaining 4 calls are the curate/suggest passes. They read the **merged lists**, not the raw inputs, so this mechanism doesn't apply and they're deliberately left alone.

## Where the idea came from

Content-hash caching, seen in `Aillian/CVsAgent` while reviewing external CV-extraction projects. Adopted as an **idea, not a dependency** — no new packages.

`80 passed` on the gate (`test_llm_input_cache.py`, `test_models.py`, `test_two_pass.py`); `132 passed` across the wider profile suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6DsQH5EUxJc3Vnqz9YHgQ