### PR TITLE
fix(sources): detail-fetch budgets — un-break workday + smartrecruiters nightly

### DIFF
--- a/backend/src/sources/ats/smartrecruiters.py
+++ b/backend/src/sources/ats/smartrecruiters.py
@@ -14,6 +14,13 @@ from src.utils.dates import normalize_posted_at
 logger = logging.getLogger("job360.sources.smartrecruiters")
 
 _HTML_TAG_RE = re.compile(r"<[^>]+>")
+# Detail-fetch budget per RUN (2026-08-06). The 2026-08-05 detail pass had NO
+# cap: the nightly union refresh detail-fetched every UK posting across every
+# company, blew the 240s ATS fetch timeout, and the whole source was recorded
+# as errored with ZERO jobs stored (it produced 150 before). Jobs past the cap
+# keep an empty description — the description-backfill-on-refetch (PR #232)
+# fills them across later runs.
+_MAX_DETAIL_FETCHES = 60
 
 class SmartRecruitersSource(BaseJobSource):
     name = "smartrecruiters"
@@ -25,6 +32,7 @@ class SmartRecruitersSource(BaseJobSource):
 
     async def fetch_jobs(self) -> list[Job]:
         jobs = []
+        detail_budget = _MAX_DETAIL_FETCHES
         for slug in self._companies:
             url = f"https://api.smartrecruiters.com/v1/companies/{slug}/postings"
             data = await self._get_json(url, params={"limit": "100"})
@@ -68,7 +76,8 @@ class SmartRecruitersSource(BaseJobSource):
                 # UK/remote-relevant jobs are detail-fetched, so the extra
                 # request count matches what we actually keep. A failed detail
                 # fetch degrades to the empty description, never drops the job.
-                if _is_uk_or_remote(location):
+                if _is_uk_or_remote(location) and detail_budget > 0:
+                    detail_budget -= 1
                     job.description = await self._fetch_posting_text(
                         slug, str(item.get("id", ""))
                     )

--- a/backend/src/sources/ats/workday.py
+++ b/backend/src/sources/ats/workday.py
@@ -16,6 +16,12 @@ logger = logging.getLogger("job360.sources.workday")
 _POSTED_RE = re.compile(r"Posted\s+(\d+)\s+Days?\s+Ago", re.IGNORECASE)
 # Strip HTML tags from the CXS detail endpoint's jobDescription.
 _DESC_TAG_RE = re.compile(r"<[^>]+>")
+# Detail-fetch budget per RUN (2026-08-06) — same timeout regression as
+# smartrecruiters: uncapped detail fetches blew the 240s ATS ceiling in the
+# nightly union refresh and zeroed the source (537 jobs before). Past-cap jobs
+# keep empty descriptions; the description-backfill-on-refetch (PR #232) fills
+# them across later runs.
+_MAX_DETAIL_FETCHES = 40
 
 
 def _parse_posted_on(text: str) -> str:
@@ -45,6 +51,7 @@ class WorkdaySource(BaseJobSource):
     async def fetch_jobs(self) -> list[Job]:
         jobs = []
         seen_keys = set()
+        detail_budget = _MAX_DETAIL_FETCHES
         for entry in self._companies:
             tenant = entry["tenant"]
             wd = entry["wd"]
@@ -105,9 +112,12 @@ class WorkdaySource(BaseJobSource):
                     # 12,746 chars for an astrazeneca posting). Only UK/remote
                     # survivors reach this point, so the request count matches
                     # what we keep. Failure degrades to "", never drops the job.
