### PR TITLE
feat(feed): scorer_version — scoring fixes reach existing rows (audit cross-check)

### DIFF
--- a/backend/migrations/0026_user_feed_scorer_version.down.sql
+++ b/backend/migrations/0026_user_feed_scorer_version.down.sql
@@ -1,0 +1,4 @@
+-- Postgres can DROP COLUMN cleanly, but house style for user_feed adds (0014,
+-- 0018) is a registry-only rollback so a down-migration can never destroy
+-- per-user scoring state. Production rollback restores from backup.
+DELETE FROM _schema_migrations WHERE id = '0026_user_feed_scorer_version';

--- a/backend/migrations/0026_user_feed_scorer_version.up.sql
+++ b/backend/migrations/0026_user_feed_scorer_version.up.sql
@@ -1,0 +1,13 @@
+-- Stamps WHICH SCORER produced the row's score, alongside profile_version.
+--
+-- WHY (2026-08-06, found by the Pillar-2 ground-truth audit): user_feed.score
+-- is frozen unless the incoming profile_version differs (feed.py freeze). That
+-- makes a SCORING-CODE improvement inert — 6,165 prod rows carried the current
+-- profile version (14) with pre-fix scores, so the revived title lever (PR #224,
+-- Spearman -0.04 -> +0.29) could not reach a single existing row. Shipped code
+-- did not equal live behaviour, and nothing surfaced the gap.
+--
+-- With this column the freeze key becomes (profile_version, scorer_version):
+-- bumping SCORER_VERSION in code re-scores every row on the next backfill, no
+-- profile edit required. NULL = scored before this migration (always re-score).
+ALTER TABLE user_feed ADD COLUMN scorer_version INTEGER;

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -51,7 +51,12 @@ from src.services.profile.keyword_generator import generate_search_config
 from src.services.profile.models import SearchConfig, UserProfile
 from src.services.profile.storage import current_profile_version_id, load_profile
 from src.services.scheduler import TieredScheduler
-from src.services.skill_matcher import JobScorer, detect_experience_level, salary_in_range
+from src.services.skill_matcher import (
+    SCORER_VERSION,
+    JobScorer,
+    detect_experience_level,
+    salary_in_range,
+)
 from src.sources.apis_free.aijobs import AIJobsSource
 from src.sources.apis_free.arbeitnow import ArbeitnowSource
 from src.sources.apis_free.devitjobs import DevITJobsSource
@@ -1074,6 +1079,7 @@ async def run_search(
                             score=_score,
                             bucket=_recency_bucket(job.date_found),
                             profile_version=feed_profile_version,
+                            scorer_version=SCORER_VERSION,
                         )
                         feed_written += 1
                         _written_for_notify.append((job.id, _score))

--- a/backend/src/services/feed.py
+++ b/backend/src/services/feed.py
@@ -249,6 +249,7 @@ class FeedService:
         score: int,
         bucket: str,
         profile_version: Optional[int] = None,
+        scorer_version: Optional[int] = None,
     ) -> int:
         """Insert a feed row or update (score, bucket, profile_version) if (user, job) already tracked.
 
@@ -257,30 +258,42 @@ class FeedService:
         row's score — None for legacy/unscored rows.
 
         FIX 6 — Version-conditional score freeze:
-        On an EXISTING row, the score is FROZEN when the incoming
-        ``profile_version`` equals the stored one (SQLite ``IS`` is NULL-safe:
-        equal-or-both-NULL -> freeze).  The score is overwritten only when the
-        version differs (re-score under a new profile).  This means an ordinary
-        re-fetch of the same job under the same profile keeps its score stable
-        (no time-based drift), while a re-score under a new profile updates it.
-        ``bucket`` and ``profile_version`` are always overwritten.
+        On an EXISTING row, the score is FROZEN when BOTH the incoming
+        ``profile_version`` AND ``scorer_version`` equal the stored ones
+        (``IS NOT DISTINCT FROM`` is NULL-safe: equal-or-both-NULL -> freeze).
+        The score is overwritten when either differs. So an ordinary re-fetch
+        under the same profile AND the same scorer keeps its score stable (no
+        time-based drift), while a new profile OR a new scorer re-scores it.
+
+        The ``scorer_version`` half was added 2026-08-06 after the Pillar-2
+        ground-truth audit: profile-only freezing made SCORING-CODE fixes inert
+        — 6,165 prod rows carried the current profile version with pre-fix
+        scores, so PR #224's title fix (Spearman -0.04 -> +0.29) reached none of
+        them. Shipped code did not equal live behaviour. Bumping
+        ``skill_matcher.SCORER_VERSION`` now re-scores every row on the next
+        backfill, with no profile edit required.
+        ``bucket`` and both version stamps are always overwritten.
         """
         now = datetime.now(timezone.utc).isoformat()
         await self._db.execute(
             """
-            INSERT INTO user_feed(user_id, job_id, score, bucket, status, created_at, updated_at, profile_version)
-            VALUES (?, ?, ?, ?, 'active', ?, ?, ?)
+            INSERT INTO user_feed(user_id, job_id, score, bucket, status,
+                                  created_at, updated_at, profile_version, scorer_version)
+            VALUES (?, ?, ?, ?, 'active', ?, ?, ?, ?)
             ON CONFLICT(user_id, job_id)
             DO UPDATE SET
                 score = CASE
-                    WHEN user_feed.profile_version IS NOT DISTINCT FROM excluded.profile_version THEN user_feed.score
+                    WHEN user_feed.profile_version IS NOT DISTINCT FROM excluded.profile_version
+                     AND user_feed.scorer_version IS NOT DISTINCT FROM excluded.scorer_version
+                        THEN user_feed.score
                     ELSE excluded.score
                 END,
                 bucket = excluded.bucket,
                 updated_at = excluded.updated_at,
-                profile_version = excluded.profile_version
+                profile_version = excluded.profile_version,
+                scorer_version = excluded.scorer_version
             """,
-            (user_id, job_id, score, bucket, now, now, profile_version),
+            (user_id, job_id, score, bucket, now, now, profile_version, scorer_version),
         )
         await self._db.commit()
         cur = await self._db.execute(

--- a/backend/src/services/rescore.py
+++ b/backend/src/services/rescore.py
@@ -231,6 +231,8 @@ async def backfill_feed_from_catalog(
     if version is None:
         version = current_profile_version_id(user_id)
 
+    from src.services.skill_matcher import SCORER_VERSION as _SCORER_VERSION  # noqa: PLC0415
+
     scorer = await _build_user_scorer(db, profile)
     rows = await db.get_catalog_jobs_for_rescore()
 
@@ -294,6 +296,7 @@ async def backfill_feed_from_catalog(
                     score=ms,
                     bucket=_recency_bucket(row.get("date_found")),
                     profile_version=version,
+                    scorer_version=_SCORER_VERSION,
                 )
             )
             written += 1
@@ -431,6 +434,9 @@ async def rescore_user_feed(
                 _build_enrichment_lookup,
             )
             from src.services.profile.keyword_generator import generate_search_config  # noqa: PLC0415
+            from src.services.skill_matcher import (  # noqa: PLC0415
+                SCORER_VERSION as _SCORER_VERSION,
+            )
             from src.services.skill_matcher import JobScorer  # noqa: PLC0415
 
             search_config = generate_search_config(profile)
@@ -573,6 +579,7 @@ async def rescore_user_feed(
                             score=int(ms),
                             bucket=_recency_bucket(row.get("date_found")),
                             profile_version=version,
+                            scorer_version=_SCORER_VERSION,
                         )
                     )
                     rescored += 1

