### PR TITLE
feat(worker): enrichment_sweep cron — candidate enrichment self-heals

### DIFF
--- a/backend/src/workers/settings.py
+++ b/backend/src/workers/settings.py
@@ -31,6 +31,7 @@ from urllib.parse import urlparse
 
 from src.workers.tasks import (
     enrich_job_task,
+    enrichment_sweep,
     mark_ledger_failed_task,
     mark_ledger_sent_task,
     nightly_ghost_sweep,
@@ -153,6 +154,8 @@ class WorkerSettings:
         nightly_ghost_sweep,
         # The production loop: refill the shared catalog on a timer
         refresh_catalog,
+        # Self-heal enrichment coverage of the candidate pool
+        enrichment_sweep,
     ]
 
     # Lifecycle hooks — open/close the DB connection tasks read from ``ctx['db']``
@@ -218,6 +221,12 @@ class WorkerSettings:
             # structurally unreachable (see refresh_catalog's docstring).
             _cron(refresh_catalog, hour=4, minute=0),
             _cron(notification_tick, minute=set(range(0, 60, 5))),
+            # Self-heal enrichment coverage: every 30 min, enrich the
+            # ENRICHMENT_SWEEP_PER_TICK (default 100) highest-value candidate
+            # jobs still missing enrichment. Prod gap at ship time: 738/6,589
+            # candidates enriched — this cron closes it in ~1-2 days and keeps
+            # it closed as new jobs arrive. No-op when E2 flags are off.
+            _cron(enrichment_sweep, minute={10, 40}),
         ]
         del _cron
     except Exception:  # noqa: BLE001 — arq absent in a minimal env

--- a/backend/src/workers/tasks.py
+++ b/backend/src/workers/tasks.py
@@ -557,6 +557,77 @@ async def nightly_ghost_sweep(ctx: dict[str, Any]) -> dict[str, int]:
     return {"evaluated": evaluated, "transitioned": transitioned}
 
 
+@_logged_task
+async def enrichment_sweep(ctx: dict[str, Any]) -> dict[str, Any]:
+    """ARQ periodic task: self-heal enrichment coverage of the candidate pool.
+
+    WHY THIS EXISTS (goal: understand JOB → 100%, 2026-08-05). Enrichment is
+    per-JOB and shared (rule #17), but it only ever ran inside pipeline runs
+    with small per-run budgets — measured in prod: 24/7,309 jobs enriched
+    (0.3%), so the salary/visa/seniority/workplace preference dimensions
+    effectively never fired for anyone. Filling coverage depended on manual
+    sweeps from a laptop — exactly the kind of hands-on ops a production
+    system must not need. This cron makes coverage converge BY ITSELF.
+
+    Each tick: pick the ``ENRICHMENT_SWEEP_PER_TICK`` (default 100, 0
+    disables) highest-value ACTIVE candidate jobs still missing enrichment —
+    value = the best COALESCE(llm_fit_score, score) any user's feed gives the
+    job — and enrich them via the standard ``enrich_batch`` path (idempotent,
+    ``skip_existing``, semaphore 3). Cost: the free-tier extraction chain the
+    pipeline already uses; bounded per tick; zero per-user LLM spend.
+
+    Gated exactly like every other E2 call site: ``ENGINE2_ENABLED`` OR the
+    legacy ``ENRICHMENT_ENABLED`` flag — both off ⇒ pure no-op (rule #18).
+    """
+    import os as _os  # noqa: PLC0415
+
+    from src.core.settings import ENGINE2_ENABLED  # noqa: PLC0415
+    from src.services.job_enrichment import enrich_batch  # noqa: PLC0415
+
+    if not (ENGINE2_ENABLED or ENRICHMENT_ENABLED):
+        return {"enriched": 0, "reason": "e2_off"}
+    budget = int(_os.getenv("ENRICHMENT_SWEEP_PER_TICK", "100"))
+    if budget <= 0:
+        return {"enriched": 0, "reason": "disabled"}
+
+    db: pg.Connection = ctx["db"]
+    db.row_factory = pg.Row
+
+    cur = await db.execute(
+        """
+        SELECT j.id, j.title, j.company, j.location, j.description,
+               j.apply_url, j.source, j.date_found
+        FROM jobs j
+        JOIN user_feed f ON f.job_id = j.id AND f.status = 'active'
+        LEFT JOIN job_enrichment e ON e.job_id = j.id
+        WHERE e.job_id IS NULL
+        GROUP BY j.id, j.title, j.company, j.location, j.description,
+                 j.apply_url, j.source, j.date_found
+        ORDER BY max(COALESCE(f.llm_fit_score, f.score)) DESC
+        LIMIT ?
+        """,
+        (budget,),
+    )
+    rows = [dict(r) for r in await cur.fetchall()]
+    if not rows:
+        return {"enriched": 0, "reason": "coverage_complete"}
+
+    jobs: list[Job] = []
+    for r in rows:
+        job = Job(
+            title=r["title"] or "", company=r["company"] or "",
+            apply_url=r["apply_url"] or "", source=r["source"] or "",
+            date_found=r["date_found"] or "", location=r["location"] or "",
+            description=r["description"] or "",
+        )
+        job.id = r["id"]
+        jobs.append(job)
+
+    results = await enrich_batch(jobs, semaphore_limit=3, conn=db, skip_existing=True)
+    enriched = len([x for x in (results or []) if x])
+    return {"enriched": enriched, "remaining_batch": len(rows) - enriched}
+
+
 # ---------- Pillar 2 Batch 2.5 — job enrichment task -------------------
 #
 # Queued post-ingest (after ``score_and_ingest``) via the ARQ fan-out hook in

