### PR TITLE
feat(shelves): fix what the audit found — the instrument, two dead extractions, two dark dimensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,12 @@ data/
 # `python backend/scripts/build_uk_gazetteer.py` — UK settlements do not churn.
 !backend/data/uk_gazetteer/
 !backend/data/uk_gazetteer/**
+# ...and the job-signal vocabularies, for the same reason: the detectors run on
+# every scored job and their tests must pass OFFLINE (hard rule #4). CI proved
+# this the hard way — without the files committed, the detectors correctly
+# degraded to UNKNOWN and 4 tests failed in CI while passing locally.
+!backend/data/job_signals/
+!backend/data/job_signals/**
 .secrets/
 
 # Playwright MCP cache + ad-hoc test screenshots

--- a/backend/data/job_signals/seniority_terms.txt
+++ b/backend/data/job_signals/seniority_terms.txt
@@ -1,0 +1,73 @@
+# seniority_terms.txt — one `<value><TAB><phrase>` pair per line.
+# value is a SeniorityLevel enum value (job_enrichment_schema.py): intern |
+# junior | mid | senior | staff | principal | director. Lines starting with
+# # and blank lines are ignored. A new phrase is a line here, never a code
+# change (see job_signals.py).
+#
+# NOTE: bare "staff" is deliberately ABSENT from the staff tier. "Staff
+# Nurse" (NHS Band 5, an entry grade) and "Staff Accountant" / "Staff
+# Writer" use "staff" as an ordinary grade name in their fields, not the
+# tech-industry "staff engineer" senior-IC tier. Only compounds below.
+staff	staff engineer
+staff	staff software engineer
+staff	staff data scientist
+staff	staff developer
+staff	senior staff engineer
+#
+principal	principal engineer
+principal	principal software engineer
+principal	principal consultant
+principal	distinguished engineer
+principal	distinguished
+#
+# NOTE: bare "executive" is deliberately ABSENT from the director tier.
+# "Account Executive" / "Sales Executive" / "Customer Service Executive" are
+# common UK ENTRY-level titles despite the word "executive" — only the
+# compounds below ("chief executive", "executive director") are unambiguous.
+# "head of" is guarded in code (_SENIORITY_NOISE) against "head of year" /
+# "head of house" / "head of sixth form" — school pastoral titles, not the
+# department-leadership sense this tier means.
+director	director
+director	head of
+director	vp
+director	vice president
+director	chief
+director	c-suite
+director	cto
+director	ceo
+director	coo
+director	cfo
+director	chief executive
+director	chief technology officer
+director	chief operating officer
+director	chief financial officer
+director	managing director
+director	executive director
+director	head teacher
+director	headteacher
+#
+senior	senior
+senior	sr.
+senior	sr
+senior	lead
+#
+mid	mid level
+mid	mid-level
+mid	intermediate
+mid	mid-weight
+#
+junior	junior
+junior	graduate
+junior	entry level
+junior	entry-level
+junior	trainee
+junior	apprentice
+junior	early career
+junior	new grad
+junior	newly qualified
+#
+intern	intern
+intern	internship
+intern	placement student
+intern	industrial placement
+intern	summer intern

--- a/backend/data/job_signals/workplace_location_terms.txt
+++ b/backend/data/job_signals/workplace_location_terms.txt
@@ -1,0 +1,43 @@
+# workplace_location_terms.txt — vocabulary for the STRUCTURED location
+# field ONLY, distinct from workplace_terms.txt (free-text description /
+# title prose). See job_signals.py's "WHY LOCATION GETS ITS OWN RULES" for
+# why a bare "remote" token is trusted here but banned in prose — a
+# location field never names a job DOMAIN the way "Remote Sensing Analyst"
+# does, so there is no sentence for a bare token to be part of.
+#
+# value<TAB>phrase. Matched against a location-field SEGMENT WHOLE
+# (fullmatch, not substring search) — the field is split on
+# commas/parens/slashes/" or "/" - " first (see _location_segments), so a
+# segment is either exactly one of these phrases or it's an office name.
+#
+# remote  = the segment states remote work.
+# onsite  = the segment states onsite/office-based work.
+# ignore  = a country/nation qualifier — not an office, not a remote signal;
+#           must not count as an "office" when deciding hybrid vs pure remote.
+remote	remote
+remote	fully remote
+remote	100% remote
+remote	remote first
+remote	remote-first
+remote	wfh
+remote	work from home
+remote	work from anywhere
+remote	home based
+remote	home-based
+#
+onsite	onsite
+onsite	on-site
+onsite	on site
+onsite	office based
+onsite	office-based
+#
+ignore	uk
+ignore	u k
+ignore	gb
+ignore	united kingdom
+ignore	great britain
+ignore	england
+ignore	scotland
+ignore	wales
+ignore	northern ireland
+ignore	anywhere

--- a/backend/data/job_signals/workplace_terms.txt
+++ b/backend/data/job_signals/workplace_terms.txt
@@ -1,0 +1,69 @@
+# workplace_terms.txt — one `<value><TAB><phrase>` pair per line.
+# value is a WorkplaceType enum value (job_enrichment_schema.py): remote |
+# hybrid | onsite. Lines starting with # and blank lines are ignored.
+# A new phrase is a line here, never a code change (see job_signals.py).
+#
+# NOTE: bare "remote" is deliberately ABSENT from the remote tier. Real job
+# titles use "remote" as a DOMAIN word, not a work-arrangement word —
+# "Remote Sensing Analyst", "Remote Desktop Support Engineer", "Remote
+# Access Engineer". Every remote phrase below is multi-word and unambiguous.
+# Same rule visa_signal.py states: a signal that fires on the wrong sentence
+# is worse than no signal.
+remote	fully remote
+remote	100% remote
+remote	remote-first
+remote	remote first
+remote	full remote
+remote	totally remote
+remote	remote only
+remote	remote working
+remote	remote role
+remote	remote position
+remote	remote job
+remote	remote employee
+remote	work from home
+remote	work from anywhere
+remote	home based
+remote	home-based
+remote	fully home-based
+remote	distributed team
+#
+# "hybrid" alone is safe as a bare word — unlike "remote" it has no common
+# non-work-arrangement sense in job-ad text.
+hybrid	hybrid
+hybrid	hybrid working
+hybrid	hybrid role
+hybrid	hybrid position
+hybrid	hybrid model
+hybrid	part remote
+hybrid	part-remote
+hybrid	mix of home and office
+hybrid	mix of office and home
+hybrid	split between home and office
+hybrid	blend of office and remote
+#
+# Bare onsite phrases are guarded in code (_ONSITE_AMENITY) against amenity
+# mentions like "on-site parking" / "on-site gym" — those are perks, not a
+# workplace-arrangement statement.
+onsite	onsite
+onsite	on-site
+onsite	on site
+onsite	in office
+onsite	in-office
+onsite	office based
+onsite	office-based
+onsite	fully in office
+onsite	no remote working
+onsite	not a remote role
+onsite	office only
+onsite	office-only
+onsite	must be based in the office
+onsite	based in our office
+#
+# 5 days is a full standard UK work week — no remote days at all, so it is
+# plain onsite, not a hybrid cadence. Kept OUT of _HYBRID_CADENCE on purpose
+# (see job_signals.py module docstring) and enumerated here instead.
+onsite	5 days in the office
+onsite	five days in the office
+onsite	5 days a week in the office
+onsite	five days a week in the office

--- a/backend/scripts/shelf_xray.py
+++ b/backend/scripts/shelf_xray.py
@@ -22,12 +22,67 @@ from __future__ import annotations
 import json
 import os
 import sys
+from typing import Optional
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from src.services.coverage import DIMENSIONS, job_has_value  # noqa: E402 — needs sys.path fixup above
+
+# job/enrichment columns fetched for the job-side coverage pass. Kept as an
+# explicit tuple (rather than SELECT *) so the SQL column order and the dict
+# keys `job_has_value` expects can never drift apart silently.
+_JOB_COLS = ("title", "location", "description", "salary_min", "salary_max")
+_ENRICH_COLS = (
+    "workplace_type",
+    "seniority",
+    "visa_sponsorship",
+    "category",
+    "salary",
+    "required_skills",
+)
 
 
 def _filled(v: object) -> bool:
     return v not in (None, "", [], {}, "unknown", "Unknown")
+
+
+def _job_side_coverage(cur, n_jobs: int) -> dict[str, int]:
+    """Percent of the active catalog carrying a real value per dimension.
+
+    THE FIX: this used to be N inline SQL predicates, one of which
+    (`e.salary NOT IN ('{}', '')`) tested the salary column's *shape*, not
+    its *value* — `{"min": null, "max": null}` matched neither literal and
+    passed, reporting 83% coverage against a real figure near 5%. Counting
+    is now done in Python, one row at a time, through `job_has_value` — the
+    same value-presence rule the canary test (`tests/test_coverage_canary.py`)
+    pins down — so no predicate here can silently drift from the definition
+    the test enforces.
+    """
+    select_cols = ", ".join(f"j.{c}" for c in _JOB_COLS) + ", " + ", ".join(
+        f"e.{c}" for c in _ENRICH_COLS
+    )
+    cur.execute(
+        f"SELECT {select_cols} FROM jobs j "
+        "LEFT JOIN job_enrichment e ON e.job_id = j.id "
+        "WHERE j.staleness_state IS NULL OR j.staleness_state = 'active'"
+    )
+    n_job_cols = len(_JOB_COLS)
+    counts = dict.fromkeys(DIMENSIONS, 0)
+    for row in cur.fetchall():
+        job_row = dict(zip(_JOB_COLS, row[:n_job_cols]))
+        enrich_vals = row[n_job_cols:]
+        # A LEFT JOIN miss comes back as an all-None tuple — treat that as
+        # "no enrichment row" (None) rather than a dict of Nones, matching
+        # what a caller without a JOIN (e.g. two separate queries) would pass.
+        enrichment_row: Optional[dict] = (
+            dict(zip(_ENRICH_COLS, enrich_vals))
+            if any(v is not None for v in enrich_vals)
+            else None
+        )
+        for dim in DIMENSIONS:
+            if job_has_value(dim, job_row, enrichment_row):
+                counts[dim] += 1
+    return {dim: round(100 * counts[dim] / max(1, n_jobs)) for dim in DIMENSIONS}
 
 
 def main() -> int:
@@ -61,22 +116,21 @@ def main() -> int:
     cur.execute("SELECT count(*) FROM jobs WHERE staleness_state IS NULL OR staleness_state='active'")
     n_jobs = cur.fetchone()[0]
 
-    def cov(sql: str) -> int:
-        cur.execute(sql)
-        n = cur.fetchone()[0]
-        return round(100 * n / max(1, n_jobs))
-
+    # Every job-side percentage is now decided by job_has_value (coverage.py)
+    # — no inline SQL predicate may reappear here. See _job_side_coverage's
+    # docstring for the incident that made that a hard rule.
+    _cov = _job_side_coverage(cur, n_jobs)
     job_shelves = {
-        "skills":    cov("SELECT count(*) FROM jobs WHERE length(coalesce(description,''))>200 AND (staleness_state IS NULL OR staleness_state='active')"),
-        "titles":    cov("SELECT count(*) FROM jobs WHERE coalesce(title,'')<>'' AND (staleness_state IS NULL OR staleness_state='active')"),
+        "skills":    _cov["skills"],
+        "titles":    _cov["titles"],
         "dated_experience": None,  # job side needs no dates
         "education": None,
-        "salary":    cov("SELECT count(*) FROM jobs j WHERE (j.salary_min IS NOT NULL OR EXISTS (SELECT 1 FROM job_enrichment e WHERE e.job_id=j.id AND e.salary NOT IN ('{}',''))) AND (j.staleness_state IS NULL OR j.staleness_state='active')"),
-        "location":  cov("SELECT count(*) FROM jobs WHERE coalesce(location,'')<>'' AND (staleness_state IS NULL OR staleness_state='active')"),
-        "workplace": cov("SELECT count(*) FROM jobs j WHERE EXISTS (SELECT 1 FROM job_enrichment e WHERE e.job_id=j.id AND coalesce(e.workplace_type,'unknown')<>'unknown') AND (j.staleness_state IS NULL OR j.staleness_state='active')"),
-        "seniority": cov("SELECT count(*) FROM jobs j WHERE EXISTS (SELECT 1 FROM job_enrichment e WHERE e.job_id=j.id AND coalesce(e.seniority,'unknown')<>'unknown') AND (j.staleness_state IS NULL OR j.staleness_state='active')"),
-        "visa":      cov("SELECT count(*) FROM jobs j WHERE EXISTS (SELECT 1 FROM job_enrichment e WHERE e.job_id=j.id AND coalesce(e.visa_sponsorship,'unknown')<>'unknown') AND (j.staleness_state IS NULL OR j.staleness_state='active')"),
-        "domain":    cov("SELECT count(*) FROM jobs j WHERE EXISTS (SELECT 1 FROM job_enrichment e WHERE e.job_id=j.id AND coalesce(e.category,'')<>'') AND (j.staleness_state IS NULL OR j.staleness_state='active')"),
+        "salary":    _cov["salary"],
+        "location":  _cov["location"],
+        "workplace": _cov["workplace"],
+        "seniority": _cov["seniority"],
+        "visa":      _cov["visa"],
+        "domain":    _cov["domain"],
         "about_me":  None,
     }
 

--- a/backend/src/api/routes/jobs.py
+++ b/backend/src/api/routes/jobs.py
@@ -16,6 +16,7 @@ from src.api.auth_deps import CurrentUser, optional_user, require_user
 from src.api.dependencies import get_request_db
 from src.api.models import JobListResponse, JobResponse
 from src.repositories.database import JobDatabase
+from src.services.job_signals import signal_backed_lookup
 from src.services.visa_signal import VisaStatus, detect_visa_status
 
 if TYPE_CHECKING:  # annotation-only; the real import stays lazy (rule #16)
@@ -763,7 +764,9 @@ async def _personalize_dims(row: dict[str, Any], db: JobDatabase, user: CurrentU
     scorer = JobScorer(
         search_config,
         user_preferences=profile.preferences,
-        enrichment_lookup=lambda j: enrichment_lookup_dict.get(getattr(j, "id", None)),
+        enrichment_lookup=signal_backed_lookup(
+            lambda j: enrichment_lookup_dict.get(getattr(j, "id", None))
+        ),
     )
 
     # Reconstruct the Job for scoring — _row_to_scoring_job sets job.id so the

--- a/backend/src/services/coverage.py
+++ b/backend/src/services/coverage.py
@@ -1,0 +1,232 @@
+"""VALUE-PRESENCE for the matching dimensions — the single source of truth.
+
+Born 2026-08-07 from a real blindness incident: `scripts/shelf_xray.py` used
+to test *shape*, not *value* — its salary predicate was
+`e.salary NOT IN ('{}', '')`. A `job_enrichment.salary` column holding
+`{"min": null, "max": null}` is neither `'{}'` nor `''`, so it passed the
+predicate while carrying zero usable information. The script reported salary
+coverage at **83%**; parsing the JSON and checking for an actual number put
+the real figure at **~5%**. Sixteen points of a scoring dimension (rule #27,
+`SALARY_WEIGHT`) were being fed on data that mostly did not exist.
+
+This module is the fix: ONE function that answers "does this row actually
+carry a usable value for this matching dimension?", so every consumer
+(the X-ray, any future coverage report, any future gate) asks the same
+question the same way. Per root CLAUDE.md rule #21 (value-presence >
+schema-presence): a column being non-NULL is not evidence a value exists —
+only parsing it and finding a real value is.
+
+`job_row` / `enrichment_row` are plain dicts (or `enrichment_row=None`) on
+purpose — no ORM, no DB handle — so this module is a pure function over data
+and can be unit-tested without a database (`tests/test_coverage_canary.py`)
+and reused by scripts that fetch rows differently than shelf_xray does.
+"""
+from __future__ import annotations
+
+import json
+from typing import Any, Optional
+
+from src.services.visa_signal import VisaStatus, detect_visa_status
+
+# Every matching dimension this module knows how to grade. Keep this in sync
+# with the `job_has_value` dispatch below — it exists so callers (shelf_xray)
+# can iterate dimensions without hardcoding the list a second time.
+DIMENSIONS: tuple[str, ...] = (
+    "skills",
+    "titles",
+    "salary",
+    "location",
+    "workplace",
+    "seniority",
+    "visa",
+    "domain",
+)
+
+# job_enrichment columns backing the plain enum-style dimensions. The LLM
+# prompt (job_enrichment.py `_build_prompt`) is instructed to always emit the
+# literal string "unknown" rather than omit a field, so "present" for these
+# columns means "not unknown" — never a bare NULL check, which is what let
+# the original bug through.
+_ENUM_ENRICHMENT_FIELD = {
+    "workplace": "workplace_type",
+    "seniority": "seniority",
+    "domain": "category",
+}
+
+# Keys actually written into job_enrichment.salary — see `SalaryBand` in
+# job_enrichment_schema.py (`min: Optional[float]`, `max: Optional[float]`).
+# Do NOT guess a different key name here; it was cross-checked against the
+# schema and against `normalize_salary()` in services/salary.py, which reads
+# the identical two keys.
+_SALARY_KEYS = ("min", "max")
+
+# `skill_matcher.score_job` builds its match text as `f"{job.title} {job.description}"`
+# and only produces real skill signal once there is enough prose to match
+# against (see the length-normalisation note in scoring_dimensions.py — the
+# scorer itself treats short/empty descriptions as a known data problem, not
+# a real absence-of-skills signal). 200 chars is the same threshold the old
+# (buggy) shelf_xray predicate used for "has skill text" — kept because it
+# was never the wrong idea, only the salary predicate was.
+_SKILL_TEXT_MIN_CHARS = 200
+
+
+def _parse_json_field(value: Any) -> Any:
+    """Best-effort decode of a job_enrichment JSON-TEXT column.
+
+    Postgres returns these columns as raw TEXT (see migration 0008 — `salary
+    TEXT NOT NULL DEFAULT '{}'`), so callers always start from a string, an
+    already-parsed dict/list (test fixtures, or a caller that pre-decoded),
+    or None (no enrichment row / LEFT JOIN miss). Any decode failure
+    (empty string, non-JSON garbage like the literal word "unknown", wrong
+    type) returns None rather than raising — an unparsable column is exactly
+    as informative as a missing one, which is the whole point of this
+    module: don't let a strange shape count as a value.
+    """
+    if value is None:
+        return None
+    if isinstance(value, (dict, list)):
+        return value
+    if isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            return None
+        try:
+            return json.loads(stripped)
+        except (json.JSONDecodeError, TypeError):
+            return None
+    return None
+
+
+def _is_real_number(value: Any) -> bool:
+    """True for an actual numeric salary figure.
+
+    Excludes bool deliberately — `isinstance(True, int)` is True in Python,
+    and a stray boolean in a numeric-looking JSON field is a malformed value,
+    not a salary.
+    """
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+def _has_salary_value(job_row: dict, enrichment_row: Optional[dict]) -> bool:
+    """THE bug this module exists to fix — see the module docstring.
+
+    A job has a usable salary only if a real number is findable: either the
+    catalog's own `salary_min`/`salary_max` columns, or a numeric `min`/`max`
+    inside the parsed enrichment JSON. `{"min": null, "max": null}` — which
+    is what the LLM emits for the overwhelming majority of UK ads that never
+    state pay — must resolve to False. It could not under the old
+    `NOT IN ('{}', '')` string predicate; it does here because we parse the
+    JSON and check the values, not the container.
+    """
+    if job_row.get("salary_min") is not None or job_row.get("salary_max") is not None:
+        return True
+    if not enrichment_row:
+        return False
+    parsed = _parse_json_field(enrichment_row.get("salary"))
+    if not isinstance(parsed, dict):
+        return False
+    return any(_is_real_number(parsed.get(key)) for key in _SALARY_KEYS)
+
+
+def _has_skill_value(job_row: dict, enrichment_row: Optional[dict]) -> bool:
+    """True when there is real text (or an LLM-extracted list) to match skills against.
+
+    Two independent sources count, matching what `JobScorer` actually reads
+    (skill_matcher.py): the raw description text (title+description is the
+    scorer's match string), or the LLM's `required_skills` list when
+    enrichment has run. Either alone is sufficient — a job enriched from a
+    thin ATS description can still carry real extracted skills, and a rich
+    description carries real signal even before enrichment runs.
+    """
+    description = job_row.get("description") or ""
+    if isinstance(description, str) and len(description) > _SKILL_TEXT_MIN_CHARS:
+        return True
+    if enrichment_row:
+        skills = _parse_json_field(enrichment_row.get("required_skills"))
+        if isinstance(skills, list) and any(
+            isinstance(s, str) and s.strip() for s in skills
+        ):
+            return True
+    return False
+
+
+def _has_nonempty_string(value: Any) -> bool:
+    """True for a real, non-blank string — titles and locations are read
+    verbatim off the `jobs` row (no enrichment fallback), so this is the
+    whole rule: is there actually a string here, not just a column that
+    isn't NULL."""
+    return isinstance(value, str) and value.strip() != ""
+
+
+def _has_enum_value(raw: Any) -> bool:
+    """True for an enrichment enum-style column that carries real information.
+
+    The LLM contract (job_enrichment.py `_build_prompt` / `_SYSTEM_PROMPT`)
+    guarantees these columns are never NULL once enrichment has run — absence
+    of information is always written as the literal string `"unknown"`, not
+    omitted. So `IS NOT NULL` (the shape of the old bug) is worthless here by
+    construction; the only real test is "not unknown, not blank". Non-string
+    values (None, or a stray non-text type) can never be a real enum value,
+    since these are declared `TEXT` columns (migration 0008) — treated as
+    absent rather than raising, same reasoning as `_parse_json_field`.
+    """
+    if not isinstance(raw, str):
+        return False
+    return raw.strip().lower() not in ("", "unknown")
+
+
+def job_has_value(
+    dimension: str,
+    job_row: dict,
+    enrichment_row: Optional[dict],
+) -> bool:
+    """Does this job actually carry a usable value for `dimension`?
+
+    This is the ONLY place matching-dimension coverage should be decided.
+    `scripts/shelf_xray.py` and any future coverage consumer must call this
+    rather than writing their own SQL/Python predicate — see the module
+    docstring for why a second predicate is exactly how this class of bug
+    reappears.
+
+    Args:
+        dimension: one of `DIMENSIONS`.
+        job_row: dict with (at least) `title`, `location`, `description`,
+            `salary_min`, `salary_max` — the `jobs` table's own columns.
+        enrichment_row: dict with (at least) `workplace_type`, `seniority`,
+            `visa_sponsorship`, `category`, `salary`, `required_skills` — the
+            `job_enrichment` row for this job, or None if no row exists yet
+            (enrichment hasn't run / LEFT JOIN miss).
+
+    Returns:
+        True iff a real, usable value is present for that dimension.
+
+    Raises:
+        ValueError: unknown dimension name — fails loudly rather than
+            silently reporting 0% for a typo'd dimension key.
+    """
+    if dimension == "salary":
+        return _has_salary_value(job_row, enrichment_row)
+    if dimension == "skills":
+        return _has_skill_value(job_row, enrichment_row)
+    if dimension == "titles":
+        return _has_nonempty_string(job_row.get("title"))
+    if dimension == "location":
+        return _has_nonempty_string(job_row.get("location"))
+    if dimension == "visa":
+        # Delegates to the real detector (visa_signal.py) rather than
+        # re-reading `job_enrichment.visa_sponsorship` alone. That column is
+        # only 8% populated on prod; the text detector reads the description
+        # every job already has and resolves ~36% more of the catalog. A
+        # coverage script that doesn't call the detector reports a number
+        # the product doesn't actually deliver.
+        status = detect_visa_status(
+            job_row.get("description"),
+            job_row.get("title"),
+            enrichment_value=(enrichment_row or {}).get("visa_sponsorship"),
+        )
+        return status != VisaStatus.UNKNOWN
+    if dimension in _ENUM_ENRICHMENT_FIELD:
+        field = _ENUM_ENRICHMENT_FIELD[dimension]
+        raw = (enrichment_row or {}).get(field)
+        return _has_enum_value(raw)
+    raise ValueError(f"unknown matching dimension: {dimension!r}")

--- a/backend/src/services/coverage.py
+++ b/backend/src/services/coverage.py
@@ -225,6 +225,36 @@ def job_has_value(
             enrichment_value=(enrichment_row or {}).get("visa_sponsorship"),
         )
         return status != VisaStatus.UNKNOWN
+    if dimension in ("workplace", "seniority"):
+        # Same principle as the visa branch above, and the reason it is worth
+        # repeating: SCORING sees these dimensions through
+        # `job_signals.signal_backed_lookup`, which fills an 'unknown'
+        # enrichment value from the job's TITLE and LOCATION. Those fields
+        # exist for the 1,311 catalog rows that carry almost no description.
+        #
+        # If this function read only the enrichment column it would report
+        # coverage the product does NOT have a problem with — understating
+        # seniority by 33 points (27% stored vs 60% effective) and workplace by
+        # 7. An instrument must count with the same eyes its consumer reads.
+        field = _ENUM_ENRICHMENT_FIELD[dimension]
+        raw = (enrichment_row or {}).get(field)
+        if _has_enum_value(raw):
+            return True
+        from src.services.job_signals import (  # noqa: PLC0415 — avoids a cycle
+            detect_seniority,
+            detect_workplace,
+        )
+
+        title = job_row.get("title") or ""
+        desc = job_row.get("description") or ""
+        if dimension == "workplace":
+            got = detect_workplace(
+                desc, title, location=job_row.get("location") or ""
+            )
+        else:
+            got = detect_seniority(title, desc)
+        val = getattr(getattr(got, "value", got), "value", getattr(got, "value", got))
+        return str(val).strip().lower() not in ("", "unknown")
     if dimension in _ENUM_ENRICHMENT_FIELD:
         field = _ENUM_ENRICHMENT_FIELD[dimension]
         raw = (enrichment_row or {}).get(field)

--- a/backend/src/services/job_enrichment.py
+++ b/backend/src/services/job_enrichment.py
@@ -54,6 +54,14 @@ def _build_prompt(job: Job) -> str:
     weak free-tier models cannot infer the field names from a schema *name*
     alone (they emit ``job_title`` instead of the required ``title_canonical``,
     failing validation every time). Listing the contract inline fixes that.
+
+    Deliberately excludes ``employer_type`` and ``locations`` — never asked
+    for here (both silently rode on their Pydantic defaults) and, per the
+    2026-08 measurement across 3,119 live enriched rows, the model never
+    produced a usable value for either (`employer_type` 100% 'unknown',
+    `locations` 0% populated). Do not add them back to this key list without
+    new evidence the model can actually decide them; ``jobs.location``
+    already covers geography (validated at ingestion by `uk_gate.py`).
     """
     desc = (job.description or "")[:4000]
     return (
@@ -236,22 +244,35 @@ async def save_enrichment(
 
     JSON-serialises every list/nested-model field. Uses `INSERT OR REPLACE`
     so re-enrichment is a clean upsert without requiring a DELETE first.
+
+    ``employer_type`` and ``locations`` are RETIRED-BUT-PRESENT columns (see
+    the module comment below) — deliberately absent from this column list.
+    The table's `NOT NULL DEFAULT 'unknown'` / `DEFAULT '[]'` (migration
+    0008) fills them on INSERT, and the `ON CONFLICT` clause never touches
+    them again, so old rows keep whatever they already had. Measured on
+    3,119 live enriched rows: `employer_type` was 100% 'unknown' and
+    `locations` was 0% populated — the LLM has never once produced a usable
+    value for either, so writing a constant from Python would just be a
+    second place encoding the same dead default the DB already owns. DO NOT
+    add these columns back to the INSERT/SELECT statements in this file
+    without new evidence the LLM can actually decide them (see
+    `job_enrichment_schema.py`'s module docstring and `_build_prompt`'s
+    docstring above).
     """
     await conn.execute(
         """
         INSERT INTO job_enrichment (
             job_id, title_canonical, category, employment_type, workplace_type,
-            locations, salary, required_skills, preferred_skills,
+            salary, required_skills, preferred_skills,
             experience_min_years, experience_level, requirements_summary,
-            language, employer_type, visa_sponsorship, seniority,
+            language, visa_sponsorship, seniority,
             remote_region, apply_instructions, red_flags, enriched_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
         ON CONFLICT(job_id) DO UPDATE SET
             title_canonical = EXCLUDED.title_canonical,
             category = EXCLUDED.category,
             employment_type = EXCLUDED.employment_type,
             workplace_type = EXCLUDED.workplace_type,
-            locations = EXCLUDED.locations,
             salary = EXCLUDED.salary,
             required_skills = EXCLUDED.required_skills,
             preferred_skills = EXCLUDED.preferred_skills,
@@ -259,7 +280,6 @@ async def save_enrichment(
             experience_level = EXCLUDED.experience_level,
             requirements_summary = EXCLUDED.requirements_summary,
             language = EXCLUDED.language,
-            employer_type = EXCLUDED.employer_type,
             visa_sponsorship = EXCLUDED.visa_sponsorship,
             seniority = EXCLUDED.seniority,
             remote_region = EXCLUDED.remote_region,
@@ -273,7 +293,6 @@ async def save_enrichment(
             enrichment.category.value,
             enrichment.employment_type.value,
             enrichment.workplace_type.value,
-            json.dumps(enrichment.locations),
             enrichment.salary.model_dump_json(),
             json.dumps(enrichment.required_skills),
             json.dumps(enrichment.preferred_skills),
@@ -281,7 +300,6 @@ async def save_enrichment(
             enrichment.experience_level.value,
             enrichment.requirements_summary,
             enrichment.language,
-            enrichment.employer_type.value,
             enrichment.visa_sponsorship.value,
             enrichment.seniority.value,
             enrichment.remote_region,
@@ -308,13 +326,15 @@ async def _build_enrichment_lookup(
     treat ``{}`` as "no enrichment available, fall back to legacy 4-component
     scoring" per CLAUDE.md rule #19.
     """
+    # employer_type / locations deliberately excluded — see the module
+    # comment on save_enrichment's column list above.
     try:
         cur = await conn.execute(
             """
             SELECT job_id, title_canonical, category, employment_type, workplace_type,
-                   locations, salary, required_skills, preferred_skills,
+                   salary, required_skills, preferred_skills,
                    experience_min_years, experience_level, requirements_summary,
-                   language, employer_type, visa_sponsorship, seniority,
+                   language, visa_sponsorship, seniority,
                    remote_region, apply_instructions, red_flags
             FROM job_enrichment
             """
@@ -332,7 +352,6 @@ async def _build_enrichment_lookup(
                 category,
                 employment_type,
                 workplace_type,
-                locations_json,
                 salary_json,
                 required_json,
                 preferred_json,
@@ -340,7 +359,6 @@ async def _build_enrichment_lookup(
                 experience_level,
                 requirements_summary,
                 language,
-                employer_type,
                 visa_sponsorship,
                 seniority,
                 remote_region,
@@ -352,7 +370,6 @@ async def _build_enrichment_lookup(
                 category=category,
                 employment_type=employment_type,
                 workplace_type=workplace_type,
-                locations=json.loads(locations_json) if locations_json else [],
                 salary=json.loads(salary_json) if salary_json else {},
                 required_skills=json.loads(required_json) if required_json else [],
                 preferred_skills=json.loads(preferred_json) if preferred_json else [],
@@ -360,7 +377,6 @@ async def _build_enrichment_lookup(
                 experience_level=experience_level,
                 requirements_summary=requirements_summary or "",
                 language=language,
-                employer_type=employer_type,
                 visa_sponsorship=visa_sponsorship,
                 seniority=seniority,
                 remote_region=remote_region,
@@ -381,13 +397,16 @@ async def load_enrichment(
 
     Used by the dedup tiebreaker in `services/deduplicator.py` and by the
     Batch 2.6 embedding builder.
+
+    employer_type / locations deliberately excluded — see the module comment
+    on save_enrichment's column list above.
     """
     cur = await conn.execute(
         """
         SELECT title_canonical, category, employment_type, workplace_type,
-               locations, salary, required_skills, preferred_skills,
+               salary, required_skills, preferred_skills,
                experience_min_years, experience_level, requirements_summary,
-               language, employer_type, visa_sponsorship, seniority,
+               language, visa_sponsorship, seniority,
                remote_region, apply_instructions, red_flags
         FROM job_enrichment
         WHERE job_id = ?
@@ -402,7 +421,6 @@ async def load_enrichment(
         category,
         employment_type,
         workplace_type,
-        locations_json,
         salary_json,
         required_json,
         preferred_json,
@@ -410,7 +428,6 @@ async def load_enrichment(
         experience_level,
         requirements_summary,
         language,
-        employer_type,
         visa_sponsorship,
         seniority,
         remote_region,
@@ -422,7 +439,6 @@ async def load_enrichment(
         category=category,
         employment_type=employment_type,
         workplace_type=workplace_type,
-        locations=json.loads(locations_json) if locations_json else [],
         salary=json.loads(salary_json) if salary_json else {},
         required_skills=json.loads(required_json) if required_json else [],
         preferred_skills=json.loads(preferred_json) if preferred_json else [],
@@ -430,7 +446,6 @@ async def load_enrichment(
         experience_level=experience_level,
         requirements_summary=requirements_summary or "",
         language=language,
-        employer_type=employer_type,
         visa_sponsorship=visa_sponsorship,
         seniority=seniority,
         remote_region=remote_region,

--- a/backend/src/services/job_enrichment_schema.py
+++ b/backend/src/services/job_enrichment_schema.py
@@ -5,9 +5,18 @@ The `JobEnrichment` model is the target schema for `llm_extract_validated()`
 explicitly typed or an enum, and every list/string field is length-bounded so
 a malformed LLM response can't bloat the DB.
 
-The 18 fields below are the contract the downstream pipeline (dedup, scorer,
+The 16 fields below are the contract the downstream pipeline (dedup, scorer,
 embeddings in Batch 2.6) consumes. Keep this module import-light — no
 aiohttp, no Pydantic-v1 compat shims.
+
+Retired 2026-08 (measured on 3,119 live enriched rows): ``employer_type``
+(100% 'unknown', never once produced) and ``locations`` (0% populated, and
+redundant with ``jobs.location`` which `uk_gate.py` already validates at
+ingestion). Both cost prompt/schema surface for zero signal, so the fields
+were dropped from this schema rather than left as permanently-defaulted dead
+weight. The `job_enrichment.employer_type` / `.locations` DB columns are
+UNTOUCHED (still `NOT NULL DEFAULT`) — see the comment at the INSERT column
+list in `job_enrichment.py` before re-adding either field.
 """
 from __future__ import annotations
 
@@ -83,19 +92,6 @@ class ExperienceLevel(str, Enum):
     UNKNOWN = "unknown"
 
 
-class EmployerType(str, Enum):
-    STARTUP = "startup"
-    SCALEUP = "scaleup"
-    ENTERPRISE = "enterprise"
-    AGENCY = "agency"
-    NONPROFIT = "nonprofit"
-    GOVERNMENT = "government"
-    ACADEMIC = "academic"
-    HEALTHCARE = "healthcare"
-    OTHER = "other"
-    UNKNOWN = "unknown"
-
-
 class SalaryFrequency(str, Enum):
     HOURLY = "hourly"
     DAILY = "daily"
@@ -124,7 +120,7 @@ class SalaryBand(BaseModel):
 
 
 # ---------------------------------------------------------------------------
-# Top-level enrichment schema — 18 fields
+# Top-level enrichment schema — 16 fields
 # ---------------------------------------------------------------------------
 
 
@@ -148,46 +144,40 @@ class JobEnrichment(BaseModel):
     # 4. Workplace type
     workplace_type: WorkplaceType = Field(default=WorkplaceType.UNKNOWN)
 
-    # 5. Locations (list of free-form place strings)
-    locations: list[str] = Field(default_factory=list, max_length=10)
-
-    # 6. Salary (nested)
+    # 5. Salary (nested)
     salary: SalaryBand = Field(default_factory=SalaryBand)
 
-    # 7. Required skills (short list — not the kitchen sink)
+    # 6. Required skills (short list — not the kitchen sink)
     required_skills: list[str] = Field(default_factory=list, max_length=30)
 
-    # 8. Preferred skills
+    # 7. Preferred skills
     preferred_skills: list[str] = Field(default_factory=list, max_length=30)
 
-    # 9. Minimum years of experience
+    # 8. Minimum years of experience
     experience_min_years: Optional[int] = Field(default=None, ge=0, le=40)
 
-    # 10. Experience level enum
+    # 9. Experience level enum
     experience_level: ExperienceLevel = Field(default=ExperienceLevel.UNKNOWN)
 
-    # 11. Requirements summary (≤250 chars — for Batch 2.6 embedding input)
+    # 10. Requirements summary (≤250 chars — for Batch 2.6 embedding input)
     requirements_summary: str = Field(default="", max_length=250)
 
-    # 12. Language (ISO 639-1)
+    # 11. Language (ISO 639-1)
     language: str = Field(default="en", min_length=2, max_length=2)
 
-    # 13. Employer type
-    employer_type: EmployerType = Field(default=EmployerType.UNKNOWN)
-
-    # 14. Visa sponsorship
+    # 12. Visa sponsorship
     visa_sponsorship: VisaSponsorship = Field(default=VisaSponsorship.UNKNOWN)
 
-    # 15. Seniority
+    # 13. Seniority
     seniority: SeniorityLevel = Field(default=SeniorityLevel.UNKNOWN)
 
-    # 16. Remote region (nullable — only relevant when workplace_type=REMOTE)
+    # 14. Remote region (nullable — only relevant when workplace_type=REMOTE)
     remote_region: Optional[str] = Field(default=None, max_length=60)
 
-    # 17. Apply instructions (nullable)
+    # 15. Apply instructions (nullable)
     apply_instructions: Optional[str] = Field(default=None, max_length=500)
 
-    # 18. Red flags list (e.g. "requires unpaid work", "MLM signal")
+    # 16. Red flags list (e.g. "requires unpaid work", "MLM signal")
     red_flags: list[str] = Field(default_factory=list, max_length=10)
 
     @field_validator("language")
@@ -195,7 +185,7 @@ class JobEnrichment(BaseModel):
     def _lower_language(cls, v: str) -> str:
         return v.lower()
 
-    @field_validator("locations", "required_skills", "preferred_skills", "red_flags")
+    @field_validator("required_skills", "preferred_skills", "red_flags")
     @classmethod
     def _strip_and_dedup(cls, v: list[str]) -> list[str]:
         """Strip empties and exact-dupes while preserving order."""

--- a/backend/src/services/job_signals.py
+++ b/backend/src/services/job_signals.py
@@ -1,0 +1,544 @@
+"""Workplace type and seniority as deterministic TEXT signals — filling the
+gap where LLM enrichment says 'unknown'.
+
+WHY. Measured on prod 2026-08-04: `job_enrichment.workplace_type` is
+'unknown' for 70% of the catalog (2,181/3,119); `seniority` is 'unknown' for
+63% (1,970/3,119). Meanwhile 1,311 active jobs carry under 200 characters of
+description — the LLM literally has nothing to read. Both fields are
+FORMULAIC: employers announce workplace policy and seniority in a small,
+repeated vocabulary ("fully remote", "hybrid", "3 days in the office",
+"Senior", "Graduate", "Head of Engineering"). A regex over text we already
+store is free and repeatable — the same reasoning `visa_signal.py` uses,
+where a deterministic scan already outperforms the LLM 42% vs 4.6%.
+
+WHY SENIORITY READS THE TITLE FIRST. This is the whole point of building
+this detector at all: the title exists even for the 1,311 no-description
+jobs, and seniority is the field most likely to live there ("Senior Backend
+Engineer", "Graduate Software Developer").
+
+WHY THREE(-ish) STATES, REUSED ENUMS. Same reasoning as `visa_signal.py`: a
+value the ad never states is not the same fact as a value it contradicts.
+Both detectors return the SHARED `WorkplaceType` / `SeniorityLevel` enums
+from `job_enrichment_schema.py` — never a parallel enum — because every
+member already carries an UNKNOWN, so "the detector found nothing" and "the
+LLM never ran" collapse to the same value the rest of the pipeline already
+understands.
+
+WHY ENRICHMENT WINS WHEN IT EXISTS. The LLM read the whole ad with context;
+this module only pattern-matches surface text. Same precedence as
+`visa_signal.detect_visa_status`: a present, non-'unknown' `enrichment_value`
+short-circuits before any text is touched.
+
+VOCABULARY LIVES IN DATA FILES (rule #28's rationale, extended past its
+literal scope of profile extraction — the same brittleness applies here: a
+hand-typed keyword dict means "new term = code edit").
+`data/job_signals/workplace_terms.txt`, `workplace_location_terms.txt` and
+`seniority_terms.txt` are TSV: one `<enum_value><TAB><phrase>` pair per
+line; blank lines and lines starting with `#` are ignored. Loaded lazily and
+cached with `lru_cache`, exactly like `uk_gate._gazetteer()` — and, like
+that loader, a missing or unreadable file degrades to an empty vocabulary
+(every detector call then returns UNKNOWN) rather than raising. A forgotten
+data file in a deploy must not crash the pipeline.
+
+WHY LOCATION GETS ITS OWN VOCABULARY AND ITS OWN RULES. Added 2026-08-07
+after a manager audit found 165 prod jobs still UNKNOWN while their
+LOCATION field states the arrangement outright — e.g.
+`location='Remote', title='Ranger'`, or `location='Cardiff, London or
+Remote (UK)', title='Lead Product Designer'`. `detect_workplace` originally
+only read title + description prose.
+
+The location field is a DELIMITED list of tokens, not a sentence — "Cardiff,
+London or Remote (UK)" is offices-and-arrangement, comma/`or`/parens
+separated, never a sentence about a job's DOMAIN. That is precisely the
+condition that made bare "remote" unsafe in prose ("Remote Sensing
+Analyst" — "remote" describing the JOB, not the arrangement): a location
+field never names a job domain, so there is no sentence for a bare "remote"
+token to be part of. Same word, different field, different reliability —
+`workplace_terms.txt` (prose) still bans the bare token,
+`workplace_location_terms.txt` (location) allows it. Do NOT collapse these
+into one shared vocabulary "to simplify" — the ban exists for the prose
+failure mode specifically, and the location field doesn't have it.
+
+Location is checked LAST, strictly after prose (title + description), never
+before or merged with it: prose is the MORE SPECIFIC claim. A location field
+can be stale, generic, or set once at intake while the description says
+"this role is now fully onsite, five days a week" — the description must
+win. See `detect_workplace`'s docstring for the exact composition order.
+
+Multi-site locations — named office cities ALONGSIDE "Remote", e.g.
+"Cardiff, London or Remote (UK)" — resolve to HYBRID, not REMOTE. Reasoning:
+naming real offices next to "Remote" is the employer offering a CHOICE, not
+committing to fully remote; treating it as REMOTE would overclaim, and
+`WorkplaceType` has no "flexible" member, so HYBRID (a mix of on-site and
+remote across the role) is the closest true statement of the three enum
+values available.
+
+Some patterns stay in CODE, not data, because they are STRUCTURE, not
+vocabulary — the same distinction `uk_gate.py` draws for `_POSTCODE`:
+  * `_HYBRID_CADENCE` — the "N day(s) ... office" cadence pattern, N in
+    1-4. 5 (or "five") is deliberately EXCLUDED and left to the ONSITE
+    vocabulary instead: "5 days in the office" is UK shorthand for a full
+    standard work week with no remote days at all, i.e. plain onsite, not a
+    mix. That cutoff is a real fact about the UK working week, not an
+    arbitrary vocabulary item, so it stays a code-level rule.
+  * `_ONSITE_AMENITY` — "on-site parking" / "on-site gym" is a perk
+    mention, not a workplace-arrangement statement; this is a NEGATIVE
+    guard, stripped from the text before the onsite vocabulary ever runs.
+  * `_REMOTE_NEGATED` — "no remote working available" / "not a remote
+    role" CONTAIN the positive phrases "remote working" / "remote role" as
+    plain substrings. Checked (and stripped) before the positive remote
+    vocabulary runs, for the identical reason `visa_signal.py` checks
+    refusal before offer: a positive-first design reads a refusal as an
+    offer.
+  * `_SENIORITY_NOISE` — compound phrases that contain a tier word but mean
+    something else entirely ("Junior School" is an institution, not a
+    junior role; "Head of Year" / "Head of House" / "Head of Sixth Form"
+    are school pastoral titles, not the department-leadership sense
+    "head of" means elsewhere; "lead generation" is a sales function, not
+    a seniority claim). Stripped BEFORE any tier match runs, so it can
+    never feed a tier either.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from functools import cache, lru_cache
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+from src.services.job_enrichment_schema import SeniorityLevel, WorkplaceType
+
+_DATA = Path(__file__).resolve().parent.parent.parent / "data" / "job_signals"
+
+
+# ---------------------------------------------------------------------------
+# Data-file loading (lazy, cached — mirrors uk_gate._gazetteer())
+# ---------------------------------------------------------------------------
+
+
+def _load_terms(filename: str) -> dict[str, tuple[str, ...]]:
+    """Parse one `value<TAB>phrase` file into ``{value: (phrase, ...)}``.
+
+    Blank lines and `#`-prefixed comment lines are skipped. A missing or
+    unreadable file returns an empty dict rather than raising — callers then
+    naturally fall through to UNKNOWN, so a forgotten data file in a deploy
+    degrades the feature instead of crashing the pipeline.
+    """
+    path = _DATA / filename
+    if not path.exists():
+        return {}
+    terms: dict[str, list[str]] = {}
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError:
+        return {}
+    for line in raw.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "\t" not in line:
+            continue
+        value, _, phrase = line.partition("\t")
+        value = value.strip()
+        phrase = phrase.strip()
+        if value and phrase:
+            terms.setdefault(value, []).append(phrase)
+    return {k: tuple(v) for k, v in terms.items()}
+
+
+@lru_cache(maxsize=1)
+def _workplace_terms() -> dict[str, tuple[str, ...]]:
+    return _load_terms("workplace_terms.txt")
+
+
+@lru_cache(maxsize=1)
+def _seniority_terms() -> dict[str, tuple[str, ...]]:
+    return _load_terms("seniority_terms.txt")
+
+
+@lru_cache(maxsize=1)
+def _location_terms() -> dict[str, tuple[str, ...]]:
+    return _load_terms("workplace_location_terms.txt")
+
+
+@cache
+def _phrase_pattern(phrases: tuple[str, ...]) -> Optional[re.Pattern[str]]:
+    """Compile one tier's phrases into a single word-boundary alternation.
+
+    Longest phrase first: regex alternation is first-match not longest-match,
+    so without ordering a short phrase earlier in the list could shadow a
+    longer one that starts the same way.
+    """
+    if not phrases:
+        return None
+    ordered = sorted(set(phrases), key=len, reverse=True)
+    body = "|".join(re.escape(p) for p in ordered)
+    return re.compile(rf"\b(?:{body})\b", re.IGNORECASE)
+
+
+# ---------------------------------------------------------------------------
+# Structural patterns (shape, not vocabulary — see module docstring)
+# ---------------------------------------------------------------------------
+
+# "3 days a week in the office" / "2-3 days per week in office" / "in the
+# office 3 days a week" — the count is structure, not vocabulary. Bounded to
+# 1-4: see the module docstring for why 5/"five" is excluded on purpose.
+# Order-agnostic: cadence can precede or follow the office mention.
+_HYBRID_CADENCE = re.compile(
+    r"\b[1-4](?:\+|\s*-\s*[1-4])?\s*days?\b[^.\n]{0,30}\b(?:in|at)\s+(?:the\s+)?office\b"
+    r"|\b(?:in|at)\s+(?:the\s+)?office\b[^.\n]{0,30}\b[1-4](?:\+|\s*-\s*[1-4])?\s*days?\b",
+    re.IGNORECASE,
+)
+
+# "Free on-site parking", "on-site gym" — a perk mention, not a
+# workplace-arrangement statement. UK job ads advertise amenities this way
+# constantly; without this guard every employer with a gym would misclassify
+# as ONSITE regardless of the actual work arrangement.
+_ONSITE_AMENITY = re.compile(
+    r"\bon[\s-]?site\s+(?:parking|gym|canteen|caf(?:e|é)|catering|"
+    r"childcare|cr(?:e|è)che|kitchen|facilities|car\s*park|showers?)\b",
+    re.IGNORECASE,
+)
+
+# "No remote working available" / "not a remote role" — the NEGATIVE
+# statement contains the POSITIVE phrase as a literal substring ("remote
+# working", "remote role"). Checked and stripped before the positive remote
+# vocabulary, mirroring visa_signal.py's refusal-before-offer precedence.
+_REMOTE_NEGATED = re.compile(
+    r"\bno\s+remote\s+(?:working|work)\b"
+    r"|\bnot\s+(?:a\s+)?remote\b"
+    r"|\bno\s+remote\s+role\b"
+    r"|\bremote\s+working\s+is\s+not\s+(?:available|offered|possible)\b",
+    re.IGNORECASE,
+)
+
+# Splits a STRUCTURED location field into candidate tokens — structural, not
+# vocabulary, because these are punctuation delimiters, not phrases.
+# "Cardiff, London or Remote (UK)" -> ["Cardiff", "London", "Remote", "UK"].
+_LOCATION_SPLIT = re.compile(r"[,;/|()\[\]]|\s+or\s+|\s+-\s+", re.IGNORECASE)
+
+# Compound phrases that CONTAIN a tier word but mean something else. See the
+# module docstring for the three concrete traps this exists to close.
+_SENIORITY_NOISE = re.compile(
+    r"\bjunior\s+schools?\b"
+    r"|\bhead\s+of\s+year\b"
+    r"|\bhead\s+of\s+house\b"
+    r"|\bhead\s+of\s+sixth\s+form\b"
+    r"|\blead\s+generation\b",
+    re.IGNORECASE,
+)
+
+# Most-senior-first. A text naming two tiers picks the more senior one — see
+# `_match_seniority_tier` for why that also happens to resolve the
+# "graduate degree required" vs "graduate role" ambiguity for free.
+_SENIORITY_RANK: tuple[SeniorityLevel, ...] = (
+    SeniorityLevel.DIRECTOR,
+    SeniorityLevel.PRINCIPAL,
+    SeniorityLevel.STAFF,
+    SeniorityLevel.SENIOR,
+    SeniorityLevel.MID,
+    SeniorityLevel.JUNIOR,
+    SeniorityLevel.INTERN,
+)
+
+
+# ---------------------------------------------------------------------------
+# Result types — mirror uk_gate.GateVerdict: the REASON is the point, a bare
+# enum makes a wrong verdict as hard to debug as a bare boolean.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class WorkplaceSignal:
+    value: WorkplaceType
+    reason: str
+
+
+@dataclass(frozen=True)
+class SenioritySignal:
+    value: SeniorityLevel
+    reason: str
+
+
+# ---------------------------------------------------------------------------
+# Detectors
+# ---------------------------------------------------------------------------
+
+
+def _detect_prose_signal(title: str, description: str) -> Optional[WorkplaceSignal]:
+    """Title + description prose, read as one blob. Returns None (no
+    verdict) rather than UNKNOWN, so `detect_workplace` can tell "prose said
+    nothing" apart from "nothing said anything" and fall through to the
+    location field instead of stopping here.
+
+    Precedence within the text is load-bearing:
+
+    1. HYBRID first. A hybrid ad routinely also says "remote"
+       ("remote-friendly hybrid role, 3 days in the office") — checking
+       remote first would read that as fully remote.
+    2. REMOTE second. An explicit "fully remote" beats a passing mention of
+       an office ("we do have a small office in London if you'd like to
+       visit") — that mention alone must not demote a clearly remote ad.
+    3. ONSITE last, and only after stripping amenity mentions
+       ("on-site parking/gym"), because "office" is the weakest vocabulary
+       here and the easiest to catch as a stray mention rather than a
+       genuine work-arrangement statement.
+    """
+    text = f"{title or ''}\n{description or ''}"
+    if not text.strip():
+        return None
+
+    terms = _workplace_terms()
+
+    hybrid_pattern = _phrase_pattern(terms.get("hybrid", ()))
+    if (hybrid_pattern and hybrid_pattern.search(text)) or _HYBRID_CADENCE.search(text):
+        return WorkplaceSignal(WorkplaceType.HYBRID, "hybrid_signal")
+
+    # Negation guard runs before the positive check — see _REMOTE_NEGATED.
+    remote_text = _REMOTE_NEGATED.sub(" ", text)
+    remote_pattern = _phrase_pattern(terms.get("remote", ()))
+    if remote_pattern and remote_pattern.search(remote_text):
+        return WorkplaceSignal(WorkplaceType.REMOTE, "remote_term")
+
+    cleaned = _ONSITE_AMENITY.sub(" ", text)
+    onsite_pattern = _phrase_pattern(terms.get("onsite", ()))
+    if onsite_pattern and onsite_pattern.search(cleaned):
+        return WorkplaceSignal(WorkplaceType.ONSITE, "onsite_term")
+
+    return None
+
+
+def _location_segments(location: str) -> list[str]:
+    """Split a structured location field into candidate tokens. See
+    `_LOCATION_SPLIT` for why this is a structural split, not vocabulary.
+    """
+    return [seg.strip() for seg in _LOCATION_SPLIT.split(location or "") if seg.strip()]
+
+
+def _detect_location_signal(location: str) -> Optional[WorkplaceSignal]:
+    """Classify the STRUCTURED location field — a fallback source, consulted
+    only after prose gives no verdict (see `detect_workplace`).
+
+    Returns None (not UNKNOWN) for an empty or non-decisive field, so the
+    caller's own UNKNOWN/"no_signal" return stays the single place that
+    reason string is produced.
+
+    Deliberately does NOT infer ONSITE from a bare place name alone
+    ("London" with nothing else): hybrid and onsite jobs both routinely list
+    a plain city here too, so a place name by itself isn't decisive the way
+    it becomes once paired with an explicit remote/onsite token.
+    """
+    segments = _location_segments(location)
+    if not segments:
+        return None
+
+    terms = _location_terms()
+    remote_pattern = _phrase_pattern(terms.get("remote", ()))
+    onsite_pattern = _phrase_pattern(terms.get("onsite", ()))
+    ignore_pattern = _phrase_pattern(terms.get("ignore", ()))
+
+    # Segments are matched WHOLE (fullmatch), not searched as a substring —
+    # a location token is either exactly "Remote" or it's an office name;
+    # there is no prose to accidentally match a fragment of.
+    has_remote = has_onsite = has_office = False
+    for seg in segments:
+        if remote_pattern and remote_pattern.fullmatch(seg):
+            has_remote = True
+        elif onsite_pattern and onsite_pattern.fullmatch(seg):
+            has_onsite = True
+        elif ignore_pattern and ignore_pattern.fullmatch(seg):
+            continue  # country/nation qualifier — neither an office nor a signal
+        else:
+            has_office = True
+
+    # A named office ALONGSIDE remote is an offered CHOICE, not a commitment
+    # to fully remote — see the module docstring's multi-site decision.
+    if has_remote and (has_office or has_onsite):
+        return WorkplaceSignal(WorkplaceType.HYBRID, "location_multi_site")
+    if has_remote:
+        return WorkplaceSignal(WorkplaceType.REMOTE, "location_remote")
+    if has_onsite:
+        return WorkplaceSignal(WorkplaceType.ONSITE, "location_onsite")
+    return None
+
+
+def detect_workplace(
+    description: Optional[str],
+    title: Optional[str] = "",
+    *,
+    location: Optional[str] = "",
+    enrichment_value: Optional[str] = None,
+) -> WorkplaceSignal:
+    """Classify an ad's workplace arrangement: remote / hybrid / onsite.
+
+    Composition order, most to least specific — see the module docstring's
+    "WHY LOCATION GETS ITS OWN RULES" for the full reasoning:
+
+    1. ``enrichment_value`` — the LLM read the whole ad with context; wins
+       outright when present and not 'unknown'.
+    2. Prose (title + description) — see `_detect_prose_signal` for the
+       HYBRID > REMOTE > ONSITE precedence within it.
+    3. ``location`` — the structured field, consulted ONLY when prose said
+       nothing. Prose is the more specific claim: "fully onsite, five days
+       a week" in the description must win over a stale or generic
+       ``location='Remote'``, never the other way round.
+
+    ``location`` is keyword-only and defaults to "" so every existing
+    caller passing only ``(description, title)`` is unaffected byte-for-byte.
+    """
+    if enrichment_value:
+        ev = enrichment_value.strip().lower()
+        if ev and ev != WorkplaceType.UNKNOWN.value:
+            for member in WorkplaceType:
+                if ev == member.value:
+                    return WorkplaceSignal(member, "enrichment")
+
+    prose_signal = _detect_prose_signal(title or "", description or "")
+    if prose_signal is not None:
+        return prose_signal
+
+    location_signal = _detect_location_signal(location or "")
+    if location_signal is not None:
+        return location_signal
+
+    return WorkplaceSignal(WorkplaceType.UNKNOWN, "no_signal")
+
+
+def _match_seniority_tier(
+    text: str, terms: dict[str, tuple[str, ...]]
+) -> Optional[SeniorityLevel]:
+    """Return the highest-ranked tier whose vocabulary matches `text`, or
+    None. Noise is stripped first so a compound trap phrase can't feed
+    either the tier it superficially resembles or any other.
+    """
+    if not text.strip():
+        return None
+    cleaned = _SENIORITY_NOISE.sub(" ", text)
+    for level in _SENIORITY_RANK:
+        pattern = _phrase_pattern(terms.get(level.value, ()))
+        if pattern and pattern.search(cleaned):
+            return level
+    return None
+
+
+def detect_seniority(
+    title: Optional[str] = "",
+    description: Optional[str] = "",
+    *,
+    enrichment_value: Optional[str] = None,
+) -> SenioritySignal:
+    """Classify a role's seniority: intern / junior / mid / senior / staff /
+    principal / director.
+
+    ``enrichment_value`` wins outright when present and not 'unknown' — same
+    precedence as `detect_workplace` / `visa_signal.detect_visa_status`.
+
+    Reads the TITLE first, description second, as two independent passes
+    (not one merged blob): seniority almost always sits in the title, and
+    the title exists even for jobs with no usable description — that gap is
+    the entire reason this detector exists. A description-only mention
+    should never outrank a clear title signal.
+
+    Within either pass, a text naming two tiers picks the MORE senior one
+    (`_SENIORITY_RANK`, checked top-down). That ordering also resolves a
+    real trap for free: "graduate" often describes an educational
+    requirement ("must hold a graduate degree, 5 years' experience") rather
+    than the role's level, and such ads are disproportionately senior roles
+    that happen to also require a degree — checking SENIOR before JUNIOR
+    reads that combination correctly.
+    """
+    if enrichment_value:
+        ev = enrichment_value.strip().lower()
+        if ev and ev != SeniorityLevel.UNKNOWN.value:
+            for member in SeniorityLevel:
+                if ev == member.value:
+                    return SenioritySignal(member, "enrichment")
+
+    terms = _seniority_terms()
+
+    title_hit = _match_seniority_tier(title or "", terms)
+    if title_hit is not None:
+        return SenioritySignal(title_hit, "title")
+
+    description_hit = _match_seniority_tier(description or "", terms)
+    if description_hit is not None:
+        return SenioritySignal(description_hit, "description")
+
+    return SenioritySignal(SeniorityLevel.UNKNOWN, "no_signal")
+
+# ---------------------------------------------------------------------------
+# Wiring the detectors into scoring
+# ---------------------------------------------------------------------------
+
+
+def signal_backed_lookup(
+    base_lookup: Callable[[Any], Any],
+) -> Callable[[Any], Any]:
+    """Wrap an ``enrichment_lookup`` so the detectors fill what the LLM left blank.
+
+    THE SEAM. ``JobScorer(enrichment_lookup=...)`` takes a CALLABLE OF A JOB,
+    which is the only place in the system where the enrichment record and the
+    job's own text are both in scope. The bulk loader
+    (`job_enrichment._build_enrichment_lookup`) is keyed by job_id and never
+    sees the job, so it cannot do this; the scorer's own dim functions receive
+    only the enrichment, so they cannot either. Wrapping here means EVERY call
+    site (API read path, rescore, worker) gains the detectors at once, and no
+    scoring formula changes.
+
+    WHY THIS IS NOT INVENTING DATA. The LLM enricher returns 'unknown' whenever
+    the ad gave it nothing to read — and 1,311 live jobs have under 200
+    characters of description, so 'unknown' is overwhelmingly "we never looked
+    at any text", not "we looked and could not tell". The detectors read the
+    TITLE and the LOCATION field, which exist even for those jobs. Measured on
+    the live catalog: seniority coverage 27% -> 60%, workplace 22% -> 29%.
+
+    Precedence is one-way: an existing LLM verdict is never overwritten, only a
+    literal 'unknown' is filled. That keeps the LLM authoritative wherever it
+    actually spoke.
+    """
+    def _wrapped(job: Any) -> Any:
+        enrichment = base_lookup(job)
+        if enrichment is None:
+            return None
+        title = getattr(job, "title", "") or ""
+        desc = getattr(job, "description", "") or ""
+        loc = getattr(job, "location", "") or ""
+
+        wp = getattr(enrichment, "workplace_type", None)
+        if _is_unknown(wp):
+            detected = detect_workplace(
+                desc, title, location=loc, enrichment_value=None
+            )
+            _apply(enrichment, "workplace_type", detected)
+
+        sn = getattr(enrichment, "seniority", None)
+        if _is_unknown(sn):
+            detected = detect_seniority(title, desc, enrichment_value=None)
+            _apply(enrichment, "seniority", detected)
+
+        return enrichment
+
+    return _wrapped
+
+
+def _is_unknown(value: Any) -> bool:
+    if value is None:
+        return True
+    raw = getattr(value, "value", value)
+    return str(raw).strip().lower() in ("", "unknown")
+
+
+def _apply(enrichment: Any, field: str, detected: Any) -> None:
+    """Write a detected value back, tolerating a frozen/validated model.
+
+    ``JobEnrichment`` is a Pydantic model; some configurations forbid mutation.
+    A detector result must never crash scoring, so a failed assignment is
+    silently skipped — the dim scorer then sees 'unknown' and returns its
+    neutral constant, exactly as before this wrapper existed.
+    """
+    raw = getattr(detected, "value", detected)
+    raw = getattr(raw, "value", raw)
+    if raw is None or str(raw).strip().lower() in ("", "unknown"):
+        return
+    try:
+        setattr(enrichment, field, raw)
+    except Exception:  # noqa: BLE001 — never let a detector break scoring
+        pass

--- a/backend/src/services/profile/cv_parser.py
+++ b/backend/src/services/profile/cv_parser.py
@@ -62,7 +62,8 @@ Return a JSON object with exactly these fields:
   ],
   "experience_level": "One of: intern, junior, mid, senior, lead, principal, director — infer from experience duration and roles",
   "industries": ["Industries/domains they have experience in"],
-  "languages": ["Human languages they speak, if mentioned"]
+  "languages": ["Human languages they speak, if mentioned"],
+  "career_domain": "The ONE coarse career bucket that best fits this person's OVERALL career. Must be EXACTLY one of: software_engineering, data_and_ai, product_and_design, marketing_and_growth, sales_and_bizdev, finance_and_accounting, operations_and_supply, human_resources, legal_and_compliance, healthcare_and_lifesciences, education_and_research, engineering_physical, customer_support, media_and_content, skilled_trades, other. Return null (not a guess) when the CV genuinely does not fit any bucket clearly."
 }}
 
 RULES:
@@ -92,6 +93,10 @@ RULES:
    strategy, a structural load calculation are skills demonstrated in prose). Do NOT limit
    skills to the items already written in the skills section — the strongest signal often
    hides in what the person actually DID.
+10. For "career_domain", classify only when the evidence clearly points to ONE bucket from
+    the fixed list above. A wrong guess corrupts downstream archetype-aware scoring, so a
+    CV that spans multiple domains equally, or doesn't fit any bucket confidently, gets
+    null — never invent a value outside the listed set.
 
 CV TEXT:
 ---
@@ -833,6 +838,32 @@ def _maybe_normalise_skills_via_esco(
     return canonical, esco_map
 
 
+def _coerce_career_domain(value: Any) -> str | None:
+    """Validate a raw LLM ``career_domain`` string against the same closed
+    enum the typed path enforces (``schemas.CareerDomain``), so this untyped
+    fallback adapter can't write a bucket the strict path would have
+    rejected. Unknown/blank/invalid values become ``None`` (never guess) —
+    mirrors ``CVSchema._domain_nullable``.
+
+    Local import, not module-level: ``schemas.py`` imports THIS module at
+    module level (for ``_maybe_normalise_skills_via_esco``), so a top-level
+    `import schemas` here would cycle. cv_parser stays import-free of
+    schemas at module scope; only this function pays the cost, once, on the
+    rare defensive-fallback path.
+    """
+    from src.services.profile.schemas import CareerDomain  # noqa: PLC0415 — see docstring
+
+    if not isinstance(value, str):
+        return None
+    v = value.strip().lower()
+    if v in ("", "unknown", "n/a", "none"):
+        return None
+    try:
+        return CareerDomain(v).value
+    except ValueError:
+        return None
+
+
 def _llm_result_to_cvdata(raw_text: str, result: dict[str, Any]) -> CVData:
     """Convert LLM JSON response to CVData dataclass.
 
@@ -850,6 +881,15 @@ def _llm_result_to_cvdata(raw_text: str, result: dict[str, Any]) -> CVData:
     headline = _coerce_str(result.get("headline"))
     location = _coerce_str(result.get("location"))
     achievements = _coerce_str_list(result.get("achievements"))
+    # ADAPTER-PARITY FIX (2026-08-07). `cv_schema_to_cvdata` (the live path)
+    # has plumbed `industries` / `cv_languages` through since "review fix #1"
+    # and now plumbs `career_domain` too — this fallback adapter (only
+    # reached when strict CVSchema validation exhausts its retries) silently
+    # dropped all three. Same bug shape as `cv_positions` before it: one
+    # adapter got the fix, the other didn't. See test_adapter_parity.py.
+    industries = _coerce_str_list(result.get("industries"))
+    cv_languages = _coerce_str_list(result.get("languages"))
+    career_domain = _coerce_career_domain(result.get("career_domain"))
 
     # Education: flatten nested dicts to list of strings for display
     education_lines: list[str] = []
@@ -931,4 +971,7 @@ def _llm_result_to_cvdata(raw_text: str, result: dict[str, Any]) -> CVData:
         location=location,
         achievements=achievements,
         cv_skills_esco=cv_skills_esco,
+        industries=industries,
+        cv_languages=cv_languages,
+        career_domain=career_domain,
     )

--- a/backend/src/services/profile/schemas.py
+++ b/backend/src/services/profile/schemas.py
@@ -25,6 +25,7 @@ from typing import Any, Optional
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
+from src.services.profile.cv_parser import _maybe_normalise_skills_via_esco
 from src.services.profile.models import CVData
 
 
@@ -196,6 +197,19 @@ def cv_schema_to_cvdata(schema: CVSchema, raw_text: str) -> CVData:
     job_titles = [e.title for e in schema.experience if e.title]
     companies = [e.company for e in schema.experience if e.company]
 
+    # ADAPTER-PARITY FIX (2026-08-07) — Step-1.5 S1.5-D ESCO normalisation.
+    # `_llm_result_to_cvdata` (the untyped fallback, reached only when strict
+    # CVSchema validation exhausts its retries) has called
+    # `_maybe_normalise_skills_via_esco` since it was built. THIS adapter —
+    # the one every successful extraction actually returns through — never
+    # did, so `CVData(...)` below had no `cv_skills_esco=` argument at all.
+    # Prod runs `SEMANTIC_ENABLED=true` and every profile shipped with
+    # `cv_skills_esco={}` regardless. Same shape as the `cv_positions` bug:
+    # one adapter fixed, the other silently isn't. Graceful no-op (skills
+    # unchanged, empty map) when the flag is off or the ESCO index isn't on
+    # disk — see the helper's own docstring for the guard chain.
+    skills, cv_skills_esco = _maybe_normalise_skills_via_esco(list(schema.skills))
+
     experience_lines: list[str] = []
     for e in schema.experience:
         experience_lines.extend(e.bullets)
@@ -248,7 +262,7 @@ def cv_schema_to_cvdata(schema: CVSchema, raw_text: str) -> CVData:
 
     return CVData(
         raw_text=raw_text,
-        skills=list(schema.skills),
+        skills=skills,
         job_titles=job_titles,
         companies=companies,
         education=education_lines,
@@ -267,4 +281,5 @@ def cv_schema_to_cvdata(schema: CVSchema, raw_text: str) -> CVData:
         # values for CVs that list them.
         industries=list(schema.industries),
         cv_languages=list(schema.languages),
+        cv_skills_esco=cv_skills_esco,
     )

--- a/backend/src/services/profile/two_pass.py
+++ b/backend/src/services/profile/two_pass.py
@@ -282,6 +282,24 @@ def _merge_cv_llm_into(cv: CVData, llm_cv: CVData) -> None:
         cv.summary = llm_cv.summary
     if not cv.experience_text and llm_cv.experience_text:
         cv.experience_text = llm_cv.experience_text
+    # ADAPTER-PARITY FIX (2026-08-07). Every OTHER CV-owned scalar in this
+    # function was merged; `career_domain` was not, so even once the prompt
+    # asks for it (cv_parser._CV_PROMPT) and the schema adapter surfaces it
+    # (schemas.cv_schema_to_cvdata), the value stopped here — one layer above
+    # the fix, same shape as the `cv_positions` miss just below. Fill-if-
+    # empty like every scalar above: a re-run that classifies differently
+    # must not clobber a domain the user's profile already carries.
+    if not cv.career_domain and llm_cv.career_domain:
+        cv.career_domain = llm_cv.career_domain
+    # ESCO skill-normalisation map (Step-1.5 S1.5-D). `reset_cv_owned_fields`
+    # has always cleared `cv_skills_esco` on a CV swap — treating it as CV-
+    # owned — but nothing here ever copied it back in, so fixing the adapter
+    # (schemas.cv_schema_to_cvdata) alone still left the live profile at
+    # cv_skills_esco={} after a real re-extraction. Union rather than fill-
+    # once: a later pass can resolve a skill the first pass didn't (ESCO
+    # turned on, or a borderline cosine match), and dropping earlier
+    # resolved entries would silently regress them.
+    cv.cv_skills_esco.update(llm_cv.cv_skills_esco)
     # Structured, dated experience (Pillar-1 audit 2026-08-07). Every OTHER
     # CV-owned field was merged here; cv_positions was not, so a re-extraction
     # produced dated positions and then threw them away one layer above the

--- a/backend/src/services/rescore.py
+++ b/backend/src/services/rescore.py
@@ -76,6 +76,7 @@ async def _build_user_scorer(db: Any, profile: Any) -> Any:
         ENRICHMENT_ENABLED,
         _build_enrichment_lookup,
     )
+    from src.services.job_signals import signal_backed_lookup  # noqa: PLC0415
     from src.services.profile.keyword_generator import generate_search_config  # noqa: PLC0415
     from src.services.skill_matcher import JobScorer  # noqa: PLC0415
 
@@ -88,8 +89,8 @@ async def _build_user_scorer(db: Any, profile: Any) -> Any:
     return JobScorer(
         search_config,
         user_preferences=profile.preferences,
-        enrichment_lookup=lambda j: enrichment_lookup_dict.get(
-            cast(int, getattr(j, "id", None))
+        enrichment_lookup=signal_backed_lookup(
+            lambda j: enrichment_lookup_dict.get(cast(int, getattr(j, "id", None)))
         ),
     )
 
@@ -511,6 +512,7 @@ async def rescore_user_feed(
                 ENRICHMENT_ENABLED,
                 _build_enrichment_lookup,
             )
+            from src.services.job_signals import signal_backed_lookup  # noqa: PLC0415
             from src.services.profile.keyword_generator import generate_search_config  # noqa: PLC0415
             from src.services.skill_matcher import (  # noqa: PLC0415
                 SCORER_VERSION as _SCORER_VERSION,
@@ -532,8 +534,10 @@ async def rescore_user_feed(
                 # cast: the lookup is keyed by job id; `getattr` widens to
                 # Any|None and a missing id simply misses the dict (unchanged
                 # runtime behaviour — `cast` is a no-op).
-                enrichment_lookup=lambda j: enrichment_lookup_dict.get(
-                    cast(int, getattr(j, "id", None))
+                enrichment_lookup=signal_backed_lookup(
+                    lambda j: enrichment_lookup_dict.get(
+                        cast(int, getattr(j, "id", None))
+                    )
                 ),
             )
 

--- a/backend/src/workers/tasks.py
+++ b/backend/src/workers/tasks.py
@@ -25,6 +25,7 @@ from src.models import Job
 from src.repositories import pg
 from src.services.feed import FeedService
 from src.services.job_enrichment import ENRICHMENT_ENABLED, _build_enrichment_lookup
+from src.services.job_signals import signal_backed_lookup
 from src.services.prefilter import FilterProfile, passes_prefilter
 from src.services.profile.models import SearchConfig
 from src.services.skill_matcher import JobScorer
@@ -158,7 +159,12 @@ async def score_and_ingest(
     # always calling get(None). Reads `job.id` directly rather than through
     # getattr — the getattr dance existed only because the field was previously
     # stapled on at runtime and might genuinely be absent.
-    enrichment_lookup_fn = lambda job: enrichment_lookup_dict.get(job.id)  # noqa: E731
+    # Wrapped so the deterministic detectors fill what the LLM left 'unknown'
+    # (job_signals.signal_backed_lookup explains why this is the only seam that
+    # can see both the enrichment record and the job's own title/location).
+    enrichment_lookup_fn = signal_backed_lookup(
+        lambda job: enrichment_lookup_dict.get(job.id)
+    )
 
     def _scorer_for(user_id: str) -> JobScorer:
         if user_id not in user_scorers:

--- a/backend/tests/test_adapter_parity.py
+++ b/backend/tests/test_adapter_parity.py
@@ -1,0 +1,197 @@
+"""Adapter-parity guard — the SAME bug shape, THREE times in one day.
+
+Job360's CV LLM extraction has TWO adapters that turn an LLM's raw JSON
+answer into a ``CVData``:
+
+  * ``cv_parser._llm_result_to_cvdata`` — the untyped DEFENSIVE FALLBACK,
+    reached only when strict ``CVSchema`` validation exhausts its retries
+    (``cv_parser.py::llm_cv_fields_from_text``).
+  * ``schemas.cv_schema_to_cvdata`` — the TYPED LIVE adapter every
+    successful extraction actually returns through.
+
+Three incidents, found in ONE Pillar-1 audit on 2026-08-07, all had the
+SAME shape: a fix landed in one adapter and not the other, so production —
+which runs through the live adapter — kept shipping the bug.
+
+  1. ``cv_positions`` (structured, dated experience) — PR #241 added it to
+     the fallback adapter; the live adapter had no line for it, so real
+     extractions still came back with zero positions. Regression-guarded by
+     ``TestCvSchemaCarriesDatedExperience`` in ``test_profile.py``.
+  2. ``career_domain`` — the CV prompt never asked for it, and even once it
+     does, ``two_pass._merge_cv_llm_into`` had no line copying it from the
+     LLM pass into the live profile.
+  3. ``cv_skills_esco`` (ESCO skill normalisation) —
+     ``_maybe_normalise_skills_via_esco`` was only ever called from the
+     fallback adapter; the live adapter built ``CVData(...)`` with no
+     ``cv_skills_esco=`` argument at all, so every production profile
+     shipped with ``cv_skills_esco={}`` regardless of ``SEMANTIC_ENABLED``.
+
+This test exists so a FOURTH instance of the same bug shape cannot land
+silently. It asserts both adapters populate the SAME SET of CVData fields
+from equivalent input — add a field to one adapter and not the other, and
+this test fails immediately, instead of waiting for the next live-CV audit
+to catch it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import MISSING, fields
+from typing import Any
+from unittest.mock import patch
+
+from src.services.profile.cv_parser import _llm_result_to_cvdata
+from src.services.profile.models import CVData
+from src.services.profile.schemas import CVSchema, cv_schema_to_cvdata
+
+# The fields BOTH adapters are contractually responsible for populating from
+# a CV LLM extraction. This mirrors, deliberately, the "what the CV owns"
+# field list documented and enforced in ``two_pass.reset_cv_owned_fields`` —
+# everything that function clears is everything a CV (re-)extraction is
+# expected to (re-)populate. ``raw_text`` is excluded: both adapters take it
+# as a plain passthrough parameter, not something derived from the LLM
+# result, and ``reset_cv_owned_fields`` explicitly does not clear it either.
+_CV_OWNED_FIELDS = [
+    "skills", "job_titles", "companies", "education", "certifications",
+    "industries", "cv_languages", "cv_skills_esco", "summary",
+    "experience_text", "name", "headline", "location", "achievements",
+    "career_domain", "cv_positions",
+]
+
+# Earned, justified exceptions only. Empty on purpose: this file exists
+# because "one adapter has it, the other doesn't" happened three times
+# without anyone noticing, so a field mismatch here gets FIXED, not waved
+# through. If a genuine, permanent asymmetry is ever discovered (not just an
+# oversight), add it here with a one-line reason — never leave the set
+# comparison below silently weaker instead.
+_ALLOWED_FIELD_DIFFERENCES: dict[str, str] = {}
+
+_PAYLOAD: dict[str, Any] = {
+    "name": "Jamie Rivera",
+    "headline": "Senior Structural Engineer",
+    "location": "Bristol, UK",
+    "summary": "Structural engineer with 9 years in bridge design.",
+    "skills": ["AutoCAD", "Eurocode 2", "Finite Element Analysis"],
+    "experience": [
+        {
+            "company": "Arup",
+            "title": "Senior Structural Engineer",
+            "dates": "2019-Present",
+            "location": "Bristol",
+            "bullets": ["Led design of a 200m footbridge"],
+        }
+    ],
+    "education": [
+        {
+            "degree": "MEng Civil Engineering",
+            "institution": "University of Bristol",
+            "dates": "2011-2015",
+            "details": ["Dissertation: seismic retrofit"],
+        }
+    ],
+    "certifications": ["Chartered Engineer (IStructE, 2020)"],
+    "achievements": ["cut material cost 18% on the Severn footbridge"],
+    "industries": ["Construction", "Infrastructure"],
+    "languages": ["English", "Spanish"],
+    "career_domain": "engineering_physical",
+}
+
+
+def _populated_fields(cv: CVData) -> set[str]:
+    """CV-owned field names on ``cv`` holding something other than the
+    dataclass default (i.e. the adapter actually wrote something there)."""
+    populated = set()
+    for f in fields(CVData):
+        if f.name not in _CV_OWNED_FIELDS:
+            continue
+        default = f.default_factory() if f.default_factory is not MISSING else f.default
+        if getattr(cv, f.name) != default:
+            populated.add(f.name)
+    return populated
+
+
+def _build_both_adapters() -> tuple[CVData, CVData]:
+    schema = CVSchema.model_validate(_PAYLOAD)
+    live = cv_schema_to_cvdata(schema, raw_text="raw text")
+    fallback = _llm_result_to_cvdata("raw text", dict(_PAYLOAD))
+    return live, fallback
+
+
+class TestAdapterFieldParity:
+    def test_same_fields_populate_with_esco_unavailable(self):
+        """ESCO off/unavailable is the DEFAULT runtime state
+        (``SEMANTIC_ENABLED`` defaults false, root rule #18) — the two
+        adapters must agree here too, not only when ESCO is on."""
+        identity = lambda skills: (skills, {})  # noqa: E731
+        with patch(
+            "src.services.profile.cv_parser._maybe_normalise_skills_via_esco",
+            side_effect=identity,
+        ), patch(
+            "src.services.profile.schemas._maybe_normalise_skills_via_esco",
+            side_effect=identity,
+        ):
+            live, fallback = _build_both_adapters()
+
+        live_fields = _populated_fields(live)
+        fallback_fields = _populated_fields(fallback)
+        allowed = set(_ALLOWED_FIELD_DIFFERENCES)
+        assert live_fields - allowed == fallback_fields - allowed, (
+            f"adapters disagree on which fields populate: "
+            f"live-only={live_fields - fallback_fields}, "
+            f"fallback-only={fallback_fields - live_fields}"
+        )
+
+    def test_same_fields_populate_with_esco_available(self):
+        """When ESCO IS available, ``cv_skills_esco`` must populate on BOTH
+        paths — this is bug #3 (``cv_skills_esco`` stuck on a dead path)
+        made structurally unable to recur."""
+        fake_map = {"AutoCAD": "http://esco/autocad"}
+        normalise = lambda skills: (skills, dict(fake_map))  # noqa: E731
+        with patch(
+            "src.services.profile.cv_parser._maybe_normalise_skills_via_esco",
+            side_effect=normalise,
+        ), patch(
+            "src.services.profile.schemas._maybe_normalise_skills_via_esco",
+            side_effect=normalise,
+        ):
+            live, fallback = _build_both_adapters()
+
+        assert live.cv_skills_esco == fake_map, "live adapter did not route through ESCO"
+        assert fallback.cv_skills_esco == fake_map
+
+        live_fields = _populated_fields(live)
+        fallback_fields = _populated_fields(fallback)
+        allowed = set(_ALLOWED_FIELD_DIFFERENCES)
+        assert live_fields - allowed == fallback_fields - allowed
+
+    def test_career_domain_and_industries_and_languages_match_on_both(self):
+        """Direct value check on the fields this specific audit fixed —
+        SET parity alone can't tell you the two adapters read the SAME
+        classification, only that both wrote SOMETHING."""
+        identity = lambda skills: (skills, {})  # noqa: E731
+        with patch(
+            "src.services.profile.cv_parser._maybe_normalise_skills_via_esco",
+            side_effect=identity,
+        ), patch(
+            "src.services.profile.schemas._maybe_normalise_skills_via_esco",
+            side_effect=identity,
+        ):
+            live, fallback = _build_both_adapters()
+
+        assert live.career_domain == fallback.career_domain == "engineering_physical"
+        assert set(live.industries) == set(fallback.industries) == {"Construction", "Infrastructure"}
+        assert set(live.cv_languages) == set(fallback.cv_languages) == {"English", "Spanish"}
+
+    def test_a_field_populated_on_only_one_adapter_fails_the_test(self):
+        """Meta-test: prove the guard actually guards. Simulates the exact
+        failure mode of the three real incidents — one adapter's output has
+        a field the other's doesn't — using two hand-built CVData instances
+        instead of re-triggering a real adapter bug."""
+        richer = CVData(skills=["Python"], career_domain="data_and_ai")
+        poorer = CVData(skills=["Python"])  # career_domain missing, like the real bug
+
+        richer_fields = _populated_fields(richer)
+        poorer_fields = _populated_fields(poorer)
+        assert richer_fields != poorer_fields, (
+            "the field-population helper must be sensitive to a single "
+            "missing field, or this whole test file is a no-op guard"
+        )

--- a/backend/tests/test_coverage_canary.py
+++ b/backend/tests/test_coverage_canary.py
@@ -1,0 +1,263 @@
+"""COVERAGE CANARY — pins `job_has_value`'s value-presence rule with known
+ground truth, per matching dimension.
+
+WHY THIS EXISTS. `scripts/shelf_xray.py` used to report salary coverage as
+83% via `e.salary NOT IN ('{}', '')` — a predicate that tests JSON *shape*
+against two literal strings. `{"min": null, "max": null}` is neither literal,
+so it passed while carrying zero usable data; the real figure (parse the
+JSON, check for an actual number) was ~5%. `job_has_value` (src/services/
+coverage.py) is the fix, and this file is the guardrail: it builds rows with
+a KNOWN true-positive count `k` — some genuinely covered, the rest empty in
+every shape this codebase's data has actually taken (or could plausibly
+take) for that dimension — and asserts `job_has_value` counts EXACTLY `k`.
+
+THE POINT: any future predicate that admits one of these empty shapes as
+"covered" breaks this test the instant it is written. This is a regression
+tripwire for the exact bug class above — not a general happy-path test suite
+for coverage.py.
+
+Pure functions over plain dicts — no DB connection, no network (rule #4).
+Run: `python -m pytest tests/test_coverage_canary.py -q -p no:randomly`.
+"""
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import pytest
+
+from src.services.coverage import DIMENSIONS, job_has_value
+
+# A real ad is long — JobScorer's match text is `title + description`, and
+# the skill-text threshold in coverage.py is 200 chars (see its docstring).
+LONG_DESCRIPTION = (
+    "We are looking for a backend engineer to join our growing platform "
+    "team. You will design and build scalable services, own the data "
+    "layer, and collaborate closely with product on new features. "
+    "Experience with Python, PostgreSQL, and distributed systems is "
+    "required. Nice to have: Kubernetes, Terraform, and prior fintech "
+    "domain exposure. We offer a hybrid working pattern and a strong "
+    "engineering culture built on code review and mentorship."
+)
+SHORT_DESCRIPTION = "Great team, apply now."
+assert len(LONG_DESCRIPTION) > 200  # fixture sanity: must clear coverage.py's threshold
+assert len(SHORT_DESCRIPTION) <= 200
+
+
+def _count_covered(dimension: str, rows: list[tuple[dict, Optional[dict]]]) -> int:
+    """Run every (job_row, enrichment_row) pair through job_has_value and
+    count the Trues — the one operation every test class below pins."""
+    return sum(1 for job, enr in rows if job_has_value(dimension, job, enr))
+
+
+class TestEveryDimensionHasACanary:
+    """If `coverage.DIMENSIONS` grows a new dimension without a matching
+    canary class in this file, that dimension's predicate ships unguarded.
+    Fail loudly here rather than silently."""
+
+    _CANARIED = {
+        "salary", "skills", "titles", "location", "workplace", "seniority",
+        "domain", "visa",
+    }
+
+    def test_no_dimension_is_untested(self) -> None:
+        assert set(DIMENSIONS) == self._CANARIED
+
+    def test_unknown_dimension_raises(self) -> None:
+        with pytest.raises(ValueError):
+            job_has_value("not_a_real_dimension", {}, None)
+
+
+class TestSalaryCoverage:
+    """job_enrichment.salary is a JSON-TEXT column (migration 0008, default
+    `'{}'`). Every shape below is a real or trivially-possible value for
+    that column and must NOT be read as an actual number — this is the
+    exact incident the module exists to fix."""
+
+    COVERED: list[tuple[dict, Optional[dict]]] = [
+        ({"salary_min": 35000, "salary_max": 45000}, None),
+        (
+            {"salary_min": None, "salary_max": None},
+            {"salary": '{"min": 30000, "max": 50000, "currency": "GBP", "frequency": "annual"}'},
+        ),
+        # Already-parsed dict input (a caller that pre-decoded) with only
+        # one real bound — still a usable number.
+        ({"salary_min": None, "salary_max": None}, {"salary": {"min": None, "max": 42000}}),
+    ]
+
+    EMPTY_SALARY_SHAPES: list[Any] = [
+        "{}", '{"min": null}', '{"min": null, "max": null}', "", None,
+        "unknown", 0, [], "[]",
+    ]
+
+    @pytest.mark.parametrize("shape", EMPTY_SALARY_SHAPES)
+    def test_each_empty_shape_is_uncovered(self, shape: Any) -> None:
+        job_row = {"salary_min": None, "salary_max": None}
+        assert job_has_value("salary", job_row, {"salary": shape}) is False
+
+    def test_no_enrichment_row_is_uncovered(self) -> None:
+        job_row = {"salary_min": None, "salary_max": None}
+        assert job_has_value("salary", job_row, None) is False
+
+    def test_exact_count(self) -> None:
+        rows = list(self.COVERED)
+        rows += [
+            ({"salary_min": None, "salary_max": None}, {"salary": shape})
+            for shape in self.EMPTY_SALARY_SHAPES
+        ]
+        rows.append(({"salary_min": None, "salary_max": None}, None))
+        assert _count_covered("salary", rows) == len(self.COVERED)
+
+
+class TestSkillsCoverage:
+    """Skill signal comes from EITHER a real description (>200 chars — what
+    JobScorer's match text actually needs) OR the LLM's `required_skills`
+    list. Both must be absent, in every shape `required_skills` can take,
+    for a row to count as uncovered."""
+
+    COVERED: list[tuple[dict, Optional[dict]]] = [
+        ({"description": LONG_DESCRIPTION}, None),
+        ({"description": SHORT_DESCRIPTION}, {"required_skills": '["Python", "SQL"]'}),
+        ({"description": SHORT_DESCRIPTION}, {"required_skills": ["Kubernetes"]}),
+    ]
+
+    EMPTY_SKILLS_SHAPES: list[Any] = [
+        "{}", '{"min": null}', '{"min": null, "max": null}', "", None,
+        "unknown", 0, [], "[]",
+    ]
+
+    @pytest.mark.parametrize("shape", EMPTY_SKILLS_SHAPES)
+    def test_each_empty_shape_is_uncovered(self, shape: Any) -> None:
+        job_row = {"description": SHORT_DESCRIPTION}
+        assert job_has_value("skills", job_row, {"required_skills": shape}) is False
+
+    def test_no_description_no_enrichment_is_uncovered(self) -> None:
+        assert job_has_value("skills", {"description": None}, None) is False
+
+    def test_exact_count(self) -> None:
+        rows = list(self.COVERED)
+        rows += [
+            ({"description": SHORT_DESCRIPTION}, {"required_skills": shape})
+            for shape in self.EMPTY_SKILLS_SHAPES
+        ]
+        rows.append(({"description": SHORT_DESCRIPTION}, None))
+        rows.append(({"description": None}, None))
+        assert _count_covered("skills", rows) == len(self.COVERED)
+
+
+class TestTitleCoverage:
+    """Titles are read verbatim off the `jobs` row — no enrichment
+    fallback. Only a real non-blank string counts; a non-string value (never
+    supposed to happen on a TEXT column, but defensive) must not."""
+
+    COVERED: list[dict] = [
+        {"title": "Senior Backend Engineer"},
+        {"title": "  Data Scientist  "},  # whitespace padding is still a real title
+    ]
+    EMPTY_TITLE_SHAPES: list[Any] = ["", None, "   ", 0, [], {}]
+
+    @pytest.mark.parametrize("shape", EMPTY_TITLE_SHAPES)
+    def test_each_empty_shape_is_uncovered(self, shape: Any) -> None:
+        assert job_has_value("titles", {"title": shape}, None) is False
+
+    def test_exact_count(self) -> None:
+        rows: list[tuple[dict, Optional[dict]]] = [(j, None) for j in self.COVERED]
+        rows += [({"title": shape}, None) for shape in self.EMPTY_TITLE_SHAPES]
+        assert _count_covered("titles", rows) == len(self.COVERED)
+
+
+class TestLocationCoverage:
+    """Same rule as titles — plain non-blank string, job-row only."""
+
+    COVERED: list[dict] = [{"location": "London, UK"}, {"location": "Remote"}]
+    EMPTY_LOCATION_SHAPES: list[Any] = ["", None, "   ", 0, [], {}]
+
+    @pytest.mark.parametrize("shape", EMPTY_LOCATION_SHAPES)
+    def test_each_empty_shape_is_uncovered(self, shape: Any) -> None:
+        assert job_has_value("location", {"location": shape}, None) is False
+
+    def test_exact_count(self) -> None:
+        rows: list[tuple[dict, Optional[dict]]] = [(j, None) for j in self.COVERED]
+        rows += [({"location": shape}, None) for shape in self.EMPTY_LOCATION_SHAPES]
+        assert _count_covered("location", rows) == len(self.COVERED)
+
+
+class TestEnumEnrichmentCoverage:
+    """workplace_type / seniority / category are never NULL once enrichment
+    has run — the LLM contract (job_enrichment.py `_SYSTEM_PROMPT`) writes
+    the literal string "unknown" instead of omitting the field. So the ONLY
+    real test is "not unknown, not blank"; a bare `IS NOT NULL` check (the
+    shape of the original salary bug, applied here) would count every one
+    of these rows as covered."""
+
+    FIELD_BY_DIMENSION = {
+        "workplace": "workplace_type",
+        "seniority": "seniority",
+        "domain": "category",
+    }
+    EMPTY_ENUM_SHAPES: list[Any] = [
+        None, "", "   ", "unknown", "UNKNOWN", "Unknown", 0, [], {},
+    ]
+
+    @pytest.mark.parametrize("dimension,field", list(FIELD_BY_DIMENSION.items()))
+    @pytest.mark.parametrize("shape", EMPTY_ENUM_SHAPES)
+    def test_each_empty_shape_is_uncovered(self, dimension: str, field: str, shape: Any) -> None:
+        assert job_has_value(dimension, {}, {field: shape}) is False
+
+    @pytest.mark.parametrize("dimension,field", list(FIELD_BY_DIMENSION.items()))
+    def test_no_enrichment_row_is_uncovered(self, dimension: str, field: str) -> None:
+        assert job_has_value(dimension, {}, None) is False
+
+    @pytest.mark.parametrize(
+        "dimension,field,real_value",
+        [
+            ("workplace", "workplace_type", "remote"),
+            ("seniority", "seniority", "senior"),
+            ("domain", "category", "software_engineering"),
+        ],
+    )
+    def test_exact_count(self, dimension: str, field: str, real_value: str) -> None:
+        covered: list[tuple[dict, Optional[dict]]] = [
+            ({}, {field: real_value}),
+            ({}, {field: f"  {real_value}  "}),  # incidental whitespace around a real value
+        ]
+        empty: list[tuple[dict, Optional[dict]]] = [
+            ({}, {field: shape}) for shape in self.EMPTY_ENUM_SHAPES
+        ]
+        empty.append(({}, None))
+        assert _count_covered(dimension, covered + empty) == len(covered)
+
+
+class TestVisaCoverage:
+    """Delegates to `detect_visa_status` (visa_signal.py) rather than
+    reading `job_enrichment.visa_sponsorship` alone — that column alone is
+    why the old script under-reported visa coverage at 3% against the ~42%
+    the text detector actually resolves. Every empty shape below must fall
+    through to UNKNOWN when the text contains no visa phrase."""
+
+    NO_MENTION = {"title": "Backend Engineer", "description": "Great team, competitive salary."}
+    POSITIVE_TEXT = {"title": "Backend Engineer", "description": "Visa sponsorship available for this role."}
+
+    EMPTY_VISA_SHAPES: list[Any] = [
+        "{}", '{"min": null}', '{"min": null, "max": null}', "", None,
+        "unknown", 0, [], "[]",
+    ]
+
+    @pytest.mark.parametrize("shape", EMPTY_VISA_SHAPES)
+    def test_each_empty_shape_is_uncovered(self, shape: Any) -> None:
+        assert job_has_value("visa", self.NO_MENTION, {"visa_sponsorship": shape}) is False
+
+    def test_exact_count(self) -> None:
+        covered: list[tuple[dict, Optional[dict]]] = [
+            (self.POSITIVE_TEXT, None),  # text-detected positive, no enrichment at all
+            (self.NO_MENTION, {"visa_sponsorship": "yes"}),
+            # "no_sponsorship" is a real, non-UNKNOWN verdict — it counts as
+            # covered even though it isn't a sponsorship offer (rule #29 /
+            # visa_signal.py: silence vs refusal are opposite facts, both
+            # are "known", only silence is "unknown").
+            (self.NO_MENTION, {"visa_sponsorship": "no"}),
+        ]
+        empty: list[tuple[dict, Optional[dict]]] = [
+            (self.NO_MENTION, {"visa_sponsorship": shape}) for shape in self.EMPTY_VISA_SHAPES
+        ]
+        empty.append((self.NO_MENTION, None))
+        assert _count_covered("visa", covered + empty) == len(covered)

--- a/backend/tests/test_job_enrichment.py
+++ b/backend/tests/test_job_enrichment.py
@@ -20,7 +20,6 @@ from src.services.job_enrichment import (
     save_enrichment,
 )
 from src.services.job_enrichment_schema import (
-    EmployerType,
     EmploymentType,
     ExperienceLevel,
     JobCategory,
@@ -56,7 +55,6 @@ def _make_valid_enrichment(**overrides) -> JobEnrichment:
         category=JobCategory.MACHINE_LEARNING,
         employment_type=EmploymentType.FULL_TIME,
         workplace_type=WorkplaceType.HYBRID,
-        locations=["London, UK"],
         salary=SalaryBand(min=60000, max=90000, currency="GBP", frequency=SalaryFrequency.ANNUAL),
         required_skills=["Python", "PyTorch"],
         preferred_skills=["MLOps"],
@@ -64,7 +62,6 @@ def _make_valid_enrichment(**overrides) -> JobEnrichment:
         experience_level=ExperienceLevel.MID,
         requirements_summary="Build and ship ML systems end-to-end.",
         language="en",
-        employer_type=EmployerType.SCALEUP,
         visa_sponsorship=VisaSponsorship.YES,
         seniority=SeniorityLevel.MID,
         remote_region=None,
@@ -156,13 +153,18 @@ def test_schema_uppercases_currency():
     assert e.salary.currency == "GBP"
 
 
-def test_schema_dedups_locations():
+def test_schema_dedups_required_skills():
+    """Retargeted 2026-08 — this pinned `_strip_and_dedup` via the now-removed
+    `locations` field (100% dead: 0/3,119 live rows ever populated it, and it
+    duplicated `jobs.location`). The dedup validator itself still applies to
+    `required_skills`/`preferred_skills`/`red_flags`, so prove it there
+    instead of dropping the coverage."""
     e = JobEnrichment(
         title_canonical="Dev",
         category=JobCategory.SOFTWARE_ENGINEERING,
-        locations=["London", "london", "  London  ", "Remote"],
+        required_skills=["Python", "python", "  Python  ", "SQL"],
     )
-    assert e.locations == ["London", "Remote"]
+    assert e.required_skills == ["Python", "SQL"]
 
 
 def test_schema_lowercases_language():
@@ -184,6 +186,45 @@ def test_schema_caps_required_skills_list():
             category=JobCategory.SOFTWARE_ENGINEERING,
             required_skills=too_many,
         )
+
+
+def test_enrichment_never_asks_for_employer_type_or_locations():
+    """Regression guard, 2026-08.
+
+    Measured on all 3,119 live-production `job_enrichment` rows:
+      * `employer_type` was 'unknown' on 100% of rows — never once produced.
+      * `locations` was empty on 100% of rows (0% populated) — and would be
+        redundant even if fixed, since `jobs.location` already holds
+        geography and is validated at ingestion by `uk_gate.py`.
+
+    Both fields were still paid for on every enrichment call (they widened
+    the validated-output schema) despite never returning anything usable.
+    This test pins two things so neither field can quietly come back:
+      1. `JobEnrichment` no longer declares either field (schema surface).
+      2. The rendered prompt text never mentions them (token surface) — this
+         was already true before the fix (they were never in the prompt,
+         only defaulted in the schema), and this test keeps it true.
+    """
+    assert "employer_type" not in JobEnrichment.model_fields
+    assert "locations" not in JobEnrichment.model_fields
+
+    from src.models import Job
+    from src.services.job_enrichment import _SYSTEM_PROMPT, _build_prompt
+
+    job = Job(
+        title="ML Engineer",
+        company="Acme AI",
+        apply_url="https://example.com/job/1",
+        source="greenhouse",
+        date_found="2026-04-21T10:00:00+00:00",
+        location="London, UK",
+        description="Python PyTorch role.",
+    )
+    prompt = _build_prompt(job)
+    assert "employer_type" not in prompt
+    assert "locations" not in prompt
+    assert "employer_type" not in _SYSTEM_PROMPT
+    assert "locations" not in _SYSTEM_PROMPT
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_job_signals.py
+++ b/backend/tests/test_job_signals.py
@@ -1,0 +1,527 @@
+"""Workplace + seniority as deterministic signals — precedence, traps, and
+the missing-data-file degrade path (the same shape as test_visa_signal.py)."""
+from __future__ import annotations
+
+import pytest
+
+from src.services.job_enrichment_schema import SeniorityLevel, WorkplaceType
+from src.services.job_signals import (
+    SenioritySignal,
+    WorkplaceSignal,
+    detect_seniority,
+    detect_workplace,
+)
+
+# ---------------------------------------------------------------------------
+# Workplace — each detected value
+# ---------------------------------------------------------------------------
+
+
+class TestWorkplaceDetectedValues:
+    @pytest.mark.parametrize("text", [
+        "This is a fully remote position.",
+        "100% remote — work from anywhere in the UK.",
+        "We are a remote-first company.",
+        "Remote working, occasional team offsites.",
+        "This is a remote role based in the UK.",
+    ])
+    def test_remote_detected(self, text: str) -> None:
+        assert detect_workplace(text).value is WorkplaceType.REMOTE
+
+    @pytest.mark.parametrize("text", [
+        "This is a hybrid role.",
+        "Hybrid working, 2 days a week in the office.",
+        "3 days a week in the office, 2 days remote.",
+        "2-3 days per week in office required.",
+        "You'll be in the office 3 days a week.",
+    ])
+    def test_hybrid_detected(self, text: str) -> None:
+        assert detect_workplace(text).value is WorkplaceType.HYBRID
+
+    @pytest.mark.parametrize("text", [
+        "This role is onsite, based in our Leeds office.",
+        "On-site position, no remote working available.",
+        "This is an office-based role, 5 days in the office.",
+        "Office only — must be based in the office full time.",
+    ])
+    def test_onsite_detected(self, text: str) -> None:
+        assert detect_workplace(text).value is WorkplaceType.ONSITE
+
+
+class TestWorkplaceUnknownWhenSilent:
+    def test_no_mention_is_unknown(self) -> None:
+        assert detect_workplace(
+            "Great team, competitive salary, based in Leeds."
+        ).value is WorkplaceType.UNKNOWN
+
+    def test_empty_and_none_are_unknown(self) -> None:
+        assert detect_workplace("").value is WorkplaceType.UNKNOWN
+        assert detect_workplace(None).value is WorkplaceType.UNKNOWN
+        assert detect_workplace(None, None).value is WorkplaceType.UNKNOWN
+
+
+class TestWorkplacePrecedenceOrderingTrap:
+    """The spec's own example: hybrid signals must win over a co-occurring
+    'remote' mention, and an explicit remote statement must win over a
+    passing office mention."""
+
+    def test_hybrid_beats_a_co_occurring_remote_mention(self) -> None:
+        text = "Remote considered, but this hybrid role needs 2 days a week in the office."
+        assert detect_workplace(text).value is WorkplaceType.HYBRID
+
+    def test_day_cadence_beats_remote_even_without_the_word_hybrid(self) -> None:
+        text = "This role is remote-friendly with 3 days a week in the office."
+        # "remote-friendly" is NOT in the remote vocabulary (deliberately —
+        # see workplace_terms.txt); the cadence pattern alone should still
+        # win HYBRID here.
+        assert detect_workplace(text).value is WorkplaceType.HYBRID
+
+    def test_explicit_remote_beats_a_passing_office_mention(self) -> None:
+        text = (
+            "This is a fully remote position — we do have a small office "
+            "in London if you'd ever like to visit."
+        )
+        assert detect_workplace(text).value is WorkplaceType.REMOTE
+
+
+class TestWorkplaceOnsiteAmenityTrap:
+    """'On-site parking' / 'on-site gym' is a perk mention, not a
+    workplace-arrangement statement — a real UK ad-copy pattern."""
+
+    def test_onsite_parking_alone_is_not_a_workplace_verdict(self) -> None:
+        assert detect_workplace(
+            "Great benefits including free on-site parking and a pension scheme."
+        ).value is WorkplaceType.UNKNOWN
+
+    def test_onsite_gym_alone_is_not_a_workplace_verdict(self) -> None:
+        assert detect_workplace(
+            "We offer an on-site gym and subsidised canteen."
+        ).value is WorkplaceType.UNKNOWN
+
+    def test_amenity_mention_does_not_block_a_real_onsite_signal_elsewhere(self) -> None:
+        text = "Office-based role with free on-site parking."
+        assert detect_workplace(text).value is WorkplaceType.ONSITE
+
+
+class TestWorkplaceEnrichmentWins:
+    def test_llm_verdict_takes_precedence(self) -> None:
+        result = detect_workplace(
+            "This is a fully remote position.", enrichment_value="onsite"
+        )
+        assert result.value is WorkplaceType.ONSITE
+        assert result.reason == "enrichment"
+
+    def test_unknown_enrichment_falls_through_to_text(self) -> None:
+        result = detect_workplace(
+            "This is a fully remote position.", enrichment_value="unknown"
+        )
+        assert result.value is WorkplaceType.REMOTE
+        assert result.reason == "remote_term"
+
+    def test_none_enrichment_falls_through_to_text(self) -> None:
+        result = detect_workplace("Hybrid role.", enrichment_value=None)
+        assert result.value is WorkplaceType.HYBRID
+
+
+# ---------------------------------------------------------------------------
+# Location field — a fallback source, consulted only when prose is silent.
+# Real prod examples (manager audit, 2026-08-07): 165 jobs UNKNOWN while
+# location stated the arrangement outright.
+# ---------------------------------------------------------------------------
+
+
+class TestLocationBareRemote:
+    """A bare 'Remote' token is trusted in the LOCATION field even though
+    the identical bare word is banned in prose — see the module docstring's
+    'WHY LOCATION GETS ITS OWN RULES' for why that asymmetry is deliberate,
+    not an oversight."""
+
+    def test_bare_remote_location_no_description(self) -> None:
+        result = detect_workplace("", "Ranger", location="Remote")
+        assert result.value is WorkplaceType.REMOTE
+        assert result.reason == "location_remote"
+
+    def test_bare_remote_location_second_prod_example(self) -> None:
+        result = detect_workplace("", "Insight", location="Remote")
+        assert result.value is WorkplaceType.REMOTE
+
+    def test_empty_description_and_title_still_reads_location(self) -> None:
+        result = detect_workplace(None, None, location="Remote")
+        assert result.value is WorkplaceType.REMOTE
+
+
+class TestLocationMultiSite:
+    """Named office cities ALONGSIDE 'Remote' resolve to HYBRID — the
+    employer is offering a choice of site, not committing to fully remote.
+    WorkplaceType has no 'flexible' member, so HYBRID is the closest true
+    statement among remote/onsite/hybrid. See the module docstring for the
+    full defence of this call."""
+
+    def test_prod_example_lead_product_designer(self) -> None:
+        result = detect_workplace(
+            "", "Lead Product Designer", location="Cardiff, London or Remote (UK)"
+        )
+        assert result.value is WorkplaceType.HYBRID
+        assert result.reason == "location_multi_site"
+
+    def test_prod_example_ml_manager(self) -> None:
+        result = detect_workplace(
+            "",
+            "Machine Learning Manager, Operations",
+            location="Cardiff, London or Remote (UK)",
+        )
+        assert result.value is WorkplaceType.HYBRID
+
+    def test_office_and_remote_without_country_qualifier(self) -> None:
+        result = detect_workplace("", "Engineer", location="London or Remote")
+        assert result.value is WorkplaceType.HYBRID
+
+    def test_country_qualifier_alone_does_not_count_as_an_office(self) -> None:
+        """'Remote (UK)' — 'UK' is a nation qualifier, not a named office,
+        so this must stay pure REMOTE, not be dragged into HYBRID."""
+        result = detect_workplace("", "Engineer", location="Remote (UK)")
+        assert result.value is WorkplaceType.REMOTE
+        assert result.reason == "location_remote"
+
+
+class TestLocationVsDescriptionConflict:
+    """Prose is the MORE SPECIFIC claim and must win over a stale or
+    generic location field — requirement from the manager review."""
+
+    def test_explicit_onsite_description_beats_remote_location(self) -> None:
+        result = detect_workplace(
+            "This role is fully onsite, 5 days a week in the office.",
+            "Backend Engineer",
+            location="Remote",
+        )
+        assert result.value is WorkplaceType.ONSITE
+        assert result.reason == "onsite_term"
+
+    def test_explicit_hybrid_description_beats_remote_location(self) -> None:
+        result = detect_workplace(
+            "This is a hybrid role.",
+            "Backend Engineer",
+            location="Remote",
+        )
+        assert result.value is WorkplaceType.HYBRID
+
+    def test_explicit_remote_description_agrees_with_office_location(self) -> None:
+        """Description wins regardless of which way the conflict points."""
+        result = detect_workplace(
+            "This is a fully remote position.",
+            "Backend Engineer",
+            location="London",
+        )
+        assert result.value is WorkplaceType.REMOTE
+        assert result.reason == "remote_term"
+
+
+class TestLocationEmptyBehavesAsBefore:
+    def test_no_location_argument_is_unknown_when_text_is_silent(self) -> None:
+        result = detect_workplace("Great team, competitive salary.", "Engineer")
+        assert result.value is WorkplaceType.UNKNOWN
+
+    def test_empty_string_location_is_unknown_when_text_is_silent(self) -> None:
+        result = detect_workplace("Great team, competitive salary.", "Engineer", location="")
+        assert result.value is WorkplaceType.UNKNOWN
+
+    def test_none_location_is_unknown_when_text_is_silent(self) -> None:
+        result = detect_workplace("Great team, competitive salary.", "Engineer", location=None)
+        assert result.value is WorkplaceType.UNKNOWN
+
+    def test_whitespace_only_location_is_unknown(self) -> None:
+        result = detect_workplace("Great team, competitive salary.", "Engineer", location="   ")
+        assert result.value is WorkplaceType.UNKNOWN
+
+    def test_location_default_matches_omitted_location(self) -> None:
+        """The default value behaves identically to not passing it at all."""
+        omitted = detect_workplace("Great team, competitive salary.", "Engineer")
+        defaulted = detect_workplace("Great team, competitive salary.", "Engineer", location="")
+        assert omitted == defaulted
+
+
+class TestExistingCallersUnaffectedByLocationParam:
+    """Every existing (description, title) caller must be byte-for-byte
+    unaffected by adding the keyword-only `location` parameter."""
+
+    def test_positional_two_arg_call_still_works(self) -> None:
+        assert detect_workplace("This is a hybrid role.", "Engineer").value \
+            is WorkplaceType.HYBRID
+
+    def test_single_positional_arg_call_still_works(self) -> None:
+        assert detect_workplace("This is a fully remote position.").value \
+            is WorkplaceType.REMOTE
+
+    def test_enrichment_only_call_still_works(self) -> None:
+        result = detect_workplace("", enrichment_value="onsite")
+        assert result.value is WorkplaceType.ONSITE
+        assert result.reason == "enrichment"
+
+
+# ---------------------------------------------------------------------------
+# Seniority — each detected value
+# ---------------------------------------------------------------------------
+
+
+class TestSeniorityDetectedValues:
+    def test_intern(self) -> None:
+        assert detect_seniority("Summer Intern, Data Team").value is SeniorityLevel.INTERN
+
+    def test_junior(self) -> None:
+        assert detect_seniority("Graduate Software Engineer").value is SeniorityLevel.JUNIOR
+
+    def test_mid(self) -> None:
+        assert detect_seniority("Mid-level Backend Developer").value is SeniorityLevel.MID
+
+    def test_senior(self) -> None:
+        assert detect_seniority("Senior Backend Engineer").value is SeniorityLevel.SENIOR
+
+    def test_staff(self) -> None:
+        assert detect_seniority("Staff Software Engineer").value is SeniorityLevel.STAFF
+
+    def test_principal(self) -> None:
+        assert detect_seniority("Principal Engineer").value is SeniorityLevel.PRINCIPAL
+
+    def test_director(self) -> None:
+        assert detect_seniority("Director of Engineering").value is SeniorityLevel.DIRECTOR
+
+
+class TestSeniorityUnknownWhenSilent:
+    def test_no_mention_is_unknown(self) -> None:
+        assert detect_seniority("Backend Developer", "Great team, nice office.").value \
+            is SeniorityLevel.UNKNOWN
+
+    def test_empty_and_none_are_unknown(self) -> None:
+        assert detect_seniority("").value is SeniorityLevel.UNKNOWN
+        assert detect_seniority(None).value is SeniorityLevel.UNKNOWN
+        assert detect_seniority(None, None).value is SeniorityLevel.UNKNOWN
+        assert detect_seniority().value is SeniorityLevel.UNKNOWN
+
+
+class TestSeniorityReadsTitleFirst:
+    def test_title_signal_wins_over_description_signal(self) -> None:
+        result = detect_seniority(
+            "Senior Backend Engineer",
+            "You'll mentor our graduate scheme intake.",
+        )
+        assert result.value is SeniorityLevel.SENIOR
+        assert result.reason == "title"
+
+    def test_description_fills_the_gap_when_title_is_silent(self) -> None:
+        result = detect_seniority(
+            "Backend Engineer",
+            "This is a senior role requiring 8+ years' experience.",
+        )
+        assert result.value is SeniorityLevel.SENIOR
+        assert result.reason == "description"
+
+    def test_title_exists_when_description_is_empty(self) -> None:
+        """The whole point: the 1,311 no-description jobs still have a title."""
+        result = detect_seniority("Graduate Data Analyst", "")
+        assert result.value is SeniorityLevel.JUNIOR
+        assert result.reason == "title"
+
+
+class TestSeniorityFalsePositiveTraps:
+    def test_junior_school_teacher_is_not_junior(self) -> None:
+        """'Junior School' is a UK institution (ages 7-11), not a claim
+        about the role's level."""
+        assert detect_seniority("Junior School Teacher").value is SeniorityLevel.UNKNOWN
+
+    def test_junior_school_teacher_with_description_still_unknown(self) -> None:
+        assert detect_seniority(
+            "Junior School Teacher",
+            "Join our friendly junior school in a supportive environment.",
+        ).value is SeniorityLevel.UNKNOWN
+
+    def test_senior_care_assistant_is_genuinely_senior(self) -> None:
+        """Contrast case: 'Senior Care Assistant' is a real, genuinely
+        senior title in the care sector — it must NOT be swept up by the
+        junior-school-style guard."""
+        assert detect_seniority("Senior Care Assistant").value is SeniorityLevel.SENIOR
+
+    def test_head_of_year_is_not_director(self) -> None:
+        """'Head of Year' is a school pastoral title, not the
+        department-leadership sense 'head of' means elsewhere."""
+        assert detect_seniority("Head of Year 5").value is SeniorityLevel.UNKNOWN
+
+    def test_head_of_house_is_not_director(self) -> None:
+        assert detect_seniority("Head of House Coordinator").value is SeniorityLevel.UNKNOWN
+
+    def test_head_of_engineering_is_genuinely_director(self) -> None:
+        """Contrast case: 'head of' outside the school-pastoral phrases is a
+        real leadership title and must still fire."""
+        assert detect_seniority("Head of Engineering").value is SeniorityLevel.DIRECTOR
+
+    def test_staff_nurse_is_not_staff_tier(self) -> None:
+        """'Staff Nurse' is an NHS entry grade (Band 5) — bare 'staff' is
+        deliberately absent from the vocabulary for this reason."""
+        assert detect_seniority("Staff Nurse").value is SeniorityLevel.UNKNOWN
+
+    def test_account_executive_is_not_director(self) -> None:
+        """'Account Executive' is a common UK entry-level sales title
+        despite containing 'executive' — bare 'executive' is deliberately
+        absent from the vocabulary."""
+        assert detect_seniority("Account Executive").value is SeniorityLevel.UNKNOWN
+
+    def test_lead_generation_is_not_a_seniority_claim(self) -> None:
+        """'Lead Generation Executive' — 'lead' here names a sales
+        prospect, not the role's seniority."""
+        assert detect_seniority("Lead Generation Executive").value is SeniorityLevel.UNKNOWN
+
+    def test_graduate_degree_requirement_reads_as_the_experience_level(self) -> None:
+        """'Graduate' can describe an educational requirement rather than
+        the role's level; when a genuine senior signal is also present, the
+        senior-first rank order resolves it correctly."""
+        result = detect_seniority(
+            "Backend Engineer",
+            "Senior role, must hold a graduate degree and have 5+ years' experience.",
+        )
+        assert result.value is SeniorityLevel.SENIOR
+
+
+class TestSeniorityEnrichmentWins:
+    def test_llm_verdict_takes_precedence(self) -> None:
+        result = detect_seniority("Graduate Software Engineer", enrichment_value="senior")
+        assert result.value is SeniorityLevel.SENIOR
+        assert result.reason == "enrichment"
+
+    def test_unknown_enrichment_falls_through_to_text(self) -> None:
+        result = detect_seniority("Graduate Software Engineer", enrichment_value="unknown")
+        assert result.value is SeniorityLevel.JUNIOR
+        assert result.reason == "title"
+
+    def test_none_enrichment_falls_through_to_text(self) -> None:
+        result = detect_seniority("Principal Engineer", enrichment_value=None)
+        assert result.value is SeniorityLevel.PRINCIPAL
+
+
+# ---------------------------------------------------------------------------
+# Missing data file degrades to UNKNOWN, never raises
+# ---------------------------------------------------------------------------
+
+
+class TestMissingDataFileDegradesGracefully:
+    def test_workplace_terms_file_missing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from src.services import job_signals
+
+        job_signals._workplace_terms.cache_clear()
+        monkeypatch.setattr(job_signals, "_DATA", job_signals._DATA / "does_not_exist")
+        try:
+            result = job_signals.detect_workplace("This is a fully remote position.")
+            assert result.value is WorkplaceType.UNKNOWN
+            assert result.reason == "no_signal"
+        finally:
+            job_signals._workplace_terms.cache_clear()
+
+    def test_seniority_terms_file_missing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from src.services import job_signals
+
+        job_signals._seniority_terms.cache_clear()
+        monkeypatch.setattr(job_signals, "_DATA", job_signals._DATA / "does_not_exist")
+        try:
+            result = job_signals.detect_seniority("Senior Backend Engineer")
+            assert result.value is SeniorityLevel.UNKNOWN
+            assert result.reason == "no_signal"
+        finally:
+            job_signals._seniority_terms.cache_clear()
+
+    def test_location_terms_file_missing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from src.services import job_signals
+
+        job_signals._location_terms.cache_clear()
+        monkeypatch.setattr(job_signals, "_DATA", job_signals._DATA / "does_not_exist")
+        try:
+            result = job_signals.detect_workplace("", "Ranger", location="Remote")
+            assert result.value is WorkplaceType.UNKNOWN
+            assert result.reason == "no_signal"
+        finally:
+            job_signals._location_terms.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# Result types are the reused enums, not parallel ones
+# ---------------------------------------------------------------------------
+
+
+class TestResultTypesReuseSharedEnums:
+    def test_workplace_signal_wraps_workplace_type(self) -> None:
+        result = detect_workplace("Hybrid role.")
+        assert isinstance(result, WorkplaceSignal)
+        assert isinstance(result.value, WorkplaceType)
+
+    def test_seniority_signal_wraps_seniority_level(self) -> None:
+        result = detect_seniority("Senior Engineer")
+        assert isinstance(result, SenioritySignal)
+        assert isinstance(result.value, SeniorityLevel)
+
+
+class TestSignalBackedLookupWiring:
+    """The detectors are only worth building if something CALLS them.
+
+    `JobScorer(enrichment_lookup=...)` takes a callable OF A JOB — the one
+    place where the enrichment record and the job's own title/location are
+    both in scope. The bulk loader is keyed by job_id and never sees the job;
+    the dim scorers receive only the enrichment. So this wrapper is the single
+    seam, and wiring it once reaches the API read path, rescore and the worker.
+    """
+
+    class _Job:
+        def __init__(self, title="", description="", location=""):
+            self.id = 1
+            self.title = title
+            self.description = description
+            self.location = location
+
+    class _Enrichment:
+        def __init__(self, workplace_type="unknown", seniority="unknown"):
+            self.workplace_type = workplace_type
+            self.seniority = seniority
+
+    def test_fills_unknown_from_the_title(self):
+        from src.services.job_signals import signal_backed_lookup
+
+        enr = self._Enrichment()
+        job = self._Job(title="Senior Data Engineer")
+        out = signal_backed_lookup(lambda j: enr)(job)
+        assert str(getattr(out.seniority, "value", out.seniority)) == "senior"
+
+    def test_fills_workplace_from_the_location_field(self):
+        from src.services.job_signals import signal_backed_lookup
+
+        enr = self._Enrichment()
+        job = self._Job(title="Ranger", location="Remote")
+        out = signal_backed_lookup(lambda j: enr)(job)
+        assert str(getattr(out.workplace_type, "value", out.workplace_type)) == "remote"
+
+    def test_never_overwrites_an_llm_verdict(self):
+        """Precedence is one-way: the LLM read the whole ad, the detector read
+        a title. Only a literal 'unknown' may be filled."""
+        from src.services.job_signals import signal_backed_lookup
+
+        enr = self._Enrichment(seniority="junior")
+        job = self._Job(title="Senior Data Engineer")
+        out = signal_backed_lookup(lambda j: enr)(job)
+        assert str(getattr(out.seniority, "value", out.seniority)) == "junior"
+
+    def test_missing_enrichment_stays_none(self):
+        from src.services.job_signals import signal_backed_lookup
+
+        assert signal_backed_lookup(lambda j: None)(self._Job()) is None
+
+    def test_a_detector_failure_can_never_break_scoring(self):
+        """A frozen/validated model may refuse assignment. The dim scorer must
+        then see 'unknown' and return its neutral constant — never raise."""
+        from src.services.job_signals import signal_backed_lookup
+
+        class Frozen:
+            workplace_type = "unknown"
+            seniority = "unknown"
+
+            def __setattr__(self, *a):
+                raise AttributeError("frozen")
+
+        out = signal_backed_lookup(lambda j: Frozen())(
+            self._Job(title="Senior Engineer")
+        )
+        assert out is not None

--- a/backend/tests/test_profile.py
+++ b/backend/tests/test_profile.py
@@ -660,6 +660,84 @@ class TestLLMCVParser:
         # None and 42 dropped from list cleanly
 
 
+class TestCvPromptRequestsCareerDomain:
+    """BUG 1a (Pillar-1 audit 2026-08-07). `_CV_PROMPT`'s JSON schema never
+    asked for `career_domain`, even though `CVSchema.career_domain` and the
+    `CareerDomain` enum have existed since Batch 1.1 — so the LLM had no
+    reason to ever return one. Asserts PROMPT CONTENT (matches the style of
+    test_cv_prompt_steering.py), not LLM behaviour."""
+
+    def test_prompt_asks_for_career_domain(self):
+        from src.services.profile import cv_parser
+
+        p = cv_parser._CV_PROMPT.lower()
+        assert '"career_domain"' in p
+
+    def test_prompt_lists_the_real_enum_members_not_invented_values(self):
+        """The allowed values in the prompt must be the ACTUAL `CareerDomain`
+        members — a mismatched or partial list would have the model return
+        buckets `CVSchema` then rejects, wasting a retry."""
+        from src.services.profile import cv_parser
+        from src.services.profile.schemas import CareerDomain
+
+        p = cv_parser._CV_PROMPT
+        for member in CareerDomain:
+            assert member.value in p, f"{member.value!r} missing from the CV prompt"
+
+    def test_prompt_tells_the_model_to_return_null_when_unclear(self):
+        """Steering against guessing — a wrong classification corrupts
+        downstream archetype-aware scoring more than an absent one."""
+        from src.services.profile import cv_parser
+
+        p = cv_parser._CV_PROMPT.lower()
+        assert "null" in p
+        assert "guess" in p
+
+
+class TestCvSchemaEscoNormalisation:
+    """BUG 2 (Pillar-1 audit 2026-08-07). `_maybe_normalise_skills_via_esco`
+    was only ever called from `cv_parser._llm_result_to_cvdata` — the untyped
+    DEFENSIVE FALLBACK, reached only when strict `CVSchema` validation
+    exhausts its retries. `cv_schema_to_cvdata` (the path every successful
+    extraction actually returns through) built `CVData(...)` with no
+    `cv_skills_esco=` argument at all, so prod (`SEMANTIC_ENABLED=true`)
+    shipped `cv_skills_esco={}` on every profile regardless of the flag.
+    """
+
+    def _schema(self):
+        from src.services.profile.schemas import CVSchema
+
+        return CVSchema(skills=["Python", "Docker"])
+
+    def test_populates_cv_skills_esco_when_esco_data_is_available(self):
+        from unittest.mock import patch
+
+        from src.services.profile.schemas import cv_schema_to_cvdata
+
+        fake_map = {"Python": "http://esco/python"}
+        with patch(
+            "src.services.profile.schemas._maybe_normalise_skills_via_esco",
+            return_value=(["Python", "Docker"], fake_map),
+        ) as mock_norm:
+            cv = cv_schema_to_cvdata(self._schema(), "raw")
+
+        mock_norm.assert_called_once_with(["Python", "Docker"])
+        assert cv.cv_skills_esco == fake_map
+
+    def test_returns_empty_dict_without_raising_when_esco_unavailable(self):
+        """Flag-off / no-index-on-disk is the DEFAULT runtime state
+        (`SEMANTIC_ENABLED` defaults false, root rule #18) — this must
+        degrade to `{}` silently, never raise. No mocking: the test
+        environment genuinely has the flag off and no ESCO index on disk
+        (conftest.py + no backend/data/esco/), so the real normaliser runs
+        its own no-op path."""
+        from src.services.profile.schemas import cv_schema_to_cvdata
+
+        cv = cv_schema_to_cvdata(self._schema(), "raw")
+        assert cv.cv_skills_esco == {}
+        assert cv.skills == ["Python", "Docker"]
+
+
 class TestCVParserFailures:
     """Tests for C2 — parse_cv_async must raise, not silently return empty."""
 

--- a/backend/tests/test_telemetry.py
+++ b/backend/tests/test_telemetry.py
@@ -151,7 +151,6 @@ def test_enrichment_telemetry_counters_increment(monkeypatch):
     from src.models import Job
     from src.services import job_enrichment as je
     from src.services.job_enrichment_schema import (
-        EmployerType,
         EmploymentType,
         ExperienceLevel,
         JobCategory,
@@ -172,7 +171,6 @@ def test_enrichment_telemetry_counters_increment(monkeypatch):
             category=JobCategory.MACHINE_LEARNING,
             employment_type=EmploymentType.FULL_TIME,
             workplace_type=WorkplaceType.HYBRID,
-            locations=["London"],
             salary=SalaryBand(min=60000, max=90000, currency="GBP", frequency=SalaryFrequency.ANNUAL),
             required_skills=["python"],
             preferred_skills=[],
@@ -180,7 +178,6 @@ def test_enrichment_telemetry_counters_increment(monkeypatch):
             experience_level=ExperienceLevel.MID,
             requirements_summary="Build models.",
             language="en",
-            employer_type=EmployerType.STARTUP,
             visa_sponsorship=VisaSponsorship.UNKNOWN,
             seniority=SeniorityLevel.MID,
             remote_region=None,

--- a/backend/tests/test_two_pass.py
+++ b/backend/tests/test_two_pass.py
@@ -909,3 +909,77 @@ async def test_cv_positions_replace_not_duplicate_on_reextraction(monkeypatch):
         out = await two_pass.run_two_pass_extraction(profile)
 
     assert len(out.cv_data.cv_positions) == 1, "re-extraction duplicated the role"
+
+
+# ── career_domain / cv_skills_esco merge — Pillar-1 audit 2026-08-07 ───────
+# Same bug shape as `cv_positions` above, twice more in one day:
+#   * career_domain: the CV prompt never asked for it, and even once it does
+#     (cv_parser._CV_PROMPT), `_merge_cv_llm_into` had no line copying it.
+#   * cv_skills_esco: `cv_schema_to_cvdata` never populated it (fixed in
+#     schemas.py), and even once it does, this merge had no line for it
+#     either — `reset_cv_owned_fields` has always CLEARED this field on a CV
+#     swap, treating it as CV-owned, but nothing ever wrote it back.
+
+
+def test_merge_cv_llm_into_fills_career_domain_when_empty():
+    from src.services.profile.two_pass import _merge_cv_llm_into
+
+    cv = CVData(skills=["Python"])
+    llm_cv = CVData(career_domain="software_engineering")
+    _merge_cv_llm_into(cv, llm_cv)
+    assert cv.career_domain == "software_engineering"
+
+
+def test_merge_cv_llm_into_never_overwrites_existing_career_domain():
+    """Fill-if-empty, like every other scalar in this function — a
+    re-classification on a later re-run must not clobber what the user's
+    profile already carries."""
+    from src.services.profile.two_pass import _merge_cv_llm_into
+
+    cv = CVData(career_domain="healthcare_and_lifesciences")
+    llm_cv = CVData(career_domain="data_and_ai")
+    _merge_cv_llm_into(cv, llm_cv)
+    assert cv.career_domain == "healthcare_and_lifesciences"
+
+
+def test_merge_cv_llm_into_unions_cv_skills_esco():
+    from src.services.profile.two_pass import _merge_cv_llm_into
+
+    cv = CVData(cv_skills_esco={"Python": "http://esco/python"})
+    llm_cv = CVData(cv_skills_esco={"Docker": "http://esco/docker"})
+    _merge_cv_llm_into(cv, llm_cv)
+    assert cv.cv_skills_esco == {
+        "Python": "http://esco/python",
+        "Docker": "http://esco/docker",
+    }
+
+
+@pytest.mark.asyncio
+async def test_career_domain_survives_the_two_pass_merge():
+    """End-to-end: a value the CV LLM pass classifies must reach the merged
+    profile, not just the isolated adapter output."""
+    from src.services.profile import llm_curate, two_pass
+    from src.services.profile.models import CVData, UserPreferences, UserProfile
+
+    async def fake_cv(text, *a, **kw):
+        return CVData(skills=["Python"], career_domain="data_and_ai")
+
+    async def _noop_list(*a, **kw):
+        return []
+
+    async def _pass(items, *a, **kw):
+        return items
+
+    profile = UserProfile(
+        cv_data=CVData(raw_text="Data scientist CV text"),
+        preferences=UserPreferences(),
+    )
+    with patch.object(two_pass, "llm_cv_fields_from_text", fake_cv), \
+         patch.object(two_pass, "llm_linkedin_fields", _noop_list), \
+         patch.object(two_pass, "llm_infer_github_skills", _noop_list), \
+         patch.object(two_pass, "llm_infer_from_about_me", _noop_list), \
+         patch.object(llm_curate, "llm_suggest_adjacent_skills", _noop_list), \
+         patch.object(llm_curate, "llm_merge_duplicates", _pass):
+        out = await two_pass.run_two_pass_extraction(profile)
+
+    assert out.cv_data.career_domain == "data_and_ai"


### PR DESCRIPTION
A full audit of `main` (= production) against the live catalog, asking one question per matching dimension: **is both sides of the shelf actually stocked?** Five real defects, all measured.

## 1. The instrument was lying — in both directions
`shelf_xray.py` tested string *shape*, not value presence: `e.salary NOT IN ('{}','')` passes `{"min": null}`.

| | claimed | truth |
|---|---|---|
| skills | 69% | **95%** |
| salary | 83% | **52%** |
| visa | 3% | **49%** |

Exactly the trap hard rule #21 warns about — in the tool built to enforce it. New `services/coverage.py` holds one `job_has_value()` per dimension; the X-ray may no longer write its own SQL. **81 canary tests** seed known ground truth in every empty shape and assert the count is *exactly k*, so a future predicate that admits a shell breaks CI immediately.

## 2. Two extractions structurally dead for every user
- **`career_domain`** — the prompt never asked for it **and** the merge dropped it. Two faults, one field.
- **`cv_skills_esco`** — the ESCO normalizer lived in the *fallback* adapter; production returns through the other one.

**Third instance today of the same shape** (`cv_positions` was the first). `test_adapter_parity.py` now asserts both adapters populate the same field set with an **empty allow-list** — the worker fixed `industries`/`cv_languages` in the fallback rather than allow-listing the gap. A fourth can't happen silently.

## 3. Two dimensions dark because the LLM had nothing to read
```
desc <200 chars       workplace 73% unknown
desc 1,000-3,000      workplace 13% unknown     ← 1,311 jobs are in the first band
```
Deterministic detectors reading **title + location** (which exist when descriptions don't):

**seniority 27% → 60%** (+1,434; 656 with almost no description) · **workplace 22% → 29%** (+296)

UK traps pinned: bare "staff" misfires on **Staff Nurse** (NHS Band 5 is *entry*), bare "executive" on **Account Executive**, `"no remote working available"` *contains* `"remote working"`. Bare "remote" is trusted in the location field but banned in prose — deliberate asymmetry, commented.

**Wired, not left as an artifact:** `signal_backed_lookup()` wraps the enrichment callable — the only seam seeing both the enrichment and the job's own text — so API/rescore/worker all gain it with no scoring formula changed. One-way precedence: an LLM verdict is never overwritten.

## 4. Two enrichment fields that never produced a value
`employer_type` 'unknown' on 3,119/3,119; `locations` 0 populated and redundant. Removed from the schema; **columns kept** (destructive schema work needs explicit sign-off).

The worker **corrected my brief** here and was right: I claimed these burned tokens — verified false, they were never in the prompt. Zero tokens saved; the real cost was feeding a false coverage signal.

+204 tests. ruff clean. Gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6DsQH5EUxJc3Vnqz9YHgQ
