### PR TITLE
feat(feed): user-feedback loop — liked/applied protected, not_interested excluded from selection

### DIFF
--- a/backend/src/services/feed.py
+++ b/backend/src/services/feed.py
@@ -183,7 +183,11 @@ class FeedService:
         return cur.rowcount or 0
 
     async def apply_candidate_selection(
-        self, user_id: str, selected_ids: set[int]
+        self,
+        user_id: str,
+        selected_ids: set[int],
+        *,
+        force_evict_ids: Optional[set[int]] = None,
     ) -> int:
         """Enforce the User-Level candidate bound (funnel Stage-1).
 
@@ -221,8 +225,21 @@ class FeedService:
             f"AND job_id NOT IN ({placeholders})",
             [now, user_id, *ids],
         )
+        evicted = cur.rowcount or 0
+        # The user-feedback loop: an explicit not_interested outranks EVERY
+        # guard — including the LLM-verdict protection. The user said no; the
+        # machine's opinion doesn't resurrect the job.
+        if force_evict_ids:
+            f_ids = list(force_evict_ids)
+            f_ph = ",".join("?" for _ in f_ids)
+            cur2 = await self._db.execute(
+                f"UPDATE user_feed SET status = 'stale', updated_at = ? "
+                f"WHERE user_id = ? AND status = 'active' AND job_id IN ({f_ph})",
+                [now, user_id, *f_ids],
+            )
+            evicted += cur2.rowcount or 0
         await self._db.commit()
-        return cur.rowcount or 0
+        return evicted
 
     async def upsert_feed_row(
         self,

--- a/backend/src/services/rescore.py
+++ b/backend/src/services/rescore.py
@@ -94,6 +94,31 @@ async def _build_user_scorer(db: Any, profile: Any) -> Any:
     )
 
 
+async def _load_action_sets(db: Any, user_id: str) -> tuple[set[Any], set[Any]]:
+    """The user-feedback loop's read side (2026-08-05).
+
+    Returns ``(protected, rejected)`` job-id sets from ``user_actions``:
+      * ``protected`` — liked/applied jobs: user investment that must survive
+        any re-selection (same principle as the LLM-verdict guard).
+      * ``rejected`` — not_interested jobs: an explicit user NO that selection
+        must honour; before this, the reject button recorded a row the
+        candidate layer completely ignored — a dead lever.
+    """
+    cur = await db._db.execute(
+        "SELECT job_id, action FROM user_actions WHERE user_id = ?",
+        (user_id,),
+    )
+    protected: set[Any] = set()
+    rejected: set[Any] = set()
+    for row in await cur.fetchall():
+        jid, action = row[0], row[1]
+        if action == "not_interested":
+            rejected.add(jid)
+        elif action in ("liked", "applied"):
+            protected.add(jid)
+    return protected, rejected
+
+
 async def backfill_feed_from_catalog(
     user_id: str,
     db: Any,
@@ -172,6 +197,11 @@ async def backfill_feed_from_catalog(
             continue
         scored.append((ms, jid, row))
 
+    # The user-feedback loop: explicit actions steer the shelf.
+    protected_ids, rejected_ids = await _load_action_sets(db, user_id)
+    if rejected_ids:
+        scored = [t for t in scored if t[1] not in rejected_ids]
+
     # Phase 2 — candidate selection: keep only the user's top-`cap` jobs.
     # cap=0 disables (legacy flood). Ties broken by score order; stable sort
     # keeps catalog order within equal scores.
@@ -204,9 +234,13 @@ async def backfill_feed_from_catalog(
     evicted = 0
     if cap > 0 and selected:
         try:
+            # Liked/applied rows join the kept set (never staled, reactivated
+            # if stale); not_interested rows are force-evicted past every guard.
             evicted = await with_write_retry(
                 lambda: feed.apply_candidate_selection(
-                    user_id, {jid for _, jid, _ in selected}
+                    user_id,
+                    {jid for _, jid, _ in selected} | protected_ids,
+                    force_evict_ids=rejected_ids,
                 )
             )
         except Exception as exc:  # noqa: BLE001
@@ -431,6 +465,12 @@ async def rescore_user_feed(
                 if ms > 0 or jid in existing_feed_ids:
                     scored_rows.append((ms, jid, row))
 
+            # The user-feedback loop: rejected jobs never re-enter selection
+            # (and never reach the paid judge); liked/applied are protected.
+            protected_ids, rejected_ids = await _load_action_sets(db, user_id)
+            if rejected_ids:
+                scored_rows = [t for t in scored_rows if t[1] not in rejected_ids]
+
             # Phase 2 — selection: top-`cap` by score. cap=0 = legacy (all).
             if cap > 0 and len(scored_rows) > cap:
                 scored_rows.sort(key=lambda t: t[0], reverse=True)
@@ -486,7 +526,9 @@ async def rescore_user_feed(
                 try:
                     evicted = await with_write_retry(
                         lambda: feed.apply_candidate_selection(
-                            user_id, {jid for _, jid, _ in selected_rows}
+                            user_id,
+                            {jid for _, jid, _ in selected_rows} | protected_ids,
+                            force_evict_ids=rejected_ids,
                         )
                     )
                     if evicted:

--- a/backend/tests/test_candidate_selection.py
+++ b/backend/tests/test_candidate_selection.py
@@ -461,3 +461,99 @@ async def test_backfill_never_enriches_when_e2_off(full_db, monkeypatch):
         await db.close()
 
     assert called["n"] == 0, "E2 off must mean zero enrichment calls"
+
+
+# ── the user-feedback loop (USER-understanding: actions steer the shelf) ─────
+
+
+@pytest.mark.asyncio
+async def test_not_interested_jobs_are_excluded_from_selection(full_db, monkeypatch):
+    """A job the user explicitly rejected must never be selected again — even
+    when it out-scores everything. Before this, 'not_interested' was recorded
+    but the candidate layer ignored it: the reject button was a dead lever."""
+    from pathlib import Path
+
+    import src.core.settings as settings_mod
+    import src.services.profile.storage as storage_mod
+
+    monkeypatch.setattr(storage_mod, "DB_PATH", Path(full_db), raising=True)
+    monkeypatch.setattr(settings_mod, "FEED_CANDIDATE_CAP", 2, raising=False)
+
+    user_id = _seed_user(full_db)
+    _seed_profile(full_db, user_id)
+
+    db = JobDatabase(full_db)
+    await db.init_db()
+    try:
+        await _seed_catalog(db, n_relevant=3, n_junk=0)
+        with pgsync.connect(full_db) as conn:
+            cur = conn.execute("SELECT id FROM jobs WHERE title LIKE 'ML Engineer%' ORDER BY id LIMIT 1")
+            rejected_id = cur.fetchone()[0]
+            conn.execute(
+                "INSERT INTO user_actions(user_id, job_id, action, notes, created_at) "
+                "VALUES (?,?,?,?,?)",
+                (user_id, rejected_id, "not_interested", "", _NOW),
+            )
+            # It also has a lingering active feed row from before the reject.
+            conn.execute(
+                "INSERT INTO user_feed(user_id, job_id, score, bucket, status, created_at, updated_at) "
+                "VALUES (?,?,?,?,'active',?,?)",
+                (user_id, rejected_id, 60, "older", _NOW, _NOW),
+            )
+
+        from src.services.rescore import backfill_feed_from_catalog
+
+        await backfill_feed_from_catalog(user_id, db)
+    finally:
+        await db.close()
+
+    rows = dict((jid, status) for jid, status, _ in _feed_rows(full_db, user_id))
+    assert rows.get(rejected_id) == "stale", (
+        "a not_interested job must be evicted, not re-offered"
+    )
+
+
+@pytest.mark.asyncio
+async def test_liked_and_applied_jobs_survive_eviction(full_db, monkeypatch):
+    """Jobs the user invested in (liked/applied) must never be evicted by a
+    re-selection, even when their score falls outside the top-N — mirroring
+    the LLM-verdict protection: user signal outranks keyword re-ranks."""
+    from pathlib import Path
+
+    import src.core.settings as settings_mod
+    import src.services.profile.storage as storage_mod
+
+    monkeypatch.setattr(storage_mod, "DB_PATH", Path(full_db), raising=True)
+    monkeypatch.setattr(settings_mod, "FEED_CANDIDATE_CAP", 1, raising=False)
+
+    user_id = _seed_user(full_db)
+    _seed_profile(full_db, user_id)
+
+    db = JobDatabase(full_db)
+    await db.init_db()
+    try:
+        await _seed_catalog(db, n_relevant=2, n_junk=1)
+        with pgsync.connect(full_db) as conn:
+            cur = conn.execute("SELECT id FROM jobs WHERE title LIKE 'Florist%'")
+            liked_junk_id = cur.fetchone()[0]
+            conn.execute(
+                "INSERT INTO user_actions(user_id, job_id, action, notes, created_at) "
+                "VALUES (?,?,?,?,?)",
+                (user_id, liked_junk_id, "liked", "", _NOW),
+            )
+            conn.execute(
+                "INSERT INTO user_feed(user_id, job_id, score, bucket, status, created_at, updated_at) "
+                "VALUES (?,?,?,?,'active',?,?)",
+                (user_id, liked_junk_id, 12, "older", _NOW, _NOW),
+            )
+
+        from src.services.rescore import backfill_feed_from_catalog
+
+        await backfill_feed_from_catalog(user_id, db)
+    finally:
+        await db.close()
+
+    rows = dict((jid, status) for jid, status, _ in _feed_rows(full_db, user_id))
+    assert rows[liked_junk_id] == "active", (
+        "a liked/applied job was evicted — user investment must survive re-selection"
+    )


### PR DESCRIPTION
## The user-feedback loop — USER-understanding brick

The action buttons (`liked` / `applied` / `not_interested`) wrote rows the candidate layer completely ignored: a rejected job could ride the feed forever; a liked/applied job could be silently evicted by re-selection. **The explicit user signal was a dead lever.**

Now, in both backfill and profile-change rescore:
- **`not_interested`** → excluded from selection, never reaches the paid LLM judge, force-evicted past every guard (including the LLM-verdict protection — the user's NO outranks the machine's opinion).
- **`liked`/`applied`** → join the kept set: never staled by re-selection, reactivated if stale. User investment survives, same principle as the verdict guard.

Note: the diff vs main is only the feedback-loop change (`f53a355`); earlier commits in the list are already on main via #224's squash.

**Tests:** +2 (rejected-excluded, liked-survives); 40 passed across candidate/rescore/feed suites. Gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6DsQH5EUxJc3Vnqz9YHgQ
