### PR TITLE
fix(pipeline): description backfill on re-fetch + repair hollow enrichment (sim findings)

### DIFF
--- a/backend/src/repositories/database.py
+++ b/backend/src/repositories/database.py
@@ -411,7 +411,23 @@ class JobDatabase:
                 job.deadline_source,
             ),
         )
-        return cursor.rowcount > 0
+        inserted = cursor.rowcount > 0
+        # Description backfill on re-fetch (2026-08-06, found by the Pillar-2
+        # simulation). INSERT OR IGNORE means a re-fetched job that NOW carries
+        # a description (the four 0%-desc source fixes) silently kept its old
+        # empty one — the fixes only ever benefited brand-new postings, and
+        # existing rows had to age through the 30-day purge to become readable
+        # (measured: catalog text coverage stuck at 35% the morning after the
+        # fixes shipped). Empty -> non-empty is the only allowed transition, so
+        # an upstream description REMOVAL can never wipe stored text.
+        if not inserted and job.description:
+            await self._db.execute(
+                """UPDATE jobs SET description = ?
+                   WHERE normalized_company = ? AND normalized_title = ?
+                     AND (description IS NULL OR description = '')""",
+                (job.description, company, title),
+            )
+        return inserted
 
     async def update_job_scores(self, job: Job) -> None:
         """Persist a re-scored job's match_score + dim columns to the catalog.

--- a/backend/src/workers/tasks.py
+++ b/backend/src/workers/tasks.py
@@ -609,11 +609,41 @@ async def enrichment_sweep(ctx: dict[str, Any]) -> dict[str, Any]:
         (budget,),
     )
     rows = [dict(r) for r in await cur.fetchall()]
-    if not rows:
+
+    # REPAIR phase (2026-08-06, found by the Pillar-2 simulation): enrichment
+    # that ran against an EMPTY description extracted mostly 'unknown' (prod:
+    # visa 94% / seniority 62% / workplace 61% unknown), and skip_existing
+    # froze those hollow rows forever — even after the description-backfill
+    # fixes delivered the text. Spend whatever budget the missing-coverage
+    # phase left on re-enriching unknown-heavy rows whose job NOW has real
+    # text. save_enrichment upserts, so the repair overwrites in place.
+    repair_budget = budget - len(rows)
+    repair_rows: list[dict[str, Any]] = []
+    if repair_budget > 0:
+        cur = await db.execute(
+            """
+            SELECT j.id, j.title, j.company, j.location, j.description,
+                   j.apply_url, j.source, j.date_found
+            FROM jobs j
+            JOIN job_enrichment e ON e.job_id = j.id
+            JOIN user_feed f ON f.job_id = j.id AND f.status = 'active'
+            WHERE e.visa_sponsorship = 'unknown'
+              AND e.seniority = 'unknown'
+              AND e.workplace_type = 'unknown'
+              AND length(coalesce(j.description, '')) > 200
+            GROUP BY j.id, j.title, j.company, j.location, j.description,
+                     j.apply_url, j.source, j.date_found
+            ORDER BY max(COALESCE(f.llm_fit_score, f.score)) DESC
+            LIMIT ?
+            """,
+            (repair_budget,),
+        )
+        repair_rows = [dict(r) for r in await cur.fetchall()]
+
+    if not rows and not repair_rows:
         return {"enriched": 0, "reason": "coverage_complete"}
 
-    jobs: list[Job] = []
-    for r in rows:
+    def _mk_job(r: dict[str, Any]) -> Job:
         job = Job(
             title=r["title"] or "", company=r["company"] or "",
             apply_url=r["apply_url"] or "", source=r["source"] or "",
@@ -621,11 +651,21 @@ async def enrichment_sweep(ctx: dict[str, Any]) -> dict[str, Any]:
             description=r["description"] or "",
         )
         job.id = r["id"]
-        jobs.append(job)
+        return job
 
-    results = await enrich_batch(jobs, semaphore_limit=3, conn=db, skip_existing=True)
-    enriched = len([x for x in (results or []) if x])
-    return {"enriched": enriched, "remaining_batch": len(rows) - enriched}
+    enriched = repaired = 0
+    if rows:
+        results = await enrich_batch(
+            [_mk_job(r) for r in rows], semaphore_limit=3, conn=db, skip_existing=True
+        )
+        enriched = len([x for x in (results or []) if x])
+    if repair_rows:
+        results = await enrich_batch(
+            [_mk_job(r) for r in repair_rows], semaphore_limit=3, conn=db,
+            skip_existing=False,  # deliberate: overwrite the hollow rows
+        )
+        repaired = len([x for x in (results or []) if x])
+    return {"enriched": enriched, "repaired": repaired}
 
 
 # ---------- Pillar 2 Batch 2.5 — job enrichment task -------------------

--- a/backend/tests/test_database.py
+++ b/backend/tests/test_database.py
@@ -328,3 +328,39 @@ def test_notification_rules_unique_user(db):
 
     with pytest.raises(pg.IntegrityError):
         asyncio.run(_insert_duplicate())
+
+
+@pytest.mark.asyncio
+async def test_refetch_backfills_empty_description():
+    """Pillar-2 sim finding (2026-08-06): INSERT OR IGNORE kept old EMPTY
+    descriptions forever, so the 0%-desc source fixes only helped brand-new
+    postings. A re-fetch carrying text must fill an empty stored description —
+    and never overwrite existing text (empty -> non-empty only)."""
+    from src.models import Job as _Job
+
+    db = JobDatabase(":memory:")
+    await db.init_db()
+    try:
+        j1 = _Job(title="ML Engineer", company="Acme", apply_url="https://x/1",
+                  source="greenhouse", date_found="2026-08-06T00:00:00+00:00",
+                  location="London, UK", description="")
+        assert await db.insert_job(j1) is True
+
+        j2 = _Job(title="ML Engineer", company="Acme", apply_url="https://x/1",
+                  source="greenhouse", date_found="2026-08-06T01:00:00+00:00",
+                  location="London, UK", description="Full posting text now available.")
+        assert await db.insert_job(j2) is False  # duplicate, not a new insert
+
+        cur = await db._db.execute("SELECT description FROM jobs")
+        desc = (await cur.fetchone())[0]
+        assert desc == "Full posting text now available.", "backfill did not land"
+
+        # Value-presence guard (rule #21): a later EMPTY re-fetch must not wipe it.
+        j3 = _Job(title="ML Engineer", company="Acme", apply_url="https://x/1",
+                  source="greenhouse", date_found="2026-08-06T02:00:00+00:00",
+                  location="London, UK", description="")
+        await db.insert_job(j3)
+        cur = await db._db.execute("SELECT description FROM jobs")
+        assert (await cur.fetchone())[0] == "Full posting text now available."
+    finally:
+        await db.close()

--- a/backend/tests/test_enrichment_sweep_task.py
+++ b/backend/tests/test_enrichment_sweep_task.py
@@ -122,3 +122,51 @@ async def test_sweep_reports_complete_when_nothing_missing(tmp_path, monkeypatch
         assert result["reason"] == "coverage_complete"
     finally:
         await db.close()
+
+
+@pytest.mark.asyncio
+async def test_sweep_repairs_hollow_enrichment_when_text_arrives(tmp_path, monkeypatch):
+    """REPAIR phase (Pillar-2 sim finding): enrichment that ran on an empty
+    description extracted all-unknowns and skip_existing froze it forever.
+    Once the job HAS text, leftover budget must re-enrich it in place."""
+    import src.core.settings as settings_mod
+    import src.workers.tasks as tasks_mod
+
+    monkeypatch.setattr(settings_mod, "ENGINE2_ENABLED", True, raising=False)
+    monkeypatch.setenv("ENRICHMENT_SWEEP_PER_TICK", "5")
+
+    db = await _full_db(str(tmp_path / "t3.db"))
+    try:
+        await db.insert_job(Job(
+            title="ML Engineer", company="Co", apply_url="https://x/1",
+            source="reed", date_found=_NOW, location="London, UK",
+            description="A real, substantial description " * 20,
+        ))
+        conn = db._db
+        user_id = _seed_user(str(tmp_path / "t3.db"))
+        cur = await conn.execute("SELECT id FROM jobs LIMIT 1")
+        jid = (await cur.fetchone())[0]
+        await conn.execute(
+            "INSERT INTO user_feed(user_id, job_id, score, bucket, status, created_at, updated_at) "
+            "VALUES (?,?,?,?,'active',?,?)", (user_id, jid, 50, "older", _NOW, _NOW))
+        # A hollow enrichment row — the empty-text artifact.
+        await conn.execute(
+            "INSERT INTO job_enrichment(job_id, title_canonical, category, visa_sponsorship, "
+            "seniority, workplace_type, enriched_at) VALUES (?,?,?,?,?,?,?)",
+            (jid, "ML Engineer", "software_engineering", "unknown", "unknown", "unknown", _NOW))
+        await db.commit()
+
+        calls = []
+
+        async def fake_enrich_batch(jobs, semaphore_limit=3, conn=None, skip_existing=True, **kw):
+            calls.append((sorted(j.id for j in jobs), skip_existing))
+            return [object()] * len(jobs)
+
+        with patch("src.services.job_enrichment.enrich_batch", new=fake_enrich_batch):
+            result = await tasks_mod.enrichment_sweep({"db": conn})
+
+        assert result.get("repaired") == 1, result
+        # The repair call must run with skip_existing=False so it overwrites.
+        assert any(ids == [jid] and skip is False for ids, skip in calls), calls
+    finally:
+        await db.close()


### PR DESCRIPTION
The Pillar-2 simulation against live prod found the common root behind text coverage stuck at 35% and enrichment unknowns at 94%/62%/61% (visa/seniority/workplace): **data written before yesterday's fixes could never be repaired by them**.

1. **insert_job**: re-fetch carrying text now fills an EMPTY stored description (empty→non-empty only; new-job semantics untouched so notifications can't double-fire).
2. **enrichment_sweep REPAIR phase**: leftover per-tick budget re-enriches all-unknown rows whose job now has real text (skip_existing=False → upsert overwrites), highest-value first.

Sim baseline recorded: title fix holds on prod (−0.04→+0.29), dims lift ceiling to 93; dims' correlation gain is ~0 *because* of the hollow rows this repairs — re-measure after convergence.

Tests: +2, suites 67 green, gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6DsQH5EUxJc3Vnqz9YHgQ