### PR TITLE
feat(matcher): Verified Window + gem-rescue lane (eval-loop iteration 2)

### DIFF
--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -350,6 +350,7 @@ async def _run_matcher_stage(db: JobDatabase, *, user_id: str, jobs: list[Job]) 
             MATCHER_ENABLED,
             MATCHER_MAX_JOBS,
             MATCHER_THRESHOLD,
+            MATCHER_WINDOW,
             match_batch,
             profile_to_matcher_text,
         )
@@ -363,17 +364,57 @@ async def _run_matcher_stage(db: JobDatabase, *, user_id: str, jobs: list[Job]) 
         if profile is None:
             logger.info("matcher: no profile for user %s — skipping", user_id)
             return
-        shortlist = sorted(
-            (
-                j
-                for j in jobs
-                if getattr(j, "id", None) is not None
-                and j.match_score is not None
-                and j.match_score >= MATCHER_THRESHOLD
-            ),
-            key=lambda j: j.match_score,
-            reverse=True,
-        )[:MATCHER_MAX_JOBS]
+
+        # THE VERIFIED WINDOW (2026-08-06, ground-truth audit finding). The old
+        # shortlist came only from `jobs` — the postings THIS run fetched — so
+        # the backfilled catalog rows that actually fill the dashboard were
+        # never judged: 28 of the measured top-100 were unjudged junk sitting
+        # above judged rows. The judge now targets what the user WILL SEE — the
+        # top MATCHER_WINDOW feed rows by display rank — judging any without a
+        # verdict. Verdicts cache per (user, job), so only new window entrants
+        # cost anything after the first pass. MATCHER_WINDOW=0 falls back to
+        # the legacy fetched-only shortlist.
+        assert db._conn is not None  # set by init_db() before this stage runs
+        shortlist: list[Job] = []
+        if MATCHER_WINDOW > 0:
+            cur = await db._conn.execute(
+                """
+                SELECT j.id, j.title, j.company, j.location, j.description,
+                       j.apply_url, j.source, j.date_found, j.salary_min,
+                       j.salary_max, f.score
+                FROM (
+                    SELECT job_id, score, llm_fit_score FROM user_feed
+                    WHERE user_id = ? AND status = 'active' AND score >= ?
+                    ORDER BY COALESCE(llm_fit_score, score) DESC
+                    LIMIT ?
+                ) f
+                JOIN jobs j ON j.id = f.job_id
+                WHERE f.llm_fit_score IS NULL
+                """,
+                (user_id, MATCHER_THRESHOLD, MATCHER_WINDOW),
+            )
+            for r in await cur.fetchall():
+                wj = Job(
+                    title=r[1] or "", company=r[2] or "", apply_url=r[5] or "",
+                    source=r[6] or "", date_found=r[7] or "",
+                    location=r[3] or "", description=r[4] or "",
+                    salary_min=r[8], salary_max=r[9],
+                )
+                wj.id = r[0]
+                wj.match_score = int(r[10] or 0)
+                shortlist.append(wj)
+        else:
+            shortlist = sorted(
+                (
+                    j
+                    for j in jobs
+                    if getattr(j, "id", None) is not None
+                    and j.match_score is not None
+                    and j.match_score >= MATCHER_THRESHOLD
+                ),
+                key=lambda j: j.match_score,
+                reverse=True,
+            )[:MATCHER_MAX_JOBS]
         if not shortlist:
             return
         t0 = time.perf_counter()

