### PR TITLE
fix(semantic): move job vectors into Postgres - semantic was structurally impossible

### DIFF
--- a/.github/workflows/ci-offline.yml
+++ b/.github/workflows/ci-offline.yml
@@ -41,7 +41,7 @@ jobs:
     # :5433 and fail with "connection refused".
     services:
       postgres:
-        image: postgres:16
+        image: pgvector/pgvector:pg16
         env:
           POSTGRES_USER: job360
           POSTGRES_PASSWORD: job360dev
@@ -121,7 +121,7 @@ jobs:
     # Postgres-backed backend needs a DB + Redis (see offline-suite note above).
     services:
       postgres:
-        image: postgres:16
+        image: pgvector/pgvector:pg16
         env:
           POSTGRES_USER: job360
           POSTGRES_PASSWORD: job360dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:16
+        image: pgvector/pgvector:pg16
         env:
           POSTGRES_USER: job360
           POSTGRES_PASSWORD: job360dev

--- a/backend/migrations/0027_job_embedding_vectors.down.sql
+++ b/backend/migrations/0027_job_embedding_vectors.down.sql
@@ -1,0 +1,6 @@
+-- Reverse of 0027 — drops the in-Postgres vector column. The extension is
+-- left installed (dropping it would break any other consumer, and it is
+-- inert when unused). Registry-only rollback for the column would leave the
+-- schema lying, so this one really drops it: no other table references it.
+ALTER TABLE job_embeddings DROP COLUMN IF EXISTS embedding;
+DELETE FROM _schema_migrations WHERE id = '0027_job_embedding_vectors';

