### PR TITLE
feat(funnel): embedding convergence + learned-preference v1

### DIFF
--- a/backend/src/core/settings.py
+++ b/backend/src/core/settings.py
@@ -212,6 +212,12 @@ PROFILE_EXTRACT_MAX_PER_HOUR = int(os.getenv("PROFILE_EXTRACT_MAX_PER_HOUR", "12
 # When false (default), embeddings + ChromaDB + ESCO normalisation all skip.
 # When true, callers that check this flag activate the semantic retrieval path.
 SEMANTIC_ENABLED = os.getenv("SEMANTIC_ENABLED", "false").lower() in {"1", "true", "yes", "on"}
+# Convergence backfill (2026-08-05): each pipeline run ALSO embeds up to this
+# many EXISTING catalog jobs that never got a vector, so embedding coverage
+# converges to 100% through ordinary searches — no manual sweep on the prod
+# box needed. ~50ms/job on CPU => 300 ≈ 15s inside a background search task.
+# 0 disables. Only active when SEMANTIC_ENABLED is on (rule #18).
+EMBED_BACKFILL_PER_RUN = int(os.getenv("EMBED_BACKFILL_PER_RUN", "300"))
 
 
 def _env_flag(name: str, default: bool) -> bool:

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -474,6 +474,67 @@ def _encode_and_upsert(
     )
 
 
+async def _embed_backfill_budget(db: Any, conn: Any, budget: int) -> int:
+    """Embed up to ``budget`` EXISTING catalog jobs that have no vector yet.
+
+    Convergence backfill (2026-08-05): jobs inserted before semantic was on
+    would otherwise stay vectorless until purged. Same encode path as new-job
+    embedding (enrichment-aware, worker-thread hop). Per-job failures are
+    logged and skipped — one bad row never stops the sweep. Returns embedded
+    count. Callers gate on SEMANTIC_ENABLED.
+    """
+    from src.services.embeddings import MODEL_NAME, encode_job  # noqa: PLC0415 — lazy (rule #16)
+    from src.services.job_enrichment import load_enrichment  # noqa: PLC0415
+    from src.services.vector_index import VectorIndex  # noqa: PLC0415
+
+    try:
+        vix = VectorIndex()
+    except Exception as e:  # noqa: BLE001
+        logger.warning("embed backfill: VectorIndex init failed: %s", e)
+        return 0
+
+    cur = await conn.execute(
+        """
+        SELECT j.id, j.title, j.company, j.location, j.description,
+               j.apply_url, j.source, j.date_found
+        FROM jobs j LEFT JOIN job_embeddings e ON e.job_id = j.id
+        WHERE e.job_id IS NULL
+        ORDER BY j.id
+        LIMIT ?
+        """,
+        (budget,),
+    )
+    rows = await cur.fetchall()
+    embedded = 0
+    for r in rows:
+        try:
+            job = Job(
+                title=r[1] or "", company=r[2] or "", apply_url=r[5] or "",
+                source=r[6] or "", date_found=r[7] or "",
+                location=r[3] or "", description=r[4] or "",
+            )
+            job.id = r[0]
+            try:
+                enrichment = await load_enrichment(conn, r[0])
+            except Exception:  # noqa: BLE001
+                enrichment = None
+            await asyncio.to_thread(
+                _encode_and_upsert, vix, encode_job, job, enrichment, r[0]
+            )
+            await conn.execute(
+                "INSERT INTO job_embeddings(job_id, model_version) VALUES (?, ?) "
+                "ON CONFLICT(job_id) DO UPDATE SET model_version = EXCLUDED.model_version",
+                (r[0], MODEL_NAME),
+            )
+            embedded += 1
+        except Exception as e:  # noqa: BLE001
+            logger.warning("embed backfill: job %s failed: %s", r[0], e)
+    await db.commit()
+    if embedded:
+        logger.info("embed backfill: %s existing jobs embedded this run", embedded)
+    return embedded
+
+
 def _score_dedup_and_filter(all_jobs: list[Job], scorer: JobScorer) -> list[Job]:
     """Score every job, extract deadlines, dedup, and score-filter — the whole
     SYNCHRONOUS, CPU-heavy stage of the pipeline in one place.
@@ -1106,6 +1167,18 @@ async def run_search(
                         except Exception as e:
                             logger.warning("vector upsert failed for job %r: %s", j.title, e)
                     await db.commit()
+
+            # Convergence backfill (2026-08-05, goal: JOB understanding → 100%).
+            # New jobs embed above; EXISTING catalog jobs that predate semantic
+            # (prod: 284/7,309 embedded) would otherwise stay vectorless until
+            # the 30-day purge cycled them out. Each run therefore also embeds
+            # a budget of missing-embedding jobs — same pattern as candidate
+            # enrichment: coverage converges through ordinary searches, no
+            # manual sweep on the prod box. Gated on SEMANTIC_ENABLED (rule #18).
+            if SEMANTIC_ENABLED:
+                from src.core.settings import EMBED_BACKFILL_PER_RUN  # noqa: PLC0415
+                if EMBED_BACKFILL_PER_RUN > 0:
+                    await _embed_backfill_budget(db, conn, EMBED_BACKFILL_PER_RUN)
 
             # Stats
             stats = {

--- a/backend/src/services/rescore.py
+++ b/backend/src/services/rescore.py
@@ -94,6 +94,48 @@ async def _build_user_scorer(db: Any, profile: Any) -> Any:
     )
 
 
+async def _load_preference_signals(db: Any, user_id: str) -> dict[str, set[str]]:
+    """Learned-preference v1 (2026-08-05): what the user's OWN actions teach us.
+
+    Companies and title tokens of liked/applied jobs. Used as a SELECTION
+    boost — jobs resembling what the user chose get priority for the shelf's
+    last slots. Deliberately deterministic and explainable (no model): the
+    boost affects candidate MEMBERSHIP only, never the stored score, so the
+    dashboard ranking stays the raw scorer output.
+    """
+    import re as _re  # noqa: PLC0415
+
+    cur = await db._db.execute(
+        "SELECT j.company, j.title FROM user_actions a JOIN jobs j ON j.id = a.job_id "
+        "WHERE a.user_id = ? AND a.action IN (?, ?)",
+        (user_id, "liked", "applied"),
+    )
+    companies: set[str] = set()
+    tokens: set[str] = set()
+    for row in await cur.fetchall():
+        comp, title = (row[0] or ""), (row[1] or "")
+        if comp.strip():
+            companies.add(comp.strip().lower())
+        for w in _re.findall(r"\w+", title.lower()):
+            if len(w) > 2:
+                tokens.add(w)
+    return {"companies": companies, "tokens": tokens}
+
+
+def _preference_boost(row: dict[str, Any], signals: dict[str, set[str]]) -> int:
+    """Selection-priority boost from learned preferences. +8 same company as a
+    liked/applied job; +4 when >=2 title tokens overlap the liked vocabulary."""
+    import re as _re  # noqa: PLC0415
+
+    boost = 0
+    if (row.get("company") or "").strip().lower() in signals["companies"]:
+        boost += 8
+    title_tokens = set(_re.findall(r"\w+", (row.get("title") or "").lower()))
+    if len(title_tokens & signals["tokens"]) >= 2:
+        boost += 4
+    return boost
+
+
 async def _load_action_sets(db: Any, user_id: str) -> tuple[set[Any], set[Any]]:
     """The user-feedback loop's read side (2026-08-05).
 
@@ -203,10 +245,18 @@ async def backfill_feed_from_catalog(
         scored = [t for t in scored if t[1] not in rejected_ids]
 
     # Phase 2 — candidate selection: keep only the user's top-`cap` jobs.
-    # cap=0 disables (legacy flood). Ties broken by score order; stable sort
-    # keeps catalog order within equal scores.
+    # cap=0 disables (legacy flood). Selection priority = score + learned-
+    # preference boost (v1: liked/applied companies + title vocabulary), so
+    # jobs resembling what the user chose win the shelf's marginal slots.
+    # The boost affects MEMBERSHIP only — stored scores stay raw.
     if cap > 0 and len(scored) > cap:
-        scored.sort(key=lambda t: t[0], reverse=True)
+        signals = await _load_preference_signals(db, user_id)
+        if signals["companies"] or signals["tokens"]:
+            scored.sort(
+                key=lambda t: t[0] + _preference_boost(t[2], signals), reverse=True
+            )
+        else:
+            scored.sort(key=lambda t: t[0], reverse=True)
         selected = scored[:cap]
     else:
         selected = scored
@@ -471,9 +521,18 @@ async def rescore_user_feed(
             if rejected_ids:
                 scored_rows = [t for t in scored_rows if t[1] not in rejected_ids]
 
-            # Phase 2 — selection: top-`cap` by score. cap=0 = legacy (all).
+            # Phase 2 — selection: top-`cap` by score + learned-preference
+            # boost (same rule as backfill, so the two paths never disagree
+            # about shelf membership). cap=0 = legacy (all).
             if cap > 0 and len(scored_rows) > cap:
-                scored_rows.sort(key=lambda t: t[0], reverse=True)
+                signals = await _load_preference_signals(db, user_id)
+                if signals["companies"] or signals["tokens"]:
+                    scored_rows.sort(
+                        key=lambda t: t[0] + _preference_boost(t[2], signals),
+                        reverse=True,
+                    )
+                else:
+                    scored_rows.sort(key=lambda t: t[0], reverse=True)
                 selected_rows = scored_rows[:cap]
             else:
                 selected_rows = scored_rows

--- a/backend/tests/test_candidate_selection.py
+++ b/backend/tests/test_candidate_selection.py
@@ -557,3 +557,67 @@ async def test_liked_and_applied_jobs_survive_eviction(full_db, monkeypatch):
     assert rows[liked_junk_id] == "active", (
         "a liked/applied job was evicted — user investment must survive re-selection"
     )
+
+
+@pytest.mark.asyncio
+async def test_learned_preference_wins_marginal_shelf_slot(full_db, monkeypatch):
+    """Learned-preference v1: when two jobs tie on score for the last shelf
+    slot, the one from a company the user LIKED before must win it. The boost
+    affects membership only — stored scores stay the raw scorer output."""
+    from pathlib import Path
+
+    import src.core.settings as settings_mod
+    import src.services.profile.storage as storage_mod
+
+    monkeypatch.setattr(storage_mod, "DB_PATH", Path(full_db), raising=True)
+    monkeypatch.setattr(settings_mod, "FEED_CANDIDATE_CAP", 1, raising=False)
+
+    user_id = _seed_user(full_db)
+    _seed_profile(full_db, user_id)
+
+    db = JobDatabase(full_db)
+    await db.init_db()
+    try:
+        # Two identical-scoring relevant jobs from different companies...
+        await db.insert_job(Job(
+            title="ML Engineer A", company="LovedCo",
+            apply_url="https://x/a", source="reed", date_found=_NOW,
+            location="London, UK", description="Python machine learning role with pytorch.",
+        ))
+        await db.insert_job(Job(
+            title="ML Engineer B", company="StrangerCo",
+            apply_url="https://x/b", source="reed", date_found=_NOW,
+            location="London, UK", description="Python machine learning role with pytorch.",
+        ))
+        # ...and an EARLIER liked job from LovedCo (different posting).
+        await db.insert_job(Job(
+            title="Data Platform Engineer", company="LovedCo",
+            apply_url="https://x/old", source="reed", date_found=_NOW,
+            location="London, UK", description="Old role.",
+        ))
+        with pgsync.connect(full_db) as conn:
+            cur = conn.execute("SELECT id FROM jobs WHERE title = 'Data Platform Engineer'")
+            liked_id = cur.fetchone()[0]
+            conn.execute(
+                "INSERT INTO user_actions(user_id, job_id, action, notes, created_at) "
+                "VALUES (?,?,?,?,?)",
+                (user_id, liked_id, "liked", "", _NOW),
+            )
+
+        from src.services.rescore import backfill_feed_from_catalog
+
+        await backfill_feed_from_catalog(user_id, db)
+
+        with pgsync.connect(full_db) as conn:
+            cur = conn.execute(
+                "SELECT j.company FROM user_feed f JOIN jobs j ON j.id=f.job_id "
+                "WHERE f.user_id=? AND f.status='active' AND j.title LIKE ?",
+                (user_id, "ML Engineer%"),
+            )
+            active_companies = [r[0] for r in cur.fetchall()]
+    finally:
+        await db.close()
+
+    assert active_companies == ["LovedCo"], (
+        f"the liked company's job must win the marginal slot, got {active_companies}"
+    )

--- a/backend/tests/test_embed_backfill.py
+++ b/backend/tests/test_embed_backfill.py
@@ -1,0 +1,114 @@
+"""Convergence backfill (2026-08-05): each run embeds a budget of EXISTING
+catalog jobs missing vectors, so coverage reaches 100% through ordinary
+searches — no manual sweep on the prod box. Pins: the budget cap, idempotence
+(already-embedded jobs skipped), and per-row fault tolerance."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import pytest
+
+from migrations import runner
+from src.models import Job
+from src.repositories.database import JobDatabase
+
+
+async def _full_db(path: str) -> JobDatabase:
+    """init + ALL migrations — job_embeddings arrives in migration 0009; without
+    it the schema-per-test isolation silently falls through to public (the
+    search_path trap in saved memory)."""
+    db = JobDatabase(path)
+    await db.init_db()
+    await db.close()
+    await runner.up(path)
+    db = JobDatabase(path)
+    await db.init_db()
+    return db
+
+_NOW = datetime.now(timezone.utc).isoformat()
+
+
+def _mk(i: int) -> Job:
+    return Job(
+        title=f"Engineer {i}", company=f"Co{i}",
+        apply_url=f"https://x/{i}", source="reed",
+        date_found=_NOW, location="London, UK",
+        description="Python role.",
+    )
+
+
+@pytest.mark.asyncio
+async def test_backfill_embeds_only_missing_up_to_budget(tmp_path):
+    from src import main as main_mod
+
+    db = await _full_db(str(tmp_path / "t.db"))
+    try:
+        for i in range(5):
+            await db.insert_job(_mk(i))
+        conn = db._db
+        # Pretend job #1 is already embedded.
+        cur = await conn.execute("SELECT id FROM jobs ORDER BY id")
+        ids = [r[0] for r in await cur.fetchall()]
+        await conn.execute(
+            "INSERT INTO job_embeddings(job_id, model_version) VALUES (?, 'm')", (ids[0],)
+        )
+        await db.commit()
+
+        upserted: list[int] = []
+
+        class _FakeVix:
+            def upsert(self, job_id=None, vector=None, metadata=None):
+                upserted.append(int(job_id))
+
+        def fake_encode(job, enrichment=None):
+            return [0.0] * 3
+
+        async def fake_load_enrichment(conn, jid):
+            return None
+
+        with patch("src.services.vector_index.VectorIndex", return_value=_FakeVix()), \
+             patch("src.services.embeddings.encode_job", new=fake_encode), \
+             patch("src.services.job_enrichment.load_enrichment", new=fake_load_enrichment):
+            n = await main_mod._embed_backfill_budget(db, conn, budget=2)
+
+        assert n == 2, "budget must cap the sweep"
+        assert ids[0] not in upserted, "an already-embedded job was re-embedded"
+        cur = await conn.execute("SELECT count(*) FROM job_embeddings")
+        assert (await cur.fetchone())[0] == 3  # 1 pre-existing + 2 new
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_backfill_survives_a_poison_row(tmp_path):
+    from src import main as main_mod
+
+    db = await _full_db(str(tmp_path / "t2.db"))
+    try:
+        for i in range(3):
+            await db.insert_job(_mk(i))
+        conn = db._db
+        calls = {"n": 0}
+
+        class _FakeVix:
+            def upsert(self, **kw):
+                pass
+
+        def flaky_encode(job, enrichment=None):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise RuntimeError("encoder blew up")
+            return [0.0] * 3
+
+        async def fake_load_enrichment(conn, jid):
+            return None
+
+        with patch("src.services.vector_index.VectorIndex", return_value=_FakeVix()), \
+             patch("src.services.embeddings.encode_job", new=flaky_encode), \
+             patch("src.services.job_enrichment.load_enrichment", new=fake_load_enrichment):
+            n = await main_mod._embed_backfill_budget(db, conn, budget=10)
+
+        assert n == 2, "the poison row must be skipped, the rest embedded"
+    finally:
+        await db.close()


### PR DESCRIPTION
Two convergence bricks — closing the last autonomously-buildable gaps toward "understand USER × understand JOB = 100 × 100".

## 1 · Embedding coverage converges hands-free (`dcaa096`)
New jobs already embed at ingest, but the existing catalog (prod: 284/7,309 vectors) would stay vectorless until purged, and a manual sweep needs prod shell access. Now each pipeline run also embeds up to `EMBED_BACKFILL_PER_RUN` (default 300, `0` disables) existing jobs missing vectors — same pattern as candidate enrichment: **coverage → 100% through ordinary searches**. Gated on `SEMANTIC_ENABLED` (rule #18). Per-row fault guard; worker-thread hop (event loop never starves).

## 2 · Learned-preference v1 (`latest`)
The feedback loop made actions *binding* (exclude/protect); this makes them *predictive*: selection priority = score + boost (+8 liked/applied company, +4 ≥2-token title-vocabulary overlap). Deterministic, explainable, membership-only (stored scores stay raw). Applied identically in backfill + rescore via shared helpers so the paths never disagree.

## Tests
+3 new (budget cap + skip-existing, poison-row survival, liked-company wins the marginal slot). 41 passed across candidate/rescore/feed suites; embed tests written with the full-migration bootstrap (the schema-per-test/public-fallthrough trap from saved memory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6DsQH5EUxJc3Vnqz9YHgQ
