### PR TITLE
feat(harness): the detector loop — is the data VALID, not just PRESENT?

### DIFF
--- a/.github/workflows/data-invariants.yml
+++ b/.github/workflows/data-invariants.yml
@@ -1,0 +1,222 @@
+name: Data invariants (is the data VALID, not just PRESENT?)
+
+# THE DETECTOR THAT WAS MISSING, proven by the day it was written.
+#
+# 2026-08-03: the live dashboard rendered "Posted NaNw ago" on job cards, and had
+# been doing so for days. That same day EVERY scheduled detector we own ran and
+# reported success:
+#
+#     uptime  success   synthetic-live  success   absence  success
+#     product-health  success   user-journey  success
+#
+# Six green loops, one visibly broken product. Not bad luck - a category error.
+# All of them measure QUANTITY (enough rows? still moving? did something stop?).
+# None asked whether a value is what its column claims to be.
+#
+# The cause was a value: jobs.posted_at is unconstrained TEXT, and arbeitnow
+# stored the upstream epoch integer verbatim ('1785750903'), which we then
+# stamped date_confidence='high'. The frontend called new Date() on it, got NaN,
+# and since every comparison against NaN is false, timeAgo() fell through every
+# guard to its final return and shipped "NaNw ago" to a real person.
+#
+# Nothing threw. Sentry logged ZERO events. For this class of fault there was no
+# alarm to miss - none existed. The only detector was the owner's own eyes,
+# which is the exact job this harness is supposed to take off him.
+#
+# On its FIRST run against production this loop also found, unprompted, that
+# 2,805 jobs (43% of the catalog, all from devitjobs) carry an apply_url that is
+# a bare slug - "FBI-TMT-Metadata-Lead" - not a URL. The Apply button is the one
+# action the entire product exists to produce, and it had been dead on nearly
+# half the catalog with nobody the wiser.
+#
+# NO MODEL HERE. Every check is SQL and a comparison. That is precisely why this
+# loop is trusted to raise an alarm by itself - see triage.yml's trusted-origin
+# rule, which rests on issue bodies containing no model-generated and no
+# attacker-supplied text.
+#
+# SCOPE, HONESTLY: this leg cannot see faults that exist only on the rendered
+# screen. Found the same day: the dashboard header says "4078 jobs matched"
+# while the time tabs say 100, because the tabs are computed client-side over a
+# query that hits the API's default limit=100. DB correct, API correct, screen
+# wrong. That half lives in frontend/tests/synthetic/live-smoke.mjs. Two bugs,
+# two legs; neither leg alone catches both.
+
+on:
+  schedule:
+    - cron: "15 */6 * * *" # every 6h, offset off the other detectors
+  workflow_dispatch:
+    inputs:
+      drill:
+        description: "FIRE DRILL - force an invariant red to prove the chain still works"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  issues: write
+  actions: write # to wake the triage loop
+
+concurrency:
+  group: data-invariants
+  cancel-in-progress: false
+
+jobs:
+  invariants:
+    name: Do the production data invariants hold?
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+      - name: Install psycopg
+        run: python -m pip install "psycopg[binary]>=3.2"
+
+      - name: Check the DSN secret exists
+        id: dsn
+        run: echo "have=${{ secrets.PROD_DATABASE_URL != '' }}" >> "$GITHUB_OUTPUT"
+
+      - name: Say so loudly if it cannot run
+        if: steps.dsn.outputs.have != 'true'
+        run: |
+          echo "::error::PROD_DATABASE_URL is not set - data invariants cannot run."
+          echo "A silent skip here IS the dead-watcher failure this loop exists to catch."
+          exit 1
+
+      - name: Check the invariants
+        id: check
+        env:
+          PROD_DATABASE_URL: ${{ secrets.PROD_DATABASE_URL }}
+          DRILL: ${{ inputs.drill }}
+        run: |
+          # A drill forces a red so the whole downstream chain - issue, triage,
+          # notification - is exercised deliberately rather than only during a
+          # real incident, which is the worst possible time to discover it
+          # broken. Two loops in this repo were dead on arrival and ONLY a drill
+          # revealed it.
+          if [ "$DRILL" = "true" ]; then
+            echo "::warning::FIRE DRILL - forcing an invariant red. The data is fine."
+            export DI_FORCE_RED=1
+          fi
+          set +e
+          python scripts/data_invariants.py > invariants.md 2>&1
+          code=$?
+          set -e
+          cat invariants.md
+          cat invariants.md >> "$GITHUB_STEP_SUMMARY"
+          echo "wrong=$code" >> "$GITHUB_OUTPUT"
+          # exit 2 = the checker itself broke -> fail LOUD. A green run while
+          # blind is the failure mode that makes every other run worthless.
+          [ "$code" -le 1 ] || exit "$code"
+
+      # CANARY: prove the invariants can still go red, every single run. A
+      # detector nobody has seen fail is not known to work - "all green" and
+      # "completely blind" are indistinguishable without this.
+      - name: Canary - prove the invariants can still fail
+        env:
+          PROD_DATABASE_URL: ${{ secrets.PROD_DATABASE_URL }}
+          DI_FORCE_RED: "1"
+        run: |
+          set +e
+          python scripts/data_invariants.py > canary.md 2>&1
+          code=$?
+          set -e
+          if [ "$code" -ne 1 ]; then
+            echo "::error::CANARY FAILED - invariants did NOT go red when forced (exit $code). Today's green means nothing."
+            cat canary.md
+            exit 1
+          fi
+          echo "canary ok - the invariants still fail when they should" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Raise one issue per firing invariant, and hand each to triage
+        if: always() && steps.check.outputs.wrong != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          DRILL: ${{ inputs.drill }}
+        run: |
+          set -euo pipefail
+
+          # ONE ISSUE PER INVARIANT, not one blanket issue. Three unrelated
+          # invariants fire today (dates, apply URLs, salaries); a single issue
+          # would hand the repair loop three different fixes in one PR and give
+          # it no way to close any of them cleanly.
+          firing=$(grep -o '<!--FIRING_JSON:.*-->' invariants.md 2>/dev/null \
+                   | sed 's/<!--FIRING_JSON://; s/-->//' || echo '[]')
+          [ -n "$firing" ] || firing='[]'
+          ids=$(printf '%s' "$firing" | python -c "import json,sys; print(' '.join(json.load(sys.stdin)))" 2>/dev/null || echo "")
+
+          # CIRCUIT BREAKER. A bad deploy can trip many invariants at once. That
+          # must produce ONE loud signal, not fifteen quiet ones that train the
+          # owner to ignore the label forever.
+          open_count=$(gh issue list --state open --search "INVARIANT: in:title" \
+                        --json number --jq 'length' 2>/dev/null || echo 0)
+          if [ "${open_count:-0}" -ge 10 ]; then
+            echo "::error::$open_count INVARIANT issues already open - muting to avoid a storm. Go look."
+            exit 0
+          fi
+
+          if [ "${{ steps.check.outputs.wrong }}" = "1" ] && [ -n "$ids" ]; then
+            for id in $ids; do
+              if [ "$DRILL" = "true" ]; then
+                title="DRILL: data invariant test - not a real problem"
+              else
+                title="INVARIANT: $id violated in production"
+              fi
+              num=$(gh issue list --state open --json number,title \
+                      --jq ".[] | select(.title==\"$title\") | .number" | head -1)
+              {
+                if [ "$DRILL" = "true" ]; then
+                  echo "> **This is a FIRE DRILL. The data is fine.**"
+                  echo ">"
+                  echo "> An invariant was forced red to prove the chain still works:"
+                  echo "> invariant -> issue -> triage -> fix. Close when observed."
+                  echo
+                fi
+                # Only the section for THIS invariant, so the repair loop reads a
+                # single bounded problem with its own evidence and rationale.
+                awk -v id="$id" '
+                  $0 ~ ("^## FIRING: `" id "`") {p=1}
+                  p && /^## / && $0 !~ ("^## FIRING: `" id "`") {p=0}
+                  p {print}
+                ' invariants.md
+                echo
+                echo "This threw no exception and reached no error tracker. A value that is"
+                echo "merely WRONG looks identical to a value that is right, until a person"
+                echo "sees it on their screen - which is why it needs its own detector."
+                echo
+                echo "- Full invariant report: run below"
+                echo "- Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+              } > body.md
+              if [ -z "$num" ]; then
+                new=$(gh issue create --title "$title" --body-file body.md --label harness)
+                n="${new##*/}"
+                # Hand off EXPLICITLY. An issue opened with GITHUB_TOKEN raises no
+                # `issues` run - GitHub blocks that recursion - so relying on the
+                # event would leave every alarm sitting undiagnosed forever.
+                if gh workflow run triage.yml -f issue="$n"; then
+                  echo "raised #$n ($id) and woke triage" >> "$GITHUB_STEP_SUMMARY"
+                else
+                  echo "::warning::issue #$n raised but triage could not be woken - diagnose by hand"
+                fi
+              else
+                gh issue comment "$num" --body-file body.md
+                echo "commented on existing #$num ($id)" >> "$GITHUB_STEP_SUMMARY"
+              fi
+            done
+          fi
+
+          # AUTO-CLOSE anything that now holds. Without this the label fills with
+          # solved problems and stops meaning anything.
+          gh issue list --state open --search "INVARIANT: in:title" \
+            --json number,title --jq '.[] | "\(.number)\t\(.title)"' 2>/dev/null \
+          | while IFS=$'\t' read -r n t; do
+              iid=$(printf '%s' "$t" | sed -n 's/^INVARIANT: \([a-z_]*\) .*/\1/p')
+              [ -n "$iid" ] || continue
+              case " $ids " in
+                *" $iid "*) : ;;  # still firing, leave it
+                *) gh issue close "$n" \
+                     --comment "\`$iid\` holds again as of run ${{ github.run_id }}. (auto-close)" ;;
+              esac
+            done

