### PR TITLE
feat(harness): shelf X-ray — both sides of the match, one picture

### DIFF
--- a/.github/workflows/checker-scorecard.yml
+++ b/.github/workflows/checker-scorecard.yml
@@ -43,6 +43,34 @@ jobs:
         with:
           python-version: "3.12"
 
+      # Shelf X-ray — both sides of the match, one picture. The matching model
+      # is a product (user shelf x job shelf per dimension); a dimension can
+      # only fire when BOTH sides hold data. Weekly, committed, so an empty
+      # shelf is SEEN — not rediscovered weeks later. Born 2026-08-07 after a
+      # day of blindness incidents: scoring dims were built job-side while
+      # their user-side partners were empty for every user. Report-only by
+      # design (exit code ignored): coverage is a trend, not an alarm — the
+      # data-invariants loop owns alarms. Identities are masked (u1/u2/...)
+      # because this lands in a PUBLIC repo.
+      - name: Shelf X-ray (user side x job side)
+        if: ${{ !cancelled() }}
+        env:
+          PROD_DATABASE_URL: ${{ secrets.PROD_DATABASE_URL }}
+        run: |
+          set -uo pipefail
+          if [ -z "$PROD_DATABASE_URL" ]; then
+            echo "::warning::PROD_DATABASE_URL not set - shelf X-ray skipped."
+            exit 0
+          fi
+          python -m pip install --quiet "psycopg[binary]>=3.2"
+          {
+            echo ""
+            echo "## Shelf X-ray ($(date -u +%F))"
+            echo '```'
+            DATABASE_URL="$PROD_DATABASE_URL" python backend/scripts/shelf_xray.py 2>&1
+            echo '```'
+          } >> docs/maintenance/CHECKER-SCORECARD.md
+
       - name: Measure the checker
         env:
           GH_TOKEN: ${{ github.token }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,8 @@ Rules are reference material — keep them in one place. Long-form context for e
 
 ### Scoring + enrichment
 
+29. **STRICT — "Filled shelves work harder; empty shelves stay silent" (owner rule, 2026-08-07).** Like Indeed/LinkedIn: match on what the user filled; an empty preference (salary range, locations, workplace, experience level, about_me) means **"don't care" — never a penalty, never a per-job zero, never a guess**. In code: dim scorers return a CONSTANT for an empty user side (constants can't change ranking order); prefilter stages pass everything when their preference is empty; the judge prompt omits unset prefs entirely; the frontend never blocks on or silently defaults an unfilled preference. Full rule + audit table: `docs/product_design_rules.md`. The test: empty ONE user field and re-rank — if any job moves *relative to another*, the rule is broken.
+
 9. **Scoring changes require running `test_scorer.py` AND `test_profile.py`.** 53 + 55 tests cover edge cases.
 18. **Pillar 2 flags default off.** When `ENRICHMENT_ENABLED` / `SEMANTIC_ENABLED` are false, behaviour must **exactly** match pre-Pillar-2 — no implicit semantic queries, no LLM calls. Test with both flags OFF.
 19. **`JobScorer` legacy default = 4-component formula.** New 7-dim scoring activates only when `JobScorer(config, user_preferences=..., enrichment_lookup=...)` gets all three kwargs. Don't flip defaults silently.

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -19,6 +19,15 @@ The Job360 backend: Python 3.9+, FastAPI, Postgres via psycopg3 (`pg.py` — an 
 Entry points: `main.py` (uvicorn) and `python -m src.cli`. Runtime data (gitignored)
 lives in `data/` (`jobs.db`, `user_profile.json`, `exports/`, `reports/`, `logs/`, `chroma/`).
 
+## Owner rule #29 — empty user fields stay SILENT
+
+Like Indeed/LinkedIn: match on what the user filled. An empty preference
+(salary, locations, workplace, experience level, about_me) = "don't care" —
+never a penalty, never a per-job zero, never a guess. Dim scorers return a
+constant for an empty user side; prefilter passes everything; the judge prompt
+omits unset prefs. Details + audit: `../docs/product_design_rules.md` (root
+CLAUDE.md rule #29).
+
 ## Commands (run from `backend/`)
 
 ```bash

--- a/backend/scripts/shelf_xray.py
+++ b/backend/scripts/shelf_xray.py
@@ -1,0 +1,122 @@
+"""SHELF X-RAY — both sides of the match, one picture.
+
+The matching model is a product: user-side shelf x job-side shelf, per
+dimension. A dimension can only fire when BOTH sides are filled. This script
+reads production and reports, for every matching pair, whether the left
+(user) shelf and the right (job) shelf actually hold data — so "the shelf is
+empty" is seen, not discovered weeks later.
+
+Born 2026-08-07 after three separate blindness incidents in one day: an audit
+that stopped one step before storage, a field table read from code instead of
+prod, and scoring dimensions built job-side while their user-side partners
+were empty for every user. One instrument, run any time, ends that class.
+
+Read-only. Usage:  DATABASE_URL=<dsn> python scripts/shelf_xray.py
+
+Output is committed to the PUBLIC repo by the weekly scorecard, so users are
+masked to u1/u2/... by default. Set XRAY_SHOW_EMAILS=1 for a local run that
+needs to know which row is which.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+def _filled(v: object) -> bool:
+    return v not in (None, "", [], {}, "unknown", "Unknown")
+
+
+def main() -> int:
+    import psycopg
+
+    conn = psycopg.connect(os.environ["DATABASE_URL"])
+    cur = conn.cursor()
+
+    # ---------- LEFT: user shelves ----------
+    cur.execute(
+        "SELECT u.email, p.cv_data, p.preferences FROM user_profiles p "
+        "JOIN users u ON u.id = p.user_id ORDER BY u.email"
+    )
+    users = [(e, json.loads(cv), json.loads(pr)) for e, cv, pr in cur.fetchall()]
+
+    user_shelves = {
+        "skills":     lambda c, p: c.get("skills") or c.get("linkedin_skills"),
+        "titles":     lambda c, p: c.get("job_titles") or p.get("target_job_titles"),
+        "dated_experience": lambda c, p: c.get("cv_positions") or c.get("linkedin_positions"),
+        "education":  lambda c, p: c.get("education"),
+        "salary":     lambda c, p: p.get("salary_min") or p.get("salary_max"),
+        "location":   lambda c, p: p.get("preferred_locations") or c.get("location"),
+        "workplace":  lambda c, p: p.get("preferred_workplace") or p.get("work_arrangement"),
+        "seniority":  lambda c, p: p.get("experience_level"),
+        "visa":       lambda c, p: p.get("needs_visa") is not None,
+        "domain":     lambda c, p: c.get("career_domain") or (p.get("industries") or c.get("industries")),
+        "about_me":   lambda c, p: p.get("about_me"),
+    }
+
+    # ---------- RIGHT: job shelves ----------
+    cur.execute("SELECT count(*) FROM jobs WHERE staleness_state IS NULL OR staleness_state='active'")
+    n_jobs = cur.fetchone()[0]
+
+    def cov(sql: str) -> int:
+        cur.execute(sql)
+        n = cur.fetchone()[0]
+        return round(100 * n / max(1, n_jobs))
+
+    job_shelves = {
+        "skills":    cov("SELECT count(*) FROM jobs WHERE length(coalesce(description,''))>200 AND (staleness_state IS NULL OR staleness_state='active')"),
+        "titles":    cov("SELECT count(*) FROM jobs WHERE coalesce(title,'')<>'' AND (staleness_state IS NULL OR staleness_state='active')"),
+        "dated_experience": None,  # job side needs no dates
+        "education": None,
+        "salary":    cov("SELECT count(*) FROM jobs j WHERE (j.salary_min IS NOT NULL OR EXISTS (SELECT 1 FROM job_enrichment e WHERE e.job_id=j.id AND e.salary NOT IN ('{}',''))) AND (j.staleness_state IS NULL OR j.staleness_state='active')"),
+        "location":  cov("SELECT count(*) FROM jobs WHERE coalesce(location,'')<>'' AND (staleness_state IS NULL OR staleness_state='active')"),
+        "workplace": cov("SELECT count(*) FROM jobs j WHERE EXISTS (SELECT 1 FROM job_enrichment e WHERE e.job_id=j.id AND coalesce(e.workplace_type,'unknown')<>'unknown') AND (j.staleness_state IS NULL OR j.staleness_state='active')"),
+        "seniority": cov("SELECT count(*) FROM jobs j WHERE EXISTS (SELECT 1 FROM job_enrichment e WHERE e.job_id=j.id AND coalesce(e.seniority,'unknown')<>'unknown') AND (j.staleness_state IS NULL OR j.staleness_state='active')"),
+        "visa":      cov("SELECT count(*) FROM jobs j WHERE EXISTS (SELECT 1 FROM job_enrichment e WHERE e.job_id=j.id AND coalesce(e.visa_sponsorship,'unknown')<>'unknown') AND (j.staleness_state IS NULL OR j.staleness_state='active')"),
+        "domain":    cov("SELECT count(*) FROM jobs j WHERE EXISTS (SELECT 1 FROM job_enrichment e WHERE e.job_id=j.id AND coalesce(e.category,'')<>'') AND (j.staleness_state IS NULL OR j.staleness_state='active')"),
+        "about_me":  None,
+    }
+
+    # ---------- THE PAIRS TABLE ----------
+    print(f"jobs in catalog: {n_jobs}   profiles: {len(users)}")
+    show = os.getenv("XRAY_SHOW_EMAILS", "") == "1"
+    labels = [(e.split("@")[0][:14] if show else f"u{i + 1}") for i, (e, _, _) in enumerate(users)]
+    header = f"{'DIM':<18}{'job side':<10}" + "".join(f"{lb:<16}" for lb in labels) + "pair"
+    print(header)
+    print("-" * len(header))
+    dead_pairs: list[str] = []
+    for dim, ufn in user_shelves.items():
+        j = job_shelves.get(dim)
+        jtxt = "  n/a" if j is None else f"{j:>3}%"
+        cells, any_user = [], False
+        for _, cvd, prefs in users:
+            got = _filled(ufn(cvd, prefs))
+            any_user = any_user or got
+            cells.append("FILLED" if got else "EMPTY")
+        alive = (j is None or j > 0) and any_user
+        if not alive:
+            dead_pairs.append(dim)
+        print(f"{dim:<18}{jtxt:<10}" + "".join(f"{c:<16}" for c in cells)
+              + ("ALIVE" if alive else "** DEAD **"))
+
+    # ---------- field-level detail for still-empty user fields ----------
+    print("\nuser fields empty for EVERY profile (stale-or-broken candidates):")
+    all_keys: set[str] = set()
+    for _, cvd, prefs in users:
+        all_keys |= set(cvd.keys())
+    empty_everywhere = sorted(
+        k for k in all_keys
+        if not any(_filled(cvd.get(k)) for _, cvd, _ in users)
+    )
+    print("  " + (", ".join(empty_everywhere) if empty_everywhere else "none"))
+
+    print(f"\nDEAD PAIRS: {dead_pairs if dead_pairs else 'none — every dimension can fire'}")
+    conn.close()
+    return 1 if dead_pairs else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/test_design_rules.py
+++ b/backend/tests/test_design_rules.py
@@ -1,0 +1,81 @@
+"""Product design rule #29: filled shelves work harder; empty shelves stay SILENT.
+
+Owner rule (2026-08-07, docs/product_design_rules.md). Like Indeed/LinkedIn:
+match on what the user filled; an empty preference means "don't care" — never
+a penalty, never a per-job zero, never a guess.
+
+The enforceable form: with an EMPTY user side, every dimension scorer must
+return a CONSTANT no matter what the job looks like. A constant cannot change
+ranking order — that is what "silent" means. These tests feed each scorer
+wildly different jobs and assert the empty-side result never varies.
+"""
+from __future__ import annotations
+
+from src.services.job_enrichment import JobEnrichment
+from src.services.prefilter import FilterProfile, location_ok
+from src.services.scoring_dimensions import (
+    salary_score,
+    seniority_score,
+    visa_score,
+    workplace_score,
+)
+
+# A spread of very different jobs: none, senior/remote/high-pay, junior/onsite.
+_ENRICHMENTS = [
+    None,
+    JobEnrichment(
+        title_canonical="Staff Engineer", category="software_engineering",
+        seniority="senior", workplace_type="remote",
+        salary={"min": 120000, "max": 150000, "currency": "GBP", "period": "year"},
+        visa_sponsorship="yes",
+    ),
+    JobEnrichment(
+        title_canonical="Junior Analyst", category="data_science",
+        seniority="junior", workplace_type="onsite",
+        salary={"min": 22000, "max": 26000, "currency": "GBP", "period": "year"},
+        visa_sponsorship="no",
+    ),
+]
+
+
+def _constant(values: list) -> bool:
+    return len(set(values)) == 1
+
+
+def test_empty_salary_pref_is_silent() -> None:
+    assert _constant([salary_score(e, None, None) for e in _ENRICHMENTS])
+
+
+def test_empty_experience_level_is_silent() -> None:
+    assert _constant([seniority_score(e, "") for e in _ENRICHMENTS])
+
+
+def test_empty_workplace_pref_is_silent() -> None:
+    assert _constant([workplace_score(e, None) for e in _ENRICHMENTS])
+    assert _constant([workplace_score(e, "") for e in _ENRICHMENTS])
+
+
+def test_no_visa_need_is_silent() -> None:
+    assert _constant([visa_score(e, False) for e in _ENRICHMENTS])
+
+
+def test_empty_location_prefs_prefilter_passes_everything() -> None:
+    from src.models import Job
+
+    profile = FilterProfile()  # nothing filled
+    jobs = [
+        Job(title="A", company="X", apply_url="", source="", date_found="",
+            location="London"),
+        Job(title="B", company="Y", apply_url="", source="", date_found="",
+            location="Tokyo"),
+        Job(title="C", company="Z", apply_url="", source="", date_found="",
+            location=""),
+    ]
+    assert all(location_ok(profile, j) for j in jobs)
+
+
+def test_filled_side_still_discriminates() -> None:
+    """The rule has two halves — silence when empty, WORK when filled. Guard
+    against a lazy fix that makes scorers constant always."""
+    filled = [seniority_score(e, "senior") for e in _ENRICHMENTS]
+    assert not _constant(filled)

--- a/docs/product_design_rules.md
+++ b/docs/product_design_rules.md
@@ -1,0 +1,54 @@
+# Product Design Rules
+
+Owner-set rules that shape every feature. Each rule records WHY it exists and
+what obeying it looks like in code, so a future session applies it rather than
+rediscovering it. When code contradicts a rule here, the finding goes to the
+owner — do not silently "fix" in either direction.
+
+---
+
+## Rule 1 — Filled shelves work harder; empty shelves stay silent
+
+*Set by the owner, 2026-08-07, after the shelf X-ray found four scoring
+dimensions dead because their user-side inputs were empty.*
+
+**The rule.** The matcher works like a person searching Indeed or LinkedIn:
+it uses what the user gave it, and what they left blank is **"don't care" —
+never a penalty, never a zero, never a guess.** Every filled field narrows
+and sharpens the match; every empty field switches its dimension off and
+lets the filled ones carry the weight.
+
+**Canonical example.** A user types "AI engineer" and nothing else. Indeed
+does not punish jobs for missing a salary the user never stated. It matches
+on the title alone. Job360 behaves the same for salary range, preferred
+locations, remote/hybrid/office, experience level, and about_me.
+
+**What this means in code:**
+
+| Layer | Compliant behaviour |
+|---|---|
+| Dim scorers (`scoring_dimensions.py`) | Empty user side → a **constant** for every job (neutral half-weight or 0). A constant cannot change ranking order — that is what "silent" means. Never a per-job penalty for a preference that was never stated. |
+| Prefilter (`prefilter.py`) | Empty `preferred_locations` / `work_arrangement` / `experience_level` → the stage **passes everything**. A filter you didn't fill is a filter that doesn't exist. |
+| LLM judge (`llm_matcher.profile_to_matcher_text`) | Empty prefs are **not mentioned** in the prompt at all — the judge cannot penalise what it never sees. |
+| Embeddings (`embeddings.py`) | Empty fields contribute no text. |
+| Frontend | Preference inputs are **optional and say so**. Never block a search on unfilled preferences; never silently write a default value the user didn't choose (a written default is indistinguishable from a choice — see the contradiction below). |
+| Extraction (Pillar 1) | The mirror rule: extract everything offered, invent nothing. An input the user didn't provide (no LinkedIn, no GitHub) produces empty fields, not guesses. |
+
+**Audited 2026-08-07:** prefilter, judge, embeddings, and all four dim scorers
+comply. One contradiction found and reported:
+
+- **`needs_visa: bool` cannot say "unset".** `False` conflates "I don't need
+  sponsorship" with "I never answered". Every other preference has an empty
+  state (empty list / empty string / None) that means "don't care" — this one
+  can't express it, so the visa dimension can never be switched off, only
+  answered. Schema fix (`Optional[bool]`, default `None`) awaiting owner
+  decision.
+
+**Deliberate exception (documented, not a violation):** the legacy scorer's
+foreign-location penalty (−15) applies even with no location preference. That
+is UK-market product scope — every source is UK/remote by design — not an
+inference from an empty user field.
+
+**The test for new code:** take any scoring/filter change, empty ONE user
+field, and re-rank. If any job's position changes *relative to another job*
+because of the emptiness alone, the rule is broken.

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -20,6 +20,16 @@ shadcn 4**. Talks to the FastAPI backend on `:8000`. State via **TanStack Query 
 forms via **react-hook-form 7 + zod 4**; Kanban drag via **@dnd-kit**; charts via
 **recharts**; toasts via **sonner**. Auth is cookie-session — guarded in `src/middleware.ts`.
 
+## Owner rule #29 — empty preferences stay SILENT (never default, never require)
+
+Preference inputs (salary range, locations, remote/hybrid/office, experience
+level, about_me) are OPTIONAL and must read as optional. Never block a search
+on an unfilled preference, and never write a default value the user didn't
+choose — a silently-written default is indistinguishable from a real choice
+and turns "don't care" into a fake constraint. The backend treats empty as
+"dimension off"; the UI must not manufacture emptiness away. Details:
+`../docs/product_design_rules.md` (root CLAUDE.md rule #29).
+
 ## ⚠️ Next.js 16 — this is NOT the Next.js your training data knows (root rule #22)
 
 Training data for Next.js 14–15 is **wrong** here. Before any App Router pattern, read


### PR DESCRIPTION
One instrument that shows, per matching dimension, the **job-side coverage %** next to **per-user FILLED/EMPTY** — with a DEAD verdict when either side is empty everywhere.

First run found **4 dead pairs** (salary, workplace, seniority, about_me — all dead on the USER side while the job side is stocked) and one reversed case (**visa**: user side filled, job side 3%). Scoring dims existed for months that could never fire; each side looked healthy alone.

Wired into the weekly checker-scorecard (report-only, committed output, masked identities — public repo). Gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6DsQH5EUxJc3Vnqz9YHgQ