--- a/backend/tests/test_enrichment_sweep_task.py
+++ b/backend/tests/test_enrichment_sweep_task.py
@@ -1,0 +1,124 @@
+"""The enrichment self-heal cron (2026-08-05): coverage of the candidate pool
+must converge WITHOUT a human or a laptop — measured prod gap at ship time was
+738/6,589 active candidates enriched (11%), the rest depending on manual
+sweeps. Pins: budget + prioritization, E2-off no-op, empty-coverage no-op."""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import pytest
+
+from migrations import runner
+from src.models import Job
+from src.repositories import pgsync
+from src.repositories.database import JobDatabase
+
+_NOW = datetime.now(timezone.utc).isoformat()
+
+
+async def _full_db(path: str) -> JobDatabase:
+    db = JobDatabase(path)
+    await db.init_db()
+    await db.close()
+    await runner.up(path)
+    db = JobDatabase(path)
+    await db.init_db()
+    return db
+
+
+def _seed_user(db_path: str) -> str:
+    user_id = str(uuid.uuid4())
+    with pgsync.connect(db_path) as conn:
+        conn.execute(
+            "INSERT INTO users(id, email, password_hash) VALUES (?,?,?)",
+            (user_id, f"{user_id}@t.example", "hash"),
+        )
+    return user_id
+
+
+def _mk(i: int) -> Job:
+    return Job(
+        title=f"Engineer {i}", company=f"Co{i}", apply_url=f"https://x/{i}",
+        source="reed", date_found=_NOW, location="London, UK",
+        description="Python role.",
+    )
+
+
+@pytest.mark.asyncio
+async def test_sweep_enriches_highest_value_candidates_within_budget(tmp_path, monkeypatch):
+    import src.core.settings as settings_mod
+    import src.workers.tasks as tasks_mod
+
+    monkeypatch.setattr(settings_mod, "ENGINE2_ENABLED", True, raising=False)
+    monkeypatch.setenv("ENRICHMENT_SWEEP_PER_TICK", "2")
+
+    db = await _full_db(str(tmp_path / "t.db"))
+    try:
+        for i in range(4):
+            await db.insert_job(_mk(i))
+        conn = db._db
+        user_id = _seed_user(str(tmp_path / "t.db"))
+        cur = await conn.execute("SELECT id FROM jobs ORDER BY id")
+        ids = [r[0] for r in await cur.fetchall()]
+        # Active feed rows with distinct scores; job ids[3] highest value.
+        for jid, score in zip(ids, (10, 20, 30, 90)):
+            await conn.execute(
+                "INSERT INTO user_feed(user_id, job_id, score, bucket, status, created_at, updated_at) "
+                "VALUES (?,?,?,?,'active',?,?)",
+                (user_id, jid, score, "older", _NOW, _NOW),
+            )
+        await db.commit()
+
+        captured: list[int] = []
+
+        async def fake_enrich_batch(jobs, semaphore_limit=3, conn=None, skip_existing=True, **kw):
+            captured.extend(j.id for j in jobs)
+            return [object()] * len(jobs)
+
+        with patch("src.services.job_enrichment.enrich_batch", new=fake_enrich_batch):
+            result = await tasks_mod.enrichment_sweep({"db": conn})
+
+        assert result["enriched"] == 2, result
+        assert set(captured) == {ids[3], ids[2]}, (
+            f"must pick the 2 HIGHEST-value candidates, got {captured}"
+        )
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_sweep_noop_when_e2_off(tmp_path, monkeypatch):
+    import src.core.settings as settings_mod
+    import src.workers.tasks as tasks_mod
+
+    monkeypatch.setattr(settings_mod, "ENGINE2_ENABLED", False, raising=False)
+    monkeypatch.setattr(tasks_mod, "ENRICHMENT_ENABLED", False)
+
+    called = {"n": 0}
+
+    async def fake_enrich_batch(*a, **kw):
+        called["n"] += 1
+        return []
+
+    with patch("src.services.job_enrichment.enrich_batch", new=fake_enrich_batch):
+        result = await tasks_mod.enrichment_sweep({"db": None})
+
+    assert result == {"enriched": 0, "reason": "e2_off"}
+    assert called["n"] == 0, "E2 off must mean zero LLM calls (rule #18)"
+
+
+@pytest.mark.asyncio
+async def test_sweep_reports_complete_when_nothing_missing(tmp_path, monkeypatch):
+    import src.core.settings as settings_mod
+    import src.workers.tasks as tasks_mod
+
+    monkeypatch.setattr(settings_mod, "ENGINE2_ENABLED", True, raising=False)
+
+    db = await _full_db(str(tmp_path / "t2.db"))
+    try:
+        result = await tasks_mod.enrichment_sweep({"db": db._db})
+        assert result["reason"] == "coverage_complete"
+    finally:
+        await db.close()


### PR DESCRIPTION
## Candidate-pool enrichment self-heals — no laptop, no human crank

Prod at ship time: **738/6,589 active candidates enriched (11%)** — the rest depended on manual sweeps, which the permission system rightly gates. A production system must not need hands for its own data completeness.

New ARQ cron (every 30 min): enriches the `ENRICHMENT_SWEEP_PER_TICK` (default 100, `0` disables) **highest-value** candidate jobs missing enrichment (value = best `COALESCE(llm_fit_score, score)` across all feeds — most user-visible first). Standard `enrich_batch` path: idempotent, skip-existing, semaphore 3, free-tier chain, zero per-user LLM spend. Closes today's gap in ~1-2 days, keeps it closed forever.

Gate: `ENGINE2_ENABLED OR ENRICHMENT_ENABLED`; both off = pure no-op (rule #18, pinned).

**Tests:** +3 (budget+prioritization, E2-off zero-call, coverage-complete no-op). Worker suites 33 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6DsQH5EUxJc3Vnqz9YHgQ