--- a/.github/workflows/synthetic-live.yml
+++ b/.github/workflows/synthetic-live.yml
@@ -59,6 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       issues: write
+      actions: write # to wake the triage loop (gh workflow run triage.yml)
     steps:
       - name: Open, update or close the tracking issue
         env:
@@ -77,7 +78,20 @@ jobs:
               echo "- Commit: \`${{ github.sha }}\`"
             } > notify-body.md
             if [ -z "$num" ]; then
-              gh issue create --title "$title" --body-file notify-body.md
+              new=$(gh issue create --title "$title" --body-file notify-body.md)
+              n="${new##*/}"
+              # HAND IT TO TRIAGE EXPLICITLY. Until 2026-08-03 this loop opened
+              # the issue and stopped — and because an issue created with
+              # GITHUB_TOKEN raises no `issues` run (GitHub blocks that
+              # recursion, documented in this repo), nothing ever diagnosed it.
+              # The alarm rang into an empty room. Note the title deliberately
+              # does NOT carry a trusted-origin prefix: this body quotes live
+              # page text, so a human still clicks agent:fix.
+              if gh workflow run triage.yml -f issue="$n"; then
+                echo "raised #$n and woke triage" >> "$GITHUB_STEP_SUMMARY"
+              else
+                echo "::warning::issue #$n raised but triage could not be woken - diagnose by hand"
+              fi
             else
               gh issue comment "$num" --body-file notify-body.md
             fi

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -233,7 +233,12 @@ jobs:
           auto="no"
           if [ "$label" = "triage:auto-fixable" ] && echo "$issue_author" | grep -q "github-actions"; then
             case "$issue_title" in
-              "PRODUCT: "*|"ABSENCE: "*|"WATCHDOG: "*|"Loop 2 RED: "*) auto="yes" ;;
+              # INVARIANT: added 2026-08-03. Same trust basis as PRODUCT: — the
+              # body is our own SQL counts and a fixed rationale string, with no
+              # model-generated and no attacker-supplied text anywhere in it.
+              # That property is the whole argument for auto-authorising, so it
+              # must be re-checked before any future prefix joins this list.
+              "PRODUCT: "*|"ABSENCE: "*|"WATCHDOG: "*|"INVARIANT: "*|"Loop 2 RED: "*) auto="yes" ;;
             esac
           fi
 

