### PR TITLE
fix(profile): list one capability once, not two or three times

### DIFF
--- a/backend/src/services/profile/cv_parser.py
+++ b/backend/src/services/profile/cv_parser.py
@@ -557,6 +557,29 @@ def _det_is_prose(token: str) -> bool:
     return False
 
 
+def _acronym_words(skill: str) -> list[str]:
+    """Split a skill into the words an acronym would be built from.
+
+    Hyphens and slashes join words INSIDE a term, so a plain ``.split()`` sees
+    "Retrieval-Augmented Generation" as two words and builds "rg" — missing the
+    "RAG" sitting right next to it in the same list. Observed in a real profile,
+    which showed both "RAG" and "Retrieval-Augmented Generation" as separate
+    skills. Structural only (punctuation), no vocabulary — rule #28 safe.
+    """
+    return [w for w in re.split(r"[\s\-/]+", skill or "") if w]
+
+
+def _strip_possessive(skill: str) -> str:
+    """Turn "LLM'S" into "LLM".
+
+    LinkedIn prose yields possessives and stylised plurals of acronyms, and they
+    reach the profile verbatim — a real extraction showed "LLM'S" as a skill. It
+    matches no job posting and reads as junk to the person whose profile it is.
+    Punctuation-only, so it is profession-agnostic.
+    """
+    return re.sub(r"['’]s$", "", (skill or "").strip(), flags=re.I)
+
+
 def _det_collapse_acronyms(skills: list[str]) -> list[str]:
     """Drop an expansion when its own acronym is already present (or vice versa).
 
@@ -571,11 +594,11 @@ def _det_collapse_acronyms(skills: list[str]) -> list[str]:
     """
     if len(skills) < 2:
         return skills
-    short = {s.lower(): s for s in skills if len(s.split()) == 1}
+    short = {s.lower(): s for s in skills if len(_acronym_words(s)) == 1}
     out: list[str] = []
     dropped: set[str] = set()
     for s in skills:
-        words = s.split()
+        words = _acronym_words(s)
         if len(words) >= 2:
             initials = "".join(w[0] for w in words if w and w[0].isalpha()).lower()
             if len(initials) >= 2 and initials in short:

--- a/backend/src/services/profile/two_pass.py
+++ b/backend/src/services/profile/two_pass.py
@@ -312,6 +312,24 @@ async def run_two_pass_extraction(profile: UserProfile) -> UserProfile:
     cv.certifications = dedup_fuzzy(dedup_by_containment(cv.certifications))
     cv.education = dedup_by_containment(cv.education)
 
+    # Clean the LinkedIn skill list the same way the CV list is cleaned.
+    #
+    # It never was, and a real profile showed the cost: "RAG" AND
+    # "Retrieval-Augmented Generation", "LoRA" AND "Low-Rank Adaptation", plus a
+    # stray "LLM'S". One capability counted two or three times inflates the skill
+    # count without adding capability — which makes a profile look broad and
+    # match everything weakly, the opposite of what the user wants. Both helpers
+    # are punctuation-structural, no vocabulary, so this stays rule-#28 safe and
+    # works for any profession.
+    if cv.linkedin_skills:
+        from src.services.profile.cv_parser import (  # noqa: PLC0415
+            _det_collapse_acronyms,
+            _strip_possessive,
+        )
+
+        cleaned = [_strip_possessive(s) for s in cv.linkedin_skills]
+        cv.linkedin_skills = _det_collapse_acronyms([s for s in cleaned if s])
+
     # LLM curation — the reasoning layer. The deterministic + fuzzy passes can't
     # safely merge entries that mean the same thing but are worded very
     # differently ("Master of Science…" vs "Master's degree…"; "AI/ML Engineer

