### PR TITLE
fix(profile): dated CV experience reaches storage - #241 patched an adapter nothing calls

### DIFF
--- a/backend/src/services/profile/schemas.py
+++ b/backend/src/services/profile/schemas.py
@@ -200,6 +200,33 @@ def cv_schema_to_cvdata(schema: CVSchema, raw_text: str) -> CVData:
     for e in schema.experience:
         experience_lines.extend(e.bullets)
 
+    # STRUCTURED experience — the dated, paired record (2026-08-07).
+    #
+    # ``ExperienceEntry`` has always carried ``dates`` and ``location``, and
+    # the CV prompt has always asked for them, but this function flattened
+    # experience into two UNPAIRED lists and dropped both. Nothing downstream
+    # could say which title was held at which company, for how long, or how
+    # recently — the reason the engine has no skill-recency signal and the
+    # judge could not answer the seniority question its own rubric asks.
+    #
+    # PR #241 added ``cv_positions`` to the OTHER adapter
+    # (``cv_parser._llm_result_to_cvdata``) — but ``llm_cv_fields_from_text``
+    # returns through THIS one, so the fix reached no real extraction. Caught
+    # by the Pillar-1 audit on a live CV: the LLM returned
+    # "Freelance AI Trainer, 2023-2024" and cv_positions still came out 0.
+    # Two adapters for one contract is the bug; both now populate the field.
+    cv_positions: list[dict[str, Any]] = [
+        {
+            "company": e.company or "",
+            "title": e.title or "",
+            "dates": e.dates or "",
+            "location": e.location or "",
+            "bullets": list(e.bullets),
+        }
+        for e in schema.experience
+        if (e.title or e.company)
+    ]
+
     # ONE entry per degree — "degree — institution | dates" combined on a single
     # line so the "Education: N" stat counts qualifications, not lines. The
     # per-degree DETAILS (coursework, thesis, project bullets) are NOT flattened
@@ -228,6 +255,7 @@ def cv_schema_to_cvdata(schema: CVSchema, raw_text: str) -> CVData:
         certifications=list(schema.certifications),
         summary=schema.summary or "",
         experience_text="\n".join(experience_lines),
+        cv_positions=cv_positions,
         name=schema.name or "",
         headline=schema.headline or "",
         location=schema.location or "",

--- a/backend/src/services/profile/two_pass.py
+++ b/backend/src/services/profile/two_pass.py
@@ -282,6 +282,18 @@ def _merge_cv_llm_into(cv: CVData, llm_cv: CVData) -> None:
         cv.summary = llm_cv.summary
     if not cv.experience_text and llm_cv.experience_text:
         cv.experience_text = llm_cv.experience_text
+    # Structured, dated experience (Pillar-1 audit 2026-08-07). Every OTHER
+    # CV-owned field was merged here; cv_positions was not, so a re-extraction
+    # produced dated positions and then threw them away one layer above the
+    # adapter that had just been fixed to emit them. Measured on a live CV:
+    # "CV LLM pass: positions=3" followed by "merged: cv_positions 0".
+    #
+    # Replace rather than union: this is ONE ordered record of the same career
+    # read from the same CV, so a union would duplicate every role on each
+    # re-extraction. A non-empty result wins; an empty one never clobbers what
+    # is already there (same guard as the GitHub/LinkedIn raw fields).
+    if llm_cv.cv_positions:
+        cv.cv_positions = list(llm_cv.cv_positions)
 
 
 async def run_two_pass_extraction(profile: UserProfile) -> UserProfile:

--- a/backend/tests/test_profile.py
+++ b/backend/tests/test_profile.py
@@ -791,3 +791,60 @@ class TestCoreDomainWordEvidence:
         assert "department" not in cfg.core_domain_words
         assert "solutions" not in cfg.core_domain_words
         assert "ai" in cfg.core_domain_words