--- a/backend/src/services/skill_matcher.py
+++ b/backend/src/services/skill_matcher.py
@@ -22,6 +22,16 @@ from src.core.skill_synonyms import aliases_for
 from src.models import Job
 from src.services.scoring_dimensions import ScoreBreakdown
 
+# SCORER_VERSION — bump this whenever a change alters the score a given
+# (job, profile) pair produces. user_feed.score is frozen per
+# (profile_version, scorer_version), so this constant is what makes a scoring
+# fix REACH existing rows: bump it and every row re-scores on the next
+# backfill. Found necessary 2026-08-06 — PR #224's title fix was inert on
+# 6,165 prod rows because their profile_version was unchanged.
+#   1 = pre-2026-08-06 (legacy title matching)
+#   2 = revived title lever: evidence-based core domain words + domain+role band
+SCORER_VERSION = 2
+
 # Weights for scoring components (total = 100)
 TITLE_WEIGHT = 40
 SKILL_WEIGHT = 40

--- a/backend/tests/test_feed_service.py
+++ b/backend/tests/test_feed_service.py
@@ -316,3 +316,46 @@ async def test_upsert_score_overwritten_when_version_changes(feed_db):
     # score overwritten because version changed (5 -> 6)
     assert row["score"] == 40
     assert row["profile_version"] == 6
+
+
+@pytest.mark.asyncio
+async def test_scorer_version_bump_unfreezes_the_score(feed_db):
+    """THE FIX FOR SHIPPED-CODE-THAT-NEVER-LANDS (2026-08-06).
+
+    The freeze used to key on profile_version ALONE, which made a
+    SCORING-CODE improvement inert: 6,165 prod rows carried the CURRENT
+    profile version with pre-fix scores, so PR #224's revived title lever
+    (Spearman -0.04 -> +0.29) reached none of them — shipped code did not
+    equal live behaviour, and nothing surfaced the gap. A scorer_version bump
+    must re-score even when the profile is unchanged.
+    """
+    async with pg.connect(feed_db) as db:
+        db.row_factory = pg.Row
+        svc = FeedService(db)
+        await svc.upsert_feed_row(
+            user_id="alice", job_id=31, score=27, bucket="24h",
+            profile_version=14, scorer_version=1,
+        )
+        # Same profile AND same scorer -> still frozen (unchanged contract).
+        await svc.upsert_feed_row(
+            user_id="alice", job_id=31, score=99, bucket="24h",
+            profile_version=14, scorer_version=1,
+        )
+        cur = await db.execute(
+            "SELECT score FROM user_feed WHERE user_id = ? AND job_id = ?",
+            ("alice", 31),
+        )
+        assert (await cur.fetchone())["score"] == 27, "same scorer must still freeze"
+
+        # Same profile, NEW scorer -> the score MUST be re-written.
+        await svc.upsert_feed_row(
+            user_id="alice", job_id=31, score=81, bucket="24h",
+            profile_version=14, scorer_version=2,
+        )
+        cur = await db.execute(
+            "SELECT score, scorer_version FROM user_feed WHERE user_id = ? AND job_id = ?",
+            ("alice", 31),
+        )
+        row2 = await cur.fetchone()
+    assert row2["score"] == 81, "a scorer_version bump must re-score the row"
+    assert row2["scorer_version"] == 2


### PR DESCRIPTION
Freeze key becomes (profile_version, scorer_version): 6,165 prod rows carried the current profile version with pre-fix scores — shipped scoring improvements were structurally inert. Migration 0026 + SCORER_VERSION=2 + all three write paths. Same-scorer still freezes (no drift); new scorer re-scores on next backfill. Tests +1; 87 green across suites.

Iteration 1 of the eval-fix-merge loop (benchmark: precision@25 ≥80%, @100 ≥75%, Spearman ≥+0.5, 0 unjudged shown).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6DsQH5EUxJc3Vnqz9YHgQ