### PR TITLE
fix: every fault the Fable audit and the detector found in production

### DIFF
--- a/backend/src/api/routes/jobs.py
+++ b/backend/src/api/routes/jobs.py
@@ -763,7 +763,12 @@ async def get_job(
     user: Optional[CurrentUser] = Depends(optional_user),  # noqa: B008 — shared catalog; generateMetadata reads unauthenticated
 ) -> JobResponse:
     # Step-1 B6: single LEFT JOIN — JobResponse surfaces enrichment fields.
-    row = await db.get_job_by_id_with_enrichment(job_id)
+    # Passing the user lets them open a job THEY applied to or acted on even
+    # after it goes stale. Hiding a ghost from browsing is right; hiding a
+    # person's own application from them reads as data loss (found 2026-08-03).
+    row = await db.get_job_by_id_with_enrichment(
+        job_id, user_id=user.id if user is not None else None
+    )
     if not row:
         raise HTTPException(status_code=404, detail="Job not found")
     job_action = await db.get_action_for_job(job_id, user.id) if user is not None else None

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -837,9 +837,35 @@ async def run_search(
 
             # Insert new jobs (INSERT OR IGNORE returns rowcount=1 for actual inserts)
             new_jobs: list[Job] = []
+            # ONE POISON ROW MUST NOT KILL THE WHOLE SEARCH.
+            #
+            # 2026-07-27: both of a real user's searches aborted here. A
+            # HackerNews "Who's hiring" comment had been stored as title AND
+            # company, so (normalized_company, normalized_title) exceeded
+            # Postgres's 2,704-byte btree index limit and insert_job raised
+            # ProgramLimitExceeded. With no guard, that single row took down the
+            # entire run: his feed then received ZERO new rows for seven days
+            # while the catalog grew by ~2,800 jobs. He pressed Search twice,
+            # got a failure twice, and had no idea why.
+            #
+            # The rescore and backfill paths were given per-row guards after an
+            # earlier incident; this loop never was. Skipping one unstorable job
+            # costs that job; aborting costs every job AND the user's feed.
+            skipped = 0
             for job in unique_jobs:
-                if await db.insert_job(job):
-                    new_jobs.append(job)
+                try:
+                    if await db.insert_job(job):
+                        new_jobs.append(job)
+                except Exception as exc:  # noqa: BLE001 — never sink the whole run
+                    skipped += 1
+                    logger.error(
+                        "insert failed for %r @ %r (%s: %s) — skipping this job "
+                        "and continuing the run",
+                        (job.title or "")[:80], (job.company or "")[:60],
+                        type(exc).__name__, str(exc)[:200],
+                    )
+            if skipped:
+                logger.warning("%d job(s) could not be stored this run", skipped)
             await db.commit()
 
             new_jobs.sort(key=lambda j: (j.match_score, salary_in_range(j)), reverse=True)

--- a/backend/src/repositories/database.py
+++ b/backend/src/repositories/database.py
@@ -713,12 +713,25 @@ class JobDatabase:
         rows = await cursor.fetchall()
         return [dict(row) for row in rows]
 
-    async def get_catalog_jobs_for_rescore(self, limit: int = 5000) -> list[dict[str, Any]]:
+    async def get_catalog_jobs_for_rescore(self, limit: int = 50000) -> list[dict[str, Any]]:
         """Return the most-recently-found jobs from the shared catalog for rescoring.
 
         Read-only. Returns a list of plain dicts with the columns that
         ``score_catalog_row`` (``src/services/rescore.py``) needs to reconstruct
         a ``Job`` for scoring. Respects ``limit`` so callers can cap memory use.
+
+        THE LIMIT MUST EXCEED THE CATALOG, or a "full re-score" silently is not
+        one. It was 5,000 while the catalog had grown to 6,457, so the oldest
+        1,457 jobs were never re-scored when a profile changed: 43 of one real
+        user's feed rows still carried scores computed on 2026-07-02 against a
+        profile he had since replaced. Those sit on a different scale from
+        everything around them, so they sort wrongly and mislead every threshold
+        that reads them — and the gap widened every single day.
+
+        purge_old_jobs() caps the catalog at 30 days of live postings, so 50,000
+        is far above any real size while still bounding memory if that ever
+        changes. The data-invariants detector alarms if the catalog approaches
+        it (`rescore_covers_whole_catalog`), so this cannot silently rot again.
         """
         cursor = await self._db.execute(
             "SELECT id, title, company, apply_url, source, date_found, location, "
@@ -1256,30 +1269,60 @@ class JobDatabase:
             out.append(d)
         return out
 
-    async def get_job_by_id_with_enrichment(self, job_id: int) -> dict[str, Any] | None:
+    async def get_job_by_id_with_enrichment(
+        self, job_id: int, user_id: str | None = None
+    ) -> dict[str, Any] | None:
         """Same as :meth:`get_job_by_id` plus a LEFT JOIN to job_enrichment.
 
         C-1 fix: mirrors the staleness filter from
         :meth:`get_recent_jobs_with_enrichment` so a single-job lookup
         cannot surface a ghost-detected expired posting that the list
         path correctly hides.
+
+        BUT A JOB THE USER ALREADY ACTED ON IS THEIRS TO OPEN. When ``user_id``
+        is given, a job they applied to or acted on is returned even if it has
+        since gone stale.
+
+        Found 2026-08-03: a real user's own application (job 56, stage
+        "applied") could no longer be opened — clicking your own application and
+        getting "not found" reads as data loss, on the highest-intent object in
+        the product. Hiding a ghost from BROWSING is right; hiding a person's
+        own history from them is not, and staleness is a guess about the
+        employer, not a fact about the user's record.
         """
         # _JOBS_ENRICHMENT_JOIN_COLS is a class constant, not user input — S608 is a false positive here.
+        own = ""
+        params: tuple[Any, ...] = (job_id,)
+        if user_id:
+            own = (
+                " OR EXISTS (SELECT 1 FROM applications a "
+                "WHERE a.job_id = j.id AND a.user_id = ?)"
+                " OR EXISTS (SELECT 1 FROM user_actions ua "
+                "WHERE ua.job_id = j.id AND ua.user_id = ?)"
+            )
+            params = (job_id, user_id, user_id)
         sql = (
             f"SELECT {self._JOBS_ENRICHMENT_JOIN_COLS} "  # noqa: S608
             "FROM jobs j "
             "LEFT JOIN job_enrichment je ON je.job_id = j.id "
             "WHERE j.id = ? "
-            "AND (j.staleness_state IS NULL OR j.staleness_state = 'active')"
+            f"AND (j.staleness_state IS NULL OR j.staleness_state = 'active'{own})"
         )
         try:
-            cursor = await self._db.execute(sql, (job_id,))
+            cursor = await self._db.execute(sql, params)
         except pg.OperationalError:
             # Fallback for fresh DBs without migration 0008 — still apply
             # the staleness filter so the read path stays consistent.
+            fb_own = (
+                " OR EXISTS (SELECT 1 FROM applications a "
+                "WHERE a.job_id = jobs.id AND a.user_id = ?)"
+                " OR EXISTS (SELECT 1 FROM user_actions ua "
+                "WHERE ua.job_id = jobs.id AND ua.user_id = ?)"
+            ) if user_id else ""
             cursor = await self._db.execute(
-                "SELECT * FROM jobs WHERE id = ? " "AND (staleness_state IS NULL OR staleness_state = 'active')",
-                (job_id,),
+                "SELECT * FROM jobs WHERE id = ? "
+                f"AND (staleness_state IS NULL OR staleness_state = 'active'{fb_own})",
+                (job_id, user_id, user_id) if user_id else (job_id,),
             )
             row = await cursor.fetchone()
             if not row:

--- a/backend/src/sources/apis_free/aijobs.py
+++ b/backend/src/sources/apis_free/aijobs.py
@@ -3,9 +3,9 @@ from datetime import datetime, timezone
 
 from src.models import Job
 from src.sources.base import BaseJobSource, _is_uk_or_remote
+from src.utils.dates import normalize_posted_at
 
 logger = logging.getLogger("job360.sources.aijobs")
-
 
 class AIJobsSource(BaseJobSource):
     name = "aijobs"
@@ -28,8 +28,8 @@ class AIJobsSource(BaseJobSource):
 
             now_iso = datetime.now(timezone.utc).isoformat()
             raw_date = item.get("date")
-            posted_at = raw_date if raw_date else None
-            confidence = "high" if raw_date else "low"
+            posted_at, confidence = normalize_posted_at(raw_date)
+
             apply_url = item.get("url", "")
 
             jobs.append(Job(

--- a/backend/src/sources/apis_free/arbeitnow.py
+++ b/backend/src/sources/apis_free/arbeitnow.py
@@ -4,9 +4,9 @@ from typing import Any, cast
 
 from src.models import Job
 from src.sources.base import BaseJobSource, _is_uk_or_remote
+from src.utils.dates import normalize_posted_at
 
 logger = logging.getLogger("job360.sources.arbeitnow")
-
 
 class ArbeitnowSource(BaseJobSource):
     name = "arbeitnow"
@@ -20,8 +20,8 @@ class ArbeitnowSource(BaseJobSource):
         for item in cast(dict[str, Any], data)["data"]:
             now_iso = datetime.now(timezone.utc).isoformat()
             raw_created = item.get("created_at")
-            posted_at = raw_created if raw_created else None
-            confidence = "high" if raw_created else "low"
+            posted_at, confidence = normalize_posted_at(raw_created)
+
             jobs.append(Job(
                 title=item.get("title", ""),
                 company=item.get("company_name", ""),

--- a/backend/src/sources/apis_free/devitjobs.py
+++ b/backend/src/sources/apis_free/devitjobs.py
@@ -3,9 +3,9 @@ from datetime import datetime, timezone
 
 from src.models import Job
 from src.sources.base import BaseJobSource, _is_uk_or_remote
+from src.utils.dates import normalize_posted_at
 
 logger = logging.getLogger("job360.sources.devitjobs")
-
 
 class DevITJobsSource(BaseJobSource):
     name = "devitjobs"
@@ -22,11 +22,21 @@ class DevITJobsSource(BaseJobSource):
             title = item.get("name", "")
             company = item.get("company", "")
             location = item.get("actualCity", "")
-            apply_url = item.get("jobUrl", "")
+            # The API's `jobUrl` is a SLUG, not a URL — "FBI-TMT-Metadata-Lead".
+            # Stored raw, it produced an Apply button that goes nowhere, on 2,805
+            # jobs: 43% of the entire catalog, since devitjobs is our largest
+            # source. Nothing detected it for months, because a bad link only
+            # fails when a user clicks it and we never see that click.
+            # Found 2026-08-03 by the data-invariants detector on its first run.
+            apply_url = (item.get("jobUrl") or "").strip()
+            if apply_url and not apply_url.startswith(("http://", "https://")):
+                # VERIFIED against the live site, not guessed: /jobs/<slug>
+                # returns the real page (9.6 KB, company name present) while
+                # /job/<slug> and /<slug> both return the 4.7 KB empty SPA shell.
+                apply_url = f"https://devitjobs.uk/jobs/{apply_url.lstrip('/')}"
             now_iso = datetime.now(timezone.utc).isoformat()
             raw_published = item.get("publishedAt")
-            posted_at = raw_published if raw_published else None
-            confidence = "high" if raw_published else "low"
+            posted_at, confidence = normalize_posted_at(raw_published)
 
             salary_min = item.get("annualSalaryFrom")
             salary_max = item.get("annualSalaryTo")

--- a/backend/src/sources/apis_free/himalayas.py
+++ b/backend/src/sources/apis_free/himalayas.py
@@ -4,9 +4,9 @@ from typing import Any, cast
 
 from src.models import Job
 from src.sources.base import BaseJobSource, _is_uk_or_remote
+from src.utils.dates import normalize_posted_at
 
 logger = logging.getLogger("job360.sources.himalayas")
-
 
 class HimalayasSource(BaseJobSource):
     name = "himalayas"
@@ -25,8 +25,8 @@ class HimalayasSource(BaseJobSource):
             location = ", ".join(loc_restrictions) if isinstance(loc_restrictions, list) else str(loc_restrictions)
             now_iso = datetime.now(timezone.utc).isoformat()
             raw_pub = item.get("pubDate") or item.get("createdAt")
-            posted_at = raw_pub if raw_pub else None
-            confidence = "high" if raw_pub else "low"
+            posted_at, confidence = normalize_posted_at(raw_pub)
+
             jobs.append(Job(
                 title=item.get("title", ""),
                 company=item.get("companyName", ""),

--- a/backend/src/sources/apis_free/hn_jobs.py
+++ b/backend/src/sources/apis_free/hn_jobs.py
@@ -62,8 +62,10 @@ class HNJobsSource(BaseJobSource):
         now_iso = datetime.now(timezone.utc).isoformat()
         ts = item.get("time", 0)
         posted_at = datetime.fromtimestamp(ts, tz=timezone.utc).isoformat() if ts else None
-        confidence = "high" if ts else "low"
-
+        # Confidence follows the RESULT, not the input. A present-but-
+        # unparseable value used to be stamped "high" purely because the
+        # field existed — certifying as trustworthy a date we could not read.
+        confidence = "high" if posted_at else "low"
         return Job(
             title=title,
             company=company,

--- a/backend/src/sources/apis_free/jobicy.py
+++ b/backend/src/sources/apis_free/jobicy.py
@@ -4,9 +4,9 @@ from typing import Any, cast
 
 from src.models import Job
 from src.sources.base import BaseJobSource, _is_uk_or_remote
+from src.utils.dates import normalize_posted_at
 
 logger = logging.getLogger("job360.sources.jobicy")
-
 
 class JobicySource(BaseJobSource):
     name = "jobicy"
@@ -31,8 +31,8 @@ class JobicySource(BaseJobSource):
             description = item.get("jobExcerpt", "")
             now_iso = datetime.now(timezone.utc).isoformat()
             raw_pub = item.get("pubDate")
-            posted_at = raw_pub if raw_pub else None
-            confidence = "high" if raw_pub else "low"
+            posted_at, confidence = normalize_posted_at(raw_pub)
+
             jobs.append(Job(
                 title=title,
                 company=item.get("companyName", ""),

--- a/backend/src/sources/apis_free/landingjobs.py
+++ b/backend/src/sources/apis_free/landingjobs.py
@@ -3,13 +3,13 @@ from datetime import datetime, timezone
 
 from src.models import Job
 from src.sources.base import BaseJobSource, _is_uk_or_remote
+from src.utils.dates import normalize_posted_at
 
 logger = logging.getLogger("job360.sources.landingjobs")
 
 # Country codes that count as UK/relevant
 _UK_CODES = {"GB", "UK"}
 _MAX_JOBS = 200
-
 
 class LandingJobsSource(BaseJobSource):
     name = "landingjobs"
@@ -61,8 +61,7 @@ class LandingJobsSource(BaseJobSource):
                 apply_url = item.get("url", "")
                 now_iso = datetime.now(timezone.utc).isoformat()
                 raw_pub = item.get("published_at")
-                posted_at = raw_pub if raw_pub else None
-                confidence = "high" if raw_pub else "low"
+                posted_at, confidence = normalize_posted_at(raw_pub)
 
                 jobs.append(Job(
                     title=title,

--- a/backend/src/sources/apis_free/remoteok.py
+++ b/backend/src/sources/apis_free/remoteok.py
@@ -4,9 +4,9 @@ from datetime import datetime, timezone
 from src.core.settings import USER_AGENT
 from src.models import Job
 from src.sources.base import BaseJobSource, _is_uk_or_remote
+from src.utils.dates import normalize_posted_at
 
 logger = logging.getLogger("job360.sources.remoteok")
-
 
 class RemoteOKSource(BaseJobSource):
     name = "remoteok"
@@ -24,8 +24,8 @@ class RemoteOKSource(BaseJobSource):
                 continue
             now_iso = datetime.now(timezone.utc).isoformat()
             raw_date = item.get("date")
-            posted_at = raw_date if raw_date else None
-            confidence = "high" if raw_date else "low"
+            posted_at, confidence = normalize_posted_at(raw_date)
+
             jobs.append(Job(
                 title=item.get("position", ""),
                 company=item.get("company", ""),

--- a/backend/src/sources/apis_free/remotive.py
+++ b/backend/src/sources/apis_free/remotive.py
@@ -4,9 +4,9 @@ from typing import Any, cast
 
 from src.models import Job
 from src.sources.base import BaseJobSource, _is_uk_or_remote
+from src.utils.dates import normalize_posted_at
 
 logger = logging.getLogger("job360.sources.remotive")
-
 
 class RemotiveSource(BaseJobSource):
     name = "remotive"
@@ -25,8 +25,8 @@ class RemotiveSource(BaseJobSource):
             desc = item.get("description", "")
             now_iso = datetime.now(timezone.utc).isoformat()
             raw_pub = item.get("publication_date")
-            posted_at = raw_pub if raw_pub else None
-            confidence = "high" if raw_pub else "low"
+            posted_at, confidence = normalize_posted_at(raw_pub)
+
             salary = item.get("salary", "")
             salary_min = None
             salary_max = None

--- a/backend/src/sources/apis_free/teaching_vacancies.py
+++ b/backend/src/sources/apis_free/teaching_vacancies.py
@@ -9,9 +9,9 @@ from datetime import datetime, timezone
 
 from src.models import Job
 from src.sources.base import BaseJobSource, _is_uk_or_remote
+from src.utils.dates import normalize_posted_at
 
 logger = logging.getLogger("job360.sources.teaching_vacancies")
-
 
 class TeachingVacanciesSource(BaseJobSource):
     name = "teaching_vacancies"
@@ -57,8 +57,7 @@ class TeachingVacanciesSource(BaseJobSource):
                 continue
 
             raw_posted = item.get("datePosted") or item.get("date_posted")
-            posted_at = raw_posted if raw_posted else None
-            confidence = "high" if raw_posted else "low"
+            posted_at, confidence = normalize_posted_at(raw_posted)
 
             apply_url = item.get("url") or item.get("applyUrl") or ""
             description = (item.get("description") or "")[:5000]

--- a/backend/src/sources/apis_keyed/adzuna.py
+++ b/backend/src/sources/apis_keyed/adzuna.py
@@ -7,9 +7,9 @@ import aiohttp
 from src.models import Job
 from src.services.profile.models import SearchConfig
 from src.sources.base import BaseJobSource, _is_uk_or_remote
+from src.utils.dates import normalize_posted_at
 
 logger = logging.getLogger("job360.sources.adzuna")
-
 
 class AdzunaSource(BaseJobSource):
     name = "adzuna"
@@ -50,8 +50,8 @@ class AdzunaSource(BaseJobSource):
                 location = item.get("location", {})
                 now_iso = datetime.now(timezone.utc).isoformat()
                 raw_created = item.get("created")
-                posted_at = raw_created if raw_created else None
-                confidence = "high" if raw_created else "low"
+                posted_at, confidence = normalize_posted_at(raw_created)
+
                 jobs.append(Job(
                     title=item.get("title", ""),
                     company=company.get("display_name", "") if isinstance(company, dict) else str(company),

--- a/backend/src/sources/apis_keyed/careerjet.py
+++ b/backend/src/sources/apis_keyed/careerjet.py
@@ -7,9 +7,9 @@ import aiohttp
 from src.models import Job
 from src.services.profile.models import SearchConfig
 from src.sources.base import BaseJobSource, _is_uk_or_remote
+from src.utils.dates import normalize_posted_at
 
 logger = logging.getLogger("job360.sources.careerjet")
-
 
 class CareerjetSource(BaseJobSource):
     name = "careerjet"
@@ -59,8 +59,7 @@ class CareerjetSource(BaseJobSource):
 
                 now_iso = datetime.now(timezone.utc).isoformat()
                 raw_date = item.get("date")
-                posted_at = raw_date if raw_date else None
-                confidence = "high" if raw_date else "low"
+                posted_at, confidence = normalize_posted_at(raw_date)
 
                 # Parse salary if available
                 salary_min = item.get("salary_min")

--- a/backend/src/sources/apis_keyed/findwork.py
+++ b/backend/src/sources/apis_keyed/findwork.py
@@ -7,9 +7,9 @@ import aiohttp
 from src.models import Job
 from src.services.profile.models import SearchConfig
 from src.sources.base import BaseJobSource, _is_uk_or_remote
+from src.utils.dates import normalize_posted_at
 
 logger = logging.getLogger("job360.sources.findwork")
-
 
 class FindworkSource(BaseJobSource):
     name = "findwork"
@@ -57,8 +57,8 @@ class FindworkSource(BaseJobSource):
 
             now_iso = datetime.now(timezone.utc).isoformat()
             raw_posted = item.get("date_posted")
-            posted_at = raw_posted if raw_posted else None
-            confidence = "high" if raw_posted else "low"
+            posted_at, confidence = normalize_posted_at(raw_posted)
+
             apply_url = item.get("url", "")
 
             jobs.append(Job(

--- a/backend/src/sources/apis_keyed/jsearch.py
+++ b/backend/src/sources/apis_keyed/jsearch.py
@@ -8,6 +8,7 @@ import aiohttp
 from src.models import Job
 from src.services.profile.models import SearchConfig
 from src.sources.base import BaseJobSource, _is_uk_or_remote
+from src.utils.dates import normalize_posted_at
 
 logger = logging.getLogger("job360.sources.jsearch")
 
@@ -74,8 +75,8 @@ class JSearchSource(BaseJobSource):
 
                 now_iso = datetime.now(timezone.utc).isoformat()
                 raw_posted = item.get("job_posted_at_datetime_utc")
-                posted_at = raw_posted if raw_posted else None
-                confidence = "high" if raw_posted else "low"
+                posted_at, confidence = normalize_posted_at(raw_posted)
+
                 jobs.append(Job(
                     title=title,
                     company=item.get("employer_name", ""),

--- a/backend/src/sources/apis_keyed/reed.py
+++ b/backend/src/sources/apis_keyed/reed.py
@@ -9,9 +9,9 @@ from src.core.settings import RATE_LIMITS, SOURCE_FETCH_TIMEOUT
 from src.models import Job
 from src.services.profile.models import SearchConfig
 from src.sources.base import BaseJobSource, _is_uk_or_remote
+from src.utils.dates import normalize_posted_at
 
 logger = logging.getLogger("job360.sources.reed")
-
 
 class ReedSource(BaseJobSource):
     name = "reed"
@@ -68,8 +68,8 @@ class ReedSource(BaseJobSource):
                 for item in cast(dict[str, Any], data)["results"]:
                     now_iso = datetime.now(timezone.utc).isoformat()
                     raw_date = item.get("date") or item.get("datePosted")
-                    posted_at = raw_date if raw_date else None
-                    confidence = "high" if raw_date else "low"
+                    posted_at, confidence = normalize_posted_at(raw_date)
+
                     jobs.append(Job(
                         title=item.get("jobTitle", ""),
                         company=item.get("employerName", ""),

--- a/backend/src/sources/ats/ashby.py
+++ b/backend/src/sources/ats/ashby.py
@@ -8,9 +8,9 @@ from src.core.companies import ASHBY_COMPANIES, COMPANY_NAME_OVERRIDES
 from src.models import Job
 from src.services.profile.models import SearchConfig
 from src.sources.base import BaseJobSource, _is_uk_or_remote
+from src.utils.dates import normalize_posted_at
 
 logger = logging.getLogger("job360.sources.ashby")
-
 
 class AshbySource(BaseJobSource):
     name = "ashby"
@@ -38,8 +38,8 @@ class AshbySource(BaseJobSource):
                 # mutation timestamp and must not populate posted_at.
                 now_iso = datetime.now(timezone.utc).isoformat()
                 raw_published = item.get("publishedAt")
-                posted_at = raw_published if raw_published else None
-                confidence = "high" if raw_published else "low"
+                posted_at, confidence = normalize_posted_at(raw_published)
+
                 jobs.append(Job(
                     title=title,
                     company=company_name,

--- a/backend/src/sources/ats/recruitee.py
+++ b/backend/src/sources/ats/recruitee.py
@@ -8,9 +8,9 @@ from src.core.companies import COMPANY_NAME_OVERRIDES, RECRUITEE_COMPANIES
 from src.models import Job
 from src.services.profile.models import SearchConfig
 from src.sources.base import BaseJobSource, _is_uk_or_remote
+from src.utils.dates import normalize_posted_at
 
 logger = logging.getLogger("job360.sources.recruitee")
-
 
 class RecruiteeSource(BaseJobSource):
     name = "recruitee"
@@ -37,8 +37,8 @@ class RecruiteeSource(BaseJobSource):
                 apply_url = item.get("careers_url", "") or item.get("url", "")
                 now_iso = datetime.now(timezone.utc).isoformat()
                 raw_published = item.get("published_at")
-                posted_at = raw_published if raw_published else None
-                confidence = "high" if raw_published else "low"
+                posted_at, confidence = normalize_posted_at(raw_published)
+
                 salary_min = item.get("min_salary")
                 salary_max = item.get("max_salary")
                 jobs.append(Job(

--- a/backend/src/sources/ats/rippling.py
+++ b/backend/src/sources/ats/rippling.py
@@ -14,9 +14,9 @@ from src.core.companies import COMPANY_NAME_OVERRIDES, RIPPLING_COMPANIES
 from src.models import Job
 from src.services.profile.models import SearchConfig
 from src.sources.base import BaseJobSource, _is_uk_or_remote
+from src.utils.dates import normalize_posted_at
 
 logger = logging.getLogger("job360.sources.rippling")
-
 
 class RipplingSource(BaseJobSource):
     name = "rippling"
@@ -57,8 +57,7 @@ class RipplingSource(BaseJobSource):
                     continue
 
                 raw_created = item.get("createdAt") or item.get("created_at")
-                posted_at = raw_created if raw_created else None
-                confidence = "high" if raw_created else "low"
+                posted_at, confidence = normalize_posted_at(raw_created)
 
                 now_iso = datetime.now(timezone.utc).isoformat()
                 results.append(Job(

--- a/backend/src/sources/ats/smartrecruiters.py
+++ b/backend/src/sources/ats/smartrecruiters.py
@@ -9,11 +9,11 @@ from src.core.companies import COMPANY_NAME_OVERRIDES, SMARTRECRUITERS_COMPANIES
 from src.models import Job
 from src.services.profile.models import SearchConfig
 from src.sources.base import BaseJobSource, _is_uk_or_remote
+from src.utils.dates import normalize_posted_at
 
 logger = logging.getLogger("job360.sources.smartrecruiters")
 
 _HTML_TAG_RE = re.compile(r"<[^>]+>")
-
 
 class SmartRecruitersSource(BaseJobSource):
     name = "smartrecruiters"
@@ -47,8 +47,8 @@ class SmartRecruitersSource(BaseJobSource):
                 )
                 now_iso = datetime.now(timezone.utc).isoformat()
                 raw_released = item.get("releasedDate")
-                posted_at = raw_released if raw_released else None
-                confidence = "high" if raw_released else "low"
+                posted_at, confidence = normalize_posted_at(raw_released)
+
                 jobs.append(Job(
                     title=title,
                     company=company_name,

--- a/backend/src/sources/feeds/biospace.py
+++ b/backend/src/sources/feeds/biospace.py
@@ -67,8 +67,10 @@ class BioSpaceSource(BaseJobSource):
 
             now_iso = datetime.now(timezone.utc).isoformat()
             posted_at = self._parse_rss_date(pub_date) if pub_date else None
-            confidence = "high" if pub_date else "low"
-
+            # Confidence follows the RESULT, not the input. A present-but-
+            # unparseable value used to be stamped "high" purely because the
+            # field existed — certifying as trustworthy a date we could not read.
+            confidence = "high" if posted_at else "low"
             jobs.append(Job(
                 title=title,
                 company=company,

--- a/backend/src/sources/feeds/jobs_ac_uk.py
+++ b/backend/src/sources/feeds/jobs_ac_uk.py
@@ -65,8 +65,10 @@ class JobsAcUkSource(BaseJobSource):
 
             now_iso = datetime.now(timezone.utc).isoformat()
             posted_at = self._parse_date(pub_date) if pub_date else None
-            confidence = "high" if pub_date else "low"
-
+            # Confidence follows the RESULT, not the input. A present-but-
+            # unparseable value used to be stamped "high" purely because the
+            # field existed — certifying as trustworthy a date we could not read.
+            confidence = "high" if posted_at else "low"
             jobs.append(Job(
                 title=title,
                 company=company,

--- a/backend/src/sources/feeds/nhs_jobs_xml.py
+++ b/backend/src/sources/feeds/nhs_jobs_xml.py
@@ -17,9 +17,9 @@ from defusedxml.ElementTree import fromstring as _safe_fromstring  # type: ignor
 
 from src.models import Job
 from src.sources.base import BaseJobSource, _is_uk_or_remote, _sanitize_xml
+from src.utils.dates import normalize_posted_at
 
 logger = logging.getLogger("job360.sources.nhs_jobs_xml")
-
 
 class NHSJobsXMLSource(BaseJobSource):
     name = "nhs_jobs_xml"
@@ -66,8 +66,7 @@ class NHSJobsXMLSource(BaseJobSource):
                 continue
 
             apply_url = advert_url or f"https://www.jobs.nhs.uk/candidate/jobadvert/{vacancy_id}"
-            posted_at = created if created else None
-            confidence = "high" if created else "low"
+            posted_at, confidence = normalize_posted_at(created)
 
             results.append(Job(
                 title=title,

--- a/backend/src/sources/feeds/realworkfromanywhere.py
+++ b/backend/src/sources/feeds/realworkfromanywhere.py
@@ -56,8 +56,10 @@ class RealWorkFromAnywhereSource(BaseJobSource):
 
             now_iso = datetime.now(timezone.utc).isoformat()
             posted_at = self._parse_rss_date(pub_date) if pub_date else None
-            confidence = "high" if pub_date else "low"
-
+            # Confidence follows the RESULT, not the input. A present-but-
+            # unparseable value used to be stamped "high" purely because the
+            # field existed — certifying as trustworthy a date we could not read.
+            confidence = "high" if posted_at else "low"
             jobs.append(Job(
                 title=title,
                 company=company,

--- a/backend/src/sources/feeds/uni_jobs.py
+++ b/backend/src/sources/feeds/uni_jobs.py
@@ -58,8 +58,10 @@ class UniJobsSource(BaseJobSource):
 
             now_iso = datetime.now(timezone.utc).isoformat()
             posted_at = self._parse_rss_date(pub_date) if pub_date else None
-            confidence = "high" if pub_date else "low"
-
+            # Confidence follows the RESULT, not the input. A present-but-
+            # unparseable value used to be stamped "high" purely because the
+            # field existed — certifying as trustworthy a date we could not read.
+            confidence = "high" if posted_at else "low"
             jobs.append(Job(
                 title=title,
                 company=company,

--- a/backend/src/sources/feeds/weworkremotely.py
+++ b/backend/src/sources/feeds/weworkremotely.py
@@ -58,8 +58,10 @@ class WeWorkRemotelySource(BaseJobSource):
 
             now_iso = datetime.now(timezone.utc).isoformat()
             posted_at = self._parse_rss_date(pub_date) if pub_date else None
-            confidence = "high" if pub_date else "low"
-
+            # Confidence follows the RESULT, not the input. A present-but-
+            # unparseable value used to be stamped "high" purely because the
+            # field existed — certifying as trustworthy a date we could not read.
+            confidence = "high" if posted_at else "low"
             jobs.append(Job(
                 title=title,
                 company=company,

--- a/backend/src/sources/feeds/workanywhere.py
+++ b/backend/src/sources/feeds/workanywhere.py
@@ -63,8 +63,10 @@ class WorkAnywhereSource(BaseJobSource):
 
             now_iso = datetime.now(timezone.utc).isoformat()
             posted_at = self._parse_rss_date(pub_date) if pub_date else None
-            confidence = "high" if pub_date else "low"
-
+            # Confidence follows the RESULT, not the input. A present-but-
+            # unparseable value used to be stamped "high" purely because the
+            # field existed — certifying as trustworthy a date we could not read.
+            confidence = "high" if posted_at else "low"
             jobs.append(Job(
                 title=title,
                 company=company,

--- a/backend/src/sources/other/hackernews.py
+++ b/backend/src/sources/other/hackernews.py
@@ -5,12 +5,12 @@ from typing import Any, cast
 
 from src.models import Job
 from src.sources.base import BaseJobSource, _is_uk_or_remote
+from src.utils.dates import normalize_posted_at
 
 logger = logging.getLogger("job360.sources.hackernews")
 
 _HTML_TAG_RE = re.compile(r"<[^>]+>")
 _URL_RE = re.compile(r"https?://[^\s<>\"]+")
-
 
 def _parse_hn_comment(text: str) -> dict[str, Any] | None:
     """Parse a HN 'Who is Hiring' comment into job fields.
@@ -30,6 +30,22 @@ def _parse_hn_comment(text: str) -> dict[str, Any] | None:
     parts = [p.strip() for p in first_line.split("|")]
 
     company = parts[0] if parts else ""
+
+    # A HN "Who's hiring" post is EXPECTED to start "Company | Location | Role".
+    # When a comment is plain prose instead, there is no "|", so parts[0] is the
+    # ENTIRE paragraph — and it became both the company and the job title.
+    #
+    # Measured 2026-08-03: 14 such titles over 300 chars, longest 1,551. They
+    # render as unreadable cards, produce meaningless dedup keys, and one of them
+    # blew Postgres's 2,704-byte index limit and aborted a real user's search
+    # twice, freezing his feed for seven days.
+    #
+    # No company name is 120 characters. If we cannot find one, this comment is
+    # not a parseable job posting and we say so, rather than inventing a job out
+    # of a paragraph. Dropping a non-posting costs nothing; storing it cost a
+    # week of one user's feed.
+    if len(company) > 120:
+        return None
     location = parts[1] if len(parts) > 1 else ""
 
     # Extract URL from anywhere in the text
@@ -49,7 +65,6 @@ def _parse_hn_comment(text: str) -> dict[str, Any] | None:
         "description": description,
         "title": title,
     }
-
 
 class HackerNewsSource(BaseJobSource):
     name = "hackernews"
@@ -100,8 +115,7 @@ class HackerNewsSource(BaseJobSource):
 
             now_iso = datetime.now(timezone.utc).isoformat()
             raw_created = child.get("created_at")
-            posted_at = raw_created if raw_created else None
-            confidence = "high" if raw_created else "low"
+            posted_at, confidence = normalize_posted_at(raw_created)
 
             jobs.append(Job(
                 title=parsed["title"],

--- a/backend/src/sources/other/nofluffjobs.py
+++ b/backend/src/sources/other/nofluffjobs.py
@@ -3,6 +3,7 @@ from datetime import datetime, timezone
 
 from src.models import Job
 from src.sources.base import BaseJobSource, _is_uk_or_remote
+from src.utils.dates import normalize_posted_at
 
 logger = logging.getLogger("job360.sources.nofluffjobs")
 
@@ -13,7 +14,6 @@ _API_URLS = [
     "https://nofluffjobs.com/api/posting",
     "https://nofluffjobs.com/api/search/posting",
 ]
-
 
 class NoFluffJobsSource(BaseJobSource):
     name = "nofluffjobs"
@@ -74,8 +74,7 @@ class NoFluffJobsSource(BaseJobSource):
             # (listing refresh) and must not populate posted_at.
             now_iso = datetime.now(timezone.utc).isoformat()
             raw_posted = item.get("posted")
-            posted_at = raw_posted if raw_posted else None
-            confidence = "high" if raw_posted else "low"
+            posted_at, confidence = normalize_posted_at(raw_posted)
 
             # Salary
             salary_obj = item.get("salary", {})

--- a/backend/src/sources/other/themuse.py
+++ b/backend/src/sources/other/themuse.py
@@ -5,13 +5,13 @@ from typing import Any, cast
 
 from src.models import Job
 from src.sources.base import BaseJobSource, _is_uk_or_remote
+from src.utils.dates import normalize_posted_at
 
 logger = logging.getLogger("job360.sources.themuse")
 
 _HTML_TAG_RE = re.compile(r"<[^>]+>")
 
 MAX_PAGES = 5
-
 
 class TheMuseSource(BaseJobSource):
     name = "themuse"
@@ -56,8 +56,7 @@ class TheMuseSource(BaseJobSource):
                 apply_url = refs.get("landing_page", "") if isinstance(refs, dict) else ""
                 now_iso = datetime.now(timezone.utc).isoformat()
                 raw_pub = item.get("publication_date")
-                posted_at = raw_pub if raw_pub else None
-                confidence = "high" if raw_pub else "low"
+                posted_at, confidence = normalize_posted_at(raw_pub)
 
                 # Experience level from levels array
                 levels = item.get("levels", [])

--- a/backend/src/sources/scrapers/eightykhours.py
+++ b/backend/src/sources/scrapers/eightykhours.py
@@ -5,6 +5,7 @@ from typing import Any, cast
 
 from src.models import Job
 from src.sources.base import BaseJobSource, _is_uk_or_remote
+from src.utils.dates import normalize_posted_at
 
 logger = logging.getLogger("job360.sources.eightykhours")
 
@@ -89,8 +90,7 @@ class EightyKHoursSource(BaseJobSource):
 
                 now_iso = datetime.now(timezone.utc).isoformat()
                 raw_published = hit.get("date_published", "")
-                posted_at = raw_published if raw_published else None
-                confidence = "high" if raw_published else "low"
+                posted_at, confidence = normalize_posted_at(raw_published)
 
                 jobs.append(Job(
                     title=title,

--- a/backend/src/utils/dates.py
+++ b/backend/src/utils/dates.py
@@ -1,0 +1,97 @@
+"""Normalise whatever an upstream calls a date into ISO-8601, honestly.
+
+WHY THIS EXISTS.
+
+Every source stored its upstream's date field verbatim into `jobs.posted_at`,
+which is an unconstrained TEXT column. So the same column held three different
+things at once:
+
+    arbeitnow / himalayas   '1785750903'    Unix epoch seconds, as a string
+    reed                    '27/07/2026'    UK day-first
+    everyone else           '2026-07-27...' ISO-8601
+
+The frontend calls `new Date()` on that value. For the first two it gets NaN,
+and because every comparison against NaN is false, `timeAgo()` falls through all
+four of its guards to the final `return` and renders **"Posted NaNw ago"** —
+which is what a real user saw on the live dashboard on 2026-08-03, on 5 of the
+25 cards on his screen. Nothing threw. Sentry logged zero events.
+
+The second half of the bug was worse than the first: we then stamped
+`date_confidence='high'` on those values, purely because the field was present.
+We certified as trustworthy a value we could not parse. Anything downstream that
+believed that flag was being lied to by our own code.
+
+THE RULE THIS ENCODES: **presence is not validity.** A date field is only
+"high" confidence if it actually parsed. If it did not, we say so and store
+nothing, because a null date renders as "Seen 2d ago" (honest, from crawler
+time) while an unparseable one renders as NaN.
+
+Deliberately stdlib-only and side-effect free, so every source can call it on
+the hot path without a dependency or an exception risk.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone
+from typing import Any
+
+# Epoch seconds for 2001-09-09 .. 2286-11-20 — wide enough for any real posting,
+# narrow enough that a 4-digit year or a millisecond value cannot be mistaken
+# for it.
+_EPOCH_S_MIN, _EPOCH_S_MAX = 1_000_000_000, 9_999_999_999
+_ISO_PREFIX = re.compile(r"^\d{4}-\d{2}-\d{2}")
+_DMY = re.compile(r"^(\d{1,2})[/.-](\d{1,2})[/.-](\d{4})$")
+
+
+def normalize_posted_at(raw: Any) -> tuple[str | None, str]:
+    """Return ``(iso_or_none, confidence)`` for one upstream date value.
+
+    ``confidence`` is ``"high"`` ONLY when the value actually parsed. Callers
+    must pass both results straight through to ``Job(posted_at=...,
+    date_confidence=...)`` rather than deriving confidence from presence — that
+    derivation is the bug this function exists to end.
+    """
+    if raw is None or raw == "":
+        return None, "low"
+
+    # Already ISO — the overwhelmingly common case, so check it first and cheap.
+    if isinstance(raw, str) and _ISO_PREFIX.match(raw.strip()):
+        return raw.strip(), "high"
+
+    s = str(raw).strip()
+
+    # Unix epoch, seconds or milliseconds. Arrives as an int from JSON or as a
+    # digit-string; both are the same bug from the UI's point of view.
+    if s.isdigit():
+        n = int(s)
+        if len(s) == 13:          # milliseconds
+            n //= 1000
+        if _EPOCH_S_MIN <= n <= _EPOCH_S_MAX:
+            try:
+                return datetime.fromtimestamp(n, tz=timezone.utc).isoformat(), "high"
+            except (OverflowError, OSError, ValueError):
+                return None, "low"
+        # A bare number outside the plausible epoch range is not a date at all.
+        return None, "low"
+
+    # Day-first European / UK format. Deliberately NOT month-first: this repo is
+    # UK-facing and reed sends DD/MM/YYYY. Guessing the other way would silently
+    # swap days and months for the first 12 days of every month — a wrong date
+    # that parses is worse than one that does not.
+    m = _DMY.match(s)
+    if m:
+        d, mo, y = (int(x) for x in m.groups())
+        try:
+            return datetime(y, mo, d, tzinfo=timezone.utc).isoformat(), "high"
+        except ValueError:
+            return None, "low"
+
+    # Anything else the stdlib recognises (RFC-3339 with 'Z', etc.).
+    try:
+        return datetime.fromisoformat(s.replace("Z", "+00:00")).isoformat(), "high"
+    except ValueError:
+        pass
+
+    # Unrecognised. Say so — never store it and never call it high confidence.
+    return None, "low"

--- a/backend/tests/test_detector_findings_fixed.py
+++ b/backend/tests/test_detector_findings_fixed.py
@@ -1,0 +1,182 @@
+"""Fixes for the faults a Fable audit + the data-invariants detector found.
+
+Each test below pins one real production fault, measured on 2026-08-03 against
+the live database. None of them threw an exception, none reached Sentry, and
+none failed an existing test — which is exactly why they survived so long.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.utils.dates import normalize_posted_at
+
+# ── 1. Dates: presence is not validity ──────────────────────────────────────
+# The dashboard rendered "Posted NaNw ago" because arbeitnow's epoch integer was
+# stored verbatim in a TEXT column and `new Date('1785750903')` is NaN. We then
+# stamped date_confidence='high' on it, certifying a value we could not read.
+
+def test_a_unix_epoch_becomes_a_real_date():
+    """THE BUG THE OWNER SAW ON HIS PHONE."""
+    iso, conf = normalize_posted_at("1785750903")
+    assert iso is not None and iso.startswith("2026-08-03"), iso
+    assert conf == "high"
+
+
+def test_epoch_milliseconds_are_not_mistaken_for_seconds():
+    """A 13-digit value is milliseconds. Treated as seconds it lands in the year
+    58,000 — a date that parses and is absurd, which is worse than one that
+    fails, because nothing downstream questions it."""
+    iso, conf = normalize_posted_at("1785750903000")
+    assert iso is not None and iso.startswith("2026-08-03")
+    assert conf == "high"
+
+
+def test_uk_day_first_dates_parse_as_day_first():
+    """reed sends DD/MM/YYYY. Guessing month-first would silently swap day and
+    month for the first 12 days of every month — a wrong date that parses."""
+    iso, conf = normalize_posted_at("27/07/2026")
+    assert iso is not None and iso.startswith("2026-07-27"), iso
+    assert conf == "high"
+
+
+def test_iso_passes_through_untouched():
+    iso, conf = normalize_posted_at("2026-07-27T10:00:00+00:00")
+    assert iso == "2026-07-27T10:00:00+00:00"
+    assert conf == "high"
+
+
+@pytest.mark.parametrize("bad", ["", None, "next tuesday", "42", "N/A"])
+def test_an_unreadable_date_is_never_called_high_confidence(bad):
+    """THE SECOND HALF OF THE BUG, and the more dangerous one. If we cannot
+    parse it we must store nothing and say low — a null date renders honestly
+    as 'Seen 2d ago' from crawler time, while an unparseable one renders NaN."""
+    iso, conf = normalize_posted_at(bad)
+    assert iso is None
+    assert conf == "low"
+
+
+def test_no_source_derives_confidence_from_mere_presence():
+    """The systemic version. Every source used `confidence = "high" if raw else
+    "low"` — confidence from PRESENCE, not from parseability. This asserts the
+    pattern is gone repo-wide, because fixing four sources by hand would leave
+    the other twenty-six to re-introduce it."""
+    import pathlib
+    import re
+
+    root = pathlib.Path(__file__).resolve().parents[1] / "src" / "sources"
+    offenders = []
+    pat = re.compile(r'confidence = "high" if (\w+) else "low"')
+    for p in root.rglob("*.py"):
+        for m in pat.finditer(p.read_text(encoding="utf-8")):
+            if m.group(1) != "posted_at":  # deriving from the RESULT is correct
+                offenders.append(f"{p.name}: {m.group(0)}")
+    assert not offenders, (
+        "these sources still call a date high-confidence just because the field "
+        f"was present: {offenders}"
+    )
+
+
+# ── 2. devitjobs: the Apply button that went nowhere ────────────────────────
+
+def test_devitjobs_turns_a_slug_into_a_real_url():
+    """2,805 jobs — 43% of the whole catalog — stored 'FBI-TMT-Metadata-Lead'
+    where a URL belongs, so Apply went nowhere. A broken link fails only when a
+    user clicks it, which we never see."""
+    import inspect
+
+    from src.sources.apis_free.devitjobs import DevITJobsSource  # noqa: F401
+
+    src = inspect.getsource(DevITJobsSource)
+    assert "devitjobs.uk/jobs/" in src, "the slug is no longer expanded to a URL"
+
+
+# ── 3. HackerNews: a paragraph is not a company ─────────────────────────────
+
+def test_a_prose_comment_is_not_turned_into_a_job():
+    """HN's format is 'Company | Location | Role'. A prose comment has no '|',
+    so parts[0] was the ENTIRE paragraph and became both company and title —
+    14 titles over 300 chars, longest 1,551. One of them blew Postgres's btree
+    index limit and aborted a real user's search twice."""
+    from src.sources.other.hackernews import _parse_hn_comment
+
+    prose = (
+        "Let's support the country: who's hiring in the coronavirus economy. "
+        "Zoom out and consider that many teams are still growing headcount "
+        "across engineering, design and operations, and this thread exists to "
+        "surface those opportunities for everyone reading along today. "
+    ) * 3
+    assert _parse_hn_comment(prose) is None, "a prose paragraph was stored as a job"
+
+
+def test_a_properly_formatted_hn_post_still_parses():
+    """The guard must not reject real postings — that would silently delete a
+    whole source, which is a worse bug than the one being fixed."""
+    from src.sources.other.hackernews import _parse_hn_comment
+
+    ok = "Acme Corp | London, UK | Senior Engineer | https://acme.example/jobs"
+    parsed = _parse_hn_comment(ok)
+    assert parsed is not None
+    assert parsed["company"] == "Acme Corp"
+
+
+# ── 4. One poison row must not kill the whole search ────────────────────────
+
+def test_the_insert_loop_survives_one_unstorable_job():
+    """2026-07-27: both of a real user's searches aborted because ONE
+    HackerNews row exceeded Postgres's index limit. His feed then took zero new
+    rows for seven days while the catalog grew by ~2,800 jobs."""
+    import pathlib
+    import re
+
+    main = (pathlib.Path(__file__).resolve().parents[1] / "src" / "main.py").read_text(
+        encoding="utf-8"
+    )
+    block = re.search(
+        r"for job in unique_jobs:.*?await db\.commit\(\)", main, re.S
+    )
+    assert block, "the insert loop moved — re-point this test"
+    body = block.group(0)
+    assert "try:" in body and "except" in body, (
+        "the per-job insert guard is gone: one unstorable row will abort the "
+        "entire search again and freeze every affected user's feed"
+    )
+
+
+# ── 5. A user's own application must always open ────────────────────────────
+
+def test_the_detail_lookup_accepts_a_user_so_own_jobs_stay_open():
+    """The staleness filter correctly hides ghosts from BROWSING, but it also
+    404'd a user's own application (job 56, stage 'applied'). Clicking your own
+    application and getting 'not found' reads as data loss."""
+    import inspect
+
+    from src.repositories.database import JobDatabase
+
+    sig = inspect.signature(JobDatabase.get_job_by_id_with_enrichment)
+    assert "user_id" in sig.parameters, (
+        "the detail lookup can no longer tell whose job it is, so a stale job "
+        "the user applied to will 404 again"
+    )
+    src = inspect.getsource(JobDatabase.get_job_by_id_with_enrichment)
+    assert "applications" in src and "user_actions" in src
+
+
+# ── 6. A "full re-score" must be able to reach the whole catalog ────────────
+
+def test_rescore_limit_exceeds_any_plausible_catalog():
+    """It was 5,000 while the catalog held 6,457, so the oldest 1,457 jobs were
+    never re-scored on a profile change — 43 feed rows still carried scores from
+    a profile replaced a month earlier, on a different scale from everything
+    around them."""
+    import inspect
+
+    from src.repositories.database import JobDatabase
+
+    sig = inspect.signature(JobDatabase.get_catalog_jobs_for_rescore)
+    limit = sig.parameters["limit"].default
+    assert limit >= 50000, (
+        f"rescore limit is {limit}; purge keeps ~30 days of jobs and the catalog "
+        "already reached 6,457. A limit near the catalog size makes a 'full' "
+        "re-score silently partial."
+    )


### PR DESCRIPTION
All measured live on 2026-08-03. **None threw an exception, none reached Sentry, none failed an existing test** — which is exactly why they survived.

## 1. "Posted NaNw ago" — the one you saw on your phone

`jobs.posted_at` is unconstrained `TEXT`, and every source stored its upstream's value verbatim. So one column held three different things:

```
arbeitnow / himalayas   '1785750903'      epoch seconds, as text
reed                    '27/07/2026'      UK day-first
everyone else           '2026-07-27...'   ISO
```

`new Date('1785750903')` → NaN → every guard false → fell through to the final `return`. **526 rows, 4 sources.** New `utils/dates.py` normalises all four shapes.

## 2. We *certified* the garbage

All 30 sources did `confidence = "high" if raw_field else "low"` — confidence from **presence**, not parseability. An unreadable date was stamped high-confidence because the field existed.

Now derived from the **result**, everywhere. A test asserts the old pattern can't return repo-wide — fixing four sources by hand would leave twenty-six to reintroduce it.

## 3. 2,805 dead Apply buttons — 43% of the catalog

devitjobs returns `jobUrl` as a **slug** (`'FBI-TMT-Metadata-Lead'`), stored raw. The single action the product exists to produce went nowhere on nearly half the catalog.

Path **verified against the live site, not guessed**: `/jobs/<slug>` returns the real page (9.6 KB, company present); `/job/<slug>` — my first guess — returns the 4.7 KB empty SPA shell.

## 4. One poison row killed a whole search, twice

On 7-27 both of your user's searches aborted: one HackerNews row exceeded Postgres's 2,704-byte index limit and the insert loop had **no per-job guard**. His feed took **zero new rows for seven days** while the catalog grew by 2,800 jobs. He pressed Search twice, failed twice, no explanation.

Skipping one unstorable job costs that job. Aborting costs every job *and* the user's week.

## 5. …and its source

HN's format is `Company | Location | Role`. A prose comment has no `|`, so `parts[0]` was the **entire paragraph** — which became both company and title. 14 titles over 300 chars, longest 1,551. No company name is 120 characters.

## 6. A user's own application 404'd

The detail route serves active jobs only — correct for browsing, wrong for your own history. Clicking your own application and getting "not found" reads as data loss, on the highest-intent object in the product. Staleness is a guess about the *employer*, not a fact about the *user's record*.

## 7. A "full" re-score that wasn't

Capped at 5,000 while the catalog held 6,457 — the oldest 1,457 jobs were never re-scored on a profile change. 43 feed rows still carried scores from a profile replaced on 7-02, on a different scale from everything around them. Now 50,000, with the detector alarming if the catalog approaches it.

## Deliberately NOT fixed here

- **Notifications have never fired for anyone.** Auto-creating rules would start emailing real people — your product decision, not a bug fix.
- **69% of the catalog has no description**, starving skill scoring. Needs per-source detail fetching: a project, not a patch.

## Verification

**239 tests green** across every suite covering a changed file (sources 142; api/idor/security/main/cli/pipeline 97), plus **16 new tests** pinning each fault. The full-suite run reached 49% with zero failures before being killed externally; CI runs it complete.

**Follow-up owed:** PR #205's `rescore_covers_whole_catalog` invariant still hardcodes 5000 and must move to 50000 to match item 7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6DsQH5EUxJc3Vnqz9YHgQ