### PR TITLE
feat(scoring): length-normalise the skill score - long ads no longer out-score tight ones

### DIFF
--- a/backend/src/services/skill_matcher.py
+++ b/backend/src/services/skill_matcher.py
@@ -1,3 +1,4 @@
+import os
 import re
 from datetime import datetime, timezone
 from functools import lru_cache
@@ -30,7 +31,8 @@ from src.services.scoring_dimensions import ScoreBreakdown
 # 6,165 prod rows because their profile_version was unchanged.
 #   1 = pre-2026-08-06 (legacy title matching)
 #   2 = revived title lever: evidence-based core domain words + domain+role band
-SCORER_VERSION = 2
+#   3 = skill-score length normalisation (long ads no longer out-score tight ones)
+SCORER_VERSION = 3
 
 # Weights for scoring components (total = 100)
 TITLE_WEIGHT = 40
@@ -43,6 +45,42 @@ PRIMARY_POINTS = 3
 SECONDARY_POINTS = 2
 TERTIARY_POINTS = 1
 SKILL_CAP = SKILL_WEIGHT
+
+# LENGTH NORMALISATION for the skill score (2026-08-07, tie-band fix).
+# Skill points are +3/+2/+1 per matched skill, capped at 40. A LONGER job ad
+# simply contains more words, so it accidentally contains more of the user's
+# skills — a 5,000-char corporate description ("we value collaboration,
+# Python a plus, data-driven culture") saturates the same 40/40 as a tight,
+# genuinely-matching role. Measured consequence: 141 of one user's jobs piled
+# into a single score band (24-29), where junk and real matches were
+# indistinguishable, and the top-100 filled from that noise.
+#
+# The standard IR answer (BM25's length normalisation): divide by
+#   max(1, (1 - b) + b * words / baseline)
+# so a job at/below the baseline length is UNCHANGED and longer ads are
+# discounted in proportion. Deliberately one-sided — never boosts short text,
+# because thin descriptions are a known DATA problem here (empty-description
+# sources), and inflating them would reward missing information.
+# Baseline measured on prod 2026-08-07: avg 390 words, median 353, p90 751.
+SKILL_LENGTH_BASELINE_WORDS = int(os.getenv("SKILL_LENGTH_BASELINE_WORDS", "400"))
+SKILL_LENGTH_NORM_B = float(os.getenv("SKILL_LENGTH_NORM_B", "0.5"))
+
+
+def _length_normalise_skill_points(points: int, text: str) -> int:
+    """Discount skill points earned in an unusually long job ad.
+
+    ``SKILL_LENGTH_NORM_B = 0`` disables (byte-identical to the old
+    behaviour). Never returns more than ``points`` — short ads are not
+    inflated (see the module note above)."""
+    if points <= 0 or SKILL_LENGTH_NORM_B <= 0 or SKILL_LENGTH_BASELINE_WORDS <= 0:
+        return points
+    words = len(text.split())
+    norm = (1.0 - SKILL_LENGTH_NORM_B) + SKILL_LENGTH_NORM_B * (
+        words / SKILL_LENGTH_BASELINE_WORDS
+    )
+    if norm <= 1.0:
+        return points
+    return int(points / norm)
 
 # Location aliases — map variants to canonical form
 LOCATION_ALIASES = {
@@ -513,6 +551,16 @@ class JobScorer:
         return min(len(core_overlap) * 5, TITLE_WEIGHT // 2)
 
     def _skill_score(self, text: str) -> int:
+        """Skill points, normalised for how much text earned them.
+
+        Nothing is truncated — the whole ad is still read. But a longer ad
+        contains more words and therefore accidentally contains more of the
+        user's skills, so raw counts reward LENGTH over FIT (measured: 141
+        jobs collapsed into one score band). Points are divided by the ad's
+        length relative to a typical ad, exactly as BM25 does; ads at or below
+        typical length are untouched. See the module note on
+        ``_length_normalise_skill_points``.
+        """
         points = 0
         for skill in self._config.primary_skills:
             if _text_contains_skill(text, skill):
@@ -523,7 +571,7 @@ class JobScorer:
         for skill in self._config.tertiary_skills:
             if _text_contains_skill(text, skill):
                 points += TERTIARY_POINTS
-        return min(points, SKILL_CAP)
+        return min(_length_normalise_skill_points(points, text), SKILL_CAP)
 
     def _negative_penalty(self, job_title: str) -> int:
         for kw in self._config.negative_title_keywords:

--- a/backend/tests/test_scorer.py
+++ b/backend/tests/test_scorer.py
@@ -1147,3 +1147,69 @@ class TestDomainRoleTitleBand:
     def test_exact_match_still_wins_everything(self):
         s = self._scorer({"ai"}, {"engineer"})
         assert s._title_score("AI Solutions Engineer - R&D Department") == TITLE_WEIGHT
+
+
+# ═══ Skill-score length normalisation (tie-band fix, 2026-08-07) ══════════════
+# Skill points are +3/+2/+1 per match. A LONGER ad contains more words and so
+# accidentally contains more of the user's skills — 5,000-char corporate waffle
+# saturated the same 40/40 as a tight, genuinely-matching role. Measured: 141
+# of one user's jobs collapsed into the 24-29 band where junk and real matches
+# were indistinguishable. Nothing is truncated; only the SCORE is made fair
+# between a short ad and a long one (BM25's length normalisation).
+
+
+class TestSkillLengthNormalisation:
+    def _scorer(self):
+        cfg = SearchConfig(
+            job_titles=["ML Engineer"],
+            primary_skills=["python", "pytorch", "kubernetes", "airflow"],
+            secondary_skills=[],
+            tertiary_skills=[],
+            locations=["London"],
+            core_domain_words={"ml"},
+            supporting_role_words={"engineer"},
+        )
+        return JobScorer(cfg)
+
+    def test_a_typical_length_ad_is_unchanged(self):
+        s = self._scorer()
+        # 4 skills in ~400 words (the measured prod baseline) -> full points.
+        text = "python pytorch kubernetes airflow " + ("filler " * 396)
+        assert s._skill_score(text) == 12
+
+    def test_a_long_waffle_ad_is_discounted(self):
+        """The measured offender: the same 4 skills sprinkled through a
+        1,600-word corporate ad must NOT score like a tight 400-word match."""
+        s = self._scorer()
+        tight = "python pytorch kubernetes airflow " + ("filler " * 396)
+        waffle = "python pytorch kubernetes airflow " + ("filler " * 1596)
+        assert s._skill_score(waffle) < s._skill_score(tight)
+        assert s._skill_score(waffle) <= 5  # 12 / 2.5
+
+    def test_a_short_ad_is_never_boosted(self):
+        """One-sided by design: thin descriptions are a DATA problem here
+        (empty-description sources), so inflating them would reward missing
+        information."""
+        s = self._scorer()
+        short = "python pytorch kubernetes airflow"
+        assert s._skill_score(short) == 12, "short text must not be inflated"
+
+    def test_normalisation_can_be_disabled(self):
+        """B=0 restores byte-identical legacy behaviour (rule #18 shape)."""
+        import src.services.skill_matcher as sm
+
+        s = self._scorer()
+        waffle = "python pytorch kubernetes airflow " + ("filler " * 1596)
+        old_b = sm.SKILL_LENGTH_NORM_B
+        try:
+            sm.SKILL_LENGTH_NORM_B = 0.0
+            assert s._skill_score(waffle) == 12
+        finally:
+            sm.SKILL_LENGTH_NORM_B = old_b
+
+    def test_scorer_version_was_bumped_for_this_change(self):
+        """A scoring change that does not bump SCORER_VERSION never reaches a
+        single existing row — the exact failure PR #233 fixed."""
+        from src.services.skill_matcher import SCORER_VERSION
+
+        assert SCORER_VERSION >= 3


### PR DESCRIPTION
**Pillar-2 tie-band fix** (eval-loop iteration 4).

Skill points are +3/+2/+1 per match — so a **longer ad accidentally contains more of your skills**. A 1,500-word corporate description ("we value collaboration, Python a plus, data-driven culture") saturated the same 40/40 as a tight 300-word role that genuinely fits. **Length was out-scoring fit**: 141 of one user's jobs collapsed into the 24-29 band where junk and real matches were indistinguishable, and the shown top-100 filled from that noise.

Fix = BM25's length normalisation: divide earned points by `max(1, (1-b) + b·words/baseline)`, b=0.5, baseline 400 words (measured on prod: avg 390, median 353, p90 751).

**Nothing is truncated** — the whole ad is still read, every skill still matches. Only the score is made comparable between a short ad and a long one:

| ad length | effect |
|---|---|
| 400 words (typical) | unchanged |
| 800 words | points ÷1.5 |
| 1,600 words | points ÷2.5 |
| 200 words (short) | **unchanged — never boosted** |

One-sided by design: thin descriptions are a known *data* problem here (empty-description sources); inflating them would reward missing information. `SKILL_LENGTH_NORM_B=0` restores legacy behaviour byte-identically.

`SCORER_VERSION` 2→3 so it reaches existing rows on the next backfill — a scoring change without the bump touches nothing (the failure PR #233 exists to prevent).

+5 tests; 208 green across scorer/profile/rescore/candidate/api.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6DsQH5EUxJc3Vnqz9YHgQ