+
+
+class TestCvSchemaCarriesDatedExperience:
+    """PILLAR-1 AUDIT FINDING (2026-08-07, profile: Pavan).
+
+    PR #241 added `cv_positions` to `cv_parser._llm_result_to_cvdata` — but
+    `llm_cv_fields_from_text` returns through `schemas.cv_schema_to_cvdata`,
+    so the fix reached no real extraction. Measured on a live CV: the LLM
+    returned "Freelance AI Trainer & Subject Matter Expert, 2023 - 2024" and
+    cv_positions still came out 0. Two adapters for one contract was the bug.
+    """
+
+    def _schema(self):
+        from src.services.profile.schemas import CVSchema, ExperienceEntry
+
+        return CVSchema(
+            skills=["python"],
+            experience=[
+                ExperienceEntry(
+                    company="Acme", title="ML Engineer", dates="2023 - 2024",
+                    location="London", bullets=["Built pipelines"],
+                ),
+                ExperienceEntry(
+                    company="", title="Freelance AI Trainer", dates="2022 - 2023",
+                    location="Remote", bullets=[],
+                ),
+            ],
+        )
+
+    def test_dated_positions_survive_the_schema_adapter(self):
+        from src.services.profile.schemas import cv_schema_to_cvdata
+
+        cv = cv_schema_to_cvdata(self._schema(), "raw cv text")
+        assert len(cv.cv_positions) == 2, "experience entries were dropped"
+        first = cv.cv_positions[0]
+        assert first["title"] == "ML Engineer"
+        assert first["company"] == "Acme"
+        assert first["dates"] == "2023 - 2024", "dates discarded again"
+        assert first["location"] == "London"
+        assert first["bullets"] == ["Built pipelines"]
+
+    def test_title_and_company_stay_paired(self):
+        """The flat lists cannot express WHICH title was held WHERE — a
+        company-less entry silently shifts every later pairing."""
+        from src.services.profile.schemas import cv_schema_to_cvdata
+
+        cv = cv_schema_to_cvdata(self._schema(), "raw")
+        assert cv.cv_positions[1]["title"] == "Freelance AI Trainer"
+        assert cv.cv_positions[1]["company"] == ""
+        # the legacy flat lists are exactly the trap: 2 titles, 1 company
+        assert len(cv.job_titles) == 2 and len(cv.companies) == 1
+
+    def test_entries_without_title_or_company_are_skipped(self):
+        from src.services.profile.schemas import CVSchema, ExperienceEntry, cv_schema_to_cvdata
+
+        schema = CVSchema(experience=[ExperienceEntry(bullets=["orphan bullet"])])
+        assert cv_schema_to_cvdata(schema, "raw").cv_positions == []

--- a/backend/tests/test_two_pass.py
+++ b/backend/tests/test_two_pass.py
@@ -836,3 +836,76 @@ class TestCvReplacementResetsCvOwnedFields:
         assert cv.job_titles == ["Frontend Engineer"]
         # Other inputs still intact after the full round-trip.
         assert cv.github_llm_skills == ["LangChain"]