-                    description = await self._fetch_job_description(
-                        base_url, tenant, site, ext_path
-                    )
+                    description = ""
+                    if detail_budget > 0:
+                        detail_budget -= 1
+                        description = await self._fetch_job_description(
+                            base_url, tenant, site, ext_path
+                        )
                     jobs.append(Job(
                         title=title,
                         company=company_name,

--- a/backend/tests/test_sources.py
+++ b/backend/tests/test_sources.py
@@ -2786,3 +2786,71 @@ def test_eightykhours_declares_niche_domain():
     can exclude it for unrelated profiles."""
     assert EightyKHoursSource.DOMAINS != {"general"}
     assert EightyKHoursSource.DOMAINS == {"tech"}
+
+
+def test_smartrecruiters_detail_fetches_are_budgeted(monkeypatch):
+    """Timeout-regression guard (2026-08-06): the nightly union refresh blew
+    the 240s ATS ceiling because detail fetches were uncapped — the source
+    errored and stored ZERO jobs. The per-run budget must bound them."""
+    async def _test():
+        import src.sources.ats.smartrecruiters as sr_mod
+        monkeypatch.setattr(sr_mod, "_MAX_DETAIL_FETCHES", 2)
+        session = aiohttp.ClientSession()
+        try:
+            postings = [{"id": f"sr-{i}", "name": f"AI Engineer {i}",
+                         "location": {"city": "London", "country": "GB"},
+                         "ref": f"https://jobs.smartrecruiters.com/wise/sr-{i}",
+                         "releasedDate": "2024-01-15"} for i in range(5)]
+            detail_calls = []
+            with aioresponses() as m:
+                m.get(re.compile(r".*postings\?.*"), payload={"content": postings})
+                def _detail_cb(url, **kw):
+                    from aioresponses import CallbackResult
+                    detail_calls.append(str(url))
+                    return CallbackResult(payload={"jobAd": {"sections": {
+                        "jobDescription": {"text": "<p>role text</p>"}}}})
+                m.get(re.compile(r".*postings/sr-\d+$"), callback=_detail_cb, repeat=True)
+                source = SmartRecruitersSource(session, companies=["wise"])
+                jobs = await source.fetch_jobs()
+            assert len(jobs) == 5, "past-budget jobs must still be KEPT"
+            assert len(detail_calls) == 2, f"budget must cap details, got {len(detail_calls)}"
+            with_desc = [j for j in jobs if j.description]
+            assert len(with_desc) == 2
+        finally:
+            await session.close()
+    _run(_test())
+
+
+def test_workday_detail_fetches_are_budgeted(monkeypatch):
+    """Same guard for workday (537 jobs zeroed by the uncapped detail pass)."""
+    async def _test():
+        import src.sources.ats.workday as wd_mod
+        monkeypatch.setattr(wd_mod, "_MAX_DETAIL_FETCHES", 1)
+        session = aiohttp.ClientSession()
+        try:
+            postings = [{"title": f"ML Engineer {i}",
+                         "locationsText": "London, United Kingdom",
+                         "externalPath": f"/job/London/ML-{i}",
+                         "postedOn": "Posted Today"} for i in range(3)]
+            detail_calls = []
+            with aioresponses() as m:
+                m.post(re.compile(r".*wday/cxs/acme/ext/jobs"),
+                       payload={"jobPostings": postings}, repeat=True)
+                def _detail_cb(url, **kw):
+                    from aioresponses import CallbackResult
+                    detail_calls.append(str(url))
+                    return CallbackResult(payload={"jobPostingInfo": {
+                        "jobDescription": "<p>text</p>"}})
+                m.get(re.compile(r".*wday/cxs/acme/ext/job/London/ML-\d+"),
+                      callback=_detail_cb, repeat=True)
+                source = WorkdaySource(
+                    session,
+                    companies=[{"tenant": "acme", "wd": "wd1", "site": "ext", "name": "Acme"}],
+                    search_config=_sc_ai_defaults(),
+                )
+                jobs = await source.fetch_jobs()
+            assert len(jobs) == 3, "past-budget jobs must still be KEPT"
+            assert len(detail_calls) == 1, f"budget must cap details, got {len(detail_calls)}"
+        finally:
+            await session.close()
+    _run(_test())


### PR DESCRIPTION
Both sources have errored (zero jobs) in every nightly refresh since the uncapped 2026-08-05 detail passes blew the 240s ATS timeout. Budgets (workday 40, SR 60) keep the fetch inside its ceiling; past-budget jobs are kept with empty descriptions and filled by PR #232's backfill-on-refetch across later runs. +2 tests; sources suite 104 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6DsQH5EUxJc3Vnqz9YHgQ