### PR TITLE
fix(scripts): uk_sweep reads DATABASE_PUBLIC_URL so it runs on any shell

### DIFF
--- a/backend/scripts/uk_sweep.py
+++ b/backend/scripts/uk_sweep.py
@@ -31,7 +31,16 @@ ap.add_argument("--confident-only", action="store_true",
                      "rows; leave the judgement-call bucket alone")
 args = ap.parse_args()
 
-conn = psycopg.connect(os.environ["DATABASE_URL"])
+# Accept either name. Inside `railway run -s Postgres`, DATABASE_URL points at
+# postgres.railway.internal, which resolves only INSIDE Railway; from a laptop
+# the usable DSN is DATABASE_PUBLIC_URL. Reading both means the command is a
+# plain `railway run -s Postgres python scripts/uk_sweep.py` on any shell,
+# with no bash -c wrapper to export one from the other (PowerShell has neither
+# `&&` nor `VAR=x cmd`).
+_dsn = os.environ.get("DATABASE_PUBLIC_URL") or os.environ.get("DATABASE_URL")
+if not _dsn:
+    raise SystemExit("set DATABASE_PUBLIC_URL or DATABASE_URL")
+conn = psycopg.connect(_dsn)
 cur = conn.cursor()
 cur.execute(
     "SELECT id, title, location, source, coalesce(description,'') FROM jobs "


### PR DESCRIPTION
The documented invocation used a `bash -c` wrapper to export `DATABASE_URL` from `DATABASE_PUBLIC_URL`. On Windows PowerShell that is unusable — no `&&` statement separator, no `VAR=value cmd` prefix form, no backslash line continuation. The owner hit all three.

Inside `railway run -s Postgres`, `DATABASE_URL` points at `postgres.railway.internal`, which resolves only *inside* Railway; the DSN that works from a laptop is `DATABASE_PUBLIC_URL`. Reading either name removes the wrapper entirely:

```
railway run -s Postgres python scripts/uk_sweep.py --confident-only
```

Verified against prod (dry run): 156 rows fail the gate, 250 feed rows across 2 users. Gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6DsQH5EUxJc3Vnqz9YHgQ
