### PR TITLE
feat(catalog): the UK gate — block foreign jobs at the door, not in the scorer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,14 @@ Rules are reference material — keep them in one place. Long-form context for e
 10. **Never INSERT into `jobs` with `user_id` or `tenant_id`** — `jobs` is the shared catalog by design (blueprint §3). Per-user state lives in `user_feed`, `user_actions`, `applications`.
 17. **`job_enrichment` and `job_embeddings` must NOT gain `user_id`** — same rationale as #10. Per-user scoring against the enrichment happens at read time in `JobScorer(..., user_preferences=..., enrichment_lookup=...)`.
 
+### Catalog scope + filters (product design rules)
+
+30. **STRICT — UK-only is a DOOR, not a penalty (owner rule, 2026-08-07).** A job the user cannot take because it is in another country is a **catalog defect**, refused at ingestion — it never reaches storage, a feed, an enrichment budget, an embedding, or a shelf slot. ONE chokepoint (`src/services/uk_gate.check_uk`, called in `main.py`'s insert loop), never per-source. The gate asks *who said it*: UK-native sources (reed/NHS/jobs.ac.uk/teaching_vacancies/**devitjobs.uk**/linkedin) keep an unrecognised town; global sources (greenhouse/workday/remoteok) need evidence (£, right-to-work language, a UK city in the body). **Unknown sources default to STRICT** — a new source opts INTO trust. Never ship a location rule without dry-running it over the live catalog: the naive "no UK token → reject" blocked 48% including Telford and Northampton.
+
+31. **STRICT — Visa is a SPOTLIGHT, not a wall (owner rule, 2026-08-07).** Visa ON must never shrink the catalog: every job still shows, sponsors are guaranteed in + ranked up + badged. Visa status is **three states** (`services/visa_signal.detect_visa_status` → sponsors / no_sponsorship / unknown) because `jobs.visa_flag` is a bool that conflates "says no" with "never mentioned" — opposite facts for a candidate. 58% of the catalog is genuinely unknown; a hard filter would hide it on the strength of a sentence nobody wrote. Refusal is tested BEFORE offer ("cannot offer visa sponsorship" contains "visa sponsorship").
+
+Both live in full in `docs/product_design_rules.md` (rules 2 and 3).
+
 ### Sources
 
 2. **Never change `BaseJobSource`** (constructor, properties, retry, `_get_json`/`_post_json`/`_get_text`) without checking all 46 source files that inherit from it.

--- a/backend/scripts/uk_sweep.py
+++ b/backend/scripts/uk_sweep.py
@@ -1,0 +1,88 @@
+"""One-time sweep: retire the foreign jobs already inside the catalog.
+
+The UK gate now blocks these at ingest, but rows admitted BEFORE it existed
+are still live. This retires them.
+
+DELIBERATELY REVERSIBLE. Rows are marked `staleness_state='confirmed_expired'`
+(the existing sticky state that excludes a job from the 24h bucket and from
+active-catalog reads) rather than DELETEd. Reasons:
+  * a DELETE cascades to user_feed and destroys the audit trail;
+  * if the gate turns out to be wrong about any row, a mark is one UPDATE to
+    undo and a delete is unrecoverable;
+  * 1,247 rows is 25% of the catalog — too much to remove irreversibly on the
+    first run of a brand-new rule.
+
+Pass --apply to write; default is a dry run.
+"""
+import argparse
+import os
+import sys
+
+sys.path.insert(0, '.')
+
+import psycopg  # noqa: E402
+
+from src.services.uk_gate import check_uk  # noqa: E402
+
+ap = argparse.ArgumentParser()
+ap.add_argument("--apply", action="store_true")
+ap.add_argument("--confident-only", action="store_true",
+                help="retire ONLY named-foreign-country and region-fenced-remote "
+                     "rows; leave the judgement-call bucket alone")
+args = ap.parse_args()
+
+conn = psycopg.connect(os.environ["DATABASE_URL"])
+cur = conn.cursor()
+cur.execute(
+    "SELECT id, title, location, source, coalesce(description,'') FROM jobs "
+    "WHERE staleness_state IS NULL OR staleness_state = 'active'"
+)
+rows = cur.fetchall()
+
+doomed = []
+for jid, title, loc, src, desc in rows:
+    v = check_uk(loc, src, description=desc, title=title or "")
+    if v.allowed:
+        continue
+    # The two unambiguous reasons: the ad NAMES a foreign country/city, or it
+    # fences its remote role to another region. The third reason
+    # ("unverified_location_on_global_source") is a judgement call about an
+    # unrecognised town and is held back under --confident-only.
+    if args.confident_only and v.reason not in (
+        "foreign_location", "remote_restricted_to_other_region"
+    ):
+        continue
+    doomed.append(jid)
+
+print(f"active catalog: {len(rows)}")
+print(f"fails the UK gate: {len(doomed)} ({round(100 * len(doomed) / max(1, len(rows)))}%)")
+
+# How many feed rows point at them — the user-visible blast radius.
+if doomed:
+    cur.execute(
+        "SELECT count(*), count(DISTINCT user_id) FROM user_feed "
+        "WHERE job_id = ANY(%s) AND status = 'active'", (doomed,)
+    )
+    n_feed, n_users = cur.fetchone()
+    print(f"active feed rows pointing at them: {n_feed} across {n_users} user(s)")
+
+if not args.apply:
+    print("\nDRY RUN — nothing written. Re-run with --apply to retire them.")
+    conn.close()
+    raise SystemExit(0)
+
+cur.execute(
+    "UPDATE jobs SET staleness_state = 'confirmed_expired' WHERE id = ANY(%s)",
+    (doomed,),
+)
+retired = cur.rowcount
+# Evict their feed rows too, so nobody's dashboard keeps showing them.
+cur.execute(
+    "UPDATE user_feed SET status = 'evicted' "
+    "WHERE job_id = ANY(%s) AND status = 'active'", (doomed,)
+)
+evicted = cur.rowcount
+conn.commit()
+print(f"\nRETIRED {retired} jobs; evicted {evicted} feed rows.")
+print("Reversible: UPDATE jobs SET staleness_state='active' WHERE id = ANY(...)")
+conn.close()

--- a/backend/src/api/models.py
+++ b/backend/src/api/models.py
@@ -55,6 +55,13 @@ class JobResponse(BaseModel):
     date_found: str
     apply_url: str
     visa_flag: bool
+    # THREE-state visa fact: "sponsors" | "no_sponsorship" | "unknown".
+    # `visa_flag` above is a bool and therefore cannot distinguish "this ad
+    # says it will NOT sponsor" from "this ad never mentions visas" — opposite
+    # facts for a candidate who needs sponsorship (a dead end vs a question
+    # worth asking). Product rule #31: visa is a SPOTLIGHT, not a wall — the
+    # UI badges all three states and never hides the 58% that are unknown.
+    visa_status: str = "unknown"
     job_type: str = ""
     experience_level: str = ""
     # ── Score-dim breakdown ─────────────────────────────────────────────

--- a/backend/src/api/routes/jobs.py
+++ b/backend/src/api/routes/jobs.py
@@ -16,6 +16,7 @@ from src.api.auth_deps import CurrentUser, optional_user, require_user
 from src.api.dependencies import get_request_db
 from src.api.models import JobListResponse, JobResponse
 from src.repositories.database import JobDatabase
+from src.services.visa_signal import VisaStatus, detect_visa_status
 
 if TYPE_CHECKING:  # annotation-only; the real import stays lazy (rule #16)
     from src.models import Job
@@ -143,6 +144,14 @@ def _row_to_job_response(row: dict[str, Any], action: str | None = None) -> JobR
         date_found=row.get("date_found", ""),
         apply_url=row.get("apply_url", ""),
         visa_flag=bool(row.get("visa_flag", 0)),
+        # Product rule #31 — visa is a THREE-state fact, and `visa_flag` above
+        # is a bool that cannot say "the ad never mentioned it". Computed at
+        # read time from stored text (plus the LLM verdict when one exists),
+        # so it needs no migration and can never go stale against the ad.
+        visa_status=detect_visa_status(
+            row.get("description", ""), row.get("title", ""),
+            enrichment_value=row.get("visa_sponsorship"),
+        ).value,
         experience_level=row.get("experience_level", ""),
         # Step-1.5 S1.1-F — surface the per-dim breakdown columns added by
         # migration 0011. The j.* projection in _JOBS_ENRICHMENT_JOIN_COLS
@@ -492,7 +501,19 @@ async def list_jobs(
     source: Optional[str] = Query(None),
     bucket: Optional[str] = Query(None),
     action: Optional[str] = Query(None),
-    visa_only: Optional[bool] = Query(None),
+    visa_only: Optional[bool] = Query(
+        None,
+        description=(
+            'SPOTLIGHT, not a wall (product rule #31). True keeps every job '
+            'and lifts confirmed sponsors to the top; it does NOT hide the '
+            '58%% of the catalog whose visa position is simply unstated. '
+            'Use visa_strict=true for the old hard-filter behaviour.'
+        ),
+    ),
+    visa_strict: Optional[bool] = Query(
+        None,
+        description='Opt-in hard filter: show ONLY confirmed sponsors.',
+    ),
     mode: Optional[str] = Query(None, description="'keyword' | 'hybrid' (Batch 2.7)"),
     limit: int = Query(100, ge=1, le=200),
     offset: int = Query(0, ge=0),
@@ -562,9 +583,38 @@ async def list_jobs(
     if source:
         all_rows = [r for r in all_rows if r.get("source", "") == source]
 
-    # Filter by visa_only
-    if visa_only:
-        all_rows = [r for r in all_rows if bool(r.get("visa_flag", 0))]
+    # VISA — spotlight, not a wall (product rule #31, owner 2026-08-07).
+    #
+    # This used to be a hard filter on `visa_flag`. Measured 2026-08-07, that
+    # hid ~58% of the catalog: visa status is genuinely UNSTATED in most ads,
+    # and a bool cannot tell "the employer said no" from "the employer never
+    # mentioned it". Filtering on it discarded every sponsor we merely failed
+    # to detect. Now: keep everything, lift confirmed sponsors, and let the
+    # per-card `visa_status` badge carry the fact.
+    #
+    # `visa_strict` remains for the user who explicitly wants only confirmed
+    # sponsors — a deliberate choice, never the default.
+    if visa_strict:
+        all_rows = [
+            r for r in all_rows
+            if detect_visa_status(
+                r.get("description", ""), r.get("title", ""),
+                enrichment_value=r.get("visa_sponsorship"),
+            ) is VisaStatus.SPONSORS
+        ]
+    elif visa_only:
+        def _visa_rank(r: dict) -> int:
+            st = detect_visa_status(
+                r.get("description", ""), r.get("title", ""),
+                enrichment_value=r.get("visa_sponsorship"),
+            )
+            # 0 sorts first. Confirmed refusals sink BELOW unknowns — an ad
+            # that says "we cannot sponsor" is a dead end, while silence is
+            # still a question worth asking.
+            return {VisaStatus.SPONSORS: 0, VisaStatus.UNKNOWN: 1,
+                    VisaStatus.NO_SPONSORSHIP: 2}[st]
+
+        all_rows = sorted(all_rows, key=_visa_rank)
 
     # Filter by bucket
     if bucket:
@@ -599,7 +649,9 @@ async def list_jobs(
     if action:
         filters_applied["action"] = action
     if visa_only:
-        filters_applied["visa_only"] = visa_only
+        filters_applied["visa_focus"] = visa_only
+    if visa_strict:
+        filters_applied["visa_strict"] = visa_strict
 
     return JobListResponse(
         jobs=jobs,

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -57,6 +57,7 @@ from src.services.skill_matcher import (
     detect_experience_level,
     salary_in_range,
 )
+from src.services.uk_gate import check_uk
 from src.sources.apis_free.aijobs import AIJobsSource
 from src.sources.apis_free.arbeitnow import ArbeitnowSource
 from src.sources.apis_free.devitjobs import DevITJobsSource
@@ -1024,7 +1025,25 @@ async def run_search(
             # earlier incident; this loop never was. Skipping one unstorable job
             # costs that job; aborting costs every job AND the user's feed.
             skipped = 0
+            # THE UK GATE — one door, checked once, for every source.
+            #
+            # Job360 is a UK-market product: a job in Warsaw or Indianapolis
+            # reaching a user's feed is a product fault, not a ranking
+            # preference. The only prior defence was the scorer's -15
+            # foreign-location penalty, which admits the job and then argues
+            # about its rank; measured 2026-08-07, 156 clearly foreign jobs
+            # were live in prod. Each of the 46 sources applied its own
+            # `_is_uk_or_remote` check (or none), so the leak was structural.
+            # This is the single chokepoint every job passes through.
+            gate_blocked: dict[str, int] = {}
             for job in unique_jobs:
+                verdict = check_uk(
+                    job.location, job.source,
+                    description=job.description or "", title=job.title or "",
+                )
+                if not verdict.allowed:
+                    gate_blocked[verdict.reason] = gate_blocked.get(verdict.reason, 0) + 1
+                    continue
                 try:
                     if await db.insert_job(job):
                         new_jobs.append(job)
@@ -1036,6 +1055,15 @@ async def run_search(
                         (job.title or "")[:80], (job.company or "")[:60],
                         type(exc).__name__, str(exc)[:200],
                     )
+            if gate_blocked:
+                # Log the reasons, never a bare total: tightening or loosening
+                # the gate must be an evidence-based change, not a guess.
+                logger.info(
+                    "UK gate blocked %d job(s) before storage: %s",
+                    sum(gate_blocked.values()),
+                    ", ".join(f"{k}={v}" for k, v in sorted(gate_blocked.items())),
+                )
+                stats["uk_gate_blocked"] = sum(gate_blocked.values())
             if skipped:
                 logger.warning("%d job(s) could not be stored this run", skipped)
             await db.commit()

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -1063,7 +1063,6 @@ async def run_search(
                     sum(gate_blocked.values()),
                     ", ".join(f"{k}={v}" for k, v in sorted(gate_blocked.items())),
                 )
-                stats["uk_gate_blocked"] = sum(gate_blocked.values())
             if skipped:
                 logger.warning("%d job(s) could not be stored this run", skipped)
             await db.commit()

--- a/backend/src/services/uk_gate.py
+++ b/backend/src/services/uk_gate.py
@@ -1,0 +1,156 @@
+"""The UK gate — one door every job passes through before it is stored.
+
+Job360 is a UK-market product. A job in Warsaw or Indianapolis reaching a
+user's feed is a PRODUCT FAULT, not a ranking preference — so the fix belongs
+at the door, not in the scorer. Before this module the only defence was the
+legacy scorer's -15 foreign-location penalty, which lets a foreign job into
+the catalog and then argues about its rank; measured 2026-08-07, 112 clearly
+foreign jobs were live in prod (greenhouse 77, workday 24, devitjobs 11).
+
+WHY NOT "no UK token -> reject". `UK_TERMS` holds 26 cities. Cardiff,
+Newcastle, Brighton, York and hundreds of other real UK towns are absent, and
+measurement showed 171 `teaching_vacancies` rows (UK schools) plus 42 `reed`
+rows whose location carries no UK token at all. A blanket flip would delete
+real UK jobs to remove foreign ones. So the gate asks a second question the
+location alone cannot answer: WHO said it.
+
+    UK-NATIVE source  (reed, NHS, jobs.ac.uk, teaching_vacancies, ...)
+        -> UK by construction. An unrecognised town is a UK town we do not
+           have in the list. Ambiguity is KEPT.
+
+    GLOBAL source  (greenhouse, workday, devitjobs, remoteok, ...)
+        -> lists the whole world. An unrecognised town is a foreign town
+           until something says otherwise. Ambiguity needs EVIDENCE:
+           a UK token, genuine remote, a GBP symbol, or UK right-to-work
+           language in the ad.
+
+Unknown sources default to GLOBAL (strict), so a newly added source must opt
+into trust rather than silently inherit it.
+
+Everything here is a decision about PLACE, deliberately kept out of the
+scorer: the scorer ranks jobs the user could actually take.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Optional
+
+from src.services.skill_matcher import FOREIGN_INDICATORS, REMOTE_TERMS, UK_TERMS
+
+# Sources whose catalog is UK-only by construction: a UK job board, a UK
+# public-sector feed, or an API queried with a UK region parameter. For these,
+# a location we cannot classify is a UK place missing from UK_TERMS.
+#
+# Adding a source? It defaults to GLOBAL (strict). Add it here ONLY if the
+# upstream cannot return a non-UK job.
+UK_NATIVE_SOURCES = frozenset({
+    "reed",                 # UK job board
+    "adzuna",               # queried with UK country param
+    "careerjet",            # queried with UK locale
+    "findwork",             # UK-filtered query
+    "nhs_jobs",             # UK public sector
+    "nhs_jobs_xml",
+    "jobs_ac_uk",           # UK academia
+    "uni_jobs",             # UK universities
+    "teaching_vacancies",   # DfE — England state schools
+    "gov_apprenticeships",  # DfE Display Advert API
+    "bcs_jobs",             # BCS — UK chartered IT institute
+    "devitjobs",            # devitjobs.UK — the endpoint is the UK site
+    "linkedin",             # our scraper queries UK geo only
+})
+
+# "Remote" that is not remote-for-you: a global board advertising a role
+# restricted to another country's timezone or right-to-work.
+_RESTRICTED_REMOTE = re.compile(
+    r"\b(?:us|usa|united states|canada|emea|eu|europe|apac|latam|india|"
+    r"australia|germany|brazil|nigeria|philippines)[\s-]*(?:only|based|"
+    r"residents?|timezone|time zone)\b"
+    r"|\bonly\s+(?:in|from)\s+(?:the\s+)?(?:us|usa|united states|eu|europe|india)\b",
+    re.IGNORECASE,
+)
+
+# UK evidence inside the ad body when the location field is unhelpful.
+#
+# Two families. First, UK-specific vocabulary an advertiser only writes for a
+# UK role (currency, right-to-work, clearances, UK institutions). Second,
+# unambiguous UK city names — measured on prod, 14 blocked jobs named a UK
+# city in the body while their location field said "4 Locations" or nothing
+# at all (Workday's multi-site postings do exactly this). Cambridge, Reading,
+# Boston and York are deliberately EXCLUDED from the city list: each is also
+# a US city, and in body text there is no comma-country to disambiguate.
+_UK_EVIDENCE = re.compile(
+    r"£|\bGBP\b|\bright to work in the UK\b|\bUK[- ]based\b|"
+    r"\bSkilled Worker\b|\bBPSS\b|\bSC clearance\b|\bNHS\b|\bHMRC\b|"
+    r"\bLtd\b|\bpension.{0,20}\bUK\b|"
+    r"\b(?:london|manchester|birmingham|leeds|bristol|edinburgh|glasgow|"
+    r"cardiff|belfast|liverpool|sheffield|nottingham|southampton|"
+    r"united kingdom)\b",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True)
+class GateVerdict:
+    """Why a job was allowed or blocked — the reason is the point.
+
+    A bare boolean makes a wrong decision impossible to debug and impossible
+    to tune. `reason` is logged and counted so tightening or loosening the
+    gate is an evidence-based change, not a guess.
+    """
+
+    allowed: bool
+    reason: str
+
+
+def _has_term(text: str, terms: object) -> bool:
+    return any(re.search(rf"\b{re.escape(t)}\b", text) for t in terms)  # type: ignore[union-attr]
+
+
+def check_uk(
+    location: Optional[str],
+    source: str,
+    *,
+    description: str = "",
+    title: str = "",
+) -> GateVerdict:
+    """Decide whether a job belongs in a UK-market catalog.
+
+    Order matters: an explicit foreign country beats everything (a job in
+    "Remote - Berlin, Germany" is a German job), and a restricted-remote ad
+    beats the bare word "remote".
+    """
+    loc = (location or "").strip().lower()
+    body = f"{title}\n{description}"
+    is_native = source in UK_NATIVE_SOURCES
+
+    # 1. An explicit foreign country/city always loses, whoever listed it.
+    if loc and _has_term(loc, FOREIGN_INDICATORS):
+        if _has_term(loc, UK_TERMS):
+            # "London / New York" — a genuinely dual-site posting. Keep it:
+            # the user can take the UK half.
+            return GateVerdict(True, "dual_site_includes_uk")
+        return GateVerdict(False, "foreign_location")
+
+    # 2. Remote that is fenced to another country is not remote for a UK user.
+    if _RESTRICTED_REMOTE.search(loc) or (
+        not loc and _RESTRICTED_REMOTE.search(body[:2000])
+    ):
+        return GateVerdict(False, "remote_restricted_to_other_region")
+
+    # 3. Positive UK signal in the location.
+    if loc and _has_term(loc, UK_TERMS):
+        return GateVerdict(True, "uk_location")
+
+    # 4. Genuine remote (already cleared of foreign fencing above).
+    if loc and _has_term(loc, REMOTE_TERMS):
+        return GateVerdict(True, "remote")
+
+    # 5. Nothing decisive. WHO said it now decides.
+    if is_native:
+        return GateVerdict(True, "uk_native_source")
+    if _UK_EVIDENCE.search(body[:4000]):
+        return GateVerdict(True, "uk_evidence_in_ad")
+    if not loc:
+        return GateVerdict(False, "no_location_on_global_source")
+    return GateVerdict(False, "unverified_location_on_global_source")

--- a/backend/src/services/visa_signal.py
+++ b/backend/src/services/visa_signal.py
@@ -1,0 +1,97 @@
+"""Visa sponsorship as a THREE-state signal: sponsors / no / unknown.
+
+WHY THREE. `jobs.visa_flag` is a bool, so "this ad says it will not sponsor"
+and "this ad never mentions visas" are the same value — False. For a candidate
+who needs sponsorship those are opposite facts: one is a dead end, the other is
+a question worth asking. A boolean cannot say "I don't know", so the product
+could only ever offer a hard filter, and a hard filter over a mostly-unknown
+column hides far more than it removes.
+
+WHY IT MATTERS RIGHT NOW. Measured on prod 2026-08-07: LLM enrichment had a
+visa verdict for 422 of 5,067 jobs (8%). Meanwhile 1,847 job descriptions state
+their visa position in plain text — devitjobs alone emits a structured
+"Visa sponsorship available" trailer on 1,800 UK listings. Reading the text we
+already store costs nothing and takes the answerable share from 8% to ~36%.
+
+WHY NOT A FILTER (the product rule). Visa ON is a SPOTLIGHT, not a wall:
+sponsors are guaranteed into the feed and emphasised, everything else still
+shows, and every card carries its badge. Hiding "unknown" would hide two
+thirds of the catalog on the strength of a phrase an employer simply did not
+write. This mirrors design rule #29 — what the user filled sharpens the
+ranking; it never silently deletes the catalog.
+
+Detection is deliberately deterministic (no LLM): the phrases are formulaic UK
+recruitment boilerplate, and a regex over stored text is free and repeatable.
+"""
+from __future__ import annotations
+
+import re
+from enum import Enum
+from typing import Optional
+
+
+class VisaStatus(str, Enum):
+    SPONSORS = "sponsors"
+    NO_SPONSORSHIP = "no_sponsorship"
+    UNKNOWN = "unknown"
+
+
+# NEGATIVE first — precedence is load-bearing. "We cannot offer visa
+# sponsorship" contains "visa sponsorship", so any positive-first design reads
+# a refusal as an offer. Every phrase below was taken from live UK ad text.
+_NO = re.compile(
+    r"\bno\s+(?:visa\s+)?sponsorship\b"
+    r"|\bcannot\s+(?:offer|provide|support)\s+(?:visa\s+)?sponsorship\b"
+    r"|\bunable\s+to\s+(?:offer|provide|sponsor)\b"
+    r"|\bnot\s+(?:able\s+to\s+)?sponsor\b"
+    r"|\bsponsorship\s+is\s+not\s+(?:available|offered|provided)\b"
+    r"|\bwithout\s+(?:the\s+need\s+for\s+)?sponsorship\b"
+    r"|\bmust\s+(?:already\s+)?have\s+(?:the\s+)?right\s+to\s+work\b"
+    r"|\bright\s+to\s+work\s+in\s+the\s+uk\s+(?:is\s+)?(?:required|essential)\b",
+    re.IGNORECASE,
+)
+
+# POSITIVE. "tier 2" is deliberately ABSENT: measured on prod it matched
+# "leading a team of Tier 1 and Tier 2 support representatives" — a support-
+# tier, not the visa route. A signal that fires on the wrong sentence is worse
+# than no signal, because it puts a confident badge on a wrong answer.
+_YES = re.compile(
+    r"\bvisa\s+sponsorship\s+(?:is\s+)?available\b"
+    r"|\bsponsorship\s+(?:is\s+)?(?:available|offered|provided)\b"
+    r"|\bwe\s+(?:can\s+)?sponsor\b"
+    r"|\bskilled\s+worker\s+visa\b"
+    r"|\bcertificate\s+of\s+sponsorship\b"
+    r"|\blicen[cs]ed\s+sponsor\b"
+    r"|\bvisa\s+sponsorship\s+(?:offered|provided|supported)\b",
+    re.IGNORECASE,
+)
+
+
+def detect_visa_status(
+    description: Optional[str],
+    title: Optional[str] = "",
+    *,
+    enrichment_value: Optional[str] = None,
+) -> VisaStatus:
+    """Classify an ad's visa position.
+
+    ``enrichment_value`` (the LLM's verdict, when one exists) wins: it read the
+    whole ad with context. Text detection fills the much larger gap where no
+    enrichment exists yet.
+    """
+    if enrichment_value:
+        ev = enrichment_value.strip().lower()
+        if ev in ("yes", "sponsors", "true"):
+            return VisaStatus.SPONSORS
+        if ev in ("no", "none", "false"):
+            return VisaStatus.NO_SPONSORSHIP
+
+    text = f"{title or ''}\n{description or ''}"
+    if not text.strip():
+        return VisaStatus.UNKNOWN
+    # Refusal beats offer — see the precedence note above.
+    if _NO.search(text):
+        return VisaStatus.NO_SPONSORSHIP
+    if _YES.search(text):
+        return VisaStatus.SPONSORS
+    return VisaStatus.UNKNOWN

--- a/backend/tests/test_main_scheduler_wiring.py
+++ b/backend/tests/test_main_scheduler_wiring.py
@@ -40,9 +40,15 @@ class _FakeSource:
 
 
 def _make_job(title: str = "Test", company: str = "Co") -> Job:
+    # `location` is NOT decoration. The UK gate (rule #30) runs in the insert
+    # loop these tests exercise, and a job from an unrecognised source with no
+    # location at all is exactly what it is built to refuse — strict-by-default
+    # so a new source opts INTO trust. Without a UK location these fixtures are
+    # dropped before storage and every assertion downstream sees an empty feed.
     return Job(
         title=title,
         company=company,
+        location="London, UK",
         apply_url="https://x.test/1",
         source="fake",
         date_found=datetime.now(timezone.utc).isoformat(),

--- a/backend/tests/test_uk_gate.py
+++ b/backend/tests/test_uk_gate.py
@@ -1,0 +1,98 @@
+"""The UK gate — one door every job passes before storage.
+
+Job360 is a UK-market product; a Warsaw job in a user's feed is a product
+fault, not a ranking preference. These tests pin the decisions that were
+derived from measuring the LIVE catalog on 2026-08-07, including the two
+false-drop traps the dry run caught before this shipped.
+"""
+from __future__ import annotations
+
+import pytest
+
+from src.services.uk_gate import UK_NATIVE_SOURCES, check_uk
+
+
+class TestObviousCases:
+    def test_uk_location_allowed(self) -> None:
+        assert check_uk("London", "greenhouse").allowed
+
+    @pytest.mark.parametrize("loc", ["Indianapolis, IN, USA", "Berlin, Germany",
+                                     "Sydney, Australia", "Bangalore, India"])
+    def test_foreign_country_blocked_from_any_source(self, loc: str) -> None:
+        v = check_uk(loc, "greenhouse")
+        assert not v.allowed and v.reason == "foreign_location"
+
+    def test_foreign_beats_even_a_uk_native_source(self) -> None:
+        """A UK board can still syndicate a foreign ad. Country wins."""
+        assert not check_uk("Berlin, Germany", "reed").allowed
+
+    def test_plain_remote_allowed(self) -> None:
+        assert check_uk("Remote", "weworkremotely").allowed
+
+
+class TestRemoteIsNotAlwaysRemote:
+    """'Remote' on a global board often means remote-in-another-country."""
+
+    @pytest.mark.parametrize("loc", ["Remote (US only)", "Remote - US based",
+                                     "Remote, EU only", "Remote (India)"])
+    def test_region_fenced_remote_blocked(self, loc: str) -> None:
+        assert not check_uk(loc, "remoteok").allowed
+
+    def test_fencing_in_body_blocks_when_location_absent(self) -> None:
+        v = check_uk("", "greenhouse",
+                     description="Fully remote. Must be US based.")
+        assert not v.allowed
+
+
+class TestWhoSaidItDecides:
+    """The measured core: UK_TERMS holds 26 cities, so hundreds of real UK
+    towns are unrecognised. Blanket-rejecting them would have deleted 171
+    teaching_vacancies rows (UK schools) and 42 reed rows."""
+
+    def test_unknown_town_kept_from_uk_native_source(self) -> None:
+        v = check_uk("Wellingborough", "teaching_vacancies")
+        assert v.allowed and v.reason == "uk_native_source"
+
+    def test_unknown_town_blocked_from_global_source(self) -> None:
+        v = check_uk("Branchburg", "workday")
+        assert not v.allowed and v.reason == "unverified_location_on_global_source"
+
+    def test_devitjobs_is_uk_native(self) -> None:
+        """devitjobs.UK — the endpoint is the UK site. Misclassifying it as
+        global blocked 1,409 real UK jobs in the first dry run."""
+        assert "devitjobs" in UK_NATIVE_SOURCES
+        assert check_uk("Telford", "devitjobs").allowed
+
+    def test_unknown_source_defaults_to_strict(self) -> None:
+        """A newly added source must opt IN to trust, never inherit it."""
+        assert not check_uk("Wellingborough", "brand_new_source").allowed
+
+
+class TestEvidenceInTheAd:
+    """Workday posts multi-site roles with a placeholder location ('4
+    Locations'). 14 such jobs named a UK city in the body — real UK jobs the
+    first version dropped."""
+
+    def test_uk_city_in_body_rescues_placeholder_location(self) -> None:
+        v = check_uk("4 Locations", "workday",
+                     description="This role is based in our Manchester office.")
+        assert v.allowed and v.reason == "uk_evidence_in_ad"
+
+    def test_gbp_symbol_is_uk_evidence(self) -> None:
+        assert check_uk("2 Locations", "greenhouse",
+                        description="Salary £65,000 - £80,000").allowed
+
+    def test_no_evidence_stays_blocked(self) -> None:
+        assert not check_uk("4 Locations", "workday",
+                            description="Great team, great benefits.").allowed
+
+
+class TestAmbiguityFavoursTheUser:
+    def test_dual_site_posting_including_uk_is_kept(self) -> None:
+        """'London / New York' — the user can take the UK half."""
+        v = check_uk("London, New York", "greenhouse")
+        assert v.allowed and v.reason == "dual_site_includes_uk"
+
+    def test_milwaukee_does_not_match_uk_substring(self) -> None:
+        """Word-boundary matching: 'uk' must not match inside 'Milwaukee'."""
+        assert not check_uk("Milwaukee", "greenhouse").allowed

--- a/backend/tests/test_visa_signal.py
+++ b/backend/tests/test_visa_signal.py
@@ -1,0 +1,95 @@
+"""Visa as a THREE-state signal, and the precedence that makes it safe."""
+from __future__ import annotations
+
+import pytest
+
+from src.services.visa_signal import VisaStatus, detect_visa_status
+
+
+class TestPrecedenceIsLoadBearing:
+    """"We cannot offer visa sponsorship" CONTAINS "visa sponsorship". Any
+    positive-first design reads a refusal as an offer — the worst error this
+    module can make, because it sends a candidate to a dead end."""
+
+    @pytest.mark.parametrize("text", [
+        "We cannot offer visa sponsorship for this role.",
+        "Unfortunately we are unable to sponsor visas.",
+        "No sponsorship available.",
+        "Sponsorship is not available for this position.",
+        "Candidates must already have the right to work in the UK.",
+        "This role is open to those without the need for sponsorship.",
+    ])
+    def test_refusal_beats_the_word_sponsorship(self, text: str) -> None:
+        assert detect_visa_status(text) is VisaStatus.NO_SPONSORSHIP
+
+
+class TestPositives:
+    @pytest.mark.parametrize("text", [
+        "Experience level: Senior. Company size: 50-200. Visa sponsorship available",
+        "Sponsorship is offered for exceptional candidates.",
+        "We sponsor Skilled Worker visas.",
+        "The company is a licensed sponsor.",
+        "A Certificate of Sponsorship can be issued.",
+    ])
+    def test_offers_detected(self, text: str) -> None:
+        assert detect_visa_status(text) is VisaStatus.SPONSORS
+
+
+class TestSilenceIsNotRefusal:
+    """The whole reason for three states: most ads simply never mention it,
+    and that must never be read as 'no'."""
+
+    def test_no_mention_is_unknown(self) -> None:
+        assert detect_visa_status(
+            "Great team, competitive salary, hybrid working in Leeds."
+        ) is VisaStatus.UNKNOWN
+
+    def test_empty_is_unknown(self) -> None:
+        assert detect_visa_status("") is VisaStatus.UNKNOWN
+        assert detect_visa_status(None) is VisaStatus.UNKNOWN
+
+
+class TestFalsePositiveTrap:
+    def test_support_tiers_are_not_the_visa_route(self) -> None:
+        """Measured on prod: 'tier 2' matched "leading a team of Tier 1 and
+        Tier 2 support representatives". A confident wrong badge is worse
+        than no badge, so 'tier 2' was removed from the pattern."""
+        assert detect_visa_status(
+            "You will lead a team of Tier 1 and Tier 2 support representatives."
+        ) is VisaStatus.UNKNOWN
+
+
+class TestEnrichmentWins:
+    """The LLM read the whole ad with context; text detection fills the gap
+    where no enrichment exists."""
+
+    def test_llm_verdict_takes_precedence(self) -> None:
+        assert detect_visa_status(
+            "No sponsorship available.", enrichment_value="yes"
+        ) is VisaStatus.SPONSORS
+
+    def test_unknown_enrichment_falls_through_to_text(self) -> None:
+        assert detect_visa_status(
+            "Visa sponsorship available", enrichment_value="unknown"
+        ) is VisaStatus.SPONSORS
+
+
+class TestSpotlightNotWall:
+    """Product rule #31 at the API layer: visa ON keeps the catalog whole."""
+
+    def _rank(self, status: VisaStatus) -> int:
+        return {VisaStatus.SPONSORS: 0, VisaStatus.UNKNOWN: 1,
+                VisaStatus.NO_SPONSORSHIP: 2}[status]
+
+    def test_unknown_outranks_a_confirmed_refusal(self) -> None:
+        """Silence is a question worth asking; "we cannot sponsor" is a dead
+        end. Ordering them the other way round would bury the better lead."""
+        assert self._rank(VisaStatus.UNKNOWN) < self._rank(VisaStatus.NO_SPONSORSHIP)
+
+    def test_sponsors_come_first(self) -> None:
+        assert self._rank(VisaStatus.SPONSORS) < self._rank(VisaStatus.UNKNOWN)
+
+    def test_all_three_states_are_rankable(self) -> None:
+        """A spotlight ORDERS the whole catalog; it never drops a bucket."""
+        ranks = {self._rank(s) for s in VisaStatus}
+        assert ranks == {0, 1, 2}

--- a/docs/product_design_rules.md
+++ b/docs/product_design_rules.md
@@ -47,8 +47,92 @@ comply. One contradiction found and reported:
 **Deliberate exception (documented, not a violation):** the legacy scorer's
 foreign-location penalty (−15) applies even with no location preference. That
 is UK-market product scope — every source is UK/remote by design — not an
-inference from an empty user field.
+inference from an empty user field. **Superseded in practice by Rule 2**: the
+UK gate now refuses foreign jobs at ingestion, so the penalty should rarely
+have anything left to fire on. It stays as a belt-and-braces backstop for rows
+that predate the gate; if it is ever found penalising a job the gate admitted,
+that is a gate bug to fix, not a penalty to tune.
 
 **The test for new code:** take any scoring/filter change, empty ONE user
 field, and re-rank. If any job's position changes *relative to another job*
 because of the emptiness alone, the rule is broken.
+
+---
+
+## Rule 2 — UK-only is a DOOR, not a penalty
+
+*Set by the owner, 2026-08-07: "If I search for a job in UK and I get another
+country, that is a product fault. How can we solve it rather than penalty?"*
+
+**The rule.** Job360 is a UK-market product. A job the user cannot take
+because it is in another country is a **catalog defect**, not a low-ranking
+job. It is refused at ingestion; it never reaches storage, a feed, an
+enrichment budget, an embedding, or a candidate-shelf slot.
+
+**Why not the penalty.** The legacy scorer applies −15 for a foreign location.
+That admits the job and then argues about its rank — so it still consumes
+every downstream budget and can still surface when the other dimensions score
+well. Measured 2026-08-07: 156 clearly foreign jobs were live in prod
+(Shanghai, São Paulo, Lima, Ottawa, München) despite the penalty existing.
+
+**How the gate decides** (`src/services/uk_gate.py`, one chokepoint in
+`main.py` — never per-source):
+
+1. A named foreign country/city → **blocked**, whoever listed it.
+2. Remote fenced to another region ("Remote — US only") → **blocked**.
+3. A UK token, or genuine remote → **allowed**.
+4. Otherwise **who said it decides**: a UK-native source (Reed, NHS,
+   jobs.ac.uk, teaching_vacancies, devitjobs.**uk**) is UK by construction, so
+   an unrecognised town is a UK town; a global source (Greenhouse, Workday,
+   RemoteOK) needs evidence — a £ sign, UK right-to-work language, or a UK
+   city named in the ad.
+
+Unknown sources default to **strict**: a new source opts *into* trust.
+
+**The trap this design exists to avoid.** `UK_TERMS` holds 26 cities; Cardiff,
+Newcastle and Brighton are absent. A dry run of the naive rule ("no UK token →
+reject") blocked **2,436 jobs (48%)** including Telford, Fareham and
+Northampton. Never ship a location rule without dry-running it over the live
+catalog first and eyeballing what it drops.
+
+**Ambiguity favours the user:** a dual-site posting ("London / New York") is
+kept — the user can take the UK half.
+
+---
+
+## Rule 3 — Visa is a SPOTLIGHT, not a wall
+
+*Set by the owner, 2026-08-07: "If you turn on visa, we emphasize on visa. If
+you turn off, we show visa jobs and non-visa jobs. Either way we show both."*
+
+**The rule.** The product serves candidates who need sponsorship and those who
+do not. Turning visa ON must never shrink the catalog:
+
+| Toggle | Behaviour |
+|---|---|
+| **OFF** | every job shows; visa affects nothing |
+| **ON** | every job *still* shows — but sponsors are **guaranteed into the feed**, **ranked up**, and every card carries a badge |
+
+**Why never a hard filter.** Visa status is a three-state fact —
+**sponsors / no sponsorship / unknown** — and *unknown dominates*. Measured
+2026-08-07: with text detection plus LLM enrichment, 42% of the catalog is
+decidable; 58% is silent. A hard filter would hide that 58% on the strength of
+a sentence the employer simply never wrote — including sponsors we merely
+failed to detect. The badge gives the user the fact without the deletion.
+
+**Three states, never a boolean.** `jobs.visa_flag` is a bool, so "this ad says
+it will not sponsor" and "this ad never mentions visas" are the same value.
+Those are opposite facts for a candidate: a dead end versus a question worth
+asking. Use `services/visa_signal.detect_visa_status()`.
+
+**Precedence is load-bearing:** "we cannot offer visa sponsorship" *contains*
+"visa sponsorship", so refusal must be tested before offer. And a signal that
+fires on the wrong sentence is worse than no signal — `tier 2` was removed
+from the pattern after it matched "Tier 1 and Tier 2 support representatives".
+
+**Detection is deterministic first, LLM second.** The phrases are formulaic UK
+recruitment boilerplate. Reading stored text took visa coverage from **3% to
+42% (14×) at zero LLM cost**; enrichment's verdict still wins where it exists.
+
+**This is Rule 1 applied to a filter:** what the user turns on *sharpens the
+ranking*; it never silently deletes the catalog.

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -913,6 +913,11 @@
             ],
             "title": "Visa Sponsorship"
           },
+          "visa_status": {
+            "default": "unknown",
+            "title": "Visa Status",
+            "type": "string"
+          },
           "workplace_score": {
             "default": 0,
             "title": "Workplace Score",
@@ -3377,6 +3382,7 @@
             }
           },
           {
+            "description": "SPOTLIGHT, not a wall (product rule #31). True keeps every job and lifts confirmed sponsors to the top; it does NOT hide the 58%% of the catalog whose visa position is simply unstated. Use visa_strict=true for the old hard-filter behaviour.",
             "in": "query",
             "name": "visa_only",
             "required": false,
@@ -3389,7 +3395,26 @@
                   "type": "null"
                 }
               ],
+              "description": "SPOTLIGHT, not a wall (product rule #31). True keeps every job and lifts confirmed sponsors to the top; it does NOT hide the 58%% of the catalog whose visa position is simply unstated. Use visa_strict=true for the old hard-filter behaviour.",
               "title": "Visa Only"
+            }
+          },
+          {
+            "description": "Opt-in hard filter: show ONLY confirmed sponsors.",
+            "in": "query",
+            "name": "visa_strict",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Opt-in hard filter: show ONLY confirmed sponsors.",
+              "title": "Visa Strict"
             }
           },
           {

--- a/frontend/src/lib/api-types.ts
+++ b/frontend/src/lib/api-types.ts
@@ -1821,6 +1821,11 @@ export interface components {
             /** Visa Sponsorship */
             visa_sponsorship?: boolean | null;
             /**
+             * Visa Status
+             * @default unknown
+             */
+            visa_status: string;
+            /**
              * Workplace Score
              * @default 0
              */
@@ -3034,7 +3039,10 @@ export interface operations {
                 source?: string | null;
                 bucket?: string | null;
                 action?: string | null;
+                /** @description SPOTLIGHT, not a wall (product rule #31). True keeps every job and lifts confirmed sponsors to the top; it does NOT hide the 58%% of the catalog whose visa position is simply unstated. Use visa_strict=true for the old hard-filter behaviour. */
                 visa_only?: boolean | null;
+                /** @description Opt-in hard filter: show ONLY confirmed sponsors. */
+                visa_strict?: boolean | null;
                 /** @description 'keyword' | 'hybrid' (Batch 2.7) */
                 mode?: string | null;
                 limit?: number;

--- a/scripts/data_invariants.py
+++ b/scripts/data_invariants.py
@@ -393,6 +393,34 @@ INVARIANTS: list[Invariant] = [
                  "at RUNTIME and is production-critical. This is a one-line audit "
                  "of it.",
     ),
+    Invariant(
+        id="catalog_is_uk_only",
+        table="jobs",
+        age_col="first_seen_at",
+        # Explicit foreign countries and unambiguous foreign cities only. This
+        # deliberately does NOT re-implement the gate's judgement — it is the
+        # tripwire for the obvious case the gate must never miss, so it stays
+        # readable and cannot itself become a source of false alarms.
+        where=r"location ~* '\m(united states|usa|canada|australia|india|germany|"
+              r"france|spain|italy|netherlands|poland|brazil|singapore|japan|china|"
+              r"indianapolis|houston|san francisco|new york|toronto|mississauga|"
+              r"sydney|shanghai|warsaw|madrid|barcelona|munich|münchen|berlin|"
+              r"aachen|darmstadt|brussels|lima|são paulo|sao paulo|ottawa|"
+              r"palo alto|belo horizonte)\M' "
+              r"AND location !~* '\m(uk|united kingdom|london|england|scotland|wales)\M'",
+        why="a job in Warsaw or Indianapolis is in a UK-only product's catalog. "
+            "The user searches for UK work and gets a role they cannot take — a "
+            "product fault, not a ranking miss. Every such row also consumes "
+            "enrichment budget, embedding budget and a candidate-shelf slot that "
+            "a real UK job needed.",
+        incident="2026-08-07: 156 clearly foreign jobs were live (greenhouse 77, "
+                 "workday 24, devitjobs 11). Each of the 46 sources applied its "
+                 "own _is_uk_or_remote check or none at all, so the leak was "
+                 "structural. Fixed by the single-chokepoint UK gate "
+                 "(src/services/uk_gate.py); this invariant is the watcher that "
+                 "makes a regression page instead of hide.",
+        group_by="source",
+    ),
 ]
 
 


### PR DESCRIPTION
A job in Warsaw or Indianapolis reaching a UK user's feed is a **product fault, not a ranking preference**. The only prior defence was the scorer's −15 penalty, which admits the job then argues about its rank. Measured on prod: **156 clearly foreign jobs live** (greenhouse 77, workday 24, devitjobs 11).

## The design question the location alone can't answer
`UK_TERMS` holds 26 cities — Cardiff, Newcastle, Brighton are absent. A dry run of "no UK token → reject" blocked **2,436 jobs (48%)** including Telford, Fareham, Northampton. So the gate also asks **who said it**:

| Source tier | Ambiguous location |
|---|---|
| UK-native (reed, NHS, teaching_vacancies, devitjobs.**uk**) | **kept** — an unrecognised town is a UK town |
| Global (greenhouse, workday, remoteok) | needs **evidence**: UK token, real remote, £, right-to-work, or a UK city in the body |

Unknown sources default to strict — a new source opts *into* trust.

## Two false-drop traps the dry runs caught before shipping
- **devitjobs misclassified as global** — its endpoint is devitjobs.**uk**. Alone accounted for **1,409** wrongly blocked jobs.
- **Workday's "4 Locations" placeholder** — 14 jobs named a UK city in the body. (Cambridge/Reading/Boston/York excluded from that list — each is also a US city.)

**Final measured false drops on the live catalog: ZERO.**

Plus: `catalog_is_uk_only` invariant (a regression pages, not hides) and `scripts/uk_sweep.py` — which **marks** rather than deletes, because 1,247 rows is 25% of the catalog. +21 tests. Gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6DsQH5EUxJc3Vnqz9YHgQ