+
+
+@pytest.mark.asyncio
+async def test_cv_positions_survive_the_two_pass_merge(monkeypatch):
+    """PILLAR-1 AUDIT FINDING (2026-08-07). Every other CV-owned field was
+    merged by `_merge_cv_llm_into`; `cv_positions` was not — so a live
+    extraction produced 3 dated positions and the merge threw them away one
+    layer above the adapter that had just been fixed to emit them."""
+    from src.services.profile import llm_curate, two_pass
+    from src.services.profile.models import CVData, UserPreferences, UserProfile
+
+    positions = [
+        {"company": "Acme", "title": "ML Engineer", "dates": "2023 - 2024",
+         "location": "London", "bullets": ["Built pipelines"]},
+    ]
+
+    async def fake_cv(text, *a, **kw):
+        return CVData(skills=["Python"], job_titles=["ML Engineer"],
+                      cv_positions=positions)
+
+    async def _noop_list(*a, **kw):
+        return []
+
+    async def _pass(items, *a, **kw):
+        return items
+
+    profile = UserProfile(
+        cv_data=CVData(raw_text="Experience\nML Engineer at Acme 2023-2024\n"),
+        preferences=UserPreferences(),
+    )
+    with patch.object(two_pass, "llm_cv_fields_from_text", fake_cv), \
+         patch.object(two_pass, "llm_linkedin_fields", _noop_list), \
+         patch.object(two_pass, "llm_infer_github_skills", _noop_list), \
+         patch.object(two_pass, "llm_infer_from_about_me", _noop_list), \
+         patch.object(llm_curate, "llm_suggest_adjacent_skills", _noop_list), \
+         patch.object(llm_curate, "llm_merge_duplicates", _pass):
+        out = await two_pass.run_two_pass_extraction(profile)
+
+    got = out.cv_data.cv_positions
+    assert len(got) == 1, "dated positions were dropped by the merge"
+    assert got[0]["dates"] == "2023 - 2024"
+
+
+@pytest.mark.asyncio
+async def test_cv_positions_replace_not_duplicate_on_reextraction(monkeypatch):
+    """One CV = one ordered career record. A union would duplicate every role
+    on each re-extraction (profiles re-extract on ANY input change)."""
+    from src.services.profile import llm_curate, two_pass
+    from src.services.profile.models import CVData, UserPreferences, UserProfile
+
+    positions = [{"company": "Acme", "title": "ML Engineer", "dates": "2023",
+                  "location": "", "bullets": []}]
+
+    async def fake_cv(text, *a, **kw):
+        return CVData(skills=["Python"], cv_positions=positions)
+
+    async def _noop_list(*a, **kw):
+        return []
+
+    async def _pass(items, *a, **kw):
+        return items
+
+    cv = CVData(raw_text="cv text", cv_positions=list(positions))
+    profile = UserProfile(cv_data=cv, preferences=UserPreferences())
+    with patch.object(two_pass, "llm_cv_fields_from_text", fake_cv), \
+         patch.object(two_pass, "llm_linkedin_fields", _noop_list), \
+         patch.object(two_pass, "llm_infer_github_skills", _noop_list), \
+         patch.object(two_pass, "llm_infer_from_about_me", _noop_list), \
+         patch.object(llm_curate, "llm_suggest_adjacent_skills", _noop_list), \
+         patch.object(llm_curate, "llm_merge_duplicates", _pass):
+        out = await two_pass.run_two_pass_extraction(profile)
+
+    assert len(out.cv_data.cv_positions) == 1, "re-extraction duplicated the role"


### PR DESCRIPTION
**Pillar-1 audit findings** — both caught by running two *real* CVs through the *real* extraction path. Neither was catchable by #241's unit tests, which constructed `cv_positions` by hand.

## Bug A — I patched an adapter nothing calls
Two functions turn an LLM CV result into `CVData`: `cv_parser._llm_result_to_cvdata` (legacy) and `schemas.cv_schema_to_cvdata` (schema-validated). **#241 added `cv_positions` to the first; `llm_cv_fields_from_text` returns through the second.** `ExperienceEntry` has always carried `dates`/`location` and the prompt has always asked for them — the schema adapter flattened experience into two *unpaired* lists and dropped both.

**Live proof:** the LLM returned `"Freelance AI Trainer & Subject Matter Expert", dates "2023 – 2024"` → stored `cv_positions = 0`.

## Bug B — the merge dropped it one layer higher
`_merge_cv_llm_into` merges *every* other CV-owned field but not `cv_positions`. After fixing A, extraction produced 3 dated positions and the merge threw them away. Positions **replace** rather than union — one CV is one ordered career record, so a union would duplicate every role on each re-extraction (profiles re-extract on any input change). Empty never clobbers.

## Why it matters
The judge's rubric asks it to weigh *"seniority fit vs the candidate's level"* — until now **no dated experience existed anywhere in the system** to weigh it against.

## Verified end-to-end on two real profiles
Both passes, all four inputs (CV + LinkedIn + GitHub + preferences):

| | result | dated positions |
|---|---|---|
| Pavan | **0 failures / 22 checks** | 3 |
| Sofia | **0 failures / 22 checks** | 5 |

+5 tests; 130 green across profile/two_pass/extraction_quality/llm_input_cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6DsQH5EUxJc3Vnqz9YHgQ