--- a/backend/migrations/0027_job_embedding_vectors.up.sql
+++ b/backend/migrations/0027_job_embedding_vectors.up.sql
@@ -1,0 +1,54 @@
+-- 0027_job_embedding_vectors: the VECTOR itself moves into Postgres.
+--
+-- WHY (2026-08-07, found while diagnosing "SEMANTIC_ENABLED is true but
+-- nothing is embedded"). The vectors lived in ChromaDB at /data/chroma on the
+-- BACKEND container's local filesystem, and that placement had three
+-- structural consequences, all measured in prod:
+--
+--   1. The worker image ships without the [semantic] extra
+--      (Dockerfile.worker), and the nightly catalog refresh — the only thing
+--      that runs the pipeline on a schedule — runs on the WORKER. It could
+--      never embed anything. Catalog grew 7,761 -> 8,184 overnight while
+--      embeddings stayed at exactly 284.
+--   2. Backend and worker are separate containers with separate disks, so
+--      they cannot share an index even if both had the encoder.
+--   3. Worst: `job_embeddings` (this table, in Postgres, permanent) recorded
+--      "job N is embedded", so the backfill SKIPPED those jobs — while the
+--      vectors sat on a container disk a redeploy can reset. The bookkeeping
+--      could claim coverage the index did not have, and nothing would ever
+--      refill the hole.
+--
+-- Putting the vector in the SAME ROW as its audit record removes all three:
+-- one store shared by every service, surviving deploys, inside the existing
+-- db-backup, and structurally unable to desync from its own bookkeeping.
+--
+-- TOLERANT BY DESIGN. Migrations run inside the FastAPI lifespan
+-- (RUN_MIGRATIONS_ON_BOOT), so a hard `CREATE EXTENSION` would turn a
+-- Postgres without pgvector into a BOOT FAILURE — trading a dark feature for
+-- an outage. Prod has pgvector 0.8.3 available (verified 2026-08-07) and CI
+-- now runs the pgvector image; anywhere else this migration is a clean no-op
+-- and PgVectorIndex degrades to "no semantic results" instead of erroring.
+--
+-- At ~8k jobs an exact cosine scan is milliseconds, so no ANN index is
+-- created here; add ivfflat/hnsw when the catalog justifies it.
+--
+-- Shared catalog — no user_id (CLAUDE.md rule #10).
+
+DO $do$
+BEGIN
+    BEGIN
+        CREATE EXTENSION IF NOT EXISTS vector;
+    EXCEPTION WHEN OTHERS THEN
+        RAISE NOTICE 'pgvector unavailable — job_embeddings.embedding skipped';
+    END;
+
+    IF EXISTS (SELECT 1 FROM pg_type WHERE typname = 'vector') THEN
+        ALTER TABLE job_embeddings ADD COLUMN IF NOT EXISTS embedding vector(384);
+        -- `embedding IS NULL` is exactly the "needs embedding" predicate the
+        -- backfill uses, so rows carried over from the Chroma era (audit row,
+        -- no vector) are picked up automatically.
+        CREATE INDEX IF NOT EXISTS idx_job_embeddings_missing_vector
+            ON job_embeddings(job_id) WHERE embedding IS NULL;
+    END IF;
+END
+$do$;

--- a/backend/migrations/0027_job_embedding_vectors.up.sql
+++ b/backend/migrations/0027_job_embedding_vectors.up.sql
@@ -29,6 +29,11 @@
 -- now runs the pgvector image; anywhere else this migration is a clean no-op
 -- and PgVectorIndex degrades to "no semantic results" instead of erroring.
 --
+-- SCHEMA-QUALIFIED ON PURPOSE. The test suite isolates each test in its own
+-- Postgres schema, so an unqualified `vector` type (and the `<=>` operator)
+-- resolves only when the extension's schema is on search_path — CI failed
+-- with `type "vector" does not exist` until this was pinned to public.
+--
 -- At ~8k jobs an exact cosine scan is milliseconds, so no ANN index is
 -- created here; add ivfflat/hnsw when the catalog justifies it.
 --
@@ -37,13 +42,13 @@
 DO $do$
 BEGIN
     BEGIN
-        CREATE EXTENSION IF NOT EXISTS vector;
+        CREATE EXTENSION IF NOT EXISTS vector WITH SCHEMA public;
     EXCEPTION WHEN OTHERS THEN
         RAISE NOTICE 'pgvector unavailable — job_embeddings.embedding skipped';
     END;
 
     IF EXISTS (SELECT 1 FROM pg_type WHERE typname = 'vector') THEN
-        ALTER TABLE job_embeddings ADD COLUMN IF NOT EXISTS embedding vector(384);
+        ALTER TABLE job_embeddings ADD COLUMN IF NOT EXISTS embedding public.vector(384);
         -- `embedding IS NULL` is exactly the "needs embedding" predicate the
         -- backfill uses, so rows carried over from the Chroma era (audit row,
         -- no vector) are picked up automatically.

--- a/backend/scripts/embed_catalog.py
+++ b/backend/scripts/embed_catalog.py
@@ -35,7 +35,7 @@ async def main(limit: int | None) -> int:
     from src.repositories import pg
     from src.services.embeddings import MODEL_NAME, encode_job
     from src.services.job_enrichment import load_enrichment
-    from src.services.vector_index import VectorIndex
+    from src.services.pg_vector_index import PgVectorIndex, vector_column_available
 
     db = await pg.connect(str(DB_PATH))
     try:
@@ -45,7 +45,10 @@ async def main(limit: int | None) -> int:
                    j.apply_url, j.source, j.date_found
             FROM jobs j
             LEFT JOIN job_embeddings e ON e.job_id = j.id
-            WHERE e.job_id IS NULL
+            WHERE """ + (
+                "e.job_id IS NULL OR e.embedding IS NULL"
+                if vector_column_available(str(DB_PATH)) else "e.job_id IS NULL"
+            ) + """
             ORDER BY j.id
             """
         )
@@ -57,7 +60,7 @@ async def main(limit: int | None) -> int:
         if not total:
             return 0
 
-        vix = VectorIndex()
+        vix = PgVectorIndex()
         done = failed = 0
         for r in rows:
             jid = r["id"]

--- a/backend/src/api/routes/jobs.py
+++ b/backend/src/api/routes/jobs.py
@@ -335,14 +335,14 @@ def _maybe_apply_hybrid_reorder(rows: list[dict[str, Any]], *, profile: Any = No
         return rows
 
     try:
+        from src.services.pg_vector_index import PgVectorIndex  # noqa: PLC0415
         from src.services.retrieval import is_hybrid_available  # noqa: PLC0415 — lazy (rule #16)
-        from src.services.vector_index import VectorIndex  # noqa: PLC0415
     except Exception as e:
         logger.warning("hybrid mode requested but retrieval stack unavailable: %s", e)
         return rows
 
     try:
-        vix = VectorIndex()
+        vix = PgVectorIndex()
         count = vix.count()
     except Exception as e:
         logger.warning("hybrid mode requested but VectorIndex unavailable: %s", e)

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -568,23 +568,40 @@ async def _embed_backfill_budget(db: Any, conn: Any, budget: int) -> int:
     """
     from src.services.embeddings import MODEL_NAME, encode_job  # noqa: PLC0415 — lazy (rule #16)
     from src.services.job_enrichment import load_enrichment  # noqa: PLC0415
-    from src.services.vector_index import VectorIndex  # noqa: PLC0415
+    from src.services.pg_vector_index import (  # noqa: PLC0415
+        PgVectorIndex,
+        vector_column_available,
+    )
 
     try:
-        vix = VectorIndex()
+        vix = PgVectorIndex()
     except Exception as e:  # noqa: BLE001
         logger.warning("embed backfill: VectorIndex init failed: %s", e)
         return 0
 
-    cur = await conn.execute(
+    sql = """
+        SELECT j.id, j.title, j.company, j.location, j.description,
+               j.apply_url, j.source, j.date_found
+        FROM jobs j LEFT JOIN job_embeddings e ON e.job_id = j.id
+        WHERE e.job_id IS NULL OR e.embedding IS NULL
+        ORDER BY j.id
+        LIMIT ?
         """
+    # Migration 0027 only adds `embedding` where pgvector exists, and naming a
+    # missing column is a hard error inside run_search — so ask first. With the
+    # column present, a legacy audit row WITHOUT a vector (the Chroma-era rows)
+    # must count as "needs embedding": that desync is what this change removes.
+    if not vector_column_available(str(getattr(db, "_path", "")) or None):
+        sql = """
         SELECT j.id, j.title, j.company, j.location, j.description,
                j.apply_url, j.source, j.date_found
         FROM jobs j LEFT JOIN job_embeddings e ON e.job_id = j.id
         WHERE e.job_id IS NULL
         ORDER BY j.id
         LIMIT ?
-        """,
+        """
+    cur = await conn.execute(
+        sql,
         (budget,),
     )
     rows = await cur.fetchall()
@@ -1206,10 +1223,10 @@ async def run_search(
             if SEMANTIC_ENABLED and new_jobs:
                 from src.services.embeddings import MODEL_NAME, encode_job  # noqa: PLC0415 — lazy by design (rule #16)
                 from src.services.job_enrichment import load_enrichment  # noqa: PLC0415
-                from src.services.vector_index import VectorIndex  # noqa: PLC0415
+                from src.services.pg_vector_index import PgVectorIndex  # noqa: PLC0415
 
                 try:
-                    vix = VectorIndex()
+                    vix = PgVectorIndex()
                 except Exception as e:
                     logger.warning("VectorIndex init failed; skipping vector upsert: %s", e)
                     vix = None

--- a/backend/src/services/pg_vector_index.py
+++ b/backend/src/services/pg_vector_index.py
@@ -1,0 +1,184 @@
+"""PgVectorIndex — the job vector store, in Postgres (pgvector).
+
+WHY THIS REPLACES THE CHROMA-ON-DISK STORE (2026-08-07). The vectors lived in
+ChromaDB at ``/data/chroma`` on the BACKEND container's local filesystem, and
+that placement had three structural consequences, all measured in prod:
+
+  1. The worker image ships without the ``[semantic]`` extra, and the nightly
+     catalog refresh — the only thing that runs the pipeline on a schedule —
+     runs on the WORKER. It could never embed anything. The catalog grew
+     7,761 -> 8,184 overnight while embeddings stayed at exactly 284, with
+     ``SEMANTIC_ENABLED=true`` the whole time.
+  2. Backend and worker are separate containers with separate disks, so they
+     cannot share an index even if both had the encoder.
+  3. Worst: ``job_embeddings`` (Postgres, permanent) recorded "job N is
+     embedded", so the backfill SKIPPED those jobs — while the vectors sat on
+     a container disk a redeploy can reset. The bookkeeping could claim
+     coverage the index did not have, and nothing would ever refill the hole.
+
+Putting the vector in the SAME ROW as its audit record removes all three: one
+store shared by every service, surviving deploys, inside the existing
+db-backup, and structurally impossible to desync from its own bookkeeping.
+
+The interface mirrors ``VectorIndex`` (upsert / query / delete / count) so
+callers are unchanged. Distances are cosine distance (``<=>``), matching
+Chroma's default, so ranking code needs no adjustment.
+
+At ~8k jobs an exact scan is milliseconds; no ANN index is created (see
+migration 0027). Add ivfflat/hnsw when the catalog justifies it.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+from src.repositories import pgsync
+
+logger = logging.getLogger("job360.services.pg_vector_index")
+
+# Migration 0027 is TOLERANT: on a Postgres without pgvector it skips the
+# column rather than failing the boot. So every method here degrades to a
+# no-op / empty result instead of raising — a missing semantic index must
+# read as "no semantic results", never as a 500 on the jobs route.
+_MISSING_COLUMN_HINTS = ("embedding", "does not exist", "undefined_column")
+
+
+def _is_missing_vector_column(exc: Exception) -> bool:
+    msg = str(exc).lower()
+    return "embedding" in msg and ("does not exist" in msg or "undefined" in msg)
+
+
+def vector_column_available(db_path: Optional[str] = None) -> bool:
+    """Is ``job_embeddings.embedding`` present on THIS database?
+
+    Migration 0027 is tolerant, so the column exists only where pgvector does.
+    Callers that build "which jobs still need embedding" SQL must ask first:
+    a predicate naming a non-existent column is a hard error, and it would
+    fire inside run_search — turning a dark feature into a broken search.
+    Uses current_schema() rather than to_regclass/search_path (saved-memory
+    rule: search_path falls back to public and a schema-isolated test would
+    read the wrong table).
+    """
+    if db_path is None:
+        from src.core.settings import DB_PATH  # noqa: PLC0415
+
+        db_path = str(DB_PATH)
+    try:
+        with pgsync.connect(db_path) as conn:
+            cur = conn.execute(
+                "SELECT count(*) FROM information_schema.columns "
+                "WHERE table_schema = current_schema() "
+                "AND table_name = 'job_embeddings' AND column_name = 'embedding'"
+            )
+            row = cur.fetchone()
+            return bool(row and int(row[0]) > 0)
+    except Exception:  # noqa: BLE001 — absence is the answer, not an error
+        return False
+
+
+def _to_literal(vector: list[float]) -> str:
+    """pgvector's text input form: '[0.1,0.2,...]'.
+
+    Sent as a string parameter and cast in SQL, so no pgvector Python adapter
+    is required — the worker image needs no extra dependency to WRITE vectors
+    (it still needs sentence-transformers to COMPUTE them).
+    """
+    return "[" + ",".join(f"{float(x):.6f}" for x in vector) + "]"
+
+
+class PgVectorIndex:
+    """Job embedding store backed by ``job_embeddings.embedding``."""
+
+    def __init__(self, db_path: Optional[str] = None) -> None:
+        if db_path is None:
+            from src.core.settings import DB_PATH  # noqa: PLC0415
+
+            db_path = str(DB_PATH)
+        self._db_path = db_path
+
+    def upsert(
+        self,
+        job_id: int,
+        vector: list[float],
+        metadata: Optional[dict[str, Any]] = None,
+    ) -> None:
+        """Insert-or-replace the embedding for ``job_id``.
+
+        ``metadata`` is accepted for interface parity with the Chroma index
+        and deliberately ignored: everything it carried (source, title) is
+        already a column on ``jobs``, reachable by join — storing a second
+        copy is exactly the desync this class exists to remove.
+        """
+        from src.services.embeddings import MODEL_NAME  # noqa: PLC0415
+
+        try:
+            with pgsync.connect(self._db_path) as conn:
+                conn.execute(
+                    "INSERT INTO job_embeddings(job_id, model_version, embedding) "
+                    "VALUES (?, ?, ?::vector) "
+                    "ON CONFLICT(job_id) DO UPDATE SET "
+                    "  model_version = EXCLUDED.model_version, "
+                    "  embedding = EXCLUDED.embedding, "
+                    "  embedding_updated_at = now()::text",
+                    (int(job_id), MODEL_NAME, _to_literal(vector)),
+                )
+        except Exception as exc:  # noqa: BLE001
+            if _is_missing_vector_column(exc):
+                logger.debug("pgvector column absent — upsert skipped")
+                return
+            raise
+
+    def query(
+        self,
+        vector: list[float],
+        k: int = 10,
+        filter_metadata: Optional[dict[str, Any]] = None,
+    ) -> list[tuple[int, float]]:
+        """Nearest neighbours as ``[(job_id, distance), ...]``, ascending.
+
+        Cosine distance (``<=>``) to match Chroma's default so downstream
+        ranking is unchanged. Rows without a vector are skipped. Jobs deleted
+        from the catalog cascade out of this table, so a result always names a
+        live job.
+        """
+        try:
+            with pgsync.connect(self._db_path) as conn:
+                cur = conn.execute(
+                    "SELECT job_id, (embedding <=> ?::vector) AS distance "
+                    "FROM job_embeddings WHERE embedding IS NOT NULL "
+                    "ORDER BY embedding <=> ?::vector LIMIT ?",
+                    (_to_literal(vector), _to_literal(vector), int(k)),
+                )
+                return [(int(r[0]), float(r[1])) for r in cur.fetchall()]
+        except Exception as exc:  # noqa: BLE001
+            if _is_missing_vector_column(exc):
+                logger.debug("pgvector column absent — no semantic results")
+                return []
+            raise
+
+    def delete(self, job_id: int) -> None:
+        try:
+            with pgsync.connect(self._db_path) as conn:
+                conn.execute(
+                    "UPDATE job_embeddings SET embedding = NULL WHERE job_id = ?",
+                    (int(job_id),),
+                )
+        except Exception as exc:  # noqa: BLE001
+            if not _is_missing_vector_column(exc):
+                raise
+
+    def count(self) -> int:
+        """How many jobs actually have a VECTOR — not how many have an audit
+        row. Those two numbers could differ under the old store; here they
+        cannot, which is the point."""
+        try:
+            with pgsync.connect(self._db_path) as conn:
+                cur = conn.execute(
+                    "SELECT count(*) FROM job_embeddings WHERE embedding IS NOT NULL"
+                )
+                row = cur.fetchone()
+                return int(row[0]) if row else 0
+        except Exception as exc:  # noqa: BLE001
+            if _is_missing_vector_column(exc):
+                return 0
+            raise

--- a/backend/src/services/pg_vector_index.py
+++ b/backend/src/services/pg_vector_index.py
@@ -115,7 +115,7 @@ class PgVectorIndex:
             with pgsync.connect(self._db_path) as conn:
                 conn.execute(
                     "INSERT INTO job_embeddings(job_id, model_version, embedding) "
-                    "VALUES (?, ?, ?::vector) "
+                    "VALUES (?, ?, ?::public.vector) "
                     "ON CONFLICT(job_id) DO UPDATE SET "
                     "  model_version = EXCLUDED.model_version, "
                     "  embedding = EXCLUDED.embedding, "
@@ -144,9 +144,9 @@ class PgVectorIndex:
         try:
             with pgsync.connect(self._db_path) as conn:
                 cur = conn.execute(
-                    "SELECT job_id, (embedding <=> ?::vector) AS distance "
+                    "SELECT job_id, public.cosine_distance(embedding, ?::public.vector) AS distance "
                     "FROM job_embeddings WHERE embedding IS NOT NULL "
-                    "ORDER BY embedding <=> ?::vector LIMIT ?",
+                    "ORDER BY public.cosine_distance(embedding, ?::public.vector) LIMIT ?",
                     (_to_literal(vector), _to_literal(vector), int(k)),
                 )
                 return [(int(r[0]), float(r[1])) for r in cur.fetchall()]

--- a/backend/tests/test_embed_backfill.py
+++ b/backend/tests/test_embed_backfill.py
@@ -50,9 +50,21 @@ async def test_backfill_embeds_only_missing_up_to_budget(tmp_path):
         # Pretend job #1 is already embedded.
         cur = await conn.execute("SELECT id FROM jobs ORDER BY id")
         ids = [r[0] for r in await cur.fetchall()]
-        await conn.execute(
-            "INSERT INTO job_embeddings(job_id, model_version) VALUES (?, 'm')", (ids[0],)
-        )
+        # "Already embedded" now means "has a VECTOR", not "has an audit row" —
+        # that distinction IS the fix (a Chroma-era audit row with no vector
+        # must be re-embedded, never skipped). Seed whichever the DB supports.
+        from src.services.pg_vector_index import vector_column_available
+        if vector_column_available(str(tmp_path / "t.db")):
+            await conn.execute(
+                "INSERT INTO job_embeddings(job_id, model_version, embedding) "
+                "VALUES (?, 'm', ?::vector)",
+                (ids[0], "[" + ",".join(["0.1"] * 384) + "]"),
+            )
+        else:
+            await conn.execute(
+                "INSERT INTO job_embeddings(job_id, model_version) VALUES (?, 'm')",
+                (ids[0],),
+            )
         await db.commit()
 
         upserted: list[int] = []
@@ -67,7 +79,7 @@ async def test_backfill_embeds_only_missing_up_to_budget(tmp_path):
         async def fake_load_enrichment(conn, jid):
             return None
 
-        with patch("src.services.vector_index.VectorIndex", return_value=_FakeVix()), \
+        with patch("src.services.pg_vector_index.PgVectorIndex", return_value=_FakeVix()), \
              patch("src.services.embeddings.encode_job", new=fake_encode), \
              patch("src.services.job_enrichment.load_enrichment", new=fake_load_enrichment):
             n = await main_mod._embed_backfill_budget(db, conn, budget=2)
@@ -104,7 +116,7 @@ async def test_backfill_survives_a_poison_row(tmp_path):
         async def fake_load_enrichment(conn, jid):
             return None
 
-        with patch("src.services.vector_index.VectorIndex", return_value=_FakeVix()), \
+        with patch("src.services.pg_vector_index.PgVectorIndex", return_value=_FakeVix()), \
              patch("src.services.embeddings.encode_job", new=flaky_encode), \
              patch("src.services.job_enrichment.load_enrichment", new=fake_load_enrichment):
             n = await main_mod._embed_backfill_budget(db, conn, budget=10)

--- a/backend/tests/test_pg_vector_index.py
+++ b/backend/tests/test_pg_vector_index.py
@@ -1,0 +1,155 @@
+"""PgVectorIndex — the job vector store, in Postgres.
+
+WHY IT EXISTS (2026-08-07): the Chroma-on-local-disk store made semantic
+search structurally impossible in this deployment — the worker (which runs the
+only scheduled pipeline) has no semantic extra, backend and worker have
+separate disks, and worst, `job_embeddings` claimed coverage the on-disk index
+might not have, so the backfill skipped jobs forever. Measured: catalog grew
+7,761 -> 8,184 overnight while embeddings stayed at exactly 284, with
+SEMANTIC_ENABLED=true throughout.
+
+These tests pin the contract that makes those failures impossible: the vector
+lives in the same row as its bookkeeping.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from migrations import runner
+from src.models import Job
+from src.repositories import pgsync
+from src.repositories.database import JobDatabase
+
+_NOW = "2026-08-07T00:00:00+00:00"
+
+
+def _pgvector_available() -> bool:
+    """Migration 0027 is tolerant, so a Postgres without pgvector simply has
+    no `embedding` column and this store degrades to empty results. Skip
+    rather than fail there — CI runs the pgvector image (ci.yml /
+    ci-offline.yml) and prod has pgvector 0.8.3, so these still gate the real
+    environments."""
+    try:
+        from src.core.settings import DB_PATH
+
+        with pgsync.connect(str(DB_PATH)) as c:
+            row = c.execute(
+                "SELECT count(*) FROM pg_available_extensions WHERE name = 'vector'"
+            ).fetchone()
+            return bool(row and row[0])
+    except Exception:  # noqa: BLE001
+        return False
+
+
+pytestmark = pytest.mark.skipif(
+    not _pgvector_available(), reason="pgvector not available on this Postgres"
+)
+
+
+def _vec(*leading: float) -> list[float]:
+    v = list(leading)
+    return v + [0.0] * (384 - len(v))
+
+
+@pytest.fixture
+def vec_db(tmp_path):
+    path = str(tmp_path / "vec.db")
+
+    async def _boot():
+        db = JobDatabase(path)
+        await db.init_db()
+        for i in range(3):
+            await db.insert_job(Job(
+                title=f"Job {i}", company=f"Co{i}", apply_url=f"https://x/{i}",
+                source="reed", date_found=_NOW, location="London, UK",
+                description="text",
+            ))
+        await db.close()
+        await runner.up(path)
+
+    asyncio.run(_boot())
+    return path
+
+
+def _job_ids(path):
+    with pgsync.connect(path) as c:
+        return [r[0] for r in c.execute("SELECT id FROM jobs ORDER BY id").fetchall()]
+
+
+def test_upsert_query_roundtrip_ranks_by_cosine_distance(vec_db):
+    from src.services.pg_vector_index import PgVectorIndex
+
+    ids = _job_ids(vec_db)
+    vix = PgVectorIndex(vec_db)
+    vix.upsert(ids[0], _vec(1.0))          # identical to the query
+    vix.upsert(ids[1], _vec(0.0, 1.0))     # orthogonal
+    res = vix.query(_vec(1.0), k=5)
+
+    assert res[0][0] == ids[0], "nearest neighbour is not first"
+    assert res[0][1] == pytest.approx(0.0, abs=1e-4)
+    assert res[1][1] > res[0][1], "distances must ascend"
+
+
+def test_upsert_is_idempotent_and_replaces(vec_db):
+    from src.services.pg_vector_index import PgVectorIndex
+
+    ids = _job_ids(vec_db)
+    vix = PgVectorIndex(vec_db)
+    vix.upsert(ids[0], _vec(1.0))
+    vix.upsert(ids[0], _vec(0.0, 1.0))  # replace
+    assert vix.count() == 1
+    # The replacement vector is what answers the query now.
+    res = vix.query(_vec(0.0, 1.0), k=1)
+    assert res[0][0] == ids[0] and res[0][1] == pytest.approx(0.0, abs=1e-4)
+
+
+def test_count_reports_vectors_not_audit_rows(vec_db):
+    """THE BUG THIS STORE REMOVES. Under Chroma-on-disk, an audit row could
+    say "embedded" while the vector was gone with the container — and the
+    backfill skipped those jobs forever. Here an audit row without a vector
+    must NOT be counted as coverage."""
+    from src.services.pg_vector_index import PgVectorIndex
+
+    ids = _job_ids(vec_db)
+    with pgsync.connect(vec_db) as c:
+        c.execute(
+            "INSERT INTO job_embeddings(job_id, model_version) VALUES (?, 'legacy')",
+            (ids[2],),
+        )
+    vix = PgVectorIndex(vec_db)
+    assert vix.count() == 0, "an audit row with no vector was counted as coverage"
+
+    vix.upsert(ids[2], _vec(1.0))
+    assert vix.count() == 1
+
+
+def test_query_skips_rows_without_a_vector(vec_db):
+    from src.services.pg_vector_index import PgVectorIndex
+
+    ids = _job_ids(vec_db)
+    with pgsync.connect(vec_db) as c:
+        c.execute(
+            "INSERT INTO job_embeddings(job_id, model_version) VALUES (?, 'legacy')",
+            (ids[1],),
+        )
+    vix = PgVectorIndex(vec_db)
+    vix.upsert(ids[0], _vec(1.0))
+    res = vix.query(_vec(1.0), k=10)
+    assert [j for j, _ in res] == [ids[0]]
+
+
+def test_delete_clears_the_vector_but_keeps_the_row(vec_db):
+    from src.services.pg_vector_index import PgVectorIndex
+
+    ids = _job_ids(vec_db)
+    vix = PgVectorIndex(vec_db)
+    vix.upsert(ids[0], _vec(1.0))
+    vix.delete(ids[0])
+    assert vix.count() == 0
+    with pgsync.connect(vec_db) as c:
+        row = c.execute(
+            "SELECT model_version FROM job_embeddings WHERE job_id = ?", (ids[0],)
+        ).fetchone()
+    assert row is not None, "the audit row should survive so re-embedding is tracked"

--- a/backend/tests/test_retrieval_integration.py
+++ b/backend/tests/test_retrieval_integration.py
@@ -118,7 +118,7 @@ def test_mode_hybrid_populated_index_fuses(monkeypatch):
     piece — if it correctly reorders, the route correctly reorders.
     """
     from src.core import settings
-    from src.services import vector_index as vix_mod
+    from src.services import pg_vector_index as vix_mod
 
     monkeypatch.setattr(settings, "SEMANTIC_ENABLED", True, raising=True)
 
@@ -138,7 +138,7 @@ def test_mode_hybrid_populated_index_fuses(monkeypatch):
         def upsert(self, *a, **kw):
             pass
 
-    monkeypatch.setattr(vix_mod, "VectorIndex", _FakeIndex)
+    monkeypatch.setattr(vix_mod, "PgVectorIndex", _FakeIndex)
 
     # Patch encode_job to return a fixed vector so we never touch a real
     # sentence-transformers model.
@@ -189,7 +189,7 @@ def test_hybrid_query_uses_profile_when_provided(monkeypatch):
             return [(2, 0.1), (1, 0.2)]
 
     monkeypatch.setattr("src.services.embeddings.encode_job", fake_encode_job)
-    monkeypatch.setattr("src.services.vector_index.VectorIndex", lambda *a, **k: _FakeVix())
+    monkeypatch.setattr("src.services.pg_vector_index.PgVectorIndex", lambda *a, **k: _FakeVix())
 
     rows = [
         {"id": 1, "title": "Top Keyword Job", "description": "kw"},

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -35,7 +35,7 @@ services:
   # Host port 5433 (5432 is reserved/blocked on this Windows box).
   # DATABASE_URL=postgresql://job360:job360dev@localhost:5433/job360
   postgres:
-    image: postgres:16-alpine
+    image: pgvector/pgvector:pg16
     container_name: job360-dev-postgres
     restart: unless-stopped
     environment:


### PR DESCRIPTION
`SEMANTIC_ENABLED` has been **true** in prod — yet embeddings sat at exactly **284** while the catalog grew **7,761 → 8,184** overnight. The flag was never the blocker.

## Three structural faults, all verified
1. The **worker image has no `[semantic]` extra**, and the nightly catalog refresh — the only scheduled pipeline run — runs on the worker. It could never embed anything.
2. Chroma persisted to `/data/chroma` on the **backend container's local disk**; backend and worker have separate disks, so they could never share an index.
3. Worst: `job_embeddings` (Postgres, permanent) said "embedded", so the backfill **skipped** those jobs — while the vectors sat on a disk a redeploy can reset. Bookkeeping could claim coverage the index didn't have, and nothing would ever refill the hole.

## The fix
Postgres already had **pgvector 0.8.3** available, so the vector now lives **in the same row as its audit record**: one store, every service, survives deploys, inside the existing db-backup, structurally unable to desync.

- **Migration 0027** — `job_embeddings.embedding vector(384)`, **tolerant**: migrations run in the FastAPI lifespan, so a hard `CREATE EXTENSION` would turn a pgvector-less Postgres into a *boot failure*. Without pgvector it's a clean no-op.
- **`PgVectorIndex`** — same interface (`upsert/query/delete/count`), cosine `<=>` (matches Chroma, ranking unchanged), every method degrades to no-op/empty rather than raising.
- **`vector_column_available()`** — the backfill picks its predicate; where the column exists, a legacy audit row *without* a vector now counts as "needs embedding" (closing fault #3).
- **`count()` reports vectors, not audit rows** — pinned by test.
- dev + CI Postgres → `pgvector/pgvector:pg16`. No ANN index at 8k jobs (exact scan is ms).

**Verified on both**: a pgvector Postgres (all pass) and a plain one (skip cleanly, app degrades). +5 tests; 57 passed + 5 skipped across retrieval/embedding/api/main.

After merge, the first search or nightly run embeds via `EMBED_BACKFILL_PER_RUN` — and unlike before, it will actually stick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6DsQH5EUxJc3Vnqz9YHgQ