--- a/backend/tests/test_skill_list_cleanup.py
+++ b/backend/tests/test_skill_list_cleanup.py
@@ -1,0 +1,92 @@
+"""One capability must be listed once.
+
+FOUND IN A REAL PROFILE, on screen, during browser verification. The LinkedIn
+skill list showed:
+
+    RAG        AND   Retrieval-Augmented Generation
+    LoRA       AND   Low-Rank Adaptation
+    LLM'S
+
+Counting one capability two or three times inflates the skill count without
+adding capability, which makes a profile look broad and match everything weakly
+— the opposite of what the person wants. "LLM'S" matches no job posting at all
+and simply reads as junk to its owner.
+
+Two causes, both fixed here:
+
+  1. ``_det_collapse_acronyms`` split on SPACES only, so
+     "Retrieval-Augmented Generation" built the initials "rg" and never matched
+     the "RAG" sitting beside it in the same list.
+  2. The LinkedIn skill list was never cleaned at all — only the CV list was.
+
+Everything below is punctuation-structural. No skill vocabulary is involved
+(rule #28), so it behaves the same for a nurse, a welder, or an ML engineer.
+"""
+
+from __future__ import annotations
+
+from src.services.profile.cv_parser import _det_collapse_acronyms, _strip_possessive
+
+
+def test_a_hyphenated_expansion_collapses_into_its_acronym():
+    """THE OBSERVED BUG. Hyphens join words inside a term; the old split() saw
+    two words and built the wrong initials."""
+    out = _det_collapse_acronyms(["RAG", "Retrieval-Augmented Generation", "Python"])
+    assert "RAG" in out
+    assert "Retrieval-Augmented Generation" not in out
+    assert "Python" in out, "unrelated skills must survive untouched"
+
+
+def test_slashes_are_treated_as_word_joins_too():
+    """Same class of separator, same handling — and a DIFFERENT profession, so
+    this cannot be quietly tuned to software terms."""
+    out = _det_collapse_acronyms(["CBT", "Cognitive/Behavioural Therapy"])
+    assert out == ["CBT"]
+
+
+def test_possessives_and_stylised_plurals_are_stripped():
+    assert _strip_possessive("LLM'S") == "LLM"
+    assert _strip_possessive("LLM’s") == "LLM"       # smart quote, what PDFs emit
+    assert _strip_possessive("Python") == "Python"    # untouched
+
+
+def test_a_genuine_acronym_is_never_dropped_for_its_expansion():
+    """Direction matters: keep the SHORT form, because that is what job ads
+    use. Dropping "RAG" in favour of the long form would hurt matching."""
+    out = _det_collapse_acronyms(["Retrieval-Augmented Generation", "RAG"])
+    assert out == ["RAG"]
+
+
+def test_unrelated_multiword_skills_are_not_collapsed():
+    """The guard against over-collapsing. "Applied Machine Learning" must not
+    vanish just because some unrelated three-letter token exists."""
+    out = _det_collapse_acronyms(["Applied Machine Learning", "SQL", "AWS SageMaker"])
+    assert len(out) == 3
+
+
+def test_stylised_acronyms_are_known_to_survive():
+    """HONEST LIMIT, recorded on purpose so nobody 'fixes' it with a word list.
+
+    "LoRA" is Low-Rank Adaptation — two letters from each word, not initials.
+    No structural rule recovers that; it needs a vocabulary, and rule #28 bans
+    skill vocabularies in extraction. So this duplicate REMAINS, and that is a
+    deliberate trade: a rare cosmetic duplicate is cheaper than a hand-typed
+    dictionary that overfits and rots.
+    """
+    out = _det_collapse_acronyms(["LoRA", "Low-Rank Adaptation"])
+    assert len(out) == 2, "if this ever passes, check it was not done with a keyword list"
+
+
+def test_the_real_linkedin_list_gets_cleaner_not_emptier():
+    """End-to-end shape check on the ACTUAL list seen on screen."""
+    observed = [
+        "Pandas (Software)", "AWS SageMaker", "Applied Machine Learning",
+        "Data Handling", "Fine-tuning", "Instruction Tuning", "Domain Adaptation",
+        "RAG", "Retrieval-Augmented Generation", "Pre-training",
+        "Cloud-based ML Workflows", "Reproducible Pipelines", "AI Training", "LLM'S",
+    ]
+    out = _det_collapse_acronyms([_strip_possessive(s) for s in observed])
+    assert "Retrieval-Augmented Generation" not in out
+    assert "LLM'S" not in out and "LLM" in out
+    assert "AWS SageMaker" in out and "Applied Machine Learning" in out
+    assert len(out) == len(observed) - 1, "exactly one duplicate should be removed"


### PR DESCRIPTION
## Seen on screen

During browser verification of a real profile, the LinkedIn skill list showed:

| | |
|---|---|
| `RAG` | **and** `Retrieval-Augmented Generation` |
| `LoRA` | **and** `Low-Rank Adaptation` |
| `LLM'S` | — |

Counting one capability twice inflates the skill count **without adding capability**, which makes a profile look broad and match everything weakly — the opposite of what the person wants. `LLM'S` matches no job posting at all and reads as junk to its owner.

## Two causes

**1. The acronym collapser split on spaces only.** Hyphens and slashes join words *inside* a term, so `Retrieval-Augmented Generation` built the initials `rg` and never matched the `RAG` sitting beside it in the same list. Now splits on whitespace, hyphens and slashes alike.

**2. The LinkedIn skill list was never cleaned at all** — only the CV list was. It now gets the same treatment, plus `_strip_possessive` for the forms LinkedIn prose produces (`LLM'S` → `LLM`, smart quotes included, since that's what PDFs actually emit).

## Rule #28 safe

Both helpers are **punctuation-structural**. No skill vocabulary is involved, so this behaves identically for a nurse, a welder, or an ML engineer. One test deliberately uses a **therapy** acronym rather than a software one, so the behaviour can't be quietly tuned to one field.

## An honest limit, pinned by a test

`LoRA` is **Lo**w-**Ra**nk Adaptation — two letters from each word, not initials. No structural rule recovers that; it needs a vocabulary, which rule #28 bans in extraction.

**That duplicate remains, by choice.** A rare cosmetic duplicate is cheaper than a hand-typed dictionary that overfits and rots. The test says so explicitly, so nobody "fixes" it with a word list later.

## Result

Measured on the real list from the screenshot: **16 entries → 15**, removing exactly `Retrieval-Augmented Generation` and repairing `LLM'S`. No genuine skill is lost — a test pins that unrelated multi-word skills survive.

`10 passed` on the new suites; `222 passed` across the extraction-related suites (the collapser change also affects the CV path, so those were re-run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6DsQH5EUxJc3Vnqz9YHgQ