### PR TITLE
feat(funnel): title lever + candidate layer + job-text coverage + embedding backfill

### DIFF
--- a/backend/scripts/embed_catalog.py
+++ b/backend/scripts/embed_catalog.py
@@ -1,0 +1,111 @@
+"""Backfill embeddings for every catalog job that doesn't have one.
+
+Job-understanding goal (2026-08-05): the semantic engine (E3) can only rank
+what is embedded, and prod had 284 of 7,309 jobs embedded (3.9%) — so hybrid
+retrieval silently degraded to keyword-only. This script closes that gap:
+
+    python scripts/embed_catalog.py            # embed everything missing
+    python scripts/embed_catalog.py --limit 50 # bounded probe run
+
+Idempotent: jobs already in the `job_embeddings` audit table are skipped, so
+re-runs only touch new arrivals. Uses the same `encode_job` + `VectorIndex`
+path the pipeline uses (model all-MiniLM-L6-v2, enrichment-aware text build),
+so the vectors are indistinguishable from ingest-time ones.
+
+Heavy deps (sentence-transformers, chromadb) load lazily per rule #16 — the
+script needs the `[semantic]` extra installed.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+if os.name == "nt":
+    # psycopg cannot run async on the Windows Proactor loop.
+    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+
+
+async def main(limit: int | None) -> int:
+    from src.core.settings import DB_PATH
+    from src.models import Job
+    from src.repositories import pg
+    from src.services.embeddings import MODEL_NAME, encode_job
+    from src.services.job_enrichment import load_enrichment
+    from src.services.vector_index import VectorIndex
+
+    db = await pg.connect(str(DB_PATH))
+    try:
+        cur = await db.execute(
+            """
+            SELECT j.id, j.title, j.company, j.location, j.description,
+                   j.apply_url, j.source, j.date_found
+            FROM jobs j
+            LEFT JOIN job_embeddings e ON e.job_id = j.id
+            WHERE e.job_id IS NULL
+            ORDER BY j.id
+            """
+        )
+        rows = await cur.fetchall()
+        if limit:
+            rows = rows[:limit]
+        total = len(rows)
+        print(f"jobs missing embeddings: {total}")
+        if not total:
+            return 0
+
+        vix = VectorIndex()
+        done = failed = 0
+        for r in rows:
+            jid = r["id"]
+            try:
+                job = Job(
+                    title=r["title"] or "",
+                    company=r["company"] or "",
+                    apply_url=r["apply_url"] or "",
+                    source=r["source"] or "",
+                    date_found=r["date_found"] or "",
+                    location=r["location"] or "",
+                    description=r["description"] or "",
+                )
+                job.id = jid
+                enrichment = None
+                try:
+                    enrichment = await load_enrichment(db, jid)
+                except Exception:  # noqa: BLE001 — enrichment absence is normal
+                    enrichment = None
+                vector = encode_job(job, enrichment)
+                vix.upsert(str(jid), vector, {"job_id": jid, "source": job.source})
+                await db.execute(
+                    """
+                    INSERT INTO job_embeddings(job_id, model_version, embedding_updated_at)
+                    VALUES (?, ?, datetime('now'))
+                    ON CONFLICT(job_id) DO UPDATE SET
+                        model_version = excluded.model_version,
+                        embedding_updated_at = excluded.embedding_updated_at
+                    """,
+                    (jid, MODEL_NAME),
+                )
+                done += 1
+                if done % 250 == 0:
+                    await db.commit()
+                    print(f"  {done}/{total} embedded...")
+            except Exception as exc:  # noqa: BLE001 — one bad job must not stop the sweep
+                failed += 1
+                if failed <= 5:
+                    print(f"  job {jid} failed: {exc}")
+        await db.commit()
+        print(f"done: embedded={done} failed={failed}")
+        return 0 if failed == 0 else 1
+    finally:
+        await db.close()
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--limit", type=int, default=None, help="cap for a probe run")
+    args = ap.parse_args()
+    raise SystemExit(asyncio.run(main(args.limit)))

--- a/backend/src/core/settings.py
+++ b/backend/src/core/settings.py
@@ -111,6 +111,15 @@ MIN_MATCH_SCORE = 30
 # profile (or a job that simply aged past the recency bands) lost jobs forever
 # with no way to get them back. Store broadly, filter at read time.
 MIN_STORE_SCORE = int(os.getenv("MIN_STORE_SCORE", "1"))
+# FEED_CANDIDATE_CAP — the User-Level candidate bound (funnel Stage-1,
+# 2026-08-05). user_feed is a bounded per-user CANDIDATE SET, not a mirror of
+# the shared catalog: only the user's top-N jobs by score enter/stay in it
+# (measured before the cap: one user's feed held 85% of the whole catalog).
+# Rows that fall out of the selection are marked stale — reversible, and rows
+# carrying an LLM verdict are never evicted. `0` disables the cap entirely
+# (legacy flood behaviour). Industry anchor: Twitter materializes ~800-1000
+# candidates per user.
+FEED_CANDIDATE_CAP = int(os.getenv("FEED_CANDIDATE_CAP", "800"))
 MAX_RESULTS_PER_SOURCE = 100
 MAX_DAYS_OLD = 7
 

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -702,7 +702,7 @@ async def run_search(
             # `source_timer` populates `t.duration_ms` after the call returns;
             # we record the wall-clock duration AND any raised exception into
             # two dicts that we persist to run_log at end-of-run.
-            per_source_duration: dict[str, int] = {}
+            per_source_duration: dict[str, float] = {}
             per_source_errors: dict[str, int] = {}
 
             def _instrument(src: BaseJobSource) -> None:
@@ -717,8 +717,19 @@ async def run_search(
                         per_source_errors[src.name] = per_source_errors.get(src.name, 0) + 1
                         raise
                     finally:
-                        elapsed_ms = max(0, (time.perf_counter_ns() - started_ns) // 1_000_000)
-                        per_source_duration[src.name] = int(elapsed_ms)
+                        # Store SECONDS, not milliseconds.
+                        #
+                        # This column was written in ms while `total_duration`
+                        # (below) and the field's own un-suffixed name are
+                        # SECONDS, so every consumer read ms as seconds. Found by
+                        # the deep journey walk 2026-08-05: the source-health
+                        # endpoint reported `workday=212391s` — 59 HOURS — for a
+                        # search that finishes in ~5 minutes. 212391 ms is 212 s,
+                        # which is the real number. Verified corrupt in prod too,
+                        # so any monitoring keyed on per-source latency was acting
+                        # on garbage. Now consistent with total_duration.
+                        elapsed_s = max(0.0, (time.perf_counter_ns() - started_ns) / 1_000_000_000)
+                        per_source_duration[src.name] = round(elapsed_s, 2)
 
                 src.fetch_jobs = _timed_fetch  # type: ignore[method-assign]
 

--- a/backend/src/services/feed.py
+++ b/backend/src/services/feed.py
@@ -182,6 +182,48 @@ class FeedService:
         await self._db.commit()
         return cur.rowcount or 0
 
+    async def apply_candidate_selection(
+        self, user_id: str, selected_ids: set[int]
+    ) -> int:
+        """Enforce the User-Level candidate bound (funnel Stage-1).
+
+        ``user_feed`` is a bounded per-user candidate set, not a catalog
+        mirror. After the caller has upserted the selected rows, this method
+        synchronises MEMBERSHIP:
+
+          * active rows OUTSIDE ``selected_ids`` are marked ``stale``
+            (evicted — reversible, never a delete), EXCEPT rows carrying an
+            LLM verdict: a paid judgment is never thrown away over a keyword
+            re-rank, and there are at most ~MATCHER_MAX_JOBS of them.
+          * stale rows INSIDE ``selected_ids`` are reactivated (a job that
+            re-qualifies under a new profile comes back). Job-level ghost
+            staleness still hides such rows at read time — the dashboard
+            query filters ``jobs.staleness_state`` independently.
+
+        Returns the number of evicted rows. A defensively empty selection is
+        a no-op: mass-evicting a whole feed because scoring produced nothing
+        would turn a transient fault into a wiped shelf.
+        """
+        if not selected_ids:
+            return 0
+        now = datetime.now(timezone.utc).isoformat()
+        ids = list(selected_ids)
+        placeholders = ",".join("?" for _ in ids)
+        await self._db.execute(
+            f"UPDATE user_feed SET status = 'active', updated_at = ? "
+            f"WHERE user_id = ? AND status = 'stale' AND job_id IN ({placeholders})",
+            [now, user_id, *ids],
+        )
+        cur = await self._db.execute(
+            f"UPDATE user_feed SET status = 'stale', updated_at = ? "
+            f"WHERE user_id = ? AND status = 'active' "
+            f"AND llm_fit_score IS NULL "
+            f"AND job_id NOT IN ({placeholders})",
+            [now, user_id, *ids],
+        )
+        await self._db.commit()
+        return cur.rowcount or 0
+
     async def upsert_feed_row(
         self,
         *,

--- a/backend/src/services/profile/github_enricher.py
+++ b/backend/src/services/profile/github_enricher.py
@@ -78,6 +78,14 @@ RECENT_REPO_MULTIPLIER = 3
 # we probe to stay within GitHub's 60 unauthenticated / 5000 authenticated
 # requests-per-hour budget. Authenticated runs comfortably cover this.
 MAX_REPOS_FOR_DEPS = 10
+# "Read 100% of GitHub" — README prose is the richest signal, but each README
+# is one more request AND more prompt tokens, so cap how many we read and how
+# long each excerpt is. Authenticated (5000/hr) reads far more than
+# unauthenticated (60/hr, where the whole probe must fit ≈54 < 60).
+README_EXCERPT_CHARS = 1200          # per-repo README, truncated for the prompt
+PROFILE_README_CHARS = 2500          # the self-authored {u}/{u} portfolio README
+README_REPOS_AUTHED = 15
+README_REPOS_UNAUTHED = 4
 
 
 # NOTE (CLAUDE.md rule #28): the hardcoded LANGUAGE_TO_SKILL and TOPIC_TO_SKILL
@@ -102,6 +110,12 @@ async def _get_json(session: aiohttp.ClientSession, url: str) -> Any:
         async with session.get(url, headers=_headers(), timeout=aiohttp.ClientTimeout(total=15)) as resp:
             if resp.status == 403:
                 logger.warning("GitHub API rate limited")
+                return None
+            if resp.status == 404:
+                # Expected for optional resources (a repo with no README, a
+                # user with no {u}/{u} profile repo). Not an error — debug only,
+                # so a missing README doesn't spam warnings for every repo.
+                logger.debug("GitHub API 404 for %s", url)
                 return None
             if resp.status != 200:
                 logger.warning("GitHub API %s for %s", resp.status, url)
@@ -212,6 +226,107 @@ async def _fetch_repo_frameworks(
     return skills
 
 
+async def _fetch_user(session: aiohttp.ClientSession, username: str) -> dict[str, Any]:
+    """GET ``/users/{u}`` — the developer's own identity block.
+
+    Returns bio, name, company, blog, location, hireable, twitter — the words
+    a developer uses to describe THEMSELVES, which we never read before. One
+    cheap request. Returns ``{}`` on any failure (never raises)."""
+    data = await _get_json(session, f"{GITHUB_API}/users/{username}")
+    return data if isinstance(data, dict) else {}
+
+
+def _compose_bio(user: dict[str, Any]) -> str:
+    """Fold the /users/{u} identity fields into one short self-description
+    string for the LLM pass. Only non-empty fields are included, so a sparse
+    profile yields a short line and a rich one yields more."""
+    parts: list[str] = []
+    for label, key in (
+        ("Name", "name"), ("Bio", "bio"), ("Company", "company"),
+        ("Location", "location"), ("Website", "blog"),
+    ):
+        val = user.get(key)
+        if isinstance(val, str) and val.strip():
+            parts.append(f"{label}: {val.strip()}")
+    if user.get("hireable") is True:
+        parts.append("Open to work: yes")
+    tw = user.get("twitter_username")
+    if isinstance(tw, str) and tw.strip():
+        parts.append(f"Twitter/X: @{tw.strip()}")
+    return " | ".join(parts)
+
+
+def _decode_readme(payload: Any, limit: int) -> str:
+    """Decode a GitHub ``/readme`` payload (base64 JSON) to a truncated string.
+
+    Returns ``""`` on a missing/oversized/malformed payload. Truncation keeps
+    the LLM prompt bounded — the first ``limit`` chars of a README carry the
+    'what this is / what it's built with' summary; the tail is usually install
+    steps and licence boilerplate."""
+    if not isinstance(payload, dict):
+        return ""
+    encoded = payload.get("content")
+    if payload.get("encoding") != "base64" or not isinstance(encoded, str) or not encoded:
+        return ""
+    try:
+        text = base64.b64decode(encoded).decode("utf-8", errors="replace")
+    except Exception as e:  # noqa: BLE001
+        logger.debug("README base64 decode failed: %s", e)
+        return ""
+    return text.strip()[:limit]
+
+
+async def _fetch_readme(
+    session: aiohttp.ClientSession, username: str, repo_name: str, limit: int
+) -> str:
+    """GET ``/repos/{u}/{repo}/readme`` — the richest prose GitHub holds.
+
+    A repo ``description`` is often one line or null; the README is where the
+    real project story lives. Base64 JSON → decoded → truncated. Returns ``""``
+    on 404 (no README — common) or any failure. Routes through ``_get_json`` so
+    tests that patch it stay offline (rule #4)."""
+    payload = await _get_json(session, f"{GITHUB_API}/repos/{username}/{repo_name}/readme")
+    return _decode_readme(payload, limit)
+
+
+async def _fetch_pinned(session: aiohttp.ClientSession, username: str) -> list[str]:
+    """Return the names of the user's PINNED repos — their own curated
+    highlights — via the GraphQL API. REST cannot expose pins; GraphQL needs a
+    token, so this is a no-op (returns ``[]``) when unauthenticated. Never
+    raises. Used only to REORDER which repos we read first within the request
+    budget, so the user's showcased work is covered before the long tail."""
+    if not GITHUB_TOKEN:
+        return []
+    # Concatenation, not f-string/%: the GraphQL body is full of literal { }
+    # braces. `username` is already validated by _GITHUB_USERNAME_RE upstream
+    # (alphanumeric + hyphen), so there is no injection surface here.
+    query = (
+        '{ user(login: "' + username + '") { pinnedItems(first: 6, types: REPOSITORY) '
+        '{ nodes { ... on Repository { name } } } } }'
+    )
+    try:
+        async with session.post(
+            f"{GITHUB_API}/graphql",
+            json={"query": query},
+            headers=_headers(),
+            timeout=aiohttp.ClientTimeout(total=15),
+        ) as resp:
+            if resp.status != 200:
+                logger.debug("GitHub GraphQL pinned fetch %s", resp.status)
+                return []
+            data = await resp.json()
+    except Exception as e:  # noqa: BLE001
+        logger.debug("GitHub GraphQL pinned fetch failed: %s", e)
+        return []
+    if not isinstance(data, dict):
+        return []
+    try:
+        nodes = data["data"]["user"]["pinnedItems"]["nodes"]
+    except (KeyError, TypeError):
+        return []
+    return [n["name"] for n in nodes if isinstance(n, dict) and n.get("name")]
+
+
 async def fetch_github_profile(
     username: str, session: aiohttp.ClientSession | None = None
 ) -> dict[str, Any]:
@@ -231,6 +346,8 @@ async def fetch_github_profile(
         "skills_inferred": [],
         "frameworks_inferred": [],
         "repos_brief": [],
+        "bio": "",
+        "profile_readme": "",
     }
     # Accept a full profile URL or @handle, not just a bare username.
     username = normalize_github_username(username)
@@ -276,6 +393,21 @@ async def fetch_github_profile(
         authed = bool(GITHUB_TOKEN)
         lang_n = 20 if authed else 12
         dep_n = MAX_REPOS_FOR_DEPS if authed else 5
+        readme_n = README_REPOS_AUTHED if authed else README_REPOS_UNAUTHED
+
+        # The user's PINNED repos are their own curated highlights. Pull them to
+        # the front so the capped language / dep-file / README probes cover the
+        # work the developer chose to showcase before the long tail. No-op when
+        # unauthenticated (GraphQL needs a token); stable — pinned first in pin
+        # order, then the rest in their existing pushed-desc order.
+        pinned = await _fetch_pinned(session, username)
+        if pinned:
+            pin_rank = {name: i for i, name in enumerate(pinned)}
+            repositories.sort(key=lambda r: pin_rank.get(r["name"], len(pin_rank) + 1))
+
+        # The developer's own identity block (bio / name / company / location /
+        # blog / hireable). One cheap request; prose fed to the LLM pass.
+        user_obj = await _fetch_user(session, username)
 
         # Fetch per-repo language breakdown with temporal weight.
         # We keep a per-repo map so the recency multiplier can be applied
@@ -322,19 +454,51 @@ async def fetch_github_profile(
 
         skills_inferred = _infer_skills(weighted_languages, all_topics)
 
-        # Two-pass — compact repo briefs (name/description/topics) for the
-        # LLM pass. Only repos with prose worth reading (a description or
-        # topics) are kept, capped so the prompt stays small.
-        repos_brief = [
-            {
+        # ── READMEs — the richest per-repo prose. A repo `description` is often
+        # one line or null; the README is where "what this is / what it's built
+        # with" actually lives. Fetched for the top `readme_n` repos (pinned
+        # first after the reorder), truncated, and fed ONLY to the LLM pass
+        # (rule #28 safe). Routes through _fetch_readme → _get_json so tests stay
+        # offline. A failed/absent README just yields no excerpt for that repo.
+        readme_targets = repositories[:readme_n]
+        readme_results = await asyncio.gather(
+            *[_fetch_readme(session, username, r["name"], README_EXCERPT_CHARS)
+              for r in readme_targets],
+            return_exceptions=True,
+        )
+        readme_by_name: dict[str, str] = {}
+        for r, res in zip(readme_targets, readme_results):
+            if isinstance(res, str) and res:
+                readme_by_name[r["name"]] = res
+
+        # Two-pass — compact repo briefs for the LLM pass. Keep a repo if it has
+        # ANY prose worth reading: a description, topics, a language, OR a README
+        # we just fetched. Each brief carries its README excerpt so the offline
+        # re-run reads the same prose without re-fetching.
+        repos_brief: list[dict[str, Any]] = []
+        for r in repositories:
+            excerpt = readme_by_name.get(r["name"], "")
+            if not (r.get("description") or r.get("topics") or r.get("language") or excerpt):
+                continue
+            brief: dict[str, Any] = {
                 "name": r["name"],
                 "language": r.get("language", "") or "",
                 "description": r.get("description", ""),
                 "topics": list(r.get("topics", []) or []),
             }
-            for r in repositories
-            if r.get("description") or r.get("topics") or r.get("language")
-        ][:MAX_REPOS]
+            if excerpt:
+                brief["readme_excerpt"] = excerpt
+            repos_brief.append(brief)
+            if len(repos_brief) >= MAX_REPOS:
+                break
+
+        # ── Profile README — the {u}/{u} special repo GitHub renders at the top
+        # of a profile: the developer's self-authored portfolio. Often absent.
+        profile_readme = await _fetch_readme(session, username, username, PROFILE_README_CHARS)
+
+        # ── Identity block — bio / name / company / location the developer wrote
+        # about themselves, folded into one short self-description line.
+        bio = _compose_bio(user_obj)
 
         return {
             "repositories": repositories,
@@ -343,6 +507,8 @@ async def fetch_github_profile(
             "skills_inferred": skills_inferred,
             "frameworks_inferred": frameworks_inferred,
             "repos_brief": repos_brief,
+            "bio": bio,
+            "profile_readme": profile_readme,
         }
     finally:
         if own_session:
@@ -418,38 +584,54 @@ _GITHUB_LLM_SYSTEM = (
     "return JSON only and never invent skills the text does not support."
 )
 
-_GITHUB_LLM_PROMPT = """Below is a list of a developer's public GitHub repositories — each with
-a name, description, and topic tags.
+_GITHUB_LLM_PROMPT = """Below is a developer's public GitHub presence: an optional self-description
+(their profile bio and portfolio README), followed by their repositories —
+each with a name, language, description, topic tags, and (when available) an
+excerpt of the repo's README.
 
 Infer the concrete technical SKILLS this developer demonstrates: frameworks,
 libraries, tools, platforms, and technical domains. Focus on things a
 hard-coded language/topic table would MISS — e.g. "LangChain", "RAG",
-"Computer Vision", "Fraud Detection", "Cloudflare Workers".
+"Computer Vision", "Fraud Detection", "Cloudflare Workers". The README excerpts
+and self-description are the richest source — read them carefully.
 
 Return JSON: {{"skills": ["Skill One", "Skill Two", ...]}}
 
 Rules:
-- GROUNDED ONLY: every skill must be supported by words actually in the name,
-  description, or topics. Do NOT guess a tech stack from a repo's purpose — e.g.
-  for "cold outreach platform" do not assume "Gmail API"/"GPT-4o" unless named.
+- GROUNDED ONLY: every skill must be supported by words actually present in the
+  self-description, a name, description, topics, or a README excerpt. Do NOT
+  guess a tech stack from a repo's purpose — e.g. for "cold outreach platform"
+  do not assume "Gmail API"/"GPT-4o" unless named.
 - Individual items, not categories ("PyTorch", not "ML frameworks").
 - Skip bare programming languages (Python/Java/etc.) — those are covered elsewhere.
 
-REPOSITORIES:
+{self_desc}REPOSITORIES:
 ---
 {repos}
 ---"""
 
 
-async def llm_infer_github_skills(repos_brief: list[dict[str, Any]]) -> list[str]:
+async def llm_infer_github_skills(
+    repos_brief: list[dict[str, Any]],
+    *,
+    bio: str = "",
+    profile_readme: str = "",
+) -> list[str]:
     """Pass 2 for GitHub — ask the LLM to read repo prose and name skills the
     hard-coded ``LANGUAGE_TO_SKILL`` / ``TOPIC_TO_SKILL`` tables can't know.
 
-    Returns ``[]`` (never raises) when there are no repos worth reading or the
+    Reads, in order of richness: the profile bio + portfolio README (the
+    developer's self-description), each repo's README excerpt, then the
+    name/description/topics. All are prose the LLM canonicalises — no hardcoded
+    map (rule #28).
+
+    Returns ``[]`` (never raises) when there is nothing worth reading or the
     provider chain fails — graceful no-op, mirroring the deterministic path.
     The empty-input branch never calls the LLM (cost guard).
     """
-    if not repos_brief:
+    bio = (bio or "").strip()
+    profile_readme = (profile_readme or "").strip()
+    if not (repos_brief or bio or profile_readme):
         return []
 
     lines: list[str] = []
@@ -458,14 +640,32 @@ async def llm_infer_github_skills(repos_brief: list[dict[str, Any]]) -> list[str
         lang = (r.get("language") or "").strip()
         desc = (r.get("description") or "").strip()
         topics = ", ".join(t for t in (r.get("topics") or []) if t)
-        if not (name or desc or topics or lang):
+        readme = (r.get("readme_excerpt") or "").strip()
+        if not (name or desc or topics or lang or readme):
             continue
         lang_tag = f" [language: {lang}]" if lang else ""
-        lines.append(f"- {name}:{lang_tag} {desc} [topics: {topics}]")
-    if not lines:
+        entry = f"- {name}:{lang_tag} {desc} [topics: {topics}]"
+        if readme:
+            entry += f"\n  README: {readme}"
+        lines.append(entry)
+
+    # A self-description block (bio + portfolio README) may exist even with no
+    # repo prose — a valid reason to call the LLM on its own.
+    self_desc = ""
+    if bio or profile_readme:
+        sd_parts = []
+        if bio:
+            sd_parts.append(bio)
+        if profile_readme:
+            sd_parts.append(f"Profile README:\n{profile_readme}")
+        self_desc = "DEVELOPER SELF-DESCRIPTION:\n---\n" + "\n\n".join(sd_parts) + "\n---\n\n"
+
+    if not lines and not self_desc:
         return []
 
-    prompt = _GITHUB_LLM_PROMPT.format(repos="\n".join(lines))
+    prompt = _GITHUB_LLM_PROMPT.format(
+        self_desc=self_desc, repos="\n".join(lines) or "(none)"
+    )
     try:
         from src.services.profile.llm_provider import llm_extract  # noqa: PLC0415
         result = await llm_extract(prompt, system=_GITHUB_LLM_SYSTEM)
@@ -518,5 +718,11 @@ def enrich_cv_from_github(cv: CVData, github_data: dict[str, Any]) -> CVData:
     # a non-empty value arrives, so a partial re-enrich never wipes them.
     if github_data.get("repos_brief"):
         cv.github_repos_brief = github_data["repos_brief"]
+    # "Read 100% of GitHub" — the self-authored prose signals. Only overwrite on
+    # a non-empty fetch so a rate-limited partial re-enrich never wipes them.
+    if github_data.get("bio"):
+        cv.github_bio = github_data["bio"]
+    if github_data.get("profile_readme"):
+        cv.github_profile_readme = github_data["profile_readme"]
 
     return cv

--- a/backend/src/services/profile/keyword_generator.py
+++ b/backend/src/services/profile/keyword_generator.py
@@ -106,16 +106,61 @@ def generate_search_config(profile: UserProfile) -> SearchConfig:
             locations.append(arrangement)
 
     # --- Core domain words & supporting role words ---
-    core_words: set[str] = set()
+    # Dead-title-lever fix (funnel redesign 2026-08-05). Titles pulled from a CV
+    # are hyper-specific ("AI Solutions Engineer - R&D Department"): real
+    # postings never equal or contain them, so title scoring falls back to this
+    # vocabulary — which used to be raw title tokens, i.e. tiny AND polluted by
+    # junk like 'department'. Measured on prod: no job scored above 8/40 on
+    # title, capping every match_score at ~69 and quietly making LOCATION the
+    # feed's sort key. All corroboration below is evidence from the profile
+    # itself (titles, skills) — no hardcoded vocabulary (rule #28 spirit).
+    #
+    # A title token joins core only with corroboration:
+    #   - it appears in >=2 different titles (cross-title evidence), or
+    #   - it appears inside the user's skill tokens (skill evidence), or
+    #   - it is a short acronym token (<=3 chars: 'ai', 'ml', 'nlp' — domain
+    #     acronyms; 1-char junk like the 'r'/'d' of "R&D" is already dropped).
+    # Skill tokens seen across >=2 skills join core too, so "Machine Learning
+    # Engineer" postings match a profile whose titles never say 'learning'.
     support_words: set[str] = set()
+    title_token_titles: dict[str, int] = {}  # token -> number of DISTINCT titles
+    seen_token_sets: set[frozenset[str]] = set()
     for title in titles:
+        seen_in_title: set[str] = set()
         for word in re.findall(r'\w+', title.lower()):
             if word in _STOPWORDS or len(word) <= 1:
                 continue
             if word in _ROLE_WORDS:
                 support_words.add(word)
             else:
-                core_words.add(word)
+                seen_in_title.add(word)
+        # Near-duplicate titles ("… - R&D Department" vs "… – R&D Department",
+        # or the same title arriving from both CV and LinkedIn) must count as
+        # ONE piece of evidence, or their junk tokens fake cross-title
+        # corroboration. Identity = the token set, not the raw string.
+        fs = frozenset(seen_in_title)
+        if not fs or fs in seen_token_sets:
+            continue
+        seen_token_sets.add(fs)
+        for word in seen_in_title:
+            title_token_titles[word] = title_token_titles.get(word, 0) + 1
+
+    skill_token_freq: dict[str, int] = {}  # token -> number of skills it appears in
+    for skill in primary + secondary:
+        for word in set(re.findall(r'\w+', skill.lower())):
+            if word in _STOPWORDS or word in _ROLE_WORDS or len(word) <= 1:
+                continue
+            skill_token_freq[word] = skill_token_freq.get(word, 0) + 1
+
+    core_words: set[str] = {
+        tok for tok, n_titles in title_token_titles.items()
+        if n_titles >= 2 or tok in skill_token_freq or len(tok) <= 3
+    }
+    core_words |= {tok for tok, freq in skill_token_freq.items() if freq >= 2}
+    if not core_words:
+        # Thin-profile safety net (one title, no skills): an empty vocabulary
+        # would kill title scoring entirely — keep the old all-tokens behaviour.
+        core_words = set(title_token_titles)
 
     # --- Search queries (top 8 titles x top 2 locations) ---
     top_titles = titles[:8]

--- a/backend/src/services/profile/models.py
+++ b/backend/src/services/profile/models.py
@@ -79,6 +79,17 @@ class CVData:
     # tables can't recognise (e.g. "LangChain", "RAG"). Separate field so
     # skill-tiering can weight this signal independently.
     github_llm_skills: list[str] = field(default_factory=list)
+    # "Read 100% of GitHub" (2026-08-05) — the two richest SELF-AUTHORED prose
+    # signals on a profile. Stored so the GitHub LLM pass can re-read them
+    # offline on a later profile change (mirrors github_repos_brief). Both are
+    # prose fed only to the LLM pass (rule #28 safe — never a hardcoded map),
+    # and persist automatically via the asdict() blob, no migration.
+    #   github_bio: the /users/{u} identity block (bio + name/company/blog/
+    #               location/hireable) — the developer describing themselves.
+    #   github_profile_readme: the {u}/{u} special-repo README — the portfolio
+    #               page GitHub renders at the top of a profile.
+    github_bio: str = ""
+    github_profile_readme: str = ""
     # Batch 1.1 — archetype classification (CareerDomain enum value).
     # Optional; None means "LLM did not classify". Consumed by
     # archetype-aware scoring (Pillar 1 #10 / Pillar 2).

--- a/backend/src/services/profile/two_pass.py
+++ b/backend/src/services/profile/two_pass.py
@@ -332,7 +332,14 @@ async def run_two_pass_extraction(profile: UserProfile) -> UserProfile:
     _inputs = {
         "cv": cv.raw_text,
         "linkedin": cv.linkedin_raw_text,
-        "github": cv.github_repos_brief,
+        # GitHub input is the repo briefs (which now carry README excerpts) PLUS
+        # the self-authored bio + profile README. Any of the three changing must
+        # re-trigger the pass, so all three fold into the one cache key.
+        "github": {
+            "repos": cv.github_repos_brief,
+            "bio": cv.github_bio,
+            "readme": cv.github_profile_readme,
+        },
         "about_me": prefs.about_me,
     }
     _cached = {k: _already_read(cv, k, v) for k, v in _inputs.items()}
@@ -342,13 +349,19 @@ async def run_two_pass_extraction(profile: UserProfile) -> UserProfile:
             ", ".join(sorted(k for k, v in _cached.items() if v)),
         )
 
+    # The GitHub pass now has input when EITHER the repo briefs OR the
+    # self-authored bio / profile README are present.
+    _has_github = bool(cv.github_repos_brief or cv.github_bio or cv.github_profile_readme)
+
     _llm_cv_res, _llm_li_res, _llm_gh_res, _llm_pr_res = await asyncio.gather(
         _safe(llm_cv_fields_from_text(cv.raw_text), "CV")
         if cv.raw_text and not _cached["cv"] else _none(),
         _safe(llm_linkedin_fields(cv.linkedin_raw_text), "LinkedIn")
         if cv.linkedin_raw_text and not _cached["linkedin"] else _none(),
-        _safe(llm_infer_github_skills(cv.github_repos_brief), "GitHub")
-        if cv.github_repos_brief and not _cached["github"] else _none(),
+        _safe(llm_infer_github_skills(
+            cv.github_repos_brief, bio=cv.github_bio,
+            profile_readme=cv.github_profile_readme), "GitHub")
+        if _has_github and not _cached["github"] else _none(),
         _safe(llm_infer_from_about_me(prefs.about_me), "about_me")
         if prefs.about_me and not _cached["about_me"] else _none(),
     )
@@ -366,7 +379,9 @@ async def run_two_pass_extraction(profile: UserProfile) -> UserProfile:
     _retryable = [
         ("cv", cv.raw_text, lambda: llm_cv_fields_from_text(cv.raw_text)),
         ("linkedin", cv.linkedin_raw_text, lambda: llm_linkedin_fields(cv.linkedin_raw_text)),
-        ("github", cv.github_repos_brief, lambda: llm_infer_github_skills(cv.github_repos_brief)),
+        ("github", _has_github, lambda: llm_infer_github_skills(
+            cv.github_repos_brief, bio=cv.github_bio,
+            profile_readme=cv.github_profile_readme)),
         ("about_me", prefs.about_me, lambda: llm_infer_from_about_me(prefs.about_me)),
     ]
     _results = {"cv": _llm_cv_res, "linkedin": _llm_li_res,

--- a/backend/src/services/profile/two_pass.py
+++ b/backend/src/services/profile/two_pass.py
@@ -353,6 +353,34 @@ async def run_two_pass_extraction(profile: UserProfile) -> UserProfile:
         if prefs.about_me and not _cached["about_me"] else _none(),
     )
 
+    # RETRY A SOFT-EMPTY PASS ONCE, SEQUENTIALLY.
+    #
+    # The four passes above run concurrently in one gather. On free-tier keys
+    # that means up to four simultaneous LLM calls, and the providers
+    # rate-limit: one call gets a valid but EMPTY answer while the same input
+    # extracts fine when it runs alone (measured on Rohith — 0 positions via the
+    # concurrent API path, 7 in isolation). So any pass that RAN but produced no
+    # usable data is retried here one at a time, with no concurrent contention.
+    # Bounded: at most one extra call per empty input, and only when the input
+    # was non-empty and not cached.
+    _retryable = [
+        ("cv", cv.raw_text, lambda: llm_cv_fields_from_text(cv.raw_text)),
+        ("linkedin", cv.linkedin_raw_text, lambda: llm_linkedin_fields(cv.linkedin_raw_text)),
+        ("github", cv.github_repos_brief, lambda: llm_infer_github_skills(cv.github_repos_brief)),
+        ("about_me", prefs.about_me, lambda: llm_infer_from_about_me(prefs.about_me)),
+    ]
+    _results = {"cv": _llm_cv_res, "linkedin": _llm_li_res,
+                "github": _llm_gh_res, "about_me": _llm_pr_res}
+    for _k, _raw, _call in _retryable:
+        if _raw and not _cached[_k] and not _pass_produced_data(_k, _results[_k]):
+            retried = await _safe(_call(), f"{_k} (retry)")
+            if _pass_produced_data(_k, retried):
+                logger.info("two_pass: %s pass was empty under load — sequential "
+                            "retry recovered it", _k)
+                _results[_k] = retried
+    _llm_cv_res, _llm_li_res = _results["cv"], _results["linkedin"]
+    _llm_gh_res, _llm_pr_res = _results["github"], _results["about_me"]
+
     # Record ONLY a pass that PRODUCED USABLE DATA, not merely one that did not
     # raise.
     #

--- a/backend/src/services/profile/two_pass.py
+++ b/backend/src/services/profile/two_pass.py
@@ -74,6 +74,30 @@ def _input_hash(raw: Any) -> str:
     return hashlib.sha256(raw.encode("utf-8")).hexdigest()
 
 
+def _pass_produced_data(key: str, res: Any) -> bool:
+    """Did an LLM pass return anything worth caching?
+
+    A pass that returned an empty result from a NON-empty input is almost always
+    a soft failure (a rate-limited provider answering with `{}` instead of
+    raising), and caching it freezes that emptiness forever. So only a pass that
+    yielded usable data records its hash; an empty one re-runs next time.
+
+    Shapes differ per input: the CV pass returns a ``CVData``; the others return
+    dicts or lists. This reads the fields that actually matter for each.
+    """
+    if res is None:
+        return False
+    if key == "cv":
+        # llm_cv_fields_from_text returns a CVData; skills OR titles is enough.
+        return bool(getattr(res, "skills", None) or getattr(res, "job_titles", None))
+    if key == "linkedin":
+        # A dict of {skills, positions, education, certifications}.
+        d = res if isinstance(res, dict) else {}
+        return bool(d.get("skills") or d.get("positions") or d.get("education"))
+    # github / about_me return a list[str] of inferred skills.
+    return bool(res)
+
+
 def _already_read(cv: CVData, key: str, raw: Any) -> bool:
     """True when a paid LLM pass has already absorbed this exact input.
 
@@ -329,14 +353,28 @@ async def run_two_pass_extraction(profile: UserProfile) -> UserProfile:
         if prefs.about_me and not _cached["about_me"] else _none(),
     )
 
-    # Record ONLY what actually succeeded. `_safe` returns None on failure, so a
-    # provider outage leaves the hash unset and the next run retries — the
-    # alternative would silently freeze a half-extracted profile forever.
+    # Record ONLY a pass that PRODUCED USABLE DATA, not merely one that did not
+    # raise.
+    #
+    # THE BUG THIS FIXES (found by the journey simulation 2026-08-05). `_safe`
+    # returns None only on an EXCEPTION. But a rate-limited free-tier provider
+    # often returns a valid, EMPTY result — `{"positions": [], "skills": []}` —
+    # without raising. The old check (`_res is not None`) recorded that empty
+    # result's hash as "done", so the cache then skipped re-extraction FOREVER,
+    # freezing a profile with zero positions and zero LinkedIn skills. Measured
+    # on Rohith: the LLM extracts 7 positions in isolation, but his stored
+    # profile had 0, and every re-upload logged "reusing unchanged linkedin —
+    # skipping" and kept the empty result. A soft failure is exactly the case
+    # you MOST want to retry, and it was the one case being cached.
+    #
+    # So the hash is recorded only when the pass yielded something worth keeping.
+    # An input that genuinely contains nothing will re-run cheaply next time —
+    # far better than freezing a broken extraction.
     for _key, _res in (
         ("cv", _llm_cv_res), ("linkedin", _llm_li_res),
         ("github", _llm_gh_res), ("about_me", _llm_pr_res),
     ):
-        if _res is not None:
+        if _res is not None and _pass_produced_data(_key, _res):
             cv.llm_input_hashes[_key] = _input_hash(_inputs[_key])
 
     # ── ① CV ── raw = cv.raw_text ──────────────────────────────────────

--- a/backend/src/services/rescore.py
+++ b/backend/src/services/rescore.py
@@ -212,6 +212,54 @@ async def backfill_feed_from_catalog(
         except Exception as exc:  # noqa: BLE001
             logger.warning("catalog backfill: selection sync failed: %s", exc)
 
+    # Phase 4 — CANDIDATE enrichment (funnel Stage-2, 2026-08-05). E2 used to
+    # enrich only the top-20 of jobs a run itself fetched, so prod coverage sat
+    # at 24/7,309 jobs (0.3%) and the salary/visa/seniority/workplace
+    # preference dimensions effectively never fired. Enrichment is per-JOB and
+    # shared (rule #17: no user_id), so enriching this user's candidates
+    # benefits every user and is cached forever. Budget: the best-scoring
+    # ENRICHMENT_MAX_JOBS selected candidates still missing enrichment, per
+    # backfill — coverage of the candidate set grows with every search.
+    # Gated exactly like run_search's stage (ENGINE2_ENABLED OR legacy flag).
+    from src.core.settings import ENGINE2_ENABLED  # noqa: PLC0415
+    from src.services.job_enrichment import ENRICHMENT_ENABLED  # noqa: PLC0415
+
+    if (ENGINE2_ENABLED or ENRICHMENT_ENABLED) and selected:
+        try:
+            from src.core.settings import ENRICHMENT_MAX_JOBS  # noqa: PLC0415
+            from src.models import Job as _EJob  # noqa: PLC0415
+            from src.services.job_enrichment import (  # noqa: PLC0415
+                enrich_batch,
+                has_enrichment,
+            )
+
+            ranked = sorted(selected, key=lambda t: t[0], reverse=True)
+            to_enrich: list[Any] = []
+            for ms, jid, row in ranked:
+                if len(to_enrich) >= ENRICHMENT_MAX_JOBS:
+                    break
+                if await has_enrichment(db._db, jid):
+                    continue
+                ejob = _EJob(
+                    title=row.get("title", "") or "",
+                    company=row.get("company", "") or "",
+                    apply_url=row.get("apply_url", "") or "",
+                    source=row.get("source", "") or "",
+                    date_found=row.get("date_found", "") or "",
+                    location=row.get("location", "") or "",
+                    description=row.get("description", "") or "",
+                )
+                ejob.id = jid
+                to_enrich.append(ejob)
+            if to_enrich:
+                await enrich_batch(to_enrich, semaphore_limit=3, conn=db._db)
+                logger.info(
+                    "catalog backfill: enriched %s candidate jobs for user %s",
+                    len(to_enrich), user_id,
+                )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("catalog backfill: candidate enrichment failed: %s", exc)
+
     logger.info(
         "catalog backfill: user %s matched %s of %s catalog jobs "
         "(floor %s, cap %s, evicted %s)",

--- a/backend/src/services/rescore.py
+++ b/backend/src/services/rescore.py
@@ -146,10 +146,16 @@ async def backfill_feed_from_catalog(
     rows = await db.get_catalog_jobs_for_rescore()
 
     # recency bucket — imported lazily to dodge the main.py import cycle
+    # User-Level candidate bound (funnel Stage-1). Read at call time so tests
+    # (and a runtime env change) can adjust it without re-importing.
+    import src.core.settings as _settings  # noqa: PLC0415
     from src.main import _recency_bucket  # noqa: PLC0415
 
-    feed = FeedService(db._db)
-    written = 0
+    cap = int(getattr(_settings, "FEED_CANDIDATE_CAP", 0) or 0)
+
+    # Phase 1 — score the whole catalog (unchanged cost: this loop always
+    # scored every row; it just also WROTE every row that beat the floor).
+    scored: list[tuple[int, Any, dict[str, Any]]] = []
     for row in rows:
         jid = row.get("id")
         if jid is None:
@@ -159,8 +165,26 @@ async def backfill_feed_from_catalog(
         try:
             breakdown = score_catalog_row(scorer, row)
             ms = int(breakdown.match_score or 0)
-            if ms < MIN_STORE_SCORE:
-                continue
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("catalog backfill: skipping job %s: %s", jid, exc)
+            continue
+        if ms < MIN_STORE_SCORE:
+            continue
+        scored.append((ms, jid, row))
+
+    # Phase 2 — candidate selection: keep only the user's top-`cap` jobs.
+    # cap=0 disables (legacy flood). Ties broken by score order; stable sort
+    # keeps catalog order within equal scores.
+    if cap > 0 and len(scored) > cap:
+        scored.sort(key=lambda t: t[0], reverse=True)
+        selected = scored[:cap]
+    else:
+        selected = scored
+
+    feed = FeedService(db._db)
+    written = 0
+    for ms, jid, row in selected:
+        try:
             await with_write_retry(
                 lambda jid=jid, ms=ms, row=row: feed.upsert_feed_row(  # type: ignore[misc]
                     user_id=user_id,
@@ -175,12 +199,28 @@ async def backfill_feed_from_catalog(
             logger.warning("catalog backfill: skipping job %s: %s", jid, exc)
             continue
 
+    # Phase 3 — membership sync: evict active rows outside the selection,
+    # reactivate re-selected stale rows. Only when the cap is on.
+    evicted = 0
+    if cap > 0 and selected:
+        try:
+            evicted = await with_write_retry(
+                lambda: feed.apply_candidate_selection(
+                    user_id, {jid for _, jid, _ in selected}
+                )
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("catalog backfill: selection sync failed: %s", exc)
+
     logger.info(
-        "catalog backfill: user %s matched %s of %s catalog jobs (floor %s)",
+        "catalog backfill: user %s matched %s of %s catalog jobs "
+        "(floor %s, cap %s, evicted %s)",
         user_id,
         written,
         len(rows),
         MIN_STORE_SCORE,
+        cap or "off",
+        evicted,
     )
     return written
 
@@ -319,38 +359,58 @@ async def rescore_user_feed(
                 _Job = None  # type: ignore[assignment,misc]  # unused branch
                 shortlist_jobs = None
 
+            # User-Level candidate bound (funnel Stage-1) — same selection the
+            # backfill applies, so a profile change re-selects the shelf.
+            import src.core.settings as _settings  # noqa: PLC0415
+
+            cap = int(getattr(_settings, "FEED_CANDIDATE_CAP", 0) or 0)
+
+            # Phase 1 — score every catalog row (FIX 3 per-row guard kept:
+            # one bad row must not abort the whole re-score).
+            scored_rows: list[tuple[int, Any, dict[str, Any]]] = []
             for row in rows:
                 jid = row.get("id")
                 if jid is None:
                     continue
-                # FIX 3 — per-row error guard: one bad row must not abort the
-                # whole re-score (mirrors run_search's per-job guard in main.py).
                 try:
                     breakdown = score_catalog_row(scorer, row)
-                    ms = breakdown.match_score
+                    ms = int(breakdown.match_score or 0)
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning("rescore: skipping job %s: %s", jid, exc)
+                    continue
+                # Legacy write condition: a positive score, or an existing feed
+                # row that must be re-stamped under the new profile version.
+                if ms > 0 or jid in existing_feed_ids:
+                    scored_rows.append((ms, jid, row))
 
-                    if ms > 0 or jid in existing_feed_ids:
-                        # Finding #11: retry on 'database is locked' so a
-                        # transient lock under concurrent writes doesn't drop
-                        # this scored row (the except below used to swallow it).
-                        await with_write_retry(
-                            # Bind loop vars as defaults so the closure captures
-                            # THIS iteration's values (B023); the callback is
-                            # awaited inline here, but the explicit binding keeps
-                            # it correct if it ever becomes deferred.
-                            # ignore[misc]: a default-arg lambda is not a bare
-                            # zero-arg Callable, so mypy can't infer its type.
-                            lambda jid=jid, ms=ms, row=row: feed.upsert_feed_row(  # type: ignore[misc]
-                                user_id=user_id,
-                                job_id=jid,
-                                score=int(ms),
-                                bucket=_recency_bucket(row.get("date_found")),
-                                profile_version=version,
-                            )
+            # Phase 2 — selection: top-`cap` by score. cap=0 = legacy (all).
+            if cap > 0 and len(scored_rows) > cap:
+                scored_rows.sort(key=lambda t: t[0], reverse=True)
+                selected_rows = scored_rows[:cap]
+            else:
+                selected_rows = scored_rows
+
+            for ms, jid, row in selected_rows:
+                try:
+                    # Finding #11: retry on 'database is locked' so a transient
+                    # lock under concurrent writes doesn't drop this scored row.
+                    await with_write_retry(
+                        # Bind loop vars as defaults so the closure captures
+                        # THIS iteration's values (B023). ignore[misc]: a
+                        # default-arg lambda is not a bare zero-arg Callable.
+                        lambda jid=jid, ms=ms, row=row: feed.upsert_feed_row(  # type: ignore[misc]
+                            user_id=user_id,
+                            job_id=jid,
+                            score=int(ms),
+                            bucket=_recency_bucket(row.get("date_found")),
+                            profile_version=version,
                         )
-                        rescored += 1
+                    )
+                    rescored += 1
 
-                    # Collect shortlist for LLM judge (FIX 1: only when matcher_on)
+                    # Collect shortlist for LLM judge (FIX 1: only when
+                    # matcher_on) — built from SELECTED rows only, so the judge
+                    # never spends on a job outside the candidate set.
                     if matcher_on and ms >= MATCHER_THRESHOLD:
                         job = _Job(
                             title=row.get("title", "") or "",
@@ -371,6 +431,23 @@ async def rescore_user_feed(
                 except Exception as exc:  # noqa: BLE001
                     logger.warning("rescore: skipping job %s: %s", jid, exc)
                     continue
+
+            # Phase 3 — membership sync (evict out-of-selection, reactivate
+            # re-selected). Only when the cap is on.
+            if cap > 0 and selected_rows:
+                try:
+                    evicted = await with_write_retry(
+                        lambda: feed.apply_candidate_selection(
+                            user_id, {jid for _, jid, _ in selected_rows}
+                        )
+                    )
+                    if evicted:
+                        logger.info(
+                            "rescore: user %s evicted %s out-of-selection rows",
+                            user_id, evicted,
+                        )
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning("rescore: selection sync failed: %s", exc)
 
             # 6. LLM re-judge (FIX 1: entire block gated on matcher_on)
             if matcher_on and shortlist_jobs:

--- a/backend/src/services/rescore.py
+++ b/backend/src/services/rescore.py
@@ -235,7 +235,7 @@ async def backfill_feed_from_catalog(
 
             ranked = sorted(selected, key=lambda t: t[0], reverse=True)
             to_enrich: list[Any] = []
-            for ms, jid, row in ranked:
+            for _ms, jid, row in ranked:
                 if len(to_enrich) >= ENRICHMENT_MAX_JOBS:
                     break
                 if await has_enrichment(db._db, jid):

--- a/backend/src/services/skill_matcher.py
+++ b/backend/src/services/skill_matcher.py
@@ -484,13 +484,23 @@ class JobScorer:
                 return TITLE_WEIGHT
             if target.lower() in title_lower or title_lower in target.lower():
                 return TITLE_WEIGHT // 2
-        # Partial keyword overlap using dynamic domain words
         title_words = set(re.findall(r"\w+", title_lower))
         core_overlap = title_words & self._config.core_domain_words
         if not core_overlap:
             return 0
         support_overlap = title_words & self._config.supporting_role_words
-        return min(len(core_overlap) * 5 + len(support_overlap) * 3, TITLE_WEIGHT // 2)
+        # Dead-title-lever fix (funnel redesign 2026-08-05): a job title showing
+        # BOTH a core domain word AND a role word ("AI Engineer", "Machine
+        # Learning Engineer", "Data Scientist") is a strong role match — the
+        # thing exact/substring matching was supposed to catch but never did,
+        # because CV-derived config titles don't appear verbatim in postings.
+        # 30/40 base + 3 per extra domain word, capped at the full weight.
+        if support_overlap:
+            return min(
+                TITLE_WEIGHT * 3 // 4 + (len(core_overlap) - 1) * 3, TITLE_WEIGHT
+            )
+        # Domain word(s) with no role word: partial overlap band, capped at 20.
+        return min(len(core_overlap) * 5, TITLE_WEIGHT // 2)
 
     def _skill_score(self, text: str) -> int:
         points = 0

--- a/backend/src/sources/apis_free/devitjobs.py
+++ b/backend/src/sources/apis_free/devitjobs.py
@@ -54,10 +54,42 @@ class DevITJobsSource(BaseJobSource):
             visa_flag = bool(item.get("hasVisaSponsorship", False))
             exp_level = item.get("expLevel", "")
 
+            # Job-understanding fix (2026-08-05): jobsLight has NO prose
+            # description — 3,041 prod jobs (42% of the whole catalog, our
+            # largest source) sat with EMPTY description text, unmatchable by
+            # the skill scorer and unreadable by enrichment/embeddings. But
+            # the API publishes the tech stack + structured attributes on
+            # every row (verified live: `technologies`, `filterTags`,
+            # `techCategory`, `jobType`, `remoteType`, `companySize`).
+            # Compose them into an honest structured description — API facts
+            # verbatim, nothing fabricated.
+            desc_bits: list[str] = []
+            techs = [str(t) for t in (item.get("technologies") or []) if t]
+            if techs:
+                desc_bits.append("Technologies: " + ", ".join(techs))
+            tags = [str(t).replace("-", " ") for t in (item.get("filterTags") or []) if t]
+            if tags:
+                desc_bits.append("Tags: " + ", ".join(tags))
+            for label, key in (
+                ("Tech category", "techCategory"),
+                ("Category", "metaCategory"),
+                ("Job type", "jobType"),
+                ("Workplace", "remoteType"),
+                ("Experience level", "expLevel"),
+                ("Company size", "companySize"),
+            ):
+                val = item.get(key)
+                if val:
+                    desc_bits.append(f"{label}: {val}")
+            if visa_flag:
+                desc_bits.append("Visa sponsorship available")
+            description = ". ".join(desc_bits)
+
             jobs.append(Job(
                 title=title,
                 company=company,
                 location=location,
+                description=description,
                 apply_url=apply_url,
                 source=self.name,
                 date_found=now_iso,

--- a/backend/src/sources/ats/greenhouse.py
+++ b/backend/src/sources/ats/greenhouse.py
@@ -1,3 +1,4 @@
+import html
 import logging
 import re
 from datetime import datetime, timezone
@@ -26,7 +27,12 @@ class GreenhouseSource(BaseJobSource):
     async def fetch_jobs(self) -> list[Job]:
         jobs = []
         for slug in self._companies:
-            url = f"https://boards-api.greenhouse.io/v1/boards/{slug}/jobs"
+            # Job-understanding fix (2026-08-05): WITHOUT `?content=true` the
+            # board list endpoint returns NO `content` field at all — verified
+            # live (deepmind board: absent vs 5,359 chars). Every greenhouse
+            # job in prod (996 rows, 100% of the slice) had an empty
+            # description because this param was missing. Same request count.
+            url = f"https://boards-api.greenhouse.io/v1/boards/{slug}/jobs?content=true"
             data = await self._get_json(url)
             if not data or "jobs" not in data:
                 continue
@@ -34,7 +40,10 @@ class GreenhouseSource(BaseJobSource):
             for item in cast(dict[str, Any], data)["jobs"]:
                 title = item.get("title", "")
                 content = item.get("content", "")
-                plain = _HTML_TAG_RE.sub(" ", content)
+                # The API returns HTML-ENTITY-ESCAPED markup (`&lt;p&gt;`), so
+                # unescape first — the tag-strip regex can't see escaped tags,
+                # and skipping this stores literal `&lt;h4&gt;` noise as text.
+                plain = _HTML_TAG_RE.sub(" ", html.unescape(content or ""))
                 loc = item.get("location", {})
                 location = loc.get("name", "") if isinstance(loc, dict) else str(loc)
                 if not _is_uk_or_remote(location):

--- a/backend/src/sources/ats/smartrecruiters.py
+++ b/backend/src/sources/ats/smartrecruiters.py
@@ -49,7 +49,7 @@ class SmartRecruitersSource(BaseJobSource):
                 raw_released = item.get("releasedDate")
                 posted_at, confidence = normalize_posted_at(raw_released)
 
-                jobs.append(Job(
+                job = Job(
                     title=title,
                     company=company_name,
                     location=location,
@@ -60,7 +60,43 @@ class SmartRecruitersSource(BaseJobSource):
                     posted_at=posted_at,
                     date_confidence=confidence,
                     date_posted_raw=raw_released,
-                ))
+                )
+                # Job-understanding fix (2026-08-05): the list endpoint has no
+                # posting text (150 prod jobs, 100% empty descriptions). The
+                # public detail endpoint carries the full jobAd sections
+                # (verified live: 6,445 chars for a wise posting). Only
+                # UK/remote-relevant jobs are detail-fetched, so the extra
+                # request count matches what we actually keep. A failed detail
+                # fetch degrades to the empty description, never drops the job.
+                if _is_uk_or_remote(location):
+                    job.description = await self._fetch_posting_text(
+                        slug, str(item.get("id", ""))
+                    )
+                jobs.append(job)
         jobs = [j for j in jobs if _is_uk_or_remote(j.location)]
         logger.info("SmartRecruiters: found %s relevant jobs across %s companies", len(jobs), len(self._companies))
         return jobs
+
+    async def _fetch_posting_text(self, slug: str, posting_id: str) -> str:
+        """Fetch one posting's full text from the public detail endpoint.
+
+        Concatenates the ``jobAd.sections`` texts (companyDescription,
+        jobDescription, qualifications, additionalInformation), tag-stripped.
+        Returns ``""`` on any failure — absence of text is a data gap, not an
+        error (the scorer's unknown-handling treats it neutrally).
+        """
+        if not posting_id:
+            return ""
+        detail = await self._get_json(
+            f"https://api.smartrecruiters.com/v1/companies/{slug}/postings/{posting_id}"
+        )
+        if not isinstance(detail, dict):
+            return ""
+        sections = (detail.get("jobAd") or {}).get("sections") or {}
+        parts: list[str] = []
+        for key in ("jobDescription", "qualifications", "additionalInformation", "companyDescription"):
+            sec = sections.get(key)
+            text = (sec or {}).get("text") if isinstance(sec, dict) else None
+            if text:
+                parts.append(_HTML_TAG_RE.sub(" ", str(text)))
+        return " ".join(parts)[:5000].strip()

--- a/backend/src/sources/ats/workday.py
+++ b/backend/src/sources/ats/workday.py
@@ -14,6 +14,8 @@ logger = logging.getLogger("job360.sources.workday")
 
 # Parse "Posted 3 Days Ago", "Posted Today", "Posted Yesterday", "Posted 30+ Days Ago"
 _POSTED_RE = re.compile(r"Posted\s+(\d+)\s+Days?\s+Ago", re.IGNORECASE)
+# Strip HTML tags from the CXS detail endpoint's jobDescription.
+_DESC_TAG_RE = re.compile(r"<[^>]+>")
 
 
 def _parse_posted_on(text: str) -> str:
@@ -96,11 +98,21 @@ class WorkdaySource(BaseJobSource):
                     else:
                         parsed_posted_at = None
                         confidence = "low"
+                    # Job-understanding fix (2026-08-05): the search response
+                    # has no description (537 prod jobs, 100% empty). The CXS
+                    # detail endpoint at {base}/wday/cxs/{tenant}/{site}{path}
+                    # returns jobPostingInfo.jobDescription (verified live:
+                    # 12,746 chars for an astrazeneca posting). Only UK/remote
+                    # survivors reach this point, so the request count matches
+                    # what we keep. Failure degrades to "", never drops the job.
+                    description = await self._fetch_job_description(
+                        base_url, tenant, site, ext_path
+                    )
                     jobs.append(Job(
                         title=title,
                         company=company_name,
                         location=location,
-                        description="",
+                        description=description,
                         apply_url=apply_url,
                         source=self.name,
                         date_found=now_iso,
@@ -111,3 +123,21 @@ class WorkdaySource(BaseJobSource):
 
         logger.info("Workday: found %s relevant jobs across %s companies", len(jobs), len(self._companies))
         return jobs
+
+    async def _fetch_job_description(
+        self, base_url: str, tenant: str, site: str, ext_path: str
+    ) -> str:
+        """Fetch one posting's ``jobPostingInfo.jobDescription`` (HTML → text).
+
+        Returns ``""`` on any failure — a missing description is a data gap the
+        scorer treats neutrally, not a reason to drop the job.
+        """
+        if not ext_path:
+            return ""
+        detail = await self._get_json(f"{base_url}/wday/cxs/{tenant}/{site}{ext_path}")
+        if not isinstance(detail, dict):
+            return ""
+        desc = (detail.get("jobPostingInfo") or {}).get("jobDescription") or ""
+        if not desc:
+            return ""
+        return _DESC_TAG_RE.sub(" ", str(desc))[:5000].strip()

--- a/backend/tests/test_candidate_selection.py
+++ b/backend/tests/test_candidate_selection.py
@@ -379,3 +379,85 @@ async def test_rescore_user_feed_caps_and_evicts(full_db, monkeypatch):
     by_id = dict((jid, status) for jid, status, _ in rows)
     assert len(active) == 2
     assert by_id[junk_id] == "stale", "rescore did not evict the out-of-selection row"
+
+
+# ── candidate enrichment (funnel Stage-2) ────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_backfill_enriches_selected_candidates_when_e2_on(full_db, monkeypatch):
+    """With E2 on, backfill must enrich the best-scoring SELECTED candidates
+    that lack enrichment — coverage of the candidate set grows per search.
+    (Prod before this: 24/7,309 jobs enriched, so salary/visa/seniority
+    preference dims effectively never fired.)"""
+    from pathlib import Path
+
+    import src.core.settings as settings_mod
+    import src.services.profile.storage as storage_mod
+    import src.services.rescore as rescore_mod
+
+    monkeypatch.setattr(storage_mod, "DB_PATH", Path(full_db), raising=True)
+    monkeypatch.setattr(settings_mod, "FEED_CANDIDATE_CAP", 2, raising=False)
+    monkeypatch.setattr(settings_mod, "ENGINE2_ENABLED", True, raising=False)
+    monkeypatch.setattr(settings_mod, "ENRICHMENT_MAX_JOBS", 1, raising=False)
+
+    enriched: list[int] = []
+
+    async def fake_enrich_batch(jobs, semaphore_limit=3, conn=None, **kw):
+        enriched.extend(j.id for j in jobs)
+        return []
+
+    import src.services.job_enrichment as je_mod
+    monkeypatch.setattr(je_mod, "enrich_batch", fake_enrich_batch)
+
+    user_id = _seed_user(full_db)
+    _seed_profile(full_db, user_id)
+
+    db = JobDatabase(full_db)
+    await db.init_db()
+    try:
+        await _seed_catalog(db, n_relevant=3, n_junk=1)
+        await rescore_mod.backfill_feed_from_catalog(user_id, db)
+    finally:
+        await db.close()
+
+    # Budget 1 → exactly the single best-scoring candidate gets enriched.
+    assert len(enriched) == 1, f"expected 1 enrichment call, got {enriched}"
+
+
+@pytest.mark.asyncio
+async def test_backfill_never_enriches_when_e2_off(full_db, monkeypatch):
+    """Rule #18 analog: with E2 off, backfill must make ZERO enrichment calls —
+    behaviour identical to pre-Stage-2."""
+    from pathlib import Path
+
+    import src.core.settings as settings_mod
+    import src.services.profile.storage as storage_mod
+    import src.services.rescore as rescore_mod
+
+    monkeypatch.setattr(storage_mod, "DB_PATH", Path(full_db), raising=True)
+    monkeypatch.setattr(settings_mod, "FEED_CANDIDATE_CAP", 2, raising=False)
+    monkeypatch.setattr(settings_mod, "ENGINE2_ENABLED", False, raising=False)
+
+    called = {"n": 0}
+
+    async def fake_enrich_batch(jobs, **kw):
+        called["n"] += 1
+        return []
+
+    import src.services.job_enrichment as je_mod
+    monkeypatch.setattr(je_mod, "enrich_batch", fake_enrich_batch)
+    monkeypatch.setattr(je_mod, "ENRICHMENT_ENABLED", False)
+
+    user_id = _seed_user(full_db)
+    _seed_profile(full_db, user_id)
+
+    db = JobDatabase(full_db)
+    await db.init_db()
+    try:
+        await _seed_catalog(db, n_relevant=2, n_junk=0)
+        await rescore_mod.backfill_feed_from_catalog(user_id, db)
+    finally:
+        await db.close()
+
+    assert called["n"] == 0, "E2 off must mean zero enrichment calls"

--- a/backend/tests/test_candidate_selection.py
+++ b/backend/tests/test_candidate_selection.py
@@ -1,0 +1,381 @@
+"""The User-Level candidate layer (funnel Stage-1, 2026-08-05).
+
+WHY THIS EXISTS. The shared `jobs` catalog flowed almost entirely into every
+user's feed (measured in prod: one user's feed held 85% of the whole catalog —
+6,207 of 7,309 rows, floor MIN_STORE_SCORE=1). The feed was the warehouse with
+per-user price tags, not a personal shelf. Every downstream stage drowned:
+enrichment budgeted 20 jobs, the LLM judge saw 30, the dashboard cut top-100
+of a noisy ranking.
+
+The fix: `user_feed` becomes a BOUNDED candidate set — only the user's top
+FEED_CANDIDATE_CAP jobs by score enter it; rows that fall out of the selection
+are marked stale (evicted), and re-selected rows come back. Industry-standard
+shape (Twitter materializes ~800-1000 candidates per user; Indeed batch-stores
+recommendations).
+
+Invariants pinned here:
+  * backfill caps the feed to FEED_CANDIDATE_CAP best-scoring jobs
+  * eviction: an active row outside the selection goes stale
+  * re-selection: a stale row that re-qualifies returns to active
+  * LLM-judged rows are NEVER evicted (paid verdicts are not thrown away)
+  * FEED_CANDIDATE_CAP=0 keeps the legacy uncapped behaviour byte-identical
+  * rescore_user_feed applies the same selection on profile change
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import uuid
+from dataclasses import asdict
+from datetime import datetime, timezone
+
+import pytest
+
+from src.models import Job
+from src.repositories import pgsync
+from src.repositories.database import JobDatabase
+
+_NOW = datetime.now(timezone.utc).isoformat()
+
+
+# ── fixtures (mirrors test_rescore.py's full_db pattern) ─────────────────────
+
+
+def _bootstrap_full_db(db_path: str) -> None:
+    from migrations import runner
+
+    async def _run():
+        database = JobDatabase(db_path)
+        await database.init_db()
+        await database.close()
+        await runner.up(db_path)
+
+    asyncio.run(_run())
+
+
+def _seed_user(db_path: str) -> str:
+    user_id = str(uuid.uuid4())
+    with pgsync.connect(db_path) as conn:
+        conn.execute(
+            "INSERT INTO users(id, email, password_hash) VALUES (?,?,?)",
+            (user_id, f"{user_id}@test.example", "hash"),
+        )
+    return user_id
+
+
+def _seed_profile(db_path: str, user_id: str) -> int:
+    from src.services.profile.models import CVData, UserPreferences
+
+    cv = CVData(
+        raw_text="Experienced Senior Python Engineer with ML skills.",
+        skills=["python", "machine learning", "pytorch"],
+        job_titles=["Senior Python Engineer", "ML Engineer"],
+    )
+    prefs = UserPreferences(
+        target_job_titles=["Senior Python Engineer"],
+        additional_skills=["python"],
+    )
+    cv_json = json.dumps(asdict(cv), default=str)
+    pref_json = json.dumps(asdict(prefs), default=str)
+    now = _NOW
+    with pgsync.connect(db_path) as conn:
+        conn.execute(
+            "INSERT INTO user_profiles(user_id, cv_data, preferences, updated_at) "
+            "VALUES (?,?,?,?) ON CONFLICT(user_id) DO UPDATE SET "
+            "cv_data=excluded.cv_data, preferences=excluded.preferences, "
+            "updated_at=excluded.updated_at",
+            (user_id, cv_json, pref_json, now),
+        )
+        cur = conn.execute(
+            "INSERT INTO user_profile_versions(user_id, created_at, source_action, cv_data, preferences) "
+            "VALUES (?,?,?,?,?)",
+            (user_id, now, "test_seed", cv_json, pref_json),
+        )
+        version_id = cur.lastrowid
+    return version_id
+
+
+@pytest.fixture
+def full_db(tmp_path):
+    db_path = str(tmp_path / "candidate_test.db")
+    _bootstrap_full_db(db_path)
+    return db_path
+
+
+def _mk_job(i: int, *, relevant: bool) -> Job:
+    """A catalog job. `relevant` ones score high for the seeded ML profile;
+    the rest are deliberately unmatchable junk."""
+    if relevant:
+        return Job(
+            title=f"ML Engineer {i}",
+            company=f"GoodCo{i}",
+            apply_url=f"https://example.com/good/{i}",
+            source="reed",
+            date_found=_NOW,
+            location="London, UK",
+            description="Python machine learning role with pytorch. " * (i + 1),
+        )
+    return Job(
+        title=f"Florist {i}",
+        company=f"FlowerCo{i}",
+        apply_url=f"https://example.com/junk/{i}",
+        source="reed",
+        date_found=_NOW,
+        location="Aberdeen",
+        description="Arranging flowers and tending the shop.",
+    )
+
+
+async def _seed_catalog(db: JobDatabase, n_relevant: int, n_junk: int) -> None:
+    for i in range(n_relevant):
+        await db.insert_job(_mk_job(i, relevant=True))
+    for i in range(n_junk):
+        await db.insert_job(_mk_job(i, relevant=False))
+
+
+def _feed_rows(db_path: str, user_id: str) -> list[tuple[int, str, int]]:
+    """[(job_id, status, score)] for the user, all statuses."""
+    with pgsync.connect(db_path) as conn:
+        cur = conn.execute(
+            "SELECT job_id, status, score FROM user_feed WHERE user_id = ? ORDER BY score DESC",
+            (user_id,),
+        )
+        return [(r[0], r[1], r[2]) for r in cur.fetchall()]
+
+
+# ── backfill: cap + selection ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_backfill_caps_feed_to_candidate_limit(full_db, monkeypatch):
+    """6 catalog jobs, cap 2 → only the 2 best-scoring become active feed rows."""
+    from pathlib import Path
+
+    import src.core.settings as settings_mod
+    import src.services.profile.storage as storage_mod
+
+    monkeypatch.setattr(storage_mod, "DB_PATH", Path(full_db), raising=True)
+    monkeypatch.setattr(settings_mod, "FEED_CANDIDATE_CAP", 2, raising=False)
+
+    user_id = _seed_user(full_db)
+    _seed_profile(full_db, user_id)
+
+    db = JobDatabase(full_db)
+    await db.init_db()
+    try:
+        await _seed_catalog(db, n_relevant=4, n_junk=2)
+        from src.services.rescore import backfill_feed_from_catalog
+
+        written = await backfill_feed_from_catalog(user_id, db)
+    finally:
+        await db.close()
+
+    rows = _feed_rows(full_db, user_id)
+    active = [r for r in rows if r[1] == "active"]
+    assert written == 2, "backfill must only write the capped selection"
+    assert len(active) == 2, f"expected 2 active candidates, got {len(active)}"
+    # The kept rows must be the BEST scorers, not arbitrary ones.
+    assert all(score > 10 for _, _, score in active), (
+        "the selection kept junk over relevant jobs"
+    )
+
+
+@pytest.mark.asyncio
+async def test_backfill_evicts_active_row_outside_selection(full_db, monkeypatch):
+    """A pre-existing active feed row for a junk job must go stale when the
+    selection no longer includes it — the feed is a shelf, not an archive."""
+    from pathlib import Path
+
+    import src.core.settings as settings_mod
+    import src.services.profile.storage as storage_mod
+
+    monkeypatch.setattr(storage_mod, "DB_PATH", Path(full_db), raising=True)
+    monkeypatch.setattr(settings_mod, "FEED_CANDIDATE_CAP", 2, raising=False)
+
+    user_id = _seed_user(full_db)
+    _seed_profile(full_db, user_id)
+
+    db = JobDatabase(full_db)
+    await db.init_db()
+    try:
+        await _seed_catalog(db, n_relevant=3, n_junk=1)
+        # Give the junk job a pre-existing ACTIVE feed row (legacy flood).
+        with pgsync.connect(full_db) as conn:
+            cur = conn.execute("SELECT id FROM jobs WHERE title LIKE 'Florist%'")
+            junk_id = cur.fetchone()[0]
+            conn.execute(
+                "INSERT INTO user_feed(user_id, job_id, score, bucket, status, created_at, updated_at) "
+                "VALUES (?,?,?,?,'active',?,?)",
+                (user_id, junk_id, 15, "older", _NOW, _NOW),
+            )
+
+        from src.services.rescore import backfill_feed_from_catalog
+
+        await backfill_feed_from_catalog(user_id, db)
+    finally:
+        await db.close()
+
+    rows = dict((jid, status) for jid, status, _ in _feed_rows(full_db, user_id))
+    assert rows[junk_id] == "stale", "the junk row was not evicted from the shelf"
+
+
+@pytest.mark.asyncio
+async def test_evicted_row_is_reactivated_when_reselected(full_db, monkeypatch):
+    """A stale row that re-enters the selection returns to active — eviction
+    is reversible, never destructive."""
+    from pathlib import Path
+
+    import src.core.settings as settings_mod
+    import src.services.profile.storage as storage_mod
+
+    monkeypatch.setattr(storage_mod, "DB_PATH", Path(full_db), raising=True)
+    monkeypatch.setattr(settings_mod, "FEED_CANDIDATE_CAP", 5, raising=False)
+
+    user_id = _seed_user(full_db)
+    _seed_profile(full_db, user_id)
+
+    db = JobDatabase(full_db)
+    await db.init_db()
+    try:
+        await _seed_catalog(db, n_relevant=2, n_junk=0)
+        # Mark a relevant job's feed row stale beforehand.
+        with pgsync.connect(full_db) as conn:
+            cur = conn.execute("SELECT id FROM jobs WHERE title LIKE 'ML Engineer%' LIMIT 1")
+            good_id = cur.fetchone()[0]
+            conn.execute(
+                "INSERT INTO user_feed(user_id, job_id, score, bucket, status, created_at, updated_at) "
+                "VALUES (?,?,?,?,'stale',?,?)",
+                (user_id, good_id, 40, "older", _NOW, _NOW),
+            )
+
+        from src.services.rescore import backfill_feed_from_catalog
+
+        await backfill_feed_from_catalog(user_id, db)
+    finally:
+        await db.close()
+
+    rows = dict((jid, status) for jid, status, _ in _feed_rows(full_db, user_id))
+    assert rows[good_id] == "active", "a re-selected stale row must reactivate"
+
+
+@pytest.mark.asyncio
+async def test_llm_judged_rows_are_never_evicted(full_db, monkeypatch):
+    """A row carrying a paid LLM verdict survives selection even when its
+    keyword score would drop it — we never throw away bought intelligence."""
+    from pathlib import Path
+
+    import src.core.settings as settings_mod
+    import src.services.profile.storage as storage_mod
+
+    monkeypatch.setattr(storage_mod, "DB_PATH", Path(full_db), raising=True)
+    monkeypatch.setattr(settings_mod, "FEED_CANDIDATE_CAP", 1, raising=False)
+
+    user_id = _seed_user(full_db)
+    _seed_profile(full_db, user_id)
+
+    db = JobDatabase(full_db)
+    await db.init_db()
+    try:
+        await _seed_catalog(db, n_relevant=2, n_junk=1)
+        with pgsync.connect(full_db) as conn:
+            cur = conn.execute("SELECT id FROM jobs WHERE title LIKE 'Florist%'")
+            junk_id = cur.fetchone()[0]
+            conn.execute(
+                "INSERT INTO user_feed(user_id, job_id, score, bucket, status, created_at, updated_at, "
+                "llm_fit_score, llm_verdict) VALUES (?,?,?,?,'active',?,?,85,'Strong fit')",
+                (user_id, junk_id, 12, "older", _NOW, _NOW),
+            )
+
+        from src.services.rescore import backfill_feed_from_catalog
+
+        await backfill_feed_from_catalog(user_id, db)
+    finally:
+        await db.close()
+
+    rows = dict((jid, status) for jid, status, _ in _feed_rows(full_db, user_id))
+    assert rows[junk_id] == "active", "a judged row was evicted — paid verdict lost"
+
+
+@pytest.mark.asyncio
+async def test_cap_zero_keeps_legacy_uncapped_behaviour(full_db, monkeypatch):
+    """FEED_CANDIDATE_CAP=0 is the off switch: every scoring job lands, nothing
+    is evicted — byte-identical to the pre-candidate-layer behaviour."""
+    from pathlib import Path
+
+    import src.core.settings as settings_mod
+    import src.services.profile.storage as storage_mod
+
+    monkeypatch.setattr(storage_mod, "DB_PATH", Path(full_db), raising=True)
+    monkeypatch.setattr(settings_mod, "FEED_CANDIDATE_CAP", 0, raising=False)
+
+    user_id = _seed_user(full_db)
+    _seed_profile(full_db, user_id)
+
+    db = JobDatabase(full_db)
+    await db.init_db()
+    try:
+        await _seed_catalog(db, n_relevant=4, n_junk=1)
+        with pgsync.connect(full_db) as conn:
+            cur = conn.execute("SELECT id FROM jobs WHERE title LIKE 'Florist%'")
+            junk_id = cur.fetchone()[0]
+            conn.execute(
+                "INSERT INTO user_feed(user_id, job_id, score, bucket, status, created_at, updated_at) "
+                "VALUES (?,?,?,?,'active',?,?)",
+                (user_id, junk_id, 15, "older", _NOW, _NOW),
+            )
+
+        from src.services.rescore import backfill_feed_from_catalog
+
+        written = await backfill_feed_from_catalog(user_id, db)
+    finally:
+        await db.close()
+
+    rows = dict((jid, status) for jid, status, _ in _feed_rows(full_db, user_id))
+    assert written >= 4, "cap=0 must write every scoring job (legacy)"
+    assert rows[junk_id] == "active", "cap=0 must not evict anything (legacy)"
+
+
+# ── rescore path applies the same selection ──────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_rescore_user_feed_caps_and_evicts(full_db, monkeypatch):
+    """Profile-change rescore enforces the same candidate bound + eviction."""
+    from pathlib import Path
+
+    import src.core.settings as settings_mod
+    import src.services.llm_matcher as matcher_mod
+    import src.services.profile.storage as storage_mod
+
+    monkeypatch.setattr(storage_mod, "DB_PATH", Path(full_db), raising=True)
+    monkeypatch.setattr(settings_mod, "FEED_CANDIDATE_CAP", 2, raising=False)
+    monkeypatch.setattr(matcher_mod, "MATCHER_ENABLED", False)
+
+    user_id = _seed_user(full_db)
+    _seed_profile(full_db, user_id)
+
+    db = JobDatabase(full_db)
+    await db.init_db()
+    try:
+        await _seed_catalog(db, n_relevant=4, n_junk=2)
+        with pgsync.connect(full_db) as conn:
+            cur = conn.execute("SELECT id FROM jobs WHERE title LIKE 'Florist%' LIMIT 1")
+            junk_id = cur.fetchone()[0]
+            conn.execute(
+                "INSERT INTO user_feed(user_id, job_id, score, bucket, status, created_at, updated_at) "
+                "VALUES (?,?,?,?,'active',?,?)",
+                (user_id, junk_id, 15, "older", _NOW, _NOW),
+            )
+    finally:
+        await db.close()
+
+    from src.services.rescore import rescore_user_feed
+
+    result = await rescore_user_feed(user_id, db_path=full_db)
+    assert result["rescored"] == 2, "rescore must only write the capped selection"
+
+    rows = _feed_rows(full_db, user_id)
+    active = [r for r in rows if r[1] == "active"]
+    by_id = dict((jid, status) for jid, status, _ in rows)
+    assert len(active) == 2
+    assert by_id[junk_id] == "stale", "rescore did not evict the out-of-selection row"

--- a/backend/tests/test_github_deps.py
+++ b/backend/tests/test_github_deps.py
@@ -216,8 +216,18 @@ def test_is_recent_accepts_now_injection():
 
 
 def _make_async_session():
-    """Return an AsyncMock that emulates ``aiohttp.ClientSession`` — ``close()`` is awaitable."""
-    return AsyncMock()
+    """Return an AsyncMock that emulates ``aiohttp.ClientSession`` — ``close()``
+    is awaitable, and ``.post`` (the GraphQL pinned-repos fetch) is a benign
+    async context manager returning a non-200 so ``_fetch_pinned`` no-ops
+    without leaving a dangling coroutine."""
+    sess = AsyncMock()
+    _resp = AsyncMock()
+    _resp.status = 404
+    _cm = MagicMock()
+    _cm.__aenter__ = AsyncMock(return_value=_resp)
+    _cm.__aexit__ = AsyncMock(return_value=None)
+    sess.post = MagicMock(return_value=_cm)
+    return sess
 
 
 # ── github_enricher — username normalisation (URL / @handle / bare) ─

--- a/backend/tests/test_github_full_coverage.py
+++ b/backend/tests/test_github_full_coverage.py
@@ -1,0 +1,317 @@
+"""'Read 100% of GitHub' (2026-08-05) — the enricher now reads every high-signal
+corner of a public profile, not just languages/topics/deps.
+
+WHY THIS EXISTS. Matches from GitHub were only okay because we read the *labels*
+(languages, topics) but never the *prose* (READMEs, bio). A repo `description`
+is usually null; the README is where "I build human-in-the-loop AI agents with
+LangGraph" actually lives. These tests pin the new corners so a refactor can't
+silently drop them again:
+
+  * the /users/{u} identity block (bio/name/company/location) → github_bio
+  * each repo's README excerpt → repos_brief[i]['readme_excerpt']
+  * the {u}/{u} profile README → github_profile_readme
+  * pinned repos reorder the probe so curated work is read first (authed only)
+  * all of the above flow into the LLM pass's prompt (rule #28: prose → LLM)
+
+Every network call is mocked (rule #4 — the suite runs offline).
+"""
+
+from __future__ import annotations
+
+import base64
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from src.services.profile import github_enricher
+from src.services.profile.models import CVData
+
+
+def _b64_readme(text: str) -> dict:
+    """A GitHub /readme payload: base64-encoded content."""
+    return {"content": base64.b64encode(text.encode()).decode(), "encoding": "base64"}
+
+
+def _make_async_session():
+    """AsyncMock standing in for aiohttp.ClientSession (close() awaitable)."""
+    return AsyncMock()
+
+
+# ── The identity block (/users/{u}) ─────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_fetch_reads_user_bio_and_identity(monkeypatch):
+    """The developer's own words about themselves — never read before."""
+    monkeypatch.setattr(github_enricher, "GITHUB_TOKEN", "")
+    repos = [{"name": "proj", "language": "Python", "description": "", "fork": False,
+              "stargazers_count": 0, "topics": [], "pushed_at": None}]
+
+    async def fake_get_json(session, url):
+        if url.endswith("repos?per_page=30&sort=pushed"):
+            return repos
+        if url.endswith("/users/octocat"):
+            return {"name": "Octo Cat", "bio": "ML engineer building fraud detection",
+                    "company": "Acme", "location": "London", "hireable": True,
+                    "blog": "octo.dev", "twitter_username": "octo"}
+        if "/languages" in url:
+            return {"Python": 1}
+        return None
+
+    with patch.object(github_enricher, "_get_json", side_effect=fake_get_json), \
+         patch.object(github_enricher, "_fetch_repo_frameworks", new=AsyncMock(return_value=[])), \
+         patch.object(github_enricher.aiohttp, "ClientSession", return_value=_make_async_session()):
+        result = await github_enricher.fetch_github_profile("octocat")
+
+    bio = result["bio"]
+    assert "ML engineer building fraud detection" in bio
+    assert "Octo Cat" in bio and "Acme" in bio and "London" in bio
+    assert "Open to work: yes" in bio  # hireable=True surfaced
+
+
+# ── Repo READMEs — the richest per-repo prose ───────────────────────
+
+
+@pytest.mark.asyncio
+async def test_fetch_attaches_repo_readme_excerpt(monkeypatch):
+    """A repo with a null description but a rich README must still carry that
+    README into the brief — that is the whole point of reading READMEs."""
+    monkeypatch.setattr(github_enricher, "GITHUB_TOKEN", "")
+    repos = [{"name": "agent", "language": "Python", "description": None, "fork": False,
+              "stargazers_count": 0, "topics": [], "pushed_at": None}]
+
+    async def fake_get_json(session, url):
+        if url.endswith("repos?per_page=30&sort=pushed"):
+            return repos
+        if url.endswith("/repos/octocat/agent/readme"):
+            return _b64_readme("A human-in-the-loop agent built with LangGraph and n8n.")
+        if "/languages" in url:
+            return {"Python": 1}
+        return None
+
+    with patch.object(github_enricher, "_get_json", side_effect=fake_get_json), \
+         patch.object(github_enricher, "_fetch_repo_frameworks", new=AsyncMock(return_value=[])), \
+         patch.object(github_enricher.aiohttp, "ClientSession", return_value=_make_async_session()):
+        result = await github_enricher.fetch_github_profile("octocat")
+
+    brief = next(b for b in result["repos_brief"] if b["name"] == "agent")
+    assert "LangGraph" in brief["readme_excerpt"]
+    assert "human-in-the-loop" in brief["readme_excerpt"].lower()
+
+
+@pytest.mark.asyncio
+async def test_readme_excerpt_is_truncated(monkeypatch):
+    """A giant README is truncated so it can't blow the LLM prompt budget."""
+    monkeypatch.setattr(github_enricher, "GITHUB_TOKEN", "")
+    monkeypatch.setattr(github_enricher, "README_EXCERPT_CHARS", 50)
+    repos = [{"name": "big", "language": "Go", "description": "", "fork": False,
+              "stargazers_count": 0, "topics": [], "pushed_at": None}]
+
+    async def fake_get_json(session, url):
+        if url.endswith("repos?per_page=30&sort=pushed"):
+            return repos
+        if url.endswith("/repos/octocat/big/readme"):
+            return _b64_readme("X" * 5000)
+        if "/languages" in url:
+            return {"Go": 1}
+        return None
+
+    with patch.object(github_enricher, "_get_json", side_effect=fake_get_json), \
+         patch.object(github_enricher, "_fetch_repo_frameworks", new=AsyncMock(return_value=[])), \
+         patch.object(github_enricher.aiohttp, "ClientSession", return_value=_make_async_session()):
+        result = await github_enricher.fetch_github_profile("octocat")
+
+    brief = next(b for b in result["repos_brief"] if b["name"] == "big")
+    assert len(brief["readme_excerpt"]) == 50
+
+
+# ── The profile README ({u}/{u} special repo) ───────────────────────
+
+
+@pytest.mark.asyncio
+async def test_fetch_reads_profile_readme(monkeypatch):
+    """The {u}/{u} special-repo README is the self-authored portfolio page."""
+    monkeypatch.setattr(github_enricher, "GITHUB_TOKEN", "")
+    repos = [{"name": "octocat", "language": "Markdown", "description": "", "fork": False,
+              "stargazers_count": 0, "topics": [], "pushed_at": None}]
+
+    async def fake_get_json(session, url):
+        if url.endswith("repos?per_page=30&sort=pushed"):
+            return repos
+        if url.endswith("/repos/octocat/octocat/readme"):
+            return _b64_readme("I'm a data scientist specialising in NLP and RAG systems.")
+        if "/languages" in url:
+            return {"Markdown": 1}
+        return None
+
+    with patch.object(github_enricher, "_get_json", side_effect=fake_get_json), \
+         patch.object(github_enricher, "_fetch_repo_frameworks", new=AsyncMock(return_value=[])), \
+         patch.object(github_enricher.aiohttp, "ClientSession", return_value=_make_async_session()):
+        result = await github_enricher.fetch_github_profile("octocat")
+
+    assert "RAG systems" in result["profile_readme"]
+
+
+@pytest.mark.asyncio
+async def test_missing_readme_is_not_an_error(monkeypatch):
+    """Most repos have no README (404 → None). That must degrade to no excerpt,
+    never crash, and never fabricate content."""
+    monkeypatch.setattr(github_enricher, "GITHUB_TOKEN", "")
+    repos = [{"name": "empty", "language": "C", "description": "a thing", "fork": False,
+              "stargazers_count": 0, "topics": [], "pushed_at": None}]
+
+    async def fake_get_json(session, url):
+        if url.endswith("repos?per_page=30&sort=pushed"):
+            return repos
+        if "/languages" in url:
+            return {"C": 1}
+        return None  # every readme + user lookup 404s → None
+
+    with patch.object(github_enricher, "_get_json", side_effect=fake_get_json), \
+         patch.object(github_enricher, "_fetch_repo_frameworks", new=AsyncMock(return_value=[])), \
+         patch.object(github_enricher.aiohttp, "ClientSession", return_value=_make_async_session()):
+        result = await github_enricher.fetch_github_profile("octocat")
+
+    brief = next(b for b in result["repos_brief"] if b["name"] == "empty")
+    assert "readme_excerpt" not in brief
+    assert result["profile_readme"] == ""
+    assert result["bio"] == ""
+
+
+# ── Pinned repos reorder the probe (authed only) ────────────────────
+
+
+@pytest.mark.asyncio
+async def test_pinned_repos_are_read_first(monkeypatch):
+    """A user's PINNED repo is their curated highlight. Within the capped probe
+    it must be read before the long tail — so its README lands even when the
+    README cap is small."""
+    monkeypatch.setattr(github_enricher, "GITHUB_TOKEN", "tok")
+    monkeypatch.setattr(github_enricher, "README_REPOS_AUTHED", 1)  # only 1 README read
+    # 'showcase' is pushed OLDEST so it sorts last by default — pinning must
+    # override that and pull it to the front.
+    repos = [
+        {"name": "noise", "language": "Python", "description": "x", "fork": False,
+         "stargazers_count": 0, "topics": [], "pushed_at": "2026-01-01T00:00:00Z"},
+        {"name": "showcase", "language": "Python", "description": "x", "fork": False,
+         "stargazers_count": 0, "topics": [], "pushed_at": "2000-01-01T00:00:00Z"},
+    ]
+
+    async def fake_get_json(session, url):
+        if url.endswith("repos?per_page=30&sort=pushed"):
+            return repos
+        if url.endswith("/repos/octocat/showcase/readme"):
+            return _b64_readme("Kubernetes operator written in Go.")
+        if url.endswith("/repos/octocat/noise/readme"):
+            return _b64_readme("should not be read — cap is 1 and this isn't pinned")
+        if "/languages" in url:
+            return {"Python": 1}
+        return None
+
+    async def fake_pinned(session, username):
+        return ["showcase"]
+
+    with patch.object(github_enricher, "_get_json", side_effect=fake_get_json), \
+         patch.object(github_enricher, "_fetch_pinned", side_effect=fake_pinned), \
+         patch.object(github_enricher, "_fetch_repo_frameworks", new=AsyncMock(return_value=[])), \
+         patch.object(github_enricher.aiohttp, "ClientSession", return_value=_make_async_session()):
+        result = await github_enricher.fetch_github_profile("octocat")
+
+    showcase = next(b for b in result["repos_brief"] if b["name"] == "showcase")
+    assert "Kubernetes" in showcase["readme_excerpt"], "pinned repo's README was not read first"
+    noise = next(b for b in result["repos_brief"] if b["name"] == "noise")
+    assert "readme_excerpt" not in noise, "README cap leaked past the pinned repo"
+
+
+@pytest.mark.asyncio
+async def test_pinned_is_noop_when_unauthenticated(monkeypatch):
+    """No token → no GraphQL → _fetch_pinned returns [] and never posts."""
+    monkeypatch.setattr(github_enricher, "GITHUB_TOKEN", "")
+    session = AsyncMock()
+    out = await github_enricher._fetch_pinned(session, "octocat")
+    assert out == []
+    session.post.assert_not_called()
+
+
+# ── The LLM pass reads the new prose ────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_llm_pass_prompt_includes_bio_readme_and_excerpts():
+    """The self-description + README excerpts must reach the model. Capture the
+    prompt and assert the prose is in it."""
+    captured = {}
+
+    async def fake_extract(prompt, system=None):
+        captured["prompt"] = prompt
+        return {"skills": ["RAG"]}
+
+    briefs = [{"name": "agent", "language": "Python", "description": "",
+               "topics": [], "readme_excerpt": "Built with LangGraph for RAG."}]
+
+    with patch("src.services.profile.llm_provider.llm_extract", side_effect=fake_extract):
+        out = await github_enricher.llm_infer_github_skills(
+            briefs, bio="Bio: NLP engineer", profile_readme="I love Cloudflare Workers.")
+
+    p = captured["prompt"]
+    assert "NLP engineer" in p            # bio
+    assert "Cloudflare Workers" in p      # profile readme
+    assert "LangGraph" in p               # repo readme excerpt
+    assert out == ["RAG"]
+
+
+@pytest.mark.asyncio
+async def test_llm_pass_runs_on_self_description_alone():
+    """Even with zero repos, a bio/profile README is reason enough to call the
+    LLM — a user can have a rich profile README and few public repos."""
+    called = {"n": 0}
+
+    async def fake_extract(prompt, system=None):
+        called["n"] += 1
+        return {"skills": ["Computer Vision"]}
+
+    with patch("src.services.profile.llm_provider.llm_extract", side_effect=fake_extract):
+        out = await github_enricher.llm_infer_github_skills(
+            [], bio="", profile_readme="Portfolio: I ship computer-vision models.")
+
+    assert called["n"] == 1, "a self-description alone should still call the LLM"
+    assert out == ["Computer Vision"]
+
+
+@pytest.mark.asyncio
+async def test_llm_pass_empty_when_nothing_to_read():
+    """No repos, no bio, no README → no LLM call at all (cost guard)."""
+    called = {"n": 0}
+
+    async def fake_extract(prompt, system=None):
+        called["n"] += 1
+        return {"skills": []}
+
+    with patch("src.services.profile.llm_provider.llm_extract", side_effect=fake_extract):
+        out = await github_enricher.llm_infer_github_skills([], bio="", profile_readme="")
+
+    assert called["n"] == 0
+    assert out == []
+
+
+# ── enrich_cv_from_github stores the new prose ──────────────────────
+
+
+def test_enrich_stores_bio_and_profile_readme():
+    cv = CVData()
+    cv = github_enricher.enrich_cv_from_github(cv, {
+        "bio": "Name: Jane | Bio: SRE",
+        "profile_readme": "I run Kubernetes at scale.",
+        "repos_brief": [{"name": "r", "language": "Go"}],
+    })
+    assert cv.github_bio == "Name: Jane | Bio: SRE"
+    assert cv.github_profile_readme == "I run Kubernetes at scale."
+
+
+def test_enrich_does_not_wipe_prose_on_empty_reenrich():
+    """A rate-limited partial re-enrich (empty bio/readme) must not erase the
+    prose we already have — same guard as repos_brief."""
+    cv = CVData(github_bio="keep me", github_profile_readme="keep me too")
+    cv = github_enricher.enrich_cv_from_github(cv, {"bio": "", "profile_readme": ""})
+    assert cv.github_bio == "keep me"
+    assert cv.github_profile_readme == "keep me too"

--- a/backend/tests/test_linkedin_github.py
+++ b/backend/tests/test_linkedin_github.py
@@ -620,6 +620,7 @@ class TestFetchGitHubProfile:
 
         session = AsyncMock()
         session.get = MagicMock(side_effect=lambda url, **kw: _async_context(mock_get(url, **kw)))
+        session.post = MagicMock(side_effect=lambda *a, **kw: _async_context(_pinned_404()))
 
         result = await fetch_github_profile("testuser", session=session)
         assert len(result["repositories"]) == 2
@@ -645,6 +646,7 @@ class TestFetchGitHubProfile:
 
         session = AsyncMock()
         session.get = MagicMock(side_effect=lambda url, **kw: _async_context(mock_get(url, **kw)))
+        session.post = MagicMock(side_effect=lambda *a, **kw: _async_context(_pinned_404()))
 
         result = await fetch_github_profile("testuser", session=session)
         assert len(result["repositories"]) == 1
@@ -659,6 +661,7 @@ class TestFetchGitHubProfile:
 
         session = AsyncMock()
         session.get = MagicMock(side_effect=lambda url, **kw: _async_context(mock_get(url, **kw)))
+        session.post = MagicMock(side_effect=lambda *a, **kw: _async_context(_pinned_404()))
 
         result = await fetch_github_profile("nonexistent", session=session)
         assert result["repositories"] == []
@@ -673,6 +676,7 @@ class TestFetchGitHubProfile:
 
         session = AsyncMock()
         session.get = MagicMock(side_effect=lambda url, **kw: _async_context(mock_get(url, **kw)))
+        session.post = MagicMock(side_effect=lambda *a, **kw: _async_context(_pinned_404()))
 
         result = await fetch_github_profile("testuser", session=session)
         assert result["repositories"] == []
@@ -815,6 +819,7 @@ class TestGitHubErrors:
             raise asyncio.TimeoutError("Timed out")
         session = AsyncMock()
         session.get = MagicMock(side_effect=lambda url, **kw: _async_context(mock_get(url, **kw)))
+        session.post = MagicMock(side_effect=lambda *a, **kw: _async_context(_pinned_404()))
         result = await fetch_github_profile("testuser", session=session)
         assert result["repositories"] == []
         assert result["skills_inferred"] == []
@@ -841,6 +846,7 @@ class TestGitHubErrors:
 
         session = AsyncMock()
         session.get = MagicMock(side_effect=lambda url, **kw: _async_context(mock_get(url, **kw)))
+        session.post = MagicMock(side_effect=lambda *a, **kw: _async_context(_pinned_404()))
         result = await fetch_github_profile("testuser", session=session)
         assert len(result["repositories"]) == 2
         assert "Python" in result["skills_inferred"]
@@ -914,3 +920,11 @@ class _async_context:
 
     async def __aexit__(self, *args):
         pass
+
+
+async def _pinned_404():
+    """A 404 response for the GraphQL pinned-repos POST, so ``_fetch_pinned``
+    no-ops cleanly on the mock session (no dangling coroutine warning)."""
+    resp = AsyncMock()
+    resp.status = 404
+    return resp

--- a/backend/tests/test_llm_input_cache.py
+++ b/backend/tests/test_llm_input_cache.py
@@ -55,7 +55,11 @@ def _run(profile: UserProfile, counter: _Counter, *, cv_fails: bool = False) -> 
 
     async def fake_li(text, *a, **kw):
         counter.linkedin += 1
-        return {}
+        # A REAL successful LinkedIn pass returns usable data. Returning {} here
+        # modelled "the call succeeded but produced nothing", which the
+        # soft-failure-cache fix now (correctly) refuses to cache — so the stub
+        # must produce data or the cache legitimately keeps retrying it.
+        return {"skills": ["Triage"], "positions": [{"title": "Nurse", "company": "NHS"}]}
 
     async def fake_gh(brief, *a, **kw):
         counter.github += 1
@@ -177,3 +181,48 @@ def test_reordered_github_data_is_not_mistaken_for_a_change():
     x = tp._input_hash([{"name": "a", "lang": "Py"}])
     y = tp._input_hash([{"lang": "Py", "name": "a"}])
     assert x == y, "dict key order must not read as a content change"
+
+
+def test_a_soft_empty_pass_is_not_frozen_by_the_cache():
+    """THE ROHITH BUG, found by the journey simulation 2026-08-05.
+
+    A rate-limited free-tier provider can return a valid but EMPTY result
+    (`{"positions": [], "skills": []}`) without raising. The cache used to
+    record that as a success and skip re-extraction forever — so a profile
+    that momentarily failed extraction was frozen with zero LinkedIn data,
+    while the LLM extracted 7 positions fine when retried in isolation.
+
+    An empty result from a non-empty input must NOT be cached: it is exactly
+    the case you most want to retry.
+    """
+    calls = {"n": 0}
+
+    async def li_empty_then_full(text, *a, **kw):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return {}  # soft failure: valid response, no data
+        return {"skills": ["Triage"], "positions": [{"title": "Nurse", "company": "NHS"}]}
+
+    async def _noop(*a, **kw):
+        return CVData()
+
+    async def _noop_list(*a, **kw):
+        return []
+
+    async def _pass(items, *a, **kw):
+        return items
+
+    p = _profile(linkedin_raw_text="Top Skills\nTriage\n")
+    with patch.object(tp, "llm_cv_fields_from_text", _noop), \
+         patch.object(tp, "llm_linkedin_fields", li_empty_then_full), \
+         patch.object(tp, "llm_infer_github_skills", _noop_list), \
+         patch.object(tp, "llm_infer_from_about_me", _noop_list), \
+         patch.object(llm_curate, "llm_suggest_adjacent_skills", _noop_list), \
+         patch.object(llm_curate, "llm_merge_duplicates", _pass):
+        asyncio.run(tp.run_two_pass_extraction(p))
+        assert "linkedin" not in p.cv_data.llm_input_hashes, \
+            "an empty LinkedIn pass was cached — it will now be frozen forever"
+        asyncio.run(tp.run_two_pass_extraction(p))
+
+    assert calls["n"] == 2, "the empty pass was not retried — it was frozen"
+    assert p.cv_data.linkedin_positions, "the retry's positions never landed"

--- a/backend/tests/test_llm_input_cache.py
+++ b/backend/tests/test_llm_input_cache.py
@@ -131,7 +131,10 @@ def test_a_failed_pass_is_retried_not_cached():
     assert "cv" not in p.cv_data.llm_input_hashes, "a failure was cached"
 
     _run(p, c)
-    assert c.cv == 2, "a failed CV pass was never retried"
+    # 3 = run-1 initial (fail) + run-1 sequential in-run retry (fail) + run-2
+    # (succeeds). The in-run retry adds the middle call; the point stands: a
+    # failure is not cached, it is retried, and the eventual success lands.
+    assert c.cv == 3, "a failed CV pass was never retried across runs"
     assert "Epic" in p.cv_data.skills, "the retry's result never landed"
 
 
@@ -220,9 +223,12 @@ def test_a_soft_empty_pass_is_not_frozen_by_the_cache():
          patch.object(llm_curate, "llm_suggest_adjacent_skills", _noop_list), \
          patch.object(llm_curate, "llm_merge_duplicates", _pass):
         asyncio.run(tp.run_two_pass_extraction(p))
-        assert "linkedin" not in p.cv_data.llm_input_hashes, \
-            "an empty LinkedIn pass was cached — it will now be frozen forever"
-        asyncio.run(tp.run_two_pass_extraction(p))
 
-    assert calls["n"] == 2, "the empty pass was not retried — it was frozen"
+    # The concurrent pass returned {} first; the SEQUENTIAL in-run retry then
+    # recovered the real data. So the profile has its positions after ONE
+    # upload, and the now-non-empty result is correctly cached. This is strictly
+    # better than the old "don't cache, hope a later upload retries" behaviour.
+    assert calls["n"] == 2, "the empty pass was not retried in-run"
     assert p.cv_data.linkedin_positions, "the retry's positions never landed"
+    assert "linkedin" in p.cv_data.llm_input_hashes, \
+        "a recovered, non-empty pass should be cached"

--- a/backend/tests/test_profile.py
+++ b/backend/tests/test_profile.py
@@ -708,3 +708,86 @@ def test_has_linkedin_true_from_positions_even_without_skills():
     )
     resp = _build_profile_response(profile)
     assert resp.summary.has_linkedin is True
+
+
+# ═══ Dead-title-lever fix (P0-3, funnel redesign 2026-08-05) ══════════════════
+# core_domain_words used to be built ONLY from title tokens, so a user with two
+# hyper-specific CV titles got a 4-word vocabulary polluted by junk tokens
+# ('department', 'solutions' from "AI Solutions Engineer – R&D Department").
+# Measured on real prod data: the 40-pt title lever never scored above 8 for
+# ANY job, capping all scores at ~69 and making location the de-facto sort key.
+# The fix is evidence-based: a title token joins core only with corroboration
+# (>=2 titles, the skill pool, or an acronym); high-frequency skill tokens join
+# core so "Machine Learning Engineer" matches a deep-learning profile.
+
+
+class TestCoreDomainWordEvidence:
+    def _profile(self, titles, skills=None):
+        from src.services.profile.models import CVData, UserPreferences, UserProfile
+        return UserProfile(
+            cv_data=CVData(job_titles=titles, skills=skills or []),
+            preferences=UserPreferences(),
+        )
+
+    def test_junk_single_title_tokens_are_dropped(self):
+        """'department'/'solutions' appear in ONE title and no skill — they are
+        noise from a CV job-title string, not the user's domain."""
+        profile = self._profile(
+            titles=["AI Solutions Engineer - R&D Department", "AI/ML Engineer Intern"],
+            skills=["Deep Learning", "Generative AI"],
+        )
+        cfg = generate_search_config(profile)
+        assert "department" not in cfg.core_domain_words
+        assert "solutions" not in cfg.core_domain_words
+
+    def test_cross_title_and_acronym_tokens_survive(self):
+        """'ai' appears in both titles (corroborated); 'ml' is a short acronym
+        token — both are real domain signal and must stay."""
+        profile = self._profile(
+            titles=["AI Solutions Engineer - R&D Department", "AI/ML Engineer Intern"],
+            skills=["Deep Learning"],
+        )
+        cfg = generate_search_config(profile)
+        assert "ai" in cfg.core_domain_words
+        assert "ml" in cfg.core_domain_words
+
+    def test_frequent_skill_tokens_join_core(self):
+        """Tokens appearing across >=2 skills describe the user's domain even
+        when absent from titles — this is what lets 'Machine Learning Engineer'
+        postings match a profile whose titles never contain 'learning'."""
+        profile = self._profile(
+            titles=["AI Engineer"],
+            skills=["Deep Learning", "Supervised Learning", "Machine Learning Ops"],
+        )
+        cfg = generate_search_config(profile)
+        assert "learning" in cfg.core_domain_words
+
+    def test_single_title_no_skills_falls_back_to_all_tokens(self):
+        """A thin profile (one title, no skills) must not end up with an EMPTY
+        core vocabulary — fall back to the old all-title-tokens behaviour."""
+        profile = self._profile(titles=["Underwriting Portfolio Manager"])
+        cfg = generate_search_config(profile)
+        assert "underwriting" in cfg.core_domain_words
+        assert "portfolio" in cfg.core_domain_words
+
+    def test_role_words_still_go_to_supporting(self):
+        profile = self._profile(titles=["AI Engineer", "ML Engineer"])
+        cfg = generate_search_config(profile)
+        assert "engineer" in cfg.supporting_role_words
+        assert "engineer" not in cfg.core_domain_words
+
+    def test_near_duplicate_titles_count_as_one_evidence(self):
+        """The same title with a hyphen vs em-dash (or arriving from both CV and
+        LinkedIn) must not fake cross-title corroboration for its junk tokens."""
+        profile = self._profile(
+            titles=[
+                "AI Solutions Engineer - R&D Department",
+                "AI Solutions Engineer – R&D Department",  # em-dash variant
+                "AI/ML Engineer Intern",
+            ],
+            skills=["Deep Learning"],
+        )
+        cfg = generate_search_config(profile)
+        assert "department" not in cfg.core_domain_words
+        assert "solutions" not in cfg.core_domain_words
+        assert "ai" in cfg.core_domain_words

--- a/backend/tests/test_scorer.py
+++ b/backend/tests/test_scorer.py
@@ -6,6 +6,7 @@ from src.models import Job
 from src.services.profile.models import SearchConfig
 from src.services.skill_matcher import (
     RECENCY_WEIGHT,
+    TITLE_WEIGHT,
     JobScorer,
     ScoreBreakdown,
     _foreign_location_penalty,
@@ -1097,3 +1098,52 @@ class TestScoreBreakdown:
         breakdown = scorer.score(job)
         assert isinstance(breakdown, ScoreBreakdown)
         assert breakdown.match_score == 10  # floor
+
+
+# ═══ Dead-title-lever fix (P0-3, funnel redesign 2026-08-05) ══════════════════
+# Real postings almost never equal or contain a user's CV-derived title string
+# ("AI Solutions Engineer - R&D Department"), so exact/substring matching never
+# fired and the partial fallback capped at 20 — measured on prod: no job ever
+# scored above 8/40 on title. The fix: a job title showing BOTH a core domain
+# word AND a role word ("AI Engineer", "Machine Learning Engineer") is a strong
+# role match worth 30/40, +3 per extra core word, capped at TITLE_WEIGHT.
+
+
+class TestDomainRoleTitleBand:
+    def _scorer(self, core, support):
+        cfg = SearchConfig(
+            job_titles=["AI Solutions Engineer - R&D Department"],
+            primary_skills=["python"],
+            secondary_skills=[],
+            tertiary_skills=[],
+            locations=["London"],
+            core_domain_words=set(core),
+            supporting_role_words=set(support),
+        )
+        return JobScorer(cfg)
+
+    def test_domain_plus_role_scores_strong(self):
+        s = self._scorer({"ai", "ml", "learning"}, {"engineer"})
+        assert s._title_score("AI Engineer (UK)") >= 30
+
+    def test_ml_engineer_matches_via_skill_derived_core(self):
+        s = self._scorer({"ai", "ml", "learning"}, {"engineer"})
+        assert s._title_score("Machine Learning Engineer") >= 30
+
+    def test_role_without_domain_scores_zero(self):
+        """'Safety Engineer' has the role word but no domain word — a generic
+        role title must NOT ride the strong band."""
+        s = self._scorer({"ai", "ml"}, {"engineer"})
+        assert s._title_score("Safety Engineer") == 0
+
+    def test_domain_without_role_stays_in_partial_band(self):
+        s = self._scorer({"ai"}, {"engineer"})
+        assert 0 < s._title_score("Generative AI Newsletter") <= TITLE_WEIGHT // 2
+
+    def test_strong_band_capped_at_title_weight(self):
+        s = self._scorer({"ai", "ml", "learning", "data", "language"}, {"engineer"})
+        assert s._title_score("AI ML Learning Data Language Engineer") <= TITLE_WEIGHT
+
+    def test_exact_match_still_wins_everything(self):
+        s = self._scorer({"ai"}, {"engineer"})
+        assert s._title_score("AI Solutions Engineer - R&D Department") == TITLE_WEIGHT

--- a/backend/tests/test_source_health.py
+++ b/backend/tests/test_source_health.py
@@ -263,3 +263,30 @@ def test_source_health_results_ordered_by_priority(client, temp_db):
     # Alpha within tier: greenhouse < reed
     ok_names = [s["source"] for s in body["sources"] if s["health"] == "ok"]
     assert ok_names == ["greenhouse", "reed"]
+
+
+def test_per_source_duration_is_stored_in_seconds_not_milliseconds():
+    """A source's fetch duration must be recorded in SECONDS, consistent with
+    total_duration and the un-suffixed field name.
+
+    Found by the deep journey walk 2026-08-05: it was stored in milliseconds, so
+    the source-health endpoint reported workday=212391s (59 hours) for a search
+    that finishes in ~5 minutes. 212391 ms is 212 s — the real figure. Verified
+    corrupt in production too. This pins the unit so a source that ran for a
+    plausible time never round-trips as a nonsense duration again.
+    """
+    import re
+    from pathlib import Path
+
+    main_src = (Path(__file__).resolve().parents[1] / "src" / "main.py").read_text(encoding="utf-8")
+    # Grab the whole finally-block that computes and stores the duration, so the
+    # nanosecond→second division (on the line above the store) is in scope.
+    block = re.search(r"finally:(.*?)per_source_duration\[src\.name\] = [^\n]+", main_src, re.S)
+    assert block, "the per_source_duration write moved — re-point this test"
+    body = block.group(0)
+    # It must divide nanoseconds by 1e9 (seconds), NOT by 1e6 (milliseconds).
+    assert "1_000_000_000" in body or "1e9" in body, (
+        "per_source_duration is not converted to seconds — a millisecond value "
+        "read as seconds reports hours-long fake latency"
+    )
+    assert "// 1_000_000)" not in body, "still storing milliseconds"

--- a/backend/tests/test_sources.py
+++ b/backend/tests/test_sources.py
@@ -751,6 +751,83 @@ def test_smartrecruiters_parses_response():
     _run(_test())
 
 
+def test_smartrecruiters_fetches_posting_detail_text():
+    """Job-understanding fix (2026-08-05): the list endpoint has no posting
+    text (150 prod jobs, 100% empty descriptions); the public detail endpoint
+    carries the full jobAd sections (verified live: 6,445 chars). The detail
+    text must land in Job.description, tag-stripped."""
+    async def _test():
+        session = aiohttp.ClientSession()
+        try:
+            with aioresponses() as m:
+                m.get(
+                    re.compile(r"https://api\.smartrecruiters\.com/v1/companies/wise/postings\?.*"),
+                    payload={"content": [{
+                        "id": "sr-101", "name": "AI Research Scientist",
+                        "location": {"city": "London", "country": "GB"},
+                        "ref": "https://jobs.smartrecruiters.com/wise/sr-101",
+                        "releasedDate": "2024-01-15",
+                    }]},
+                )
+                m.get(
+                    "https://api.smartrecruiters.com/v1/companies/wise/postings/sr-101",
+                    payload={"jobAd": {"sections": {
+                        "jobDescription": {"text": "<p>Deep learning research with PyTorch.</p>"},
+                        "qualifications": {"text": "<ul><li>PhD in ML</li></ul>"},
+                    }}},
+                )
+                source = SmartRecruitersSource(session, companies=["wise"])
+                jobs = await source.fetch_jobs()
+                assert len(jobs) == 1
+                desc = jobs[0].description
+                assert "Deep learning research" in desc
+                assert "PhD in ML" in desc
+                assert "<" not in desc, "detail HTML must be tag-stripped"
+        finally:
+            await session.close()
+    _run(_test())
+
+
+def test_workday_fetches_job_description_from_detail():
+    """Same fix for Workday (537 prod jobs, 100% empty): the CXS detail
+    endpoint's jobPostingInfo.jobDescription (verified live: 12,746 chars)
+    must land in Job.description, tag-stripped."""
+    async def _test():
+        session = aiohttp.ClientSession()
+        try:
+            with aioresponses() as m:
+                m.post(
+                    re.compile(r"https://acme\.wd1\.myworkdayjobs\.com/wday/cxs/acme/ext/jobs"),
+                    payload={"jobPostings": [{
+                        "title": "ML Engineer",
+                        "locationsText": "London, United Kingdom",
+                        "externalPath": "/job/London/ML-Engineer_R123",
+                        "postedOn": "Posted Today",
+                    }]},
+                    repeat=True,
+                )
+                m.get(
+                    "https://acme.wd1.myworkdayjobs.com/wday/cxs/acme/ext/job/London/ML-Engineer_R123",
+                    payload={"jobPostingInfo": {
+                        "jobDescription": "<h2>About</h2><p>Build ML pipelines with Python and Spark.</p>",
+                    }},
+                    repeat=True,
+                )
+                source = WorkdaySource(
+                    session,
+                    companies=[{"tenant": "acme", "wd": "wd1", "site": "ext", "name": "Acme"}],
+                    search_config=_sc_ai_defaults(),
+                )
+                jobs = await source.fetch_jobs()
+                assert len(jobs) >= 1
+                desc = jobs[0].description
+                assert "Build ML pipelines" in desc
+                assert "<" not in desc, "detail HTML must be tag-stripped"
+        finally:
+            await session.close()
+    _run(_test())
+
+
 def test_pinpoint_parses_response():
     async def _test():
         session = aiohttp.ClientSession()

--- a/backend/tests/test_sources.py
+++ b/backend/tests/test_sources.py
@@ -474,6 +474,47 @@ def test_greenhouse_parses_response():
     _run(_test())
 
 
+def test_greenhouse_requests_content_and_unescapes_it():
+    """Job-understanding fix (2026-08-05): the board list endpoint returns NO
+    `content` field unless `?content=true` is sent — 996 prod jobs (100% of the
+    greenhouse slice) had empty descriptions because of it. And the content that
+    DOES come back is HTML-entity-escaped (`&lt;p&gt;`), so tag-stripping must
+    unescape first or the text keeps literal `&lt;h4&gt;` noise. Verified against
+    the live API 2026-08-05 (deepmind board: absent without the param, 5,359
+    chars with it, escaped)."""
+    async def _test():
+        session = aiohttp.ClientSession()
+        try:
+            captured: list[str] = []
+            with aioresponses() as m:
+                def _cb(url, **kwargs):
+                    captured.append(str(url))
+                    from aioresponses import CallbackResult
+                    return CallbackResult(payload={"jobs": [{
+                        "id": 7, "title": "Research Engineer",
+                        "location": {"name": "London, UK"},
+                        "absolute_url": "https://boards.greenhouse.io/x/jobs/7",
+                        # Entity-escaped HTML, exactly as the live API returns it.
+                        "content": "&lt;h4&gt;Snapshot&lt;/h4&gt;&lt;p&gt;Deep learning research role using PyTorch.&lt;/p&gt;",
+                    }]})
+                m.get(re.compile(r"https://boards-api\.greenhouse\.io/.*"), callback=_cb)
+                source = GreenhouseSource(session, companies=["deepmind"])
+                jobs = await source.fetch_jobs()
+
+            assert captured and "content=true" in captured[0], (
+                "the list request must ask for content, or every description is empty"
+            )
+            assert len(jobs) == 1
+            desc = jobs[0].description
+            assert "Deep learning research role" in desc
+            assert "&lt;" not in desc and "<" not in desc, (
+                "escaped HTML must be unescaped then stripped, not stored as noise"
+            )
+        finally:
+            await session.close()
+    _run(_test())
+
+
 def test_lever_parses_response():
     async def _test():
         session = aiohttp.ClientSession()
@@ -869,6 +910,14 @@ DEVITJOBS_PAYLOAD = [
         "expLevel": "Senior",
         "jobUrl": "https://devitjobs.uk/jobs/revolut-ml-engineer",
         "publishedAt": "2024-01-15",
+        # Structured fields the live jobsLight API provides (verified
+        # 2026-08-05) — folded into the composed description.
+        "technologies": ["Python", "PyTorch", "AWS"],
+        "filterTags": ["machine-learning", "mlops"],
+        "techCategory": "Data Science",
+        "jobType": "Full-time",
+        "remoteType": "Hybrid",
+        "companySize": "1000+",
     },
     {
         "name": "Marketing Manager",
@@ -941,6 +990,18 @@ def test_devitjobs_parses_response():
                 assert jobs[0].salary_min == 65000
                 assert jobs[0].salary_max == 95000
                 assert jobs[0].visa_flag is True
+                # Job-understanding fix (2026-08-05): jobsLight has no prose
+                # description, but it DOES publish the tech stack + structured
+                # attributes — 3,041 prod jobs (42% of the catalog) had EMPTY
+                # descriptions while the API was handing us `technologies` all
+                # along. The composed description makes them skill-matchable.
+                desc = jobs[0].description
+                assert "Python" in desc and "PyTorch" in desc, (
+                    "the technologies field must reach the description"
+                )
+                assert "machine learning" in desc or "machine-learning" in desc
+                assert "Hybrid" in desc
+                assert "Visa sponsorship" in desc
         finally:
             await session.close()
     _run(_test())

--- a/backend/tests/test_two_pass.py
+++ b/backend/tests/test_two_pass.py
@@ -622,7 +622,7 @@ class TestTwoPassOrchestrator:
                     "languages": [], "projects": [], "volunteer": [], "courses": [],
                     "skills": ["LangGraph", "Systems Design"]}
 
-        async def fake_gh(brief):
+        async def fake_gh(brief, *a, **kw):  # accepts bio=/profile_readme= kwargs
             return ["LangChain"]
 
         async def fake_about(text):

--- a/scripts/journey_probe.py
+++ b/scripts/journey_probe.py
@@ -137,7 +137,7 @@ class Journey:
 DEFAULT_BENCHMARK: dict[str, dict[str, Any]] = {
     # stage -> {min_<evidence key>: value, max_ms: value}
     "cv upload + extraction": {"min_skills": 15, "min_titles": 1, "max_ms": 120_000},
-    "linkedin enrich": {"min_gained": 1, "max_ms": 90_000},
+    "linkedin enrich": {"max_ms": 90_000},  # no min: a rich CV makes LinkedIn redundant
     "search": {"min_sources_returning": 8, "max_ms": 300_000},
     "feed written": {"min_feed_rows": 20, "max_ms": 30_000},
     "dashboard read": {"min_visible": 1, "max_ms": 15_000},
@@ -310,13 +310,22 @@ def main() -> int:
                 return
             after = (client.get("/api/profile").json() or {}).get("cv_detail") or {}
             a_sk, a_ro = len(after.get("skills") or []), len(after.get("job_titles") or [])
+            positions = len(after.get("linkedin_positions") or [])
+            li_only = len(after.get("linkedin_skills") or [])
             gained = (a_sk - b_sk) + (a_ro - b_ro)
             s.evidence.update(gained=gained, skills=a_sk, roles=a_ro,
-                              li_only_skills=len(after.get("linkedin_skills") or []))
-            s.ok = gained > 0
+                              li_only_skills=li_only, li_positions=positions)
+            # The file did SOMETHING if it produced positions, LinkedIn-only
+            # skills, or grew the merged profile. "gained=0 merged" alone is NOT
+            # a failure: a rich CV legitimately makes LinkedIn redundant on
+            # skills — measured on a 130-skill CV whose LinkedIn's 3 skills were
+            # all already present. Failing that would punish a good CV.
+            did_something = gained > 0 or li_only > 0 or positions > 0
+            s.ok = did_something
             if not s.ok:
-                s.reason = ("LinkedIn was accepted but the profile gained NOTHING — no new "
-                            "skill and no new role. The user uploaded a file for nothing.")
+                s.reason = ("LinkedIn was accepted but produced NO positions, NO "
+                            "LinkedIn-only skills, and grew the profile by nothing — "
+                            "the parse extracted zero usable data from the file.")
         j.run("linkedin enrich", enrich_li,
               skip="" if li else "no LinkedIn PDF for this person")
 

--- a/scripts/journey_probe.py
+++ b/scripts/journey_probe.py
@@ -329,6 +329,31 @@ def main() -> int:
         j.run("linkedin enrich", enrich_li,
               skip="" if li else "no LinkedIn PDF for this person")
 
+        # ── 3b. GitHub ────────────────────────────────────────────────────────
+        # Read the handle from the corpus. GitHub skills surface under
+        # skills_by_source['github'] (NOT a cv_detail field — checking the wrong
+        # place is why an earlier walk wrongly reported GitHub as producing 0).
+        gh_file = corpus / "github_urls" / f"{person}_github.txt"
+        gh_url = gh_file.read_text(encoding="utf-8").strip() if gh_file.exists() else ""
+
+        def enrich_gh(s: Step) -> None:
+            before = len((client.get("/api/profile").json().get("skills_by_source") or {}).get("github") or [])
+            r = client.post("/api/profile/github", data={"username": gh_url})
+            s.evidence["http"] = r.status_code
+            if r.status_code >= 400:
+                s.reason = f"GitHub enrich returned HTTP {r.status_code}."
+                return
+            time.sleep(75)  # GitHub fetch + LLM pass run in the background
+            sbs = client.get("/api/profile").json().get("skills_by_source") or {}
+            gained = len(sbs.get("github") or [])
+            s.evidence.update(github_skills=gained, was=before)
+            s.ok = gained > 0
+            if not s.ok:
+                s.reason = ("GitHub was accepted but contributed no skills — the fetch or "
+                            "the repo-skill inference produced nothing for this handle.")
+        j.run("github enrich", enrich_gh,
+              skip="" if gh_url else "no GitHub URL for this person")
+
         # ── 4. search ────────────────────────────────────────────────────────
         def search(s: Step) -> None:
             r = client.post("/api/search", json={}, timeout=600.0)


### PR DESCRIPTION
The funnel redesign, first four bricks — goal: `GOOD MATCH = understand USER × understand JOB`, both → 100%.

## 1 · Revive the dead 40-pt title lever (`1b8bbeb`)
CV-derived titles never match postings verbatim → title lever dead → scores capped ~69 → **location was the secret sort key**. Fix: evidence-based core domain words + domain+role strong band. **Measured: Spearman(score, LLM-oracle) −0.04 → +0.29** on the owner's real feed; top-12 became AI/ML roles.

## 2 · user_feed becomes a bounded candidate set (`7309f34`)
One prod feed held 85% of the whole catalog. Now: top `FEED_CANDIDATE_CAP` (default 800, `0`=legacy off) enter/stay; reversible eviction; LLM-judged rows never evicted; judge shortlist draws from candidates only. **Proven: 6,186 → exactly 800 active on the real local catalog.** No migration; all 15 dependent suites green.

## 3 · Job text for 55% of the catalog (`bb7559f`)
The two biggest sources shipped ZERO description text (devitjobs 3,041 = 42% of catalog; greenhouse 996). Fixes: greenhouse `?content=true` (+`html.unescape` — content arrives entity-escaped) and devitjobs structured descriptions composed from the API's own `technologies`/`filterTags`/`remoteType`/… fields. **Live-proven: devitjobs 0% → 100% (2,316/2,316), greenhouse 0% → 100%.**

## 4 · `scripts/embed_catalog.py` (`6de762e`)
Idempotent backfill: embeds every job missing a vector via the same `encode_job`+`VectorIndex` path as ingest. Unblocks E3 (prod: 284/7,309 embedded → hybrid silently degraded to keyword-only).

## Tests
+19 across the stack; sources suite 98 green; feed suites 111 green; scorer+profile 146 green.

## Rollout
- Feeds shrink to top-800 on each user's next search/profile change (gradual; `FEED_CANDIDATE_CAP=0` = instant rollback).
- Descriptions improve on the next fetch cycle automatically.
- `embed_catalog.py` needs one prod run (worker has the `[semantic]` extra) — operational follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6DsQH5EUxJc3Vnqz9YHgQ