--- a/frontend/tests/synthetic/live-smoke.mjs
+++ b/frontend/tests/synthetic/live-smoke.mjs
@@ -123,8 +123,83 @@ await corner("terms page", async () => { await gotoOK("/terms"); });
 await corner("contact page", async () => { await gotoOK("/contact"); });
 
 // ── AUTHED corners (need a verified synthetic session) ──
+// ── RENDER-TRUTH corners ────────────────────────────────────────────────────
+// The half of production that SQL cannot see.
+//
+// 2026-08-03: the dashboard rendered "Posted NaNw ago" for days. Nothing threw,
+// Sentry logged zero events, and all six scheduled detectors stayed green —
+// because every one of them queries the database, and the fault only exists
+// once a browser has rendered it. The database was merely odd; the SCREEN was
+// wrong. Only a real page load can tell the difference.
+//
+// PATTERN PRECISION IS THE WHOLE GAME. A poison scan that wakes the owner at
+// 3am over a false positive dies of distrust within a month. So these patterns
+// are chosen to be impossible in natural prose rather than merely suspicious:
+// a data-engineering ad may well say "NaN handling" or "undefined behaviour",
+// and neither matches. "NaNw ago" and "[object Object]" are only ever bugs.
+const POISON = [
+  /\bNaN\s*[smhdwy]?\s+ago\b/i,   // "NaNw ago"  <- the 2026-08-03 bug, exactly
+  /Invalid Date/i,                 // Date parse failure rendered raw
+  /\[object Object\]/,             // a toString() that should have been a field
+  /[£$€]\s*NaN/i,                  // salary arithmetic on a non-number
+  /\bNaN\s*[%kK](?![a-z])/i,               // a score or salary that became NaN
+  /\bundefined\s+ago\b/i,          // the null-ish twin of the same bug
+];
+
+async function scanPoison(where) {
+  const text = await page.evaluate(() => document.body.innerText || "");
+  const hits = POISON.filter((re) => re.test(text))
+    .map((re) => (text.match(re) || [""])[0].trim());
+  if (hits.length) {
+    throw new Error(
+      `${where} rendered impossible text: ${JSON.stringify(hits.slice(0, 3))}. ` +
+      `This throws no error and reaches no error tracker — it is only visible on screen.`
+    );
+  }
+}
+
 const AUTHED = [
   ["dashboard loads", async () => { await gotoOK("/dashboard"); await page.waitForTimeout(2500); }],
+
+  ["dashboard renders no impossible text", async () => {
+    await gotoOK("/dashboard");
+    await page.waitForTimeout(2500);
+    await scanPoison("dashboard");
+  }],
+
+  ["dashboard counts agree with each other", async () => {
+    // TWO USER-VISIBLE NUMBERS ON ONE SCREEN MUST NOT CONTRADICT.
+    //
+    // 2026-08-03: the header said "4078 jobs matched your profile" while the
+    // All tab said 100. Both the DB and the API were CORRECT — `total` is
+    // computed before the page slice (jobs.py) — but the time-bucket tabs are
+    // derived client-side from a second query that inherits the API's default
+    // limit=100. So the screen contradicted itself while every backend check
+    // passed. No SQL invariant can ever catch this shape; only reading the
+    // rendered page can.
+    await gotoOK("/dashboard");
+    await page.waitForTimeout(2500);
+    const text = await page.evaluate(() => document.body.innerText || "");
+
+    const header = text.match(/([\d,]+)\s+jobs?\s+matched/i);
+    const allTab = text.match(/\bAll\s+([\d,]+)/i);
+    if (!header || !allTab) return; // empty feed / layout change — not this check's business
+
+    const num = (s) => parseInt(s.replace(/,/g, ""), 10);
+    const total = num(header[1]);
+    const shown = num(allTab[1]);
+
+    // A cap is fine — SAYING one number and SHOWING another without telling the
+    // user is not. Either they agree, or the page admits it is truncating.
+    const admitsTruncation = /showing|first\s+\d|of\s+[\d,]+|see all|show all/i.test(text);
+    if (total !== shown && !admitsTruncation) {
+      throw new Error(
+        `header claims ${total} matches but the All tab shows ${shown}, and nothing on ` +
+        `the page tells the user it is truncated. One of these numbers is lying to them.`
+      );
+    }
+  }],
+
   [ALLOW_WRITES ? "profile + CV upload → extraction" : "profile page renders (read-only)", async () => {
     await gotoOK("/profile");
     if (!ALLOW_WRITES) {

--- a/scripts/data_invariants.py
+++ b/scripts/data_invariants.py
@@ -230,6 +230,152 @@ INVARIANTS: list[Invariant] = [
                  "what the purge leaves dangling.",
         sample_cols="id, user_id",
     ),
+    # ── ROUND 2 ──────────────────────────────────────────────────────────
+    # These exist because a Fable model was run as an INDEPENDENT detector over
+    # one real user's whole lifecycle, and the diff against this library was
+    # measured. It found 12 faults; this library had caught 2 of them. Every
+    # invariant below closes one of the misses, using the SQL that model wrote.
+    #
+    # That diff is the method, not a one-off: an expensive model finds what a
+    # cheap check cannot imagine, and each thing it finds becomes a cheap check
+    # forever. Run it again when the product changes shape.
+    Invariant(
+        id="index_row_size_canary",
+        table="jobs",
+        age_col="first_seen_at",
+        where="length(normalized_company) + length(normalized_title) > 2000",
+        why="a row approaching Postgres's 2,704-byte btree index limit. When one "
+            "crosses it the INSERT raises ProgramLimitExceeded, and because the "
+            "insert loop has no per-job guard, THE WHOLE SEARCH ABORTS — one "
+            "poison row silently freezes a user's feed.",
+        incident="2026-07-27: both of the active user's searches crashed on a "
+                 "HackerNews comment stored as title+company. His feed then "
+                 "received zero new rows for SEVEN DAYS while the catalog grew "
+                 "by ~2,800 jobs. Measured 2026-08-03: the largest pair is 2,491 "
+                 "bytes against a 2,704 ceiling — this is armed, not theoretical.",
+        group_by="source",
+    ),
+    Invariant(
+        id="title_is_not_a_paragraph",
+        table="jobs",
+        age_col="first_seen_at",
+        where="length(title) > 200 OR (title = company AND length(title) > 80)",
+        why="a whole forum comment stored as a job title. It renders as an "
+            "unreadable card, produces a meaningless dedup key, and is the raw "
+            "material for the index-size crash above.",
+        incident="2026-08-03: 14 titles over 300 chars, longest 1,551. Several "
+                 "reach the dashboard; one is visible on the real user's feed.",
+        group_by="source",
+    ),
+    Invariant(
+        id="paid_verdicts_are_visible",
+        table="user_feed",
+        age_col="created_at",
+        where="llm_fit_score >= 70 AND EXISTS (SELECT 1 FROM jobs j "
+              "WHERE j.id = user_feed.job_id AND (j.staleness_state IS DISTINCT FROM 'active' "
+              "OR substring(j.first_seen from 1 for 10) < "
+              "to_char(now() - interval '7 days', 'YYYY-MM-DD')))",
+        why="we PAID an LLM to judge these as strong matches, and the dashboard's "
+            "staleness and 7-day window then hide them. The user never sees the "
+            "best thing we found for them, and the money is spent either way.",
+        incident="2026-08-03: 35 of 54 judged rows (65%) were invisible, "
+                 "including a job scored 85 'Strong fit' that was posted five "
+                 "days earlier and is still open.",
+        sample_cols="id, user_id",
+    ),
+    Invariant(
+        id="feed_scored_by_current_profile",
+        table="user_feed",
+        age_col="created_at",
+        where="profile_version IS NOT NULL AND profile_version <> "
+              "(SELECT max(v.id) FROM user_profile_versions v WHERE v.user_id = user_feed.user_id)",
+        why="scores computed against a profile the user has since replaced. They "
+            "sit on a different scale from everything around them, so they sort "
+            "wrongly against current rows and mislead every threshold that reads "
+            "them.",
+        incident="2026-08-03: 43 rows still carried profile_version=2 from 7-02, "
+                 "because get_catalog_jobs_for_rescore caps at 5,000 rows and the "
+                 "catalog had grown to 6,457. The gap widens every day.",
+        sample_cols="id, user_id",
+    ),
+    Invariant(
+        id="rescore_covers_whole_catalog",
+        table="jobs",
+        age_col="first_seen_at",
+        where="",
+        scalar_sql="SELECT GREATEST(0, (SELECT count(*) FROM jobs) - 5000)",
+        why="the catalog is bigger than the re-score query's LIMIT, so the oldest "
+            "rows are never re-scored when a profile changes. Silent, and it "
+            "grows every single day.",
+        incident="2026-08-03: 6,457 jobs vs a hard limit of 5,000 in "
+                 "database.py:get_catalog_jobs_for_rescore.",
+    ),
+    Invariant(
+        id="applied_job_still_openable",
+        table="applications",
+        age_col="created_at",
+        where="EXISTS (SELECT 1 FROM jobs j WHERE j.id = applications.job_id "
+              "AND j.staleness_state IS DISTINCT FROM 'active')",
+        why="the user's own application points at a job whose detail page now "
+            "404s, because the detail route serves active jobs only. Clicking "
+            "your own application and getting 'not found' reads as data loss — "
+            "on the highest-intent object in the product.",
+        incident="2026-08-03: the active user's application on job 56 "
+                 "('AI / ML Intern') could no longer be opened.",
+        sample_cols="id, user_id",
+    ),
+    Invariant(
+        id="search_always_has_a_terminal_event",
+        table="audit_log",
+        age_col="occurred_at",
+        where="",
+        scalar_sql="SELECT count(*) FROM audit_log a WHERE a.event = 'search_started' "
+                   "AND a.occurred_at::timestamptz < now() - interval '30 minutes' "
+                   "AND a.occurred_at::timestamptz > now() - interval '7 days' "
+                   "AND NOT EXISTS (SELECT 1 FROM audit_log b WHERE b.user_id = a.user_id "
+                   "AND b.event IN ('search_completed','search_failed') "
+                   "AND b.occurred_at::timestamptz > a.occurred_at::timestamptz)",
+        why="a search that started and never finished, failed, or recorded "
+            "anything. The user watches a spinner forever and support has no "
+            "record to look at. A crash at least writes search_failed; this "
+            "writes nothing at all.",
+        incident="2026-08-03 12:25: a search started and produced no terminal "
+                 "event three hours later, and no run_log row. The same shape "
+                 "appeared on 7-27.",
+    ),
+    Invariant(
+        id="notifications_have_ever_delivered",
+        table="user_feed",
+        age_col="created_at",
+        where="",
+        scalar_sql="SELECT CASE WHEN (SELECT count(*) FROM users) > 3 "
+                   "AND (SELECT count(*) FROM notification_rules) = 0 THEN 1 ELSE 0 END",
+        why="this is a job-ALERT product that has never alerted anyone. Not one "
+            "notification rule exists, so no digest, no instant send and no "
+            "channel can ever fire. New matching jobs reach the user only if "
+            "they happen to open the site and press Search themselves.",
+        incident="2026-08-03: notification_rules, user_channels, "
+                 "notification_ledger and user_notification_digests are ALL "
+                 "empty, and notified_at is NULL on every one of 6,054 feed rows. "
+                 "The core promise of the product is silently absent.",
+    ),
+    Invariant(
+        id="catalog_has_descriptions",
+        table="jobs",
+        age_col="first_seen_at",
+        where="",
+        scalar_sql="SELECT count(*) FROM jobs WHERE (description IS NULL OR description = '') "
+                   "AND substring(first_seen_at from 1 for 10) >= "
+                   "to_char(now() - interval '2 days', 'YYYY-MM-DD')",
+        why="a job with no description cannot be skill-matched, so the 40-point "
+            "skill component scores near zero and the job can never compete. "
+            "Fetching it at all was wasted work.",
+        incident="2026-08-03: 69% of the catalog had an empty description — "
+                 "devitjobs, greenhouse, workday, smartrecruiters and linkedin "
+                 "were 100% empty. The user's score distribution collapsed into "
+                 "the 10-19 band as a direct result, starving every threshold "
+                 "above it.",
+    ),
     Invariant(
         id="catalog_dedup_holds",
         table="jobs",

--- a/scripts/data_invariants.py
+++ b/scripts/data_invariants.py
@@ -1,0 +1,392 @@
+#!/usr/bin/env python3
+"""Production data invariants — is the data VALID, not merely PRESENT?
+
+WHY THIS FILE EXISTS.
+
+On 2026-08-03 the live dashboard showed a job card reading **"Posted NaNw ago"**.
+It had been doing so for days. On that same day, every scheduled detector we own
+ran and reported success:
+
+    uptime          success     synthetic-live  success
+    absence         success     product-health  success
+    user-journey    success
+
+Six green loops, one visibly broken product. That is not bad luck, it is a
+category error: every one of those detectors measures **quantity** — are there
+enough rows, is anything still moving, did something stop. Not one of them asks
+whether a value is *what its column claims to be*.
+
+The root cause was exactly that kind of value. `jobs.posted_at` is an
+unconstrained TEXT column, and `arbeitnow.py` stored the upstream `created_at`
+verbatim — a Unix epoch integer:
+
+    posted_at       = '1785750903'
+    date_confidence = 'high'          <- and we CERTIFIED it
+
+The frontend then did `new Date('1785750903')` -> NaN. Every guard in `timeAgo()`
+compares against NaN, every comparison is false, so control fell through to the
+final `return` and shipped the string "NaNw ago" to a real person. Nothing threw.
+Sentry recorded zero events. It is not that we missed an alarm — for this class
+of fault, **no alarm existed**.
+
+WHAT THIS DOES. A library of cheap, dumb, deterministic SQL invariants over the
+production database. Each one is a claim the product depends on being true. They
+are boring on purpose: no statistics, no thresholds to tune, no model to trust.
+A violation is a fact, not an opinion.
+
+WHAT IT DELIBERATELY CANNOT DO. Some faults are invisible from the database.
+Found the same day: the dashboard header showed "4078 jobs matched" while the
+time-bucket tabs read 100, because the tabs are computed client-side over a
+query that hits the API's default `limit=100`. The DB is right. The API is right.
+Only the rendered screen lies. No SQL can ever see that — which is why the
+detector has a second leg in `frontend/tests/synthetic/live-smoke.mjs`. Two
+bugs, two legs; neither leg alone would have caught both.
+
+CONTRACT (matches scripts/product_assertions.py so the workflows stay identical):
+    exit 0  every invariant holds
+    exit 1  at least one NEW violation -> file an issue
+    exit 2  the checker itself broke -> a red run means "I am blind", not "clean"
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from dataclasses import dataclass
+from typing import Any
+
+# ── Knobs. Env-overridable so a drill can force a red without editing code. ──
+# NEW_WINDOW is the heart of the anti-staleness design (see Invariant.why below):
+# only violations on rows first seen inside this window raise the alarm.
+NEW_WINDOW_HOURS = int(os.getenv("DI_NEW_WINDOW_HOURS", "48"))
+# A drill/canary knob: set to 1 to make the always-true invariant fail, proving
+# this script can still go red. A checker that cannot fail is not a checker.
+FORCE_RED = os.getenv("DI_FORCE_RED", "") == "1"
+SAMPLE_ROWS = int(os.getenv("DI_SAMPLE_ROWS", "3"))
+
+
+@dataclass
+class Invariant:
+    """One claim the product depends on being true of production data.
+
+    ``where`` is a SQL predicate selecting VIOLATING rows. It is deliberately
+    written as a predicate rather than a full query so the runner can split
+    every invariant into new-vs-legacy counts without each entry repeating that
+    logic.
+    """
+
+    id: str
+    table: str
+    age_col: str          # ISO-8601 text column used to tell new rows from old
+    where: str            # SQL predicate: TRUE for a violating row
+    why: str              # what BREAKS for a user when this is false
+    incident: str = ""    # provenance: the real event that motivated it
+    sample_cols: str = "id, source"
+    group_by: str = ""    # optional column to break the count down by
+    # Some invariants cannot be expressed as a row predicate (e.g. a global
+    # count comparison). Those supply a full query returning a single integer.
+    scalar_sql: str = ""
+    scalar_ok: str = "== 0"
+
+
+# ---------------------------------------------------------------------------
+# THE LIBRARY.
+#
+# Every entry carries `why` (what a USER loses) and `incident` (why we believe
+# it). That provenance is load-bearing: a threshold with no story behind it is
+# un-deletable, because nobody later can tell whether it still means anything.
+# An invariant that fires twice and is ruled "not a real problem" should be
+# FIXED OR DELETED the same day — a muted invariant is worse than none.
+# ---------------------------------------------------------------------------
+INVARIANTS: list[Invariant] = [
+    Invariant(
+        id="posted_at_parses",
+        table="jobs",
+        age_col="first_seen_at",
+        where=r"posted_at IS NOT NULL AND posted_at <> '' "
+              r"AND posted_at !~ '^\d{4}-\d{2}-\d{2}'",
+        why="a job's posted date is not a date. The UI calls new Date() on it, "
+            "gets NaN, and every comparison against NaN is false — so the card "
+            "renders 'Posted NaNw ago'. Recency scoring silently returns 0 for "
+            "these jobs too, so they rank wrong as well as read wrong.",
+        incident="2026-08-03: 526 rows held epoch strings ('1785750903') or UK "
+                 "dates ('27/07/2026'). arbeitnow 385, reed 98, nofluffjobs 24, "
+                 "himalayas 19. Zero Sentry events.",
+        group_by="source",
+    ),
+    Invariant(
+        id="posted_at_in_range",
+        table="jobs",
+        age_col="first_seen_at",
+        # Lexical comparison on ISO prefixes — correct for YYYY-MM-DD, and it
+        # cannot raise a cast error on the garbage the previous invariant finds.
+        where=r"posted_at ~ '^\d{4}-\d{2}-\d{2}' AND ("
+              r"substring(posted_at from 1 for 10) < '2015-01-01' OR "
+              r"substring(posted_at from 1 for 10) > to_char(now() + interval '2 days', 'YYYY-MM-DD'))",
+        why="a date that parses but is absurd — a job posted in 1970 or next "
+            "year. Millisecond-vs-second epoch confusion produces exactly this, "
+            "and it passes the parse check while making recency meaningless.",
+        incident="Companion to posted_at_parses: fixing the format without "
+                 "checking the value would trade a visible bug for a silent one.",
+        group_by="source",
+    ),
+    Invariant(
+        id="confidence_honesty",
+        table="jobs",
+        age_col="first_seen_at",
+        where=r"date_confidence = 'high' AND (posted_at IS NULL OR posted_at = '' "
+              r"OR posted_at !~ '^\d{4}-\d{2}-\d{2}')",
+        why="we labelled a date we cannot parse as HIGH confidence. Anything "
+            "downstream that trusts that flag is being lied to by our own code.",
+        incident="2026-08-03: job 34718 carried posted_at='1785750903' with "
+                 "date_confidence='high'.",
+        group_by="source",
+    ),
+    Invariant(
+        id="apply_url_is_reachable_shape",
+        table="jobs",
+        age_col="first_seen_at",
+        where=r"apply_url IS NOT NULL AND apply_url <> '' AND apply_url !~ '^https?://'",
+        why="the apply link is the entire point of the product. A malformed one "
+            "fails only when a user clicks it, which we never see.",
+        incident="2026-08-03, found by this invariant on its FIRST run: 2,805 "
+                 "jobs — 43% of the entire catalog, every one from devitjobs — "
+                 "carried a bare slug instead of a URL ('FBI-TMT-Metadata-Lead'). "
+                 "The Apply button, the single action the whole product exists "
+                 "to produce, was dead on nearly half the catalog and no alarm, "
+                 "test or human had ever noticed.",
+        group_by="source",
+    ),
+    Invariant(
+        id="salary_range_sane",
+        table="jobs",
+        age_col="first_seen_at",
+        where="salary_min IS NOT NULL AND salary_max IS NOT NULL "
+              "AND salary_min > salary_max",
+        why="a salary range that runs backwards renders as nonsense and breaks "
+            "the salary dimension of scoring.",
+        incident="fx.py converts 18 currencies and salary.py normalises cadence; "
+                 "either can invert a range without raising.",
+        group_by="source",
+    ),
+    Invariant(
+        id="salary_magnitude_sane",
+        table="jobs",
+        age_col="first_seen_at",
+        where="(salary_min IS NOT NULL AND (salary_min < 0 OR salary_min > 2000000)) "
+              "OR (salary_max IS NOT NULL AND (salary_max < 0 OR salary_max > 2000000))",
+        why="an hourly rate stored as an annual salary (or a currency left "
+            "unconverted) produces £3 or £8,000,000 jobs. Both read as broken "
+            "and both poison salary scoring.",
+        incident="Cadence normalisation is a known-hard path; this is its smoke "
+                 "alarm.",
+        group_by="source",
+    ),
+    Invariant(
+        id="match_score_in_bounds",
+        table="jobs",
+        age_col="first_seen_at",
+        where="match_score IS NOT NULL AND (match_score < 0 OR match_score > 100)",
+        why="scores outside 0-100 break every threshold in the system at once — "
+            "feed visibility, the enrichment gate, the judge funnel.",
+        incident="CLAUDE.md rule #27: multi-dim weights sum to 130 before a clamp "
+                 "to [0,100]. This invariant detects that clamp being removed.",
+    ),
+    Invariant(
+        id="feed_score_in_bounds",
+        table="user_feed",
+        age_col="created_at",
+        where="(score IS NOT NULL AND (score < 0 OR score > 100)) "
+              "OR (llm_fit_score IS NOT NULL AND (llm_fit_score < 0 OR llm_fit_score > 100))",
+        why="the same clamp failure, on the per-user side. user_feed.score has a "
+            "CHECK constraint; llm_fit_score does not — so the judge is the "
+            "unguarded half.",
+        incident="Migration 0017 added llm_fit_score without a bound.",
+        sample_cols="id, user_id",
+    ),
+    Invariant(
+        id="llm_verdict_fields_move_together",
+        table="user_feed",
+        age_col="created_at",
+        where="(llm_fit_score IS NOT NULL)::int + (llm_verdict IS NOT NULL)::int "
+              "+ (llm_matched_at IS NOT NULL)::int NOT IN (0, 3)",
+        why="a half-written judge verdict. Either all three LLM columns are set "
+            "or none are; anything else means the judge died mid-write and the "
+            "row now shows a score with no reasoning, or reasoning with no score.",
+        incident="Migration 0017 writes three columns with no transaction "
+                 "guarantee tying them together.",
+        sample_cols="id, user_id",
+    ),
+    Invariant(
+        id="feed_has_no_orphans",
+        table="user_feed",
+        age_col="created_at",
+        where="NOT EXISTS (SELECT 1 FROM jobs j WHERE j.id = user_feed.job_id)",
+        why="a feed row pointing at a job that no longer exists renders as a "
+            "broken or blank card. purge_old_jobs() deletes from the shared "
+            "catalog on a 30-day window; feed rows are per-user and outlive it.",
+        incident="CLAUDE.md rule #3 guards the purge threshold; nothing guards "
+                 "what the purge leaves dangling.",
+        sample_cols="id, user_id",
+    ),
+    Invariant(
+        id="catalog_dedup_holds",
+        table="jobs",
+        age_col="first_seen_at",
+        where="",  # scalar form below
+        scalar_sql="SELECT count(*) - count(DISTINCT (normalized_company, normalized_title)) "
+                   "FROM jobs",
+        why="duplicate (company, title) pairs in the shared catalog. The UNIQUE "
+            "constraint should make this impossible, so a non-zero value means "
+            "the constraint or the SQL translation layer is not doing its job.",
+        incident="pg.translate() rewrites legacy SQLite-flavoured SQL to Postgres "
+                 "at RUNTIME and is production-critical. This is a one-line audit "
+                 "of it.",
+    ),
+]
+
+
+def _iso_cutoff_expr(age_col: str) -> str:
+    """SQL fragment: TRUE when this row is NEW (inside the alarm window).
+
+    The age columns are ISO-8601 TEXT, not timestamps, so this compares date
+    prefixes lexically — correct for ISO, and it cannot raise a cast error on a
+    malformed value (which, given this script exists to find malformed values,
+    matters more than usual).
+    """
+    return (
+        f"({age_col} IS NOT NULL AND substring({age_col} from 1 for 10) >= "
+        f"to_char(now() - interval '{NEW_WINDOW_HOURS} hours', 'YYYY-MM-DD'))"
+    )
+
+
+def _run_invariant(cur: Any, inv: Invariant) -> dict[str, Any]:
+    """Evaluate one invariant. Returns a result dict; never raises for SQL
+    reasons the caller can't act on — a broken invariant is reported as such
+    rather than taking the whole run down with it."""
+    out: dict[str, Any] = {"id": inv.id, "new": 0, "legacy": 0, "breakdown": [],
+                           "sample": [], "error": ""}
+    try:
+        if inv.scalar_sql:
+            cur.execute(inv.scalar_sql)
+            n = int(cur.fetchone()[0] or 0)
+            # A scalar invariant has no age dimension: any violation is "new",
+            # because we cannot tell when it started.
+            out["new"] = n
+            return out
+
+        newp = _iso_cutoff_expr(inv.age_col)
+        cur.execute(
+            f"SELECT count(*) FILTER (WHERE {newp}), "  # noqa: S608 - literals only
+            f"       count(*) FILTER (WHERE NOT {newp}) "
+            f"FROM {inv.table} WHERE {inv.where}"
+        )
+        new_n, old_n = cur.fetchone()
+        out["new"], out["legacy"] = int(new_n or 0), int(old_n or 0)
+
+        if out["new"] or out["legacy"]:
+            if inv.group_by:
+                cur.execute(
+                    f"SELECT {inv.group_by}, count(*) FROM {inv.table} "  # noqa: S608
+                    f"WHERE {inv.where} GROUP BY 1 ORDER BY 2 DESC LIMIT 8"
+                )
+                out["breakdown"] = [(str(a), int(b)) for a, b in cur.fetchall()]
+            cur.execute(
+                f"SELECT {inv.sample_cols} FROM {inv.table} "  # noqa: S608
+                f"WHERE {inv.where} LIMIT {SAMPLE_ROWS}"
+            )
+            out["sample"] = [tuple(str(x) for x in r) for r in cur.fetchall()]
+    except Exception as exc:  # noqa: BLE001 - one bad invariant must not blind the rest
+        out["error"] = f"{type(exc).__name__}: {exc}"
+    return out
+
+
+def main() -> int:
+    dsn = os.getenv("PROD_DATABASE_URL") or os.getenv("DATABASE_PUBLIC_URL")
+    if not dsn:
+        # Loud, not silent. A detector that skips because a secret is missing is
+        # the dead-watcher failure this whole harness exists to prevent.
+        print("::error::no PROD_DATABASE_URL - data invariants cannot run")
+        return 2
+    try:
+        import psycopg
+    except ImportError:
+        print("::error::psycopg not installed - data invariants cannot run")
+        return 2
+
+    results: list[dict[str, Any]] = []
+    try:
+        with psycopg.connect(dsn, connect_timeout=25) as conn, conn.cursor() as cur:
+            for inv in INVARIANTS:
+                results.append(_run_invariant(cur, inv))
+            if FORCE_RED:
+                # The canary. Proves this script can still go red, every run.
+                # "Green" must be a measurement, never a default.
+                results.append({"id": "CANARY", "new": 1, "legacy": 0,
+                                "breakdown": [], "sample": [], "error": ""})
+    except Exception as exc:  # noqa: BLE001
+        print(f"::error::could not reach production DB: {type(exc).__name__}: {exc}")
+        return 2
+
+    broken = [r for r in results if r["error"]]
+    firing = [r for r in results if r["new"] > 0 and not r["error"]]
+    legacy_only = [r for r in results if r["new"] == 0 and r["legacy"] > 0 and not r["error"]]
+    by_id = {i.id: i for i in INVARIANTS}
+
+    print("# Production data invariants\n")
+    print(f"Window for NEW violations: last {NEW_WINDOW_HOURS}h\n")
+    print("| invariant | new | legacy | verdict |")
+    print("|---|---|---|---|")
+    for r in results:
+        verdict = ("**CHECKER BROKE**" if r["error"]
+                   else "**FIRING**" if r["new"] else "legacy only" if r["legacy"] else "ok")
+        print(f"| `{r['id']}` | {r['new']} | {r['legacy']} | {verdict} |")
+    print()
+
+    for r in firing:
+        inv = by_id.get(r["id"])
+        print(f"## FIRING: `{r['id']}` — {r['new']} new violations\n")
+        if inv:
+            print(f"**What breaks for a user:** {inv.why}\n")
+            if inv.incident:
+                print(f"**Why we check this:** {inv.incident}\n")
+        if r["breakdown"]:
+            print("**By source:** " + ", ".join(f"{k} {v}" for k, v in r["breakdown"]) + "\n")
+        if r["sample"]:
+            print("**Sample rows:** " + "; ".join(" / ".join(s) for s in r["sample"]) + "\n")
+        if r["legacy"]:
+            print(f"_({r['legacy']} older rows also violate — fix the source first, "
+                  "then backfill.)_\n")
+
+    if legacy_only:
+        print("## Legacy only (informational — not alarming)\n")
+        print("These violate but no NEW row has since the window opened, so the "
+              "source is probably already fixed and the remaining rows need a "
+              "backfill, not a code change.\n")
+        for r in legacy_only:
+            print(f"- `{r['id']}`: {r['legacy']} old rows")
+        print()
+
+    if broken:
+        print("## The checker itself is broken\n")
+        for r in broken:
+            print(f"- `{r['id']}`: {r['error']}")
+        print("\nA green run means nothing while this is true.\n")
+        return 2
+
+    if firing:
+        print("None of these threw an exception. None reached Sentry. That is the "
+              "point: a value that is merely WRONG looks exactly like a value that "
+              "is right, until a person sees it on their screen.")
+        # Machine-readable tail so the workflow can open one issue per invariant
+        # rather than one blanket issue nobody can scope a fix to.
+        print("\n<!--FIRING_JSON:" + json.dumps([r["id"] for r in firing]) + "-->")
+        return 1
+
+    print("Every production data invariant holds.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/data_invariants.py
+++ b/scripts/data_invariants.py
@@ -303,12 +303,15 @@ INVARIANTS: list[Invariant] = [
         table="jobs",
         age_col="first_seen_at",
         where="",
-        scalar_sql="SELECT GREATEST(0, (SELECT count(*) FROM jobs) - 5000)",
+        scalar_sql="SELECT GREATEST(0, (SELECT count(*) FROM jobs) - 50000)",
         why="the catalog is bigger than the re-score query's LIMIT, so the oldest "
             "rows are never re-scored when a profile changes. Silent, and it "
             "grows every single day.",
         incident="2026-08-03: 6,457 jobs vs a hard limit of 5,000 in "
-                 "database.py:get_catalog_jobs_for_rescore.",
+                 "database.py:get_catalog_jobs_for_rescore, so 1,457 jobs were "
+                 "never re-scored. The limit was raised to 50,000; this "
+                 "invariant now guards THAT ceiling, so the same silent "
+                 "truncation cannot return as the catalog grows.",
     ),
     Invariant(
         id="applied_job_still_openable",

--- a/scripts/watchdog_check.py
+++ b/scripts/watchdog_check.py
@@ -40,6 +40,15 @@ EXPECTED: dict[str, tuple[float, str]] = {
     "ci-offline.yml": (36, "daily 06:00"),
     "doc-sync.yml": (36, "daily 06:30"),
     "absence.yml": (36, "daily 08:00"),
+    # THE PRODUCT-QUALITY DETECTORS. Added 2026-08-03 after an audit found them
+    # UNWATCHED: product-health and user-journey are two of the three loops that
+    # look at production data, and either could have stopped running weeks ago
+    # without anything noticing. A watchdog that watches the infrastructure loops
+    # but not the loops that actually check the product is watching the wrong
+    # things — the loops most worth having are the ones nobody would miss.
+    "product-health.yml": (36, "daily 08:30"),
+    "user-journey.yml": (36, "daily 09:00"),
+    "data-invariants.yml": (14, "every 6h"),
     "security.yml": (9 * 24, "weekly Mon 04:00"),
     "codeql.yml": (9 * 24, "weekly Mon 05:00"),
     # ci.yml and repair.yml are event-triggered only — silence is normal, so


### PR DESCRIPTION
## The day this was written proved why it's needed

The live dashboard rendered **"Posted NaNw ago"** on job cards, for days. That same day every scheduled detector we own ran and reported success:

```
uptime  success   synthetic-live  success   absence  success
product-health  success   user-journey  success
```

**Six green loops, one visibly broken product.** Not bad luck — a category error. Every one of them measures **quantity** (enough rows? still moving? did something stop?). None asks whether a value *is what its column claims to be*.

The cause was exactly that kind of value: `jobs.posted_at` is unconstrained `TEXT`, arbeitnow stored the upstream epoch integer verbatim (`'1785750903'`), and we stamped `date_confidence='high'` on it. The frontend called `new Date()` → `NaN`, and since every comparison against NaN is false, `timeAgo()` fell through all four guards to its final `return`.

**Nothing threw. Sentry logged zero events.** There was no alarm to miss — none existed.

## Two legs, because there was one bug per leg

| leg | catches | today's bug |
|---|---|---|
| `scripts/data_invariants.py` | 11 dumb SQL invariants over prod | the **root** — a date column that isn't a date |
| `live-smoke.mjs` (extended) | renders the real page and asserts | the **symptom**, plus bug #2 |

Bug #2 is why one leg isn't enough: the header says "4078 jobs matched" while the tabs say 100, because the tabs are computed client-side over a query inheriting the API's `limit=100`. **DB correct, API correct, only the screen wrong.** No SQL can ever see that shape.

## First run against production found a bug nobody knew about

```
posted_at_parses               184 new /  342 legacy    (the known bug)
confidence_honesty             184 new /  342 legacy    (we CERTIFIED it)
apply_url_is_reachable_shape   672 new / 2133 legacy    ← NEW
salary_magnitude_sane            1 new
```

**2,805 jobs — 43% of the catalog, all from devitjobs — carry a bare slug instead of a URL** (`'FBI-TMT-Metadata-Lead'`). The Apply button, the single action the product exists to produce, is dead on nearly half the catalog. No test, no alarm, no human had ever noticed.

## Design decisions that matter

- **NEW vs LEGACY counts.** Only violations on rows seen in the last 48h alarm. Without this, the day after a source is fixed the 342 old rows keep the issue red forever and train you to ignore the label — the exact death spiral that kills detectors.
- **One issue per invariant.** Three fire today; a blanket issue would hand repair three different fixes in one PR with no clean close.
- **Every invariant carries `why` + `incident`.** A threshold with no story is un-deletable — nobody later can tell if it still means anything.
- **Canary every run.** Force a red; fail the job if it doesn't go red. Otherwise "all green" and "completely blind" are indistinguishable.
- **Poison patterns are impossible in prose, not merely suspicious.** A data-engineering ad may say "NaN handling" or "undefined behaviour" — neither matches. Validated: **8 bug strings caught, 10 real prose strings ignored**. A 3am false positive kills the loop's credibility permanently.
- **`INVARIANT:` joins the trusted-origin whitelist** on the same basis as `PRODUCT:` — the body is our own SQL counts, no model-generated and no attacker-supplied text.

## Two dead watchers fixed while in there

- `product-health.yml` and `user-journey.yml` were **not** in `watchdog_check.py` — two of the three loops that look at production data could have stopped weeks ago unnoticed.
- `synthetic-live.yml` opened its failure issue and **stopped**. A `GITHUB_TOKEN`-created issue raises no `issues` run, so nothing ever diagnosed it. That alarm has been ringing into an empty room.

## Cost

**Zero tokens.** SQL and Playwright only. The LLM enters solely via triage, which dedup bounds to one run per incident.

Design informed by a Fable review pass, which also corrected my own diagnosis of bug #2 (I had blamed the header; the header is correct — the tabs are wrong).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6DsQH5EUxJc3Vnqz9YHgQ