--- a/backend/src/services/llm_matcher.py
+++ b/backend/src/services/llm_matcher.py
@@ -38,6 +38,24 @@ MATCHER_ENABLED = os.getenv("MATCHER_ENABLED", "false").lower() in {"1", "true",
 # it can never see a job the funnel discarded. 30 == the MIN_MATCH_SCORE floor.
 MATCHER_THRESHOLD = int(os.getenv("MATCHER_THRESHOLD", "30"))
 MATCHER_MAX_JOBS = int(os.getenv("MATCHER_MAX_JOBS", "30"))
+# The Verified Window (2026-08-06, ground-truth audit). The judge used to see
+# only jobs fetched in the CURRENT run — never the backfilled catalog rows that
+# actually fill the dashboard — so 28 of the measured top-100 were unjudged
+# junk. The judge now targets the DISPLAYED window: the top MATCHER_WINDOW
+# feed rows by rank, judging any that lack a verdict. Verdicts cache forever,
+# so the first pass pays ~window calls and steady state only pays for new
+# entrants. 0 disables the window pass (legacy fetched-only behaviour).
+MATCHER_WINDOW = int(os.getenv("MATCHER_WINDOW", "120"))
+# The gem-rescue lane: jobs whose TITLE alone is a strong match (per-user
+# title points >= TITLE_RESCUE_MIN) but whose total sank on thin/no
+# description. Iteration-1 audit: 17 buried gems, all title-strong thin-text
+# ("Senior Data Engineer", desc=0c, kw=26). They get judged regardless of
+# total score, capped per run; judged-strong ones reactivate.
+MATCHER_RESCUE_MAX = int(os.getenv("MATCHER_RESCUE_MAX", "30"))
+TITLE_RESCUE_MIN = int(os.getenv("TITLE_RESCUE_MIN", "30"))
+# A rescued/evicted row whose verdict is at least this strong returns to the
+# active shelf (COALESCE ranking then surfaces it).
+RESCUE_REACTIVATE_MIN = int(os.getenv("RESCUE_REACTIVATE_MIN", "65"))
 
 
 class MatchVerdict(BaseModel):

--- a/backend/src/services/rescore.py
+++ b/backend/src/services/rescore.py
@@ -244,7 +244,13 @@ async def backfill_feed_from_catalog(
 
     # Phase 1 — score the whole catalog (unchanged cost: this loop always
     # scored every row; it just also WROTE every row that beat the floor).
+    # `title_strong` feeds the gem-rescue lane (Phase 5): iteration-1 audit
+    # found 17 buried gems, ALL title-perfect jobs sunk by thin/no description
+    # text ("Senior Data Engineer", desc=0c, kw=26).
     scored: list[tuple[int, Any, dict[str, Any]]] = []
+    title_strong: list[tuple[int, Any, dict[str, Any]]] = []
+    from src.services.llm_matcher import TITLE_RESCUE_MIN  # noqa: PLC0415
+
     for row in rows:
         jid = row.get("id")
         if jid is None:
@@ -257,6 +263,8 @@ async def backfill_feed_from_catalog(
         except Exception as exc:  # noqa: BLE001
             logger.warning("catalog backfill: skipping job %s: %s", jid, exc)
             continue
+        if int(getattr(breakdown, "title_score", 0) or 0) >= TITLE_RESCUE_MIN:
+            title_strong.append((ms, jid, row))
         if ms < MIN_STORE_SCORE:
             continue
         scored.append((ms, jid, row))
@@ -365,6 +373,76 @@ async def backfill_feed_from_catalog(
                 )
         except Exception as exc:  # noqa: BLE001
             logger.warning("catalog backfill: candidate enrichment failed: %s", exc)
+
+    # Phase 5 — the GEM-RESCUE lane (2026-08-06, iteration-1 audit). Title-
+    # perfect jobs with thin/no descriptions lose the 40 skill points and sink
+    # below the shelf (or get evicted): 17/100 buried-sample gems, all this
+    # class. Any title-strong row without a verdict gets judged regardless of
+    # its total (capped per run); a judged-strong row is reactivated so the
+    # COALESCE ranking surfaces it, and the verdict guard makes it
+    # eviction-proof from then on. Gated like every E4 call site.
+    from src.core.settings import ENGINE4_ENABLED  # noqa: PLC0415
+    from src.services.llm_matcher import (  # noqa: PLC0415
+        MATCHER_ENABLED,
+        MATCHER_RESCUE_MAX,
+        RESCUE_REACTIVATE_MIN,
+    )
+
+    if (ENGINE4_ENABLED or MATCHER_ENABLED) and title_strong and MATCHER_RESCUE_MAX > 0:
+        try:
+            from src.models import Job as _RJob  # noqa: PLC0415
+            from src.services.llm_matcher import (  # noqa: PLC0415
+                has_verdict,
+                match_batch,
+                profile_to_matcher_text,
+            )
+
+            rescue: list[Any] = []
+            for ms, jid, row in sorted(title_strong, key=lambda t: t[0], reverse=True):
+                if len(rescue) >= MATCHER_RESCUE_MAX:
+                    break
+                if await has_verdict(db._db, user_id, jid):
+                    continue
+                rjob = _RJob(
+                    title=row.get("title", "") or "",
+                    company=row.get("company", "") or "",
+                    apply_url=row.get("apply_url", "") or "",
+                    source=row.get("source", "") or "",
+                    date_found=row.get("date_found", "") or "",
+                    location=row.get("location", "") or "",
+                    description=row.get("description", "") or "",
+                    salary_min=row.get("salary_min"),
+                    salary_max=row.get("salary_max"),
+                )
+                rjob.id = jid
+                rjob.match_score = ms
+                rescue.append(rjob)
+            if rescue:
+                await match_batch(
+                    rescue,
+                    user_id=user_id,
+                    profile_text=profile_to_matcher_text(profile),
+                    conn=db._db,
+                    semaphore_limit=3,
+                )
+                # Reactivate rescued rows whose verdict clears the bar — an
+                # evicted gem returns to the shelf, ranked by its fit score.
+                from datetime import datetime, timezone  # noqa: PLC0415
+
+                now = datetime.now(timezone.utc).isoformat()
+                cur = await db._db.execute(
+                    "UPDATE user_feed SET status = 'active', updated_at = ? "
+                    "WHERE user_id = ? AND status = 'stale' AND llm_fit_score >= ?",
+                    (now, user_id, RESCUE_REACTIVATE_MIN),
+                )
+                await db._db.commit()
+                logger.info(
+                    "catalog backfill: gem-rescue judged %s title-strong jobs "
+                    "for user %s (reactivated %s)",
+                    len(rescue), user_id, cur.rowcount or 0,
+                )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("catalog backfill: gem-rescue failed: %s", exc)
 
     logger.info(
         "catalog backfill: user %s matched %s of %s catalog jobs "

--- a/backend/tests/test_llm_matcher.py
+++ b/backend/tests/test_llm_matcher.py
@@ -113,7 +113,9 @@ async def mem_db():
             apply_url TEXT NOT NULL,
             source TEXT NOT NULL,
             date_found TEXT NOT NULL,
-            match_score INTEGER DEFAULT 0
+            match_score INTEGER DEFAULT 0,
+            salary_min REAL,
+            salary_max REAL
         );
         CREATE TABLE IF NOT EXISTS user_feed (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -270,7 +272,9 @@ async def stage_db():
             apply_url TEXT NOT NULL,
             source TEXT NOT NULL,
             date_found TEXT NOT NULL,
-            match_score INTEGER DEFAULT 0
+            match_score INTEGER DEFAULT 0,
+            salary_min REAL,
+            salary_max REAL
         );
         CREATE TABLE IF NOT EXISTS user_feed (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -691,3 +695,36 @@ async def test_match_batch_never_uses_the_shared_connection_concurrently(mem_db)
         )
         row = await cur.fetchone()
         assert row["llm_fit_score"] == 77
+
+
+@pytest.mark.asyncio
+async def test_matcher_window_judges_backfilled_rows_not_just_fetched(stage_db, monkeypatch):
+    """THE VERIFIED WINDOW (2026-08-06 audit finding). The judge used to see
+    only jobs passed in from the current fetch — backfilled catalog rows that
+    fill the dashboard were never judged (28 of the measured top-100 were
+    unjudged junk). The window pass must judge feed rows even when the
+    `jobs` argument does not contain them."""
+    from src import main as main_mod
+
+    monkeypatch.setattr("src.services.llm_matcher.MATCHER_ENABLED", True)
+    monkeypatch.setattr("src.services.profile.storage.load_profile", lambda uid: _Profile())
+
+    async def fake(prompt, schema, system):
+        return MatchVerdict(fit_score=66, verdict="good", reason="r")
+
+    monkeypatch.setattr("src.services.llm_matcher.llm_extract_validated", fake)
+
+    conn = stage_db._conn
+    # A BACKFILLED row: exists in the feed, NOT passed via `jobs`.
+    backfilled = await _seed_job(conn, "Backfilled Data Engineer", "CatalogCo", 55, _UID)
+
+    await main_mod._run_matcher_stage(stage_db, user_id=_UID, jobs=[])
+
+    cur = await conn.execute(
+        "SELECT llm_fit_score FROM user_feed WHERE user_id=? AND job_id=?",
+        (_UID, backfilled.id),
+    )
+    row = await cur.fetchone()
+    assert row is not None and row["llm_fit_score"] == 66, (
+        "a backfilled feed row inside the display window was not judged"
+    )


### PR DESCRIPTION
Judge the DISPLAYED window (top 120 feed rows incl. backfill — previously never judged: 28/100 shown were unjudged junk) + rescue title-strong thin-text gems (17 found buried, 8 evicted) with reactivation at fit≥65. Verdict caching bounds cost to new window entrants. All knobs env-tunable, 0-disables.

Iteration-1 result on the same audit: precision@100 strong 39%→66%. This PR targets the remaining gap (benchmark ≥75%) + the 17 gems (benchmark ≤2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6DsQH5EUxJc3Vnqz9YHgQ