### PR TITLE
feat(text+seniority): fetch the missing job text, and read the user's level from their CV

### DIFF
--- a/backend/migrations/0029_description_backfill_attempts.down.sql
+++ b/backend/migrations/0029_description_backfill_attempts.down.sql
@@ -1,0 +1,5 @@
+-- Reverse of 0029 — drops the retry counter. No real data loss: dropping it
+-- just means every job looks "never attempted" again on the next boot,
+-- which is the safe direction for a rollback (worst case, a few jobs get
+-- fetched once more before the column comes back).
+ALTER TABLE jobs DROP COLUMN IF EXISTS description_backfill_attempts;

--- a/backend/migrations/0029_description_backfill_attempts.up.sql
+++ b/backend/migrations/0029_description_backfill_attempts.up.sql
@@ -1,0 +1,29 @@
+-- 0029_description_backfill_attempts: a real per-job retry counter for the
+-- description-backfill sweep (workers/tasks.py::_backfill_thin_descriptions).
+--
+-- WHY (2026-08-07). The first version of this sweep tried to avoid a schema
+-- migration by padding a fetched-but-still-thin job's `description` with
+-- trailing spaces past coverage.py's `_SKILL_TEXT_MIN_CHARS` floor (200
+-- chars), purely so the SELECT that finds thin jobs would stop reselecting
+-- it. That was rejected in review: coverage.py:142 counts ANY description
+-- longer than 200 chars as real skill-text coverage, with no whitespace
+-- check — so padding a job that had ten real words manufactured a FALSE
+-- coverage signal, the exact class of bug a same-day batch had just spent
+-- effort eliminating (a shelf X-ray predicate once counted an empty JSON
+-- shell as "salary present": reported 83% coverage when the real figure was
+-- ~5%). Worse, the padded whitespace was also fed to the LLM judge and the
+-- keyword scorer as if it were content, and rendered to real users on the
+-- job card.
+--
+-- The honest fix needs real state: a counter that survives worker restarts
+-- and lives OUTSIDE the `description` column, so `description` is never
+-- written except with genuinely fetched text — never padded, never
+-- sentinel-stamped. A job that has been fetched `description_backfill_attempts`
+-- times (capped at 3 — see MAX_BACKFILL_ATTEMPTS in
+-- services/description_backfill.py) without ever clearing the 200-char floor
+-- simply stops being selected; the SELECT predicate does the "stop retrying
+-- forever" job, not the data itself.
+--
+-- Additive and non-destructive: defaults to 0, so every existing row starts
+-- with a full attempt budget. Shared catalog — no user_id (CLAUDE.md rule #10).
+ALTER TABLE jobs ADD COLUMN IF NOT EXISTS description_backfill_attempts INTEGER DEFAULT 0;

--- a/backend/src/core/settings.py
+++ b/backend/src/core/settings.py
@@ -219,6 +219,19 @@ SEMANTIC_ENABLED = os.getenv("SEMANTIC_ENABLED", "false").lower() in {"1", "true
 # 0 disables. Only active when SEMANTIC_ENABLED is on (rule #18).
 EMBED_BACKFILL_PER_RUN = int(os.getenv("EMBED_BACKFILL_PER_RUN", "300"))
 
+# Description-backfill phase of the enrichment_sweep cron (2026-08-07) —
+# workers/tasks.py::_backfill_thin_descriptions. Sources fetch job-detail
+# pages under strict PER-RUN budgets (_MAX_DETAIL_FETCHES in workday.py /
+# smartrecruiters.py) so a single run never blows the 240s ATS timeout; a job
+# stored past that budget keeps description="" forever unless something goes
+# back for it. Measured in prod: 1,311 active jobs (30% of the catalog) carry
+# under 200 chars of description, and coverage of every enriched field
+# (workplace/seniority/visa) tracks description length almost perfectly.
+# Same knobs as ENRICHMENT_SWEEP_PER_TICK: default 50/tick keeps HTTP fetch
+# volume polite across the 30-min cron cadence; `0` disables the phase
+# entirely (no SELECT, no fetch, no-op).
+DESCRIPTION_BACKFILL_PER_TICK = int(os.getenv("DESCRIPTION_BACKFILL_PER_TICK", "50"))
+
 
 def _env_flag(name: str, default: bool) -> bool:
     """Read a boolean env var. Unset -> ``default``. Accepts 1/true/yes/on."""

--- a/backend/src/repositories/database.py
+++ b/backend/src/repositories/database.py
@@ -191,6 +191,11 @@ class JobDatabase:
             # Migration 0020 — application deadline columns.
             ("deadline", "TEXT"),
             ("deadline_source", "TEXT"),
+            # Migration 0029 — description-backfill retry counter. Real state
+            # (not a padded description) so a thin job stops being re-fetched
+            # after MAX_BACKFILL_ATTEMPTS without faking coverage.py's
+            # skill-text signal (see 0029's up.sql for the full incident).
+            ("description_backfill_attempts", "INTEGER DEFAULT 0"),
         ]
         run_log_migrations = [
             # Step-0 pre-flight — migration 0010 observability columns.

--- a/backend/src/services/description_backfill.py
+++ b/backend/src/services/description_backfill.py
@@ -1,0 +1,255 @@
+"""Re-fetch fresh description text for jobs whose stored text is too thin to
+score, enrich, or judge meaningfully.
+
+WHY THIS EXISTS (measured in prod, 2026-08-07): sources fetch job-detail
+pages under strict PER-RUN budgets (``_MAX_DETAIL_FETCHES`` — workday.py 40,
+smartrecruiters.py 60, linkedin.py 30) so one run never blows the 240s ATS
+timeout. A job that lands past that budget is stored with an empty/short
+description, and NOTHING in the pipeline ever goes back for it — a source
+only re-fetches a stored job if it happens to reappear in a LATER run's
+listing. Coverage of every LLM-enriched field (workplace/seniority/visa)
+tracks description length almost perfectly, so 1,311 active jobs (30% of the
+catalog) carrying under 200 chars of description are functionally
+unscoreable. This module is the "go back for it" step. It is called from the
+``enrichment_sweep`` cron's BACKFILL phase (``workers/tasks.py``) — never a
+separate task, per the instruction to extend the existing self-heal loop
+rather than add a new cron surface.
+
+Design principle: reuse each source's OWN parsing logic; never duplicate
+HTML-tag-stripping or JSON-field-extraction here. Each allowed source already
+exposes (or, for greenhouse, gains one narrow addition) a per-JOB detail-fetch
+method — the ingestion path just never needed to call it again AFTER storage.
+This module's only genuinely new logic is reconstructing that method's call
+arguments FROM a job's stored ``apply_url``, since nothing before now needed
+to reverse that encoding.
+
+TERMINAL STATE — real counter, not a padded description (2026-08-07). The
+first version of this module tried to avoid a schema migration by padding a
+still-thin ``description`` with trailing spaces past the selection floor so
+the job would stop being reselected. That was REJECTED in review: it fakes
+coverage. ``src/services/coverage.py::_has_skill_value`` counts any
+``description`` longer than ``_SKILL_TEXT_MIN_CHARS`` (200) as real skill-text
+coverage with no whitespace check, so a padded row started reporting "we
+understand this job's skills" when it did not — the exact class of bug a
+same-day batch (``coverage.py``'s own docstring) had just spent effort
+eliminating (a shelf X-ray predicate once counted an empty JSON shell as
+"salary present": reported 83%, real figure ~5%). The padding was also fed to
+the LLM judge and the keyword scorer as if it were content, and rendered to
+real users on the job card. The fix is migration 0029
+(``jobs.description_backfill_attempts``, INTEGER DEFAULT 0): real, restart-
+durable state that lives OUTSIDE ``description``. ``description`` is now
+NEVER written except with genuinely fetched (and whitespace-stripped) text.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any, Optional
+from urllib.parse import urlparse
+
+import aiohttp
+
+from src.core.companies import GREENHOUSE_COMPANIES, SMARTRECRUITERS_COMPANIES, WORKDAY_COMPANIES
+
+logger = logging.getLogger("job360.services.description_backfill")
+
+# Selection floor shared with workers/tasks.py's SQL
+# (`length(description) < MIN_DESCRIPTION_CHARS`) and the "did this fetch
+# actually help" check below — a single constant so the two can never drift
+# apart. Also happens to equal coverage.py's `_SKILL_TEXT_MIN_CHARS` (not a
+# coincidence: this IS the floor that decides whether the skill-matcher
+# considers a description real text).
+MIN_DESCRIPTION_CHARS = 200
+
+# Real per-job retry cap (migration 0029, jobs.description_backfill_attempts).
+# A job fetched this many times without ever clearing MIN_DESCRIPTION_CHARS
+# stops being selected — see the SELECT predicate in
+# workers/tasks.py::_backfill_thin_descriptions.
+MAX_BACKFILL_ATTEMPTS = 3
+
+# PER-SOURCE CAPABILITY FLAG (non-negotiable per spec) — some sources
+# structurally cannot give more text than they already did, and hammering a
+# scraper from an unattended background sweep (rather than a human-triggered
+# search) risks getting it blocked. Every entry below states WHY it is in.
+ALLOWED_BACKFILL_SOURCES: frozenset[str] = frozenset({
+    # IN — static company registry (core/companies.py) + a real per-JOB
+    # detail endpoint that ingestion already proved works. Re-deriving the
+    # call args from apply_url is an EXACT reversal (see _refetch_workday),
+    # so this is a single, precise HTTP call per job — not a re-list.
+    "workday",
+    # IN — same shape as workday: apply_url encodes (slug, posting_id)
+    # whenever it follows SmartRecruiters' own public URL pattern.
+    "smartrecruiters",
+    # IN — apply_url encodes (slug, job_id); a new narrow per-job endpoint
+    # was added to GreenhouseSource (fetch_jobs() only ever listed a whole
+    # board before).
+    "greenhouse",
+    # IN — single flat catalog (no per-company partition): ONE HTTP call
+    # refreshes the WHOLE feed, so it can backfill every thin devitjobs job
+    # selected this tick for the cost of one request. Description is
+    # COMPOSED from structured fields (technologies/tags/etc), not prose, so
+    # some rows will stay thin forever if the upstream API genuinely has
+    # nothing more for them — that is a real ceiling of the source, not a
+    # bug in this module.
+    "devitjobs",
+})
+# OUT, by explicit spec mandate — LinkedIn is a scraper (regex over guest
+# HTML, no official API). Hammering it from an unattended 30-min cron risks
+# the shared IP/UA getting rate-limited or blocked, which would also break
+# the LIVE search path real users depend on. LinkedInSource already has its
+# own _fetch_description(view_url) and it WOULD work mechanically — this is
+# a deliberate exclusion, not a technical gap.
+#
+# OUT — hn_jobs reads the read-only Algolia HN Search API, which only ever
+# exposes a Show/Ask HN post's title + URL. There is no body-text field to
+# re-fetch, so an attempt could never produce more text than is already
+# stored — it would just waste budget every tick.
+#
+# OUT — aijobs_ai is an HTML-scraper source whose LISTING page IS the detail
+# page (no separate per-job URL exists to fetch); re-fetching would return
+# the identical content every time.
+
+_GREENHOUSE_PATH_RE = re.compile(r"/([^/]+)/jobs/(\d+)")
+_SMARTRECRUITERS_PATH_RE = re.compile(r"smartrecruiters\.com/([^/]+)/([^/?#]+)")
+
+
+def _normalize_slug(value: str) -> str:
+    """Fold a slug down to bare alnum chars.
+
+    Needed because a stored ``apply_url`` and the canonical
+    ``core/companies.py`` entry can disagree on casing/dashes — e.g.
+    SmartRecruiters' own ``ref`` links sometimes CamelCase a company that the
+    postings-list API slugs with dashes (``SamsungRAndDInstituteUk`` vs
+    ``samsung-r-and-d-institute-uk``). Comparing normalized forms lets the
+    lookup succeed anyway, while still resolving to the CANONICAL registry
+    slug the API call actually needs.
+    """
+    return re.sub(r"[^a-z0-9]", "", value.lower())
+
+
+def _match_registry_slug(candidate: str, registry: list[str]) -> Optional[str]:
+    norm = _normalize_slug(candidate)
+    for slug in registry:
+        if _normalize_slug(slug) == norm:
+            return slug
+    return None
+
+
+async def _refetch_workday(apply_url: str, session: aiohttp.ClientSession) -> Optional[str]:
+    """Reconstruct the CXS detail call from a stored Workday apply_url.
+
+    ``apply_url`` was built at ingestion as ``f"{base_url}/en-US{ext_path}"``
+    (workday.py's ``fetch_jobs``) — an EXACT, lossless encoding of
+    ``ext_path``, so stripping the ``/en-US`` prefix back off recovers the
+    identical value the detail endpoint needs. ``wd``/``site`` never appear
+    in the URL at all, so they come from the static WORKDAY_COMPANIES
+    registry, matched by tenant (the URL's first host label).
+    """
+    from src.sources.ats.workday import WorkdaySource
+
+    parsed = urlparse(apply_url)
+    host = parsed.hostname or ""
+    tenant = host.split(".")[0] if host else ""
+    if not tenant or not parsed.path:
+        return None
+    entry = next((e for e in WORKDAY_COMPANIES if e["tenant"] == tenant), None)
+    if entry is None:
+        return None
+    ext_path = parsed.path[len("/en-US"):] if parsed.path.startswith("/en-US") else parsed.path
+    base_url = f"https://{tenant}.{entry['wd']}.myworkdayjobs.com"
+    source = WorkdaySource(session)
+    return await source._fetch_job_description(base_url, tenant, entry["site"], ext_path)
+
+
+async def _refetch_smartrecruiters(apply_url: str, session: aiohttp.ClientSession) -> Optional[str]:
+    """Reconstruct the (slug, posting_id) pair a stored SmartRecruiters
+    apply_url encodes, when it follows the public
+    ``jobs.smartrecruiters.com/{slug}/{id}`` shape — SmartRecruitersSource's
+    own fallback format, and also what most ``ref`` links from the API use.
+    A URL that doesn't match (a company's own custom careers-page ref) can't
+    be reversed — return None rather than guess.
+    """
+    from src.sources.ats.smartrecruiters import SmartRecruitersSource
+
+    m = _SMARTRECRUITERS_PATH_RE.search(apply_url)
+    if not m:
+        return None
+    slug = _match_registry_slug(m.group(1), SMARTRECRUITERS_COMPANIES)
+    if slug is None:
+        return None
+    posting_id = m.group(2)
+    source = SmartRecruitersSource(session)
+    return await source._fetch_posting_text(slug, posting_id)
+
+
+async def _refetch_greenhouse(apply_url: str, session: aiohttp.ClientSession) -> Optional[str]:
+    """Reconstruct (slug, job_id) from a stored Greenhouse absolute_url and
+    hit the per-job detail endpoint added to GreenhouseSource for this."""
+    from src.sources.ats.greenhouse import GreenhouseSource
+
+    m = _GREENHOUSE_PATH_RE.search(apply_url)
+    if not m:
+        return None
+    slug = _match_registry_slug(m.group(1), GREENHOUSE_COMPANIES)
+    if slug is None:
+        return None
+    job_id = m.group(2)
+    source = GreenhouseSource(session)
+    return await source._fetch_job_content(slug, job_id)
+
+
+async def _refetch_devitjobs(
+    apply_url: str, session: aiohttp.ClientSession, *, cache: dict[str, dict[str, str]]
+) -> Optional[str]:
+    """DevITjobs has ONE flat catalog (no per-company split), so the whole
+    listing is fetched at most ONCE per sweep tick — ``cache`` is populated
+    lazily by the first devitjobs job this tick and every subsequent
+    devitjobs job is then a free dict lookup against it.
+    """
+    from src.sources.apis_free.devitjobs import DevITJobsSource
+
+    if "_data" not in cache:
+        source = DevITJobsSource(session)
+        try:
+            jobs = await source.fetch_jobs()
+        except Exception:  # noqa: BLE001 — one bad listing must not break the tick
+            logger.warning("devitjobs backfill listing fetch failed", exc_info=True)
+            jobs = []
+        cache["_data"] = {j.apply_url: j.description for j in jobs if j.apply_url}
+    return cache["_data"].get(apply_url)
+
+
+async def fetch_description(
+    job_row: dict[str, Any],
+    session: aiohttp.ClientSession,
+    *,
+    devitjobs_cache: dict[str, dict[str, str]],
+) -> Optional[str]:
+    """Attempt to fetch fresh description text for ONE thin job row.
+
+    Returns the new text (the caller decides whether it is "long enough" —
+    this function's only job is FETCHING, not judging) or ``None`` when the
+    source is out of scope, the ``apply_url`` can't be mapped back to a
+    fetchable identifier, or the fetch itself failed. Never raises — a
+    single bad row must never abort the sweep.
+    """
+    source_name = job_row.get("source")
+    apply_url = job_row.get("apply_url") or ""
+    if source_name not in ALLOWED_BACKFILL_SOURCES or not apply_url:
+        return None
+    try:
+        if source_name == "workday":
+            return await _refetch_workday(apply_url, session)
+        if source_name == "smartrecruiters":
+            return await _refetch_smartrecruiters(apply_url, session)
+        if source_name == "greenhouse":
+            return await _refetch_greenhouse(apply_url, session)
+        if source_name == "devitjobs":
+            return await _refetch_devitjobs(apply_url, session, cache=devitjobs_cache)
+    except Exception:  # noqa: BLE001 — network/parse failures degrade to "no new text"
+        logger.warning(
+            "description backfill fetch failed for %s (%s)", apply_url, source_name, exc_info=True
+        )
+        return None
+    return None

--- a/backend/src/services/profile/models.py
+++ b/backend/src/services/profile/models.py
@@ -337,6 +337,18 @@ class UserPreferences:
     salary_max: Optional[float] = None
     work_arrangement: str = ""  # "remote", "hybrid", "onsite", or ""
     experience_level: str = ""
+    # A FACT read off the CV/LinkedIn dated job titles, NOT a preference the
+    # user typed — see `services/profile/seniority.py`'s module docstring for
+    # why that distinction lets this exist under product rule #29 (an empty
+    # PREFERENCE means "don't care"; this is extraction, like skills). Kept
+    # on a separate field so it can never be mistaken for something the user
+    # stated. Populated by `services.profile.seniority.infer_experience_level`
+    # during two-pass extraction; read ONLY as a fallback when
+    # `experience_level` above is empty — see
+    # `scoring_dimensions.resolve_experience_level`, the single seam every
+    # scoring call site must go through instead of reading either field
+    # directly.
+    experience_level_inferred: str = ""
     negative_keywords: list[str] = field(default_factory=list)
     about_me: str = ""
     github_username: str = ""

--- a/backend/src/services/profile/seniority.py
+++ b/backend/src/services/profile/seniority.py
@@ -1,0 +1,327 @@
+"""Infer a user's seniority level from their CV / LinkedIn work history.
+
+WHY THIS IS ALLOWED (the rule #29 boundary). Product design rule #29
+(`docs/product_design_rules.md` rule 1) says an EMPTY user field means
+"don't care" — the matcher must never guess a PREFERENCE the user never
+stated (a salary range, a workplace choice, an experience level they simply
+never picked from the dropdown). Seniority is a different kind of thing: it
+is not a want, it is a FACT already written on the CV as dated job titles
+("Senior Backend Engineer, Acme Ltd, 2021-Present"). Deriving it here is the
+same operation as extracting skills or education off the same document —
+reading, not inventing. The one thing this module must never do is let that
+reading masquerade as something the user typed: see
+``UserPreferences.experience_level`` (typed) vs
+``UserPreferences.experience_level_inferred`` (read off the CV) in
+`services/profile/models.py`, and the resolution order in
+``scoring_dimensions.resolve_experience_level`` — typed always wins,
+inferred only fills a genuine blank, and an empty result from this module
+leaves the seniority dimension at its documented neutral half-weight,
+exactly as it behaved before this module existed.
+
+WHY A WRONG-LOW GUESS IS WORSE THAN NO GUESS (manager review, 2026-08-07).
+The first version of this module walked positions most-recent-first and
+returned the first title with a tier word — which put a 3-month internship
+ahead of a 3-year engineering role simply because it happened to be listed
+last, and (separately) put an old internship title ahead of a title-neutral
+recent role for the same reason. Measured on two real production profiles,
+both came out "intern". That is actively harmful, not merely unhelpful:
+`scoring_dimensions.seniority_score` has a NEGATIVE tail (down to -100% at
+4+ ranks apart), so an under-called level doesn't just fail to help — it
+penalises every mid/senior job for a user who never typed anything. The
+redesign below fixes that with two structural rules:
+
+  * DURATION GATES CONFIDENCE. A role has to be held for at least
+    ``_SUSTAINED_MONTHS`` (6) before it is trusted to set the floor —
+    whether the evidence is its title ("Intern", "Senior Consultant") or its
+    own length. Internships are short by definition, so this alone stops a
+    fleeting internship from outranking a multi-year role. It is applied
+    uniformly (any short role, not just internships) rather than special-
+    casing the word "intern" — an equally short "Senior Consultant" contract
+    gets the same discount, for the same reason.
+  * THE FLOOR NEVER DROPS. Across every role that DOES clear the duration
+    bar, the answer is the HIGHEST rank any of them earned — never the most
+    recent, never an average. A short, low-ranked role afterwards (the
+    walk-back bug's exact failure mode) cannot pull the result back down;
+    see `infer_experience_level`'s "signal 1+2" block.
+
+SIGNAL ORDERING (most to least trusted — see `infer_experience_level`):
+
+  1+2. Highest rank SUSTAINED (>= `_SUSTAINED_MONTHS`) by any role, where a
+     role's own rank is the higher of (a) a seniority word in its title —
+     `job_signals.detect_seniority`, the SAME data-backed detector the job
+     side already uses (CLAUDE.md rule #28: no parallel word list) — and
+     (b) a per-role duration-derived rank (`_years_to_rank`) when the role
+     ran long enough to be informative on its own, e.g. a 3-year plainly-
+     titled "Software Development Engineer" earns "mid" even though its
+     title carries no tier word. Only roles that individually clear the
+     duration bar can set this floor — this is where "sustained" beats
+     "latest mentioned".
+  3. Total accumulated duration (the SUM of every role's parseable length,
+     not the calendar span, so a gap between jobs doesn't inflate it) banded
+     the same way — used ONLY when no single role cleared the sustained
+     bar. This is the true last resort (several short stints, none alone
+     conclusive). Its band table starts at "junior", never "intern": a
+     handful of short stints is too thin a sample to assert the harshest,
+     most negative-penalty-prone tier with confidence, and calling a
+     genuinely early-career user "junior" instead of "intern" is a much
+     cheaper mistake than the reverse (rank 1 vs 0 costs a mild partial-
+     credit mismatch; a false "intern" against a real mid/senior job costs
+     the negative-penalty tail).
+  4. If nothing anywhere parsed a usable duration, the weakest fallback:
+     whatever title words exist at all, read in the given (assumed
+     most-recent-first, matching how CVs/LinkedIn list roles) list order.
+
+ON "RECENCY SHOULD TEMPER, NOT DOMINATE" — a deliberate simplification.
+Recency is not implemented as literal time-decay (down-weighting an old
+"Senior" title toward "mid" the further back it sits). Two reasons: first,
+"the highest sustained rank wins" already makes recency irrelevant to WHICH
+rank is reported once a role qualifies — decaying an old peak would only
+ever pull the answer DOWN, which is exactly the failure mode point 4 above
+forbids. Second, no fixture (real or hypothetical) in this codebase
+currently demonstrates decay is needed, and adding it without one risks
+under-crediting genuine sustained seniority — the harm this module exists to
+prevent — for a benefit nothing here tests. Recency still matters in the
+places it safely can: an "ongoing"/"Present" role's end date resolves to
+TODAY (so a currently-held senior role is fully credited), and a strong
+recent role can always set a NEW, higher floor (the max naturally lets good
+recent news through). If a real case ever needs true decay, it should arrive
+with the failing profile that justifies it.
+
+Dates arrive as free text in wildly different shapes across the two sources
+("2023 - 2024", "Jan 2020 - Present", or LinkedIn's separate ``start``/
+``end`` strings) — parsing is best-effort: split into a start/end pair, each
+read for a year (required) and a month name (optional, closed 12-name set —
+structural calendar vocabulary, not a rule-#28 skill list), plus an
+"ongoing" vocabulary (present/current/now). The whole function never raises:
+an unparseable record is simply skipped, never a crash that costs the user
+their profile save (mirrors ``two_pass.run_two_pass_extraction``'s own
+never-raise contract, which is what calls this module).
+"""
+
+from __future__ import annotations
+
+import datetime
+import re
+from typing import Any, Optional
+
+from src.services.job_signals import detect_seniority
+from src.services.scoring_dimensions import _USER_EXPERIENCE_RANK
+
+# A role must run at least this long before it is trusted to set the
+# "sustained" floor (signal 1+2) — see the module docstring's "DURATION
+# GATES CONFIDENCE". Applied uniformly to every role regardless of title.
+_SUSTAINED_MONTHS = 6
+
+_YEAR_RE = re.compile(r"(?:19|20)\d{2}")
+_ONGOING_RE = re.compile(
+    r"\b(?:present|current|currently|now|ongoing|to\s+date)\b", re.IGNORECASE
+)
+# Splits one combined "start - end" date-range string (CV shape) into its two
+# boundary texts. Whitespace around the separator is optional so both
+# "2019-2022" and "Jan 2020 - Present" split correctly. maxsplit=1 so a
+# stray extra dash elsewhere in the text can't over-split.
+_RANGE_SPLIT = re.compile(r"\s*(?:-|–|—|\bto\b)\s*", re.IGNORECASE)
+
+# Closed, fixed 12-name calendar vocabulary — structural date parsing, not a
+# domain skill/keyword list (rule #28 governs the latter, not this).
+_MONTH_RANK = {
+    "jan": 1, "january": 1,
+    "feb": 2, "february": 2,
+    "mar": 3, "march": 3,
+    "apr": 4, "april": 4,
+    "may": 5,
+    "jun": 6, "june": 6,
+    "jul": 7, "july": 7,
+    "aug": 8, "august": 8,
+    "sep": 9, "sept": 9, "september": 9,
+    "oct": 10, "october": 10,
+    "nov": 11, "november": 11,
+    "dec": 12, "december": 12,
+}
+_MONTH_RE = re.compile(
+    r"\b(jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun[e]?|jul[y]?|"
+    r"aug(?:ust)?|sep(?:t(?:ember)?)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)\b",
+    re.IGNORECASE,
+)
+
+# Total-accumulated-duration fallback bands (years -> rank, ascending).
+# Signal 3 ONLY (see module docstring) — deliberately never reaches rank 0
+# ("intern"); the lowest band is "junior" (rank 1). Boundaries follow common
+# UK career-ladder timing (junior 0-3y; mid 3-6y; senior 6-10y; staff/
+# principal/director beyond a decade-plus). A numeric threshold table is
+# structure, not a keyword vocabulary — rule #28 governs word lists, not
+# year bands.
+_YEARS_BANDS: tuple[tuple[float, int], ...] = (
+    (0.0, 1),   # junior
+    (3.0, 2),   # mid
+    (6.0, 3),   # senior
+    (10.0, 4),  # staff
+    (15.0, 5),  # principal
+    (20.0, 6),  # director
+)
+
+_RANK_TO_WORD = {
+    0: "intern", 1: "junior", 2: "mid", 3: "senior",
+    4: "staff", 5: "principal", 6: "director",
+}
+
+
+def _years_to_rank(years: float) -> int:
+    rank = _YEARS_BANDS[0][1]
+    for threshold, r in _YEARS_BANDS:
+        if years >= threshold:
+            rank = r
+    return rank
+
+
+def _parse_year_month(text: str, *, today: datetime.date) -> tuple[Optional[int], Optional[int]]:
+    """Best-effort ``(year, month)`` from ONE date boundary (e.g. "Jan 2020",
+    "2022", "Present"). Month is ``None`` when the text doesn't name one —
+    callers fall back to a coarser year-only estimate. Never raises.
+    """
+    if not text or not isinstance(text, str):
+        return None, None
+    if _ONGOING_RE.search(text):
+        return today.year, today.month
+    year_m = _YEAR_RE.search(text)
+    if not year_m:
+        return None, None
+    month = None
+    month_m = _MONTH_RE.search(text)
+    if month_m:
+        month = _MONTH_RANK.get(month_m.group(0).lower())
+    return int(year_m.group(0)), month
+
+
+def _position_boundaries(pos: dict[str, Any]) -> tuple[str, str]:
+    """Normalise one CV or LinkedIn position dict to ``(start_text, end_text)``.
+
+    CV positions (``CVData.cv_positions``) carry one combined ``dates``
+    string, split on the first dash-like separator; LinkedIn positions
+    (``CVData.linkedin_positions``) already carry separate ``start``/``end``
+    strings.
+    """
+    if "dates" in pos:
+        dates_text = str(pos.get("dates") or "")
+        if not dates_text:
+            return "", ""
+        parts = _RANGE_SPLIT.split(dates_text, maxsplit=1)
+        if len(parts) == 2:
+            return parts[0].strip(), parts[1].strip()
+        return dates_text.strip(), ""
+    return str(pos.get("start") or ""), str(pos.get("end") or "")
+
+
+def _duration_months(
+    start_y: Optional[int], start_m: Optional[int],
+    end_y: Optional[int], end_m: Optional[int],
+) -> Optional[int]:
+    """Best-effort role length in months, or ``None`` when genuinely unknown.
+
+    Both boundary months known -> exact inclusive month count. Only years
+    known -> a coarse whole-year estimate (``end_y - start_y`` years), which
+    is itself ``None`` when that diff is 0 — a same-year span with no month
+    detail could be 1 month or 11, and guessing either risks a wrong
+    "sustained" verdict in either direction, so it is left unknown rather
+    than guessed.
+    """
+    if start_y is None or end_y is None:
+        return None
+    if start_m is not None and end_m is not None:
+        return max((end_y - start_y) * 12 + (end_m - start_m) + 1, 1)
+    diff_years = end_y - start_y
+    return diff_years * 12 if diff_years > 0 else None
+
+
+def infer_experience_level(
+    cv_positions: Optional[list[dict[str, Any]]],
+    linkedin_positions: Optional[list[dict[str, Any]]] = None,
+    *,
+    today: Optional[datetime.date] = None,
+) -> str:
+    """Derive the user's current seniority level from dated positions.
+
+    Returns one of the vocabulary words `scoring_dimensions._USER_EXPERIENCE_RANK`
+    already understands (e.g. "senior", "junior", "staff") or ``""`` when
+    nothing could be inferred — an empty result is a legitimate, expected
+    outcome (no positions, no dates anywhere, no title signal), not a
+    failure. Never raises: any parsing surprise falls through to ``""``,
+    which leaves the seniority dimension at its neutral half-weight exactly
+    as if this module did not exist.
+
+    See the module docstring for the full signal ordering and the reasoning
+    behind the duration gate / floor-never-drops design.
+    """
+    try:
+        today_date = today or datetime.date.today()
+        positions: list[dict[str, Any]] = []
+        positions.extend(cv_positions or [])
+        positions.extend(linkedin_positions or [])
+        if not positions:
+            return ""
+
+        parsed: list[dict[str, Any]] = []
+        for pos in positions:
+            if not isinstance(pos, dict):
+                continue
+            title = str(pos.get("title") or "").strip()
+            start_text, end_text = _position_boundaries(pos)
+            start_y, start_m = _parse_year_month(start_text, today=today_date)
+            end_y, end_m = _parse_year_month(end_text, today=today_date)
+            if start_y is not None and end_y is not None and end_y < start_y:
+                start_y, start_m, end_y, end_m = end_y, end_m, start_y, start_m
+            duration_months = _duration_months(start_y, start_m, end_y, end_m)
+            if not title and duration_months is None:
+                continue  # nothing usable in this record — skip, don't guess
+
+            title_rank = None
+            if title:
+                signal = detect_seniority(title, "")
+                level = signal.value.value  # SeniorityLevel is a str Enum
+                if level and level != "unknown":
+                    title_rank = _USER_EXPERIENCE_RANK.get(level)
+
+            parsed.append({"title_rank": title_rank, "duration_months": duration_months})
+
+        if not parsed:
+            return ""
+
+        # Signals 1+2 — highest rank actually SUSTAINED. A role only
+        # participates once it clears `_SUSTAINED_MONTHS`; within that set,
+        # its own rank is the higher of its title word and its own
+        # duration-derived rank (never lower than either — max, not
+        # override). The floor is the max across all qualifying roles, so a
+        # later short role (however it's titled) can never pull it down.
+        floor_rank: Optional[int] = None
+        for p in parsed:
+            months = p["duration_months"]
+            if months is None or months < _SUSTAINED_MONTHS:
+                continue
+            duration_rank = _years_to_rank(months / 12)
+            candidates = [r for r in (p["title_rank"], duration_rank) if r is not None]
+            role_rank = max(candidates) if candidates else None
+            if role_rank is not None and (floor_rank is None or role_rank > floor_rank):
+                floor_rank = role_rank
+        if floor_rank is not None:
+            return _RANK_TO_WORD[floor_rank]
+
+        # Signal 3 (last resort) — nothing individually sustained. Sum
+        # whatever durations parsed across ALL roles (short stints still
+        # count toward cumulative experience even though none alone earns
+        # the sustained floor) and band the total. Never "intern" — see the
+        # module docstring.
+        total_months = sum(
+            p["duration_months"] for p in parsed if p["duration_months"] is not None
+        )
+        if total_months > 0:
+            return _RANK_TO_WORD[_years_to_rank(total_months / 12)]
+
+        # No duration info at all anywhere — weakest possible fallback:
+        # whatever title words exist, in the given (assumed most-recent-
+        # first) order.
+        for p in parsed:
+            if p["title_rank"] is not None:
+                return _RANK_TO_WORD[p["title_rank"]]
+        return ""
+    except Exception:  # noqa: BLE001 — a failed inference must never cost a save
+        return ""

--- a/backend/src/services/profile/two_pass.py
+++ b/backend/src/services/profile/two_pass.py
@@ -47,6 +47,7 @@ from src.services.profile.preferences import (
     llm_infer_from_about_me,
     merge_cv_and_preferences,
 )
+from src.services.profile.seniority import infer_experience_level
 
 logger = logging.getLogger("job360.profile.two_pass")
 
@@ -543,6 +544,21 @@ async def run_two_pass_extraction(profile: UserProfile) -> UserProfile:
         profile.preferences = merge_cv_and_preferences(
             cv.skills, cv.job_titles, prefs
         )
+
+    # ── Seniority inference (2026-08-07) — a FACT read off dated CV/LinkedIn
+    # positions, never a guessed preference; see seniority.py's module
+    # docstring for why that distinction is what makes this legal under
+    # product design rule #29. Runs LAST, after both merges above, so it
+    # reads the fully-populated cv_positions/linkedin_positions and writes
+    # onto whichever preferences object is now live (the merged one above,
+    # or the original if that merge did not run). Never raises — a failed
+    # inference just leaves the field empty and the dimension stays neutral.
+    try:
+        profile.preferences.experience_level_inferred = infer_experience_level(
+            cv.cv_positions, cv.linkedin_positions
+        )
+    except Exception as exc:  # noqa: BLE001 - inference must never cost a save
+        logger.warning("seniority inference failed (non-fatal): %s", exc)
 
     # ── THE UNIVERSAL GATE ────────────────────────────────────────────────
     # Grade what we just produced against the document it came from. This is

--- a/backend/src/services/scoring_dimensions.py
+++ b/backend/src/services/scoring_dimensions.py
@@ -16,7 +16,7 @@ Each scorer gracefully returns a neutral midpoint when its signal is missing
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from src.core.settings import (
     SALARY_WEIGHT,
@@ -31,6 +31,9 @@ from src.services.job_enrichment_schema import (
     WorkplaceType,
 )
 from src.services.salary import normalize_salary
+
+if TYPE_CHECKING:
+    from src.services.profile.models import UserPreferences
 
 # ---------------------------------------------------------------------------
 # ScoreBreakdown — Step-1 B3 per-dimension score container
@@ -100,6 +103,31 @@ _USER_EXPERIENCE_RANK = {
     "vp": 6,
     "executive": 6,
 }
+
+
+def resolve_experience_level(prefs: Optional[UserPreferences]) -> str:
+    """The one seam every scoring call site must use to read the user's level.
+
+    Typed always wins. ``UserPreferences.experience_level_inferred`` (a FACT
+    read off the CV's dated job titles by
+    ``services.profile.seniority.infer_experience_level`` — see that
+    module's docstring for why this is allowed under product design rule
+    #29 when guessing a PREFERENCE would not be) is consulted ONLY when the
+    user has not typed a value. Neither present → "", which makes
+    ``seniority_score`` fall back to its documented neutral half-weight,
+    byte-identical to before this field existed.
+
+    A single helper here (instead of each call site reading
+    ``prefs.experience_level`` directly) is what keeps that fallback
+    consistent — a call site that forgets it silently leaves the seniority
+    dimension dead even once the CV inference starts producing values.
+    """
+    if prefs is None:
+        return ""
+    typed = (getattr(prefs, "experience_level", "") or "").strip()
+    if typed:
+        return typed
+    return (getattr(prefs, "experience_level_inferred", "") or "").strip()
 
 
 def seniority_score(enrichment: Optional[JobEnrichment], user_experience: str) -> int:

--- a/backend/src/services/skill_matcher.py
+++ b/backend/src/services/skill_matcher.py
@@ -621,6 +621,7 @@ class JobScorer:
             if enrichment is not None:
                 # Lazy import to avoid import cycles during first test collection.
                 from src.services.scoring_dimensions import (
+                    resolve_experience_level,
                     salary_score,
                     seniority_score,
                     visa_score,
@@ -629,7 +630,9 @@ class JobScorer:
 
                 prefs = self._user_preferences
                 salary_pts = salary_score(enrichment, prefs.salary_min, prefs.salary_max)
-                seniority_pts = seniority_score(enrichment, prefs.experience_level)
+                # Typed value wins; CV-inferred value fills a genuine blank only
+                # — see resolve_experience_level's docstring (product rule #29).
+                seniority_pts = seniority_score(enrichment, resolve_experience_level(prefs))
                 visa_pts = visa_score(enrichment, prefs.needs_visa)
                 workplace_pts = workplace_score(enrichment, prefs.preferred_workplace)
 

--- a/backend/src/sources/ats/greenhouse.py
+++ b/backend/src/sources/ats/greenhouse.py
@@ -68,3 +68,22 @@ class GreenhouseSource(BaseJobSource):
                 ))
         logger.info("Greenhouse: found %s relevant jobs across %s companies", len(jobs), len(self._companies))
         return jobs
+
+    async def _fetch_job_content(self, slug: str, job_id: str) -> str:
+        """Fetch ONE posting's content via the per-job detail endpoint.
+
+        fetch_jobs() only ever calls the whole-board listing (?content=true
+        gets every posting's text in one shot), so this is a NEW, narrower
+        entry point — added for the description-backfill sweep
+        (services/description_backfill.py), which needs to refresh a single
+        already-stored job without re-listing its whole company. Same parse
+        as fetch_jobs(): unescape entities, strip tags, cap 5000 chars.
+        Returns "" on any failure — a miss is a data gap, not an error.
+        """
+        detail = await self._get_json(
+            f"https://boards-api.greenhouse.io/v1/boards/{slug}/jobs/{job_id}?content=true"
+        )
+        if not isinstance(detail, dict):
+            return ""
+        content = detail.get("content", "")
+        return _HTML_TAG_RE.sub(" ", html.unescape(content or ""))[:5000].strip()

--- a/backend/src/workers/tasks.py
+++ b/backend/src/workers/tasks.py
@@ -563,6 +563,172 @@ async def nightly_ghost_sweep(ctx: dict[str, Any]) -> dict[str, int]:
     return {"evaluated": evaluated, "transitioned": transitioned}
 
 
+async def _backfill_thin_descriptions(db: pg.Connection, budget: int) -> dict[str, int]:
+    """BACKFILL phase (2026-08-07) — runs FIRST inside ``enrichment_sweep``,
+    before missing-coverage and repair, so a job whose real text just landed
+    is eligible for enrichment in THIS SAME tick rather than the next one.
+
+    WHY THIS EXISTS. Sources fetch job-detail pages under strict PER-RUN
+    budgets (``_MAX_DETAIL_FETCHES`` in workday.py / smartrecruiters.py) so a
+    single run never blows the 240s ATS timeout. A job stored past that
+    budget keeps an empty/short description forever — nothing re-fetches it
+    unless it happens to reappear in a later run's listing. Coverage of every
+    enriched field (workplace/seniority/visa) tracks description length
+    almost perfectly: measured in prod, 1,311 active jobs (30% of the
+    catalog) carry under 200 chars of description.
+
+    Selects the ``budget`` highest-value ACTIVE jobs (same
+    COALESCE(llm_fit_score, score) value ordering as the other phases) whose
+    ``description`` is under ``MIN_DESCRIPTION_CHARS`` AND whose source is on
+    the ``ALLOWED_BACKFILL_SOURCES`` capability list (LinkedIn and
+    structurally-textless sources are OUT — pushed into the SQL itself,
+    not filtered in Python after the fact, so a 50/tick budget is never
+    burned on rows that were never going to be fetched) AND whose
+    ``description_backfill_attempts`` is under ``MAX_BACKFILL_ATTEMPTS``.
+
+    TERMINAL STATE — real counter (migration 0029), not a padded description.
+    An earlier version of this padded a still-thin ``description`` with
+    trailing spaces past the 200-char floor purely to stop it being
+    reselected. That was REJECTED in review: coverage.py's skill-text
+    predicate counts ANY description over 200 chars as real coverage with no
+    whitespace check, so padding manufactured a FALSE "we understand this
+    job" signal — fed to the LLM judge, the keyword scorer, and rendered to
+    users, on top of it. ``description`` is now written ONLY with genuinely
+    fetched (whitespace-stripped) text; ``description_backfill_attempts`` is
+    the thing that stops a hopeless row from being retried forever, and it
+    increments on EVERY attempt regardless of outcome — success, partial
+    improvement, no improvement, or an exception. A row that clears
+    ``MIN_DESCRIPTION_CHARS`` drops out of selection naturally (the length
+    predicate already excludes it); a row that never does stops being
+    selected once it hits ``MAX_BACKFILL_ATTEMPTS``, full stop.
+
+    Per-row try/except (rule: one poison row must never abort the sweep) —
+    the file already documents an incident where a single bad row aborted an
+    entire run.
+
+    Returns ``{"attempted", "filled", "still_thin", "skipped_by_capability",
+    "errors"}`` — merged into ``enrichment_sweep``'s return dict.
+    ``skipped_by_capability`` stays 0 in normal operation now that the SQL
+    itself excludes disallowed sources; kept as a defensive counter (belt-
+    and-braces) in case a row's source ever slips past the IN-clause.
+    """
+    stats = {"attempted": 0, "filled": 0, "still_thin": 0, "skipped_by_capability": 0, "errors": 0}
+    if budget <= 0:
+        return stats
+
+    from src.services.description_backfill import (  # noqa: PLC0415
+        ALLOWED_BACKFILL_SOURCES,
+        MAX_BACKFILL_ATTEMPTS,
+        MIN_DESCRIPTION_CHARS,
+        fetch_description,
+    )
+
+    allowed_sources = sorted(ALLOWED_BACKFILL_SOURCES)
+    if not allowed_sources:
+        return stats
+    source_placeholders = ",".join("?" for _ in allowed_sources)
+
+    cur = await db.execute(
+        f"""
+        SELECT j.id, j.title, j.company, j.location, j.description,
+               j.apply_url, j.source
+        FROM jobs j
+        JOIN user_feed f ON f.job_id = j.id AND f.status = 'active'
+        WHERE length(coalesce(j.description, '')) < ?
+          AND coalesce(j.description_backfill_attempts, 0) < ?
+          AND j.source IN ({source_placeholders})
+        GROUP BY j.id, j.title, j.company, j.location, j.description,
+                 j.apply_url, j.source
+        ORDER BY max(COALESCE(f.llm_fit_score, f.score)) DESC
+        LIMIT ?
+        """,  # noqa: S608 — source_placeholders is "?"*len(allowed_sources), no user input
+        (MIN_DESCRIPTION_CHARS, MAX_BACKFILL_ATTEMPTS, *allowed_sources, budget),
+    )
+    rows = [dict(r) for r in await cur.fetchall()]
+
+    # Defensive belt-and-braces (see docstring) — should never fire given the
+    # SQL IN-clause above, but a row landing here with a disallowed source
+    # must still never be fetched.
+    allowed_rows = []
+    for row in rows:
+        if row.get("source") in ALLOWED_BACKFILL_SOURCES:
+            allowed_rows.append(row)
+        else:
+            stats["skipped_by_capability"] += 1
+    if not allowed_rows:
+        return stats
+
+    import aiohttp  # noqa: PLC0415 — only needed when there is real fetching to do
+
+    devitjobs_cache: dict[str, dict[str, str]] = {}
+    async with aiohttp.ClientSession() as session:
+        for row in allowed_rows:
+            stats["attempted"] += 1
+            fetch_raised = False
+            new_text: Optional[str] = None
+            try:
+                new_text = await fetch_description(row, session, devitjobs_cache=devitjobs_cache)
+            except Exception:  # noqa: BLE001 — one poison row must never abort the sweep
+                fetch_raised = True
+                stats["errors"] += 1
+                _log.warning(
+                    "description_backfill_fetch_failed",
+                    extra={"event": "description_backfill_fetch_failed", "job_id": row.get("id")},
+                    exc_info=True,
+                )
+
+            try:
+                existing = row.get("description") or ""
+                # .strip() on BOTH sides — a fetch that returns whitespace-only
+                # text (or HTML that tag-strips down to nothing) must NOT be
+                # mistaken for real content, and must not be compared unfairly
+                # against padded legacy rows either. Pins the exact bug this
+                # phase was rejected for once already (see module docstring).
+                stripped_new = (new_text or "").strip()
+                stripped_existing = existing.strip()
+
+                if stripped_new and len(stripped_new) >= MIN_DESCRIPTION_CHARS:
+                    await db.execute(
+                        "UPDATE jobs SET description = ?, "
+                        "description_backfill_attempts = coalesce(description_backfill_attempts, 0) + 1 "
+                        "WHERE id = ?",
+                        (stripped_new, row["id"]),
+                    )
+                    stats["filled"] += 1
+                elif stripped_new and len(stripped_new) > len(stripped_existing):
+                    # Genuine improvement, still short — real text, written
+                    # verbatim; the attempt still counts against the cap.
+                    await db.execute(
+                        "UPDATE jobs SET description = ?, "
+                        "description_backfill_attempts = coalesce(description_backfill_attempts, 0) + 1 "
+                        "WHERE id = ?",
+                        (stripped_new, row["id"]),
+                    )
+                    stats["still_thin"] += 1
+                else:
+                    # No improvement (including a fetch that raised) — bump
+                    # the REAL attempt counter only. description is NEVER
+                    # modified except with real fetched text.
+                    await db.execute(
+                        "UPDATE jobs SET "
+                        "description_backfill_attempts = coalesce(description_backfill_attempts, 0) + 1 "
+                        "WHERE id = ?",
+                        (row["id"],),
+                    )
+                    if not fetch_raised:
+                        stats["still_thin"] += 1
+                await db.commit()
+            except Exception:  # noqa: BLE001 — one poison row must never abort the sweep
+                _log.warning(
+                    "description_backfill_write_failed",
+                    extra={"event": "description_backfill_write_failed", "job_id": row.get("id")},
+                    exc_info=True,
+                )
+                stats["errors"] += 1
+
+    return stats
+
+
 @_logged_task
 async def enrichment_sweep(ctx: dict[str, Any]) -> dict[str, Any]:
     """ARQ periodic task: self-heal enrichment coverage of the candidate pool.
@@ -575,6 +741,11 @@ async def enrichment_sweep(ctx: dict[str, Any]) -> dict[str, Any]:
     sweeps from a laptop — exactly the kind of hands-on ops a production
     system must not need. This cron makes coverage converge BY ITSELF.
 
+    A BACKFILL phase (``_backfill_thin_descriptions``, 2026-08-07) now runs
+    FIRST: it goes back for real description text on jobs a source's per-run
+    detail-fetch budget skipped over, so the enrichment phases below actually
+    have something to extract from. See that function's docstring.
+
     Each tick: pick the ``ENRICHMENT_SWEEP_PER_TICK`` (default 100, 0
     disables) highest-value ACTIVE candidate jobs still missing enrichment —
     value = the best COALESCE(llm_fit_score, score) any user's feed gives the
@@ -583,21 +754,33 @@ async def enrichment_sweep(ctx: dict[str, Any]) -> dict[str, Any]:
     pipeline already uses; bounded per tick; zero per-user LLM spend.
 
     Gated exactly like every other E2 call site: ``ENGINE2_ENABLED`` OR the
-    legacy ``ENRICHMENT_ENABLED`` flag — both off ⇒ pure no-op (rule #18).
+    legacy ``ENRICHMENT_ENABLED`` flag — both off ⇒ the MISSING-COVERAGE and
+    REPAIR phases below are a pure no-op (rule #18).
+
+    The BACKFILL phase is DELIBERATELY OUTSIDE that gate (2026-08-07 manager
+    review). E2 only controls the LLM enrichment call — but description text
+    is also what Engine 1's keyword scorer matches against and what the
+    Engine 4 LLM judge reads, so a keyword-only deployment (E2 off) would
+    otherwise never get its text fixed. Backfill is governed ONLY by its own
+    ``DESCRIPTION_BACKFILL_PER_TICK`` budget (0 disables it), and it makes no
+    LLM call of its own regardless.
     """
     import os as _os  # noqa: PLC0415
 
-    from src.core.settings import ENGINE2_ENABLED  # noqa: PLC0415
+    from src.core.settings import DESCRIPTION_BACKFILL_PER_TICK, ENGINE2_ENABLED  # noqa: PLC0415
     from src.services.job_enrichment import enrich_batch  # noqa: PLC0415
-
-    if not (ENGINE2_ENABLED or ENRICHMENT_ENABLED):
-        return {"enriched": 0, "reason": "e2_off"}
-    budget = int(_os.getenv("ENRICHMENT_SWEEP_PER_TICK", "100"))
-    if budget <= 0:
-        return {"enriched": 0, "reason": "disabled"}
 
     db: pg.Connection = ctx["db"]
     db.row_factory = pg.Row
+
+    backfill_stats = await _backfill_thin_descriptions(db, DESCRIPTION_BACKFILL_PER_TICK)
+
+    if not (ENGINE2_ENABLED or ENRICHMENT_ENABLED):
+        return {"enriched": 0, "reason": "e2_off", **backfill_stats}
+
+    budget = int(_os.getenv("ENRICHMENT_SWEEP_PER_TICK", "100"))
+    if budget <= 0:
+        return {"enriched": 0, "reason": "disabled", **backfill_stats}
 
     cur = await db.execute(
         """
@@ -647,7 +830,7 @@ async def enrichment_sweep(ctx: dict[str, Any]) -> dict[str, Any]:
         repair_rows = [dict(r) for r in await cur.fetchall()]
 
     if not rows and not repair_rows:
-        return {"enriched": 0, "reason": "coverage_complete"}
+        return {"enriched": 0, "reason": "coverage_complete", **backfill_stats}
 
     def _mk_job(r: dict[str, Any]) -> Job:
         job = Job(
@@ -671,7 +854,7 @@ async def enrichment_sweep(ctx: dict[str, Any]) -> dict[str, Any]:
             skip_existing=False,  # deliberate: overwrite the hollow rows
         )
         repaired = len([x for x in (results or []) if x])
-    return {"enriched": enriched, "repaired": repaired}
+    return {"enriched": enriched, "repaired": repaired, **backfill_stats}
 
 
 # ---------- Pillar 2 Batch 2.5 — job enrichment task -------------------

--- a/backend/tests/test_description_backfill.py
+++ b/backend/tests/test_description_backfill.py
@@ -1,0 +1,381 @@
+"""BACKFILL phase of the enrichment_sweep cron (2026-08-07). See
+workers/tasks.py::_backfill_thin_descriptions and
+services/description_backfill.py for the full design.
+
+Pins: highest-value-first selection, the DESCRIPTION_BACKFILL_PER_TICK
+budget (including its 0=disabled kill switch), the per-source capability
+flag (pre-filtered in SQL), the migration-0029 attempt counter (a job stops
+being retried after MAX_BACKFILL_ATTEMPTS — NOT a padded description; see
+the rejected-padding note below), per-row fault isolation (one bad row must
+never abort the sweep), and a freshly-backfilled job reaching the
+enrichment phase in the SAME tick.
+
+REJECTED-APPROACH PIN: an earlier version of this phase padded a
+still-thin description with trailing spaces to escape the selection floor
+without a migration. That was rejected in manager review — coverage.py's
+skill-text predicate counts ANY description over 200 chars as real
+coverage with no whitespace check, so padding manufactured a FALSE
+"we understand this job" signal.
+test_backfill_whitespace_fetch_result_is_not_treated_as_success pins that a
+whitespace-only fetch result can never be mistaken for success, and no test
+in this file ever asserts on a padded description.
+"""
+from __future__ import annotations
+
+import re
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import pytest
+from aioresponses import aioresponses
+
+from migrations import runner
+from src.models import Job
+from src.repositories import pgsync
+from src.repositories.database import JobDatabase
+
+_NOW = datetime.now(timezone.utc).isoformat()
+
+# Real prose, well over the 200-char selection floor once tag-stripped.
+_LONG_TEXT = "Deep learning research role using PyTorch and distributed training. " * 5
+
+
+async def _full_db(path: str) -> JobDatabase:
+    db = JobDatabase(path)
+    await db.init_db()
+    await db.close()
+    await runner.up(path)
+    db = JobDatabase(path)
+    await db.init_db()
+    return db
+
+
+def _seed_user(db_path: str) -> str:
+    user_id = str(uuid.uuid4())
+    with pgsync.connect(db_path) as conn:
+        conn.execute(
+            "INSERT INTO users(id, email, password_hash) VALUES (?,?,?)",
+            (user_id, f"{user_id}@t.example", "hash"),
+        )
+    return user_id
+
+
+def _mk_job(idx: int, source: str, apply_url: str, description: str = "short.") -> Job:
+    # title/company vary per idx — normalized_key() dedups on (company,
+    # title), and insert_job upserts on collision, so identical values
+    # across rows in the same test would silently collapse to one job.
+    return Job(
+        title=f"Engineer {idx}", company=f"Co{idx}", apply_url=apply_url,
+        source=source, date_found=_NOW, location="London, UK",
+        description=description,
+    )
+
+
+async def _seed_feed_row(conn, user_id: str, job_id: int, score: int) -> None:
+    await conn.execute(
+        "INSERT INTO user_feed(user_id, job_id, score, bucket, status, created_at, updated_at) "
+        "VALUES (?,?,?,?,'active',?,?)",
+        (user_id, job_id, score, "older", _NOW, _NOW),
+    )
+
+
+async def _attempts(conn, job_id: int) -> int:
+    cur = await conn.execute(
+        "SELECT coalesce(description_backfill_attempts, 0) FROM jobs WHERE id = ?", (job_id,)
+    )
+    return (await cur.fetchone())[0]
+
+
+@pytest.mark.asyncio
+async def test_backfill_selects_highest_value_within_budget(tmp_path, monkeypatch):
+    """Budget=2 over 3 candidates must pick the two HIGHEST-value jobs, and
+    leave the lowest-value one alone (selection order + budget respected).
+    Deliberately does NOT touch ENGINE2_ENABLED — backfill is independent
+    of the enrichment gate (2026-08-07 manager review)."""
+    import src.core.settings as settings_mod
+    import src.workers.tasks as tasks_mod
+
+    monkeypatch.setattr(settings_mod, "DESCRIPTION_BACKFILL_PER_TICK", 2, raising=False)
+
+    db = await _full_db(str(tmp_path / "t.db"))
+    try:
+        for i in range(3):
+            await db.insert_job(_mk_job(
+                i, "greenhouse", f"https://boards.greenhouse.io/deepmind/jobs/{100 + i}",
+            ))
+        conn = db._db
+        user_id = _seed_user(str(tmp_path / "t.db"))
+        cur = await conn.execute("SELECT id FROM jobs ORDER BY id")
+        ids = [r[0] for r in await cur.fetchall()]
+        for jid, score in zip(ids, (10, 50, 90)):
+            await _seed_feed_row(conn, user_id, jid, score)
+        await db.commit()
+
+        with aioresponses() as m:
+            m.get(
+                re.compile(r"https://boards-api\.greenhouse\.io/v1/boards/deepmind/jobs/\d+\?content=true"),
+                payload={"content": _LONG_TEXT},
+                repeat=True,
+            )
+            result = await tasks_mod.enrichment_sweep({"db": conn})
+
+        assert result["reason"] == "e2_off", result  # E2 is off by default in tests; backfill still ran
+        assert result["attempted"] == 2, result
+        assert result["filled"] == 2, result
+
+        cur = await conn.execute("SELECT id, description FROM jobs ORDER BY id")
+        rows = {r[0]: r[1] for r in await cur.fetchall()}
+        assert "Deep learning research" in rows[ids[1]], "score-50 job must be filled"
+        assert "Deep learning research" in rows[ids[2]], "score-90 job must be filled"
+        assert rows[ids[0]] == "short.", "lowest-value job must be left untouched (budget=2)"
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_backfill_skips_disallowed_source(tmp_path, monkeypatch):
+    """LinkedIn is OUT by capability flag — pre-filtered in SQL, so it must
+    never even be selected, let alone fetched."""
+    import src.core.settings as settings_mod
+    import src.workers.tasks as tasks_mod
+
+    monkeypatch.setattr(settings_mod, "DESCRIPTION_BACKFILL_PER_TICK", 10, raising=False)
+
+    db = await _full_db(str(tmp_path / "t.db"))
+    try:
+        await db.insert_job(_mk_job(0, "linkedin", "https://www.linkedin.com/jobs/view/999"))
+        conn = db._db
+        user_id = _seed_user(str(tmp_path / "t.db"))
+        cur = await conn.execute("SELECT id FROM jobs LIMIT 1")
+        jid = (await cur.fetchone())[0]
+        await _seed_feed_row(conn, user_id, jid, 90)
+        await db.commit()
+
+        # No routes registered — aioresponses raises on ANY real HTTP attempt,
+        # so this also proves the dispatch never touches the network.
+        with aioresponses():
+            result = await tasks_mod.enrichment_sweep({"db": conn})
+
+        assert result["attempted"] == 0, result
+        assert result["skipped_by_capability"] == 0, "excluded by the SQL IN-clause, never even selected"
+        cur = await conn.execute("SELECT description FROM jobs WHERE id = ?", (jid,))
+        assert (await cur.fetchone())[0] == "short."
+        assert await _attempts(conn, jid) == 0
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_backfill_attempt_counter_stops_retrying_after_cap(tmp_path, monkeypatch):
+    """A job whose fetch can never improve (unmapped Workday tenant — no
+    WORKDAY_COMPANIES entry, so no HTTP call is even possible) must stop
+    being selected once description_backfill_attempts reaches
+    MAX_BACKFILL_ATTEMPTS (3) — a REAL counter (migration 0029), not a
+    padded description. description must stay untouched throughout."""
+    import src.core.settings as settings_mod
+    import src.workers.tasks as tasks_mod
+    from src.services.description_backfill import MAX_BACKFILL_ATTEMPTS
+
+    monkeypatch.setattr(settings_mod, "DESCRIPTION_BACKFILL_PER_TICK", 10, raising=False)
+
+    db = await _full_db(str(tmp_path / "t.db"))
+    try:
+        await db.insert_job(_mk_job(
+            0, "workday", "https://nomatch.wd1.myworkdayjobs.com/en-US/job/London/X_R1",
+        ))
+        conn = db._db
+        user_id = _seed_user(str(tmp_path / "t.db"))
+        cur = await conn.execute("SELECT id FROM jobs LIMIT 1")
+        jid = (await cur.fetchone())[0]
+        await _seed_feed_row(conn, user_id, jid, 90)
+        await db.commit()
+
+        for expected_attempt in range(1, MAX_BACKFILL_ATTEMPTS + 1):
+            with aioresponses():
+                result = await tasks_mod.enrichment_sweep({"db": conn})
+            assert result["attempted"] == 1, (expected_attempt, result)
+            assert result["still_thin"] == 1, (expected_attempt, result)
+            assert await _attempts(conn, jid) == expected_attempt
+
+            cur = await conn.execute("SELECT description FROM jobs WHERE id = ?", (jid,))
+            assert (await cur.fetchone())[0] == "short.", "description must NEVER be padded/modified"
+
+        # One more tick, past the cap: no longer selected at all.
+        with aioresponses():
+            result = await tasks_mod.enrichment_sweep({"db": conn})
+        assert result["attempted"] == 0, result
+        assert await _attempts(conn, jid) == MAX_BACKFILL_ATTEMPTS, "counter must stop incrementing too"
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_backfill_whitespace_fetch_result_is_not_treated_as_success(tmp_path, monkeypatch):
+    """PIN: the exact bug the padding approach was rejected for. A fetch that
+    returns a long WHITESPACE-ONLY string must not be counted as 'filled',
+    must not overwrite the real (if short) description, and must still bump
+    the real attempt counter like any other non-improving attempt."""
+    import src.core.settings as settings_mod
+    import src.workers.tasks as tasks_mod
+
+    monkeypatch.setattr(settings_mod, "DESCRIPTION_BACKFILL_PER_TICK", 10, raising=False)
+
+    db = await _full_db(str(tmp_path / "t.db"))
+    try:
+        await db.insert_job(_mk_job(
+            0, "greenhouse", "https://boards.greenhouse.io/deepmind/jobs/555", description="short.",
+        ))
+        conn = db._db
+        user_id = _seed_user(str(tmp_path / "t.db"))
+        cur = await conn.execute("SELECT id FROM jobs LIMIT 1")
+        jid = (await cur.fetchone())[0]
+        await _seed_feed_row(conn, user_id, jid, 90)
+        await db.commit()
+
+        async def _whitespace_only(*a, **kw):
+            return " " * 250  # well over MIN_DESCRIPTION_CHARS, but pure whitespace
+
+        with patch("src.services.description_backfill.fetch_description", new=_whitespace_only):
+            result = await tasks_mod.enrichment_sweep({"db": conn})
+
+        assert result["filled"] == 0, "whitespace-only text must NEVER count as a successful fill"
+        assert result["still_thin"] == 1, result
+
+        cur = await conn.execute("SELECT description FROM jobs WHERE id = ?", (jid,))
+        assert (await cur.fetchone())[0] == "short.", (
+            "the real (if short) description must be preserved, not overwritten with whitespace"
+        )
+        assert await _attempts(conn, jid) == 1, "a whitespace result still counts as an attempt"
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_backfill_fetch_exception_does_not_abort_sweep(tmp_path, monkeypatch):
+    """One poison row (fetch raises) must not stop the sweep from finishing
+    or from processing the other candidate rows, and must still bump the
+    attempt counter so a systemically-broken row is eventually capped."""
+    import src.core.settings as settings_mod
+    import src.workers.tasks as tasks_mod
+
+    monkeypatch.setattr(settings_mod, "DESCRIPTION_BACKFILL_PER_TICK", 10, raising=False)
+
+    db = await _full_db(str(tmp_path / "t.db"))
+    try:
+        for i in range(2):
+            await db.insert_job(_mk_job(
+                i, "greenhouse", f"https://boards.greenhouse.io/deepmind/jobs/{200 + i}",
+            ))
+        conn = db._db
+        user_id = _seed_user(str(tmp_path / "t.db"))
+        cur = await conn.execute("SELECT id FROM jobs ORDER BY id")
+        ids = [r[0] for r in await cur.fetchall()]
+        for jid in ids:
+            await _seed_feed_row(conn, user_id, jid, 90)
+        await db.commit()
+
+        async def _boom(*a, **kw):
+            raise RuntimeError("simulated network failure")
+
+        with patch("src.services.description_backfill.fetch_description", new=_boom):
+            result = await tasks_mod.enrichment_sweep({"db": conn})
+
+        assert result["attempted"] == 2, result
+        assert result["errors"] == 2, result
+
+        cur = await conn.execute("SELECT id, description FROM jobs ORDER BY id")
+        for jid, desc in await cur.fetchall():
+            assert desc == "short.", "an errored row must be left untouched, not corrupted"
+            assert await _attempts(conn, jid) == 1, "an exception still counts as an attempt"
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_backfill_disabled_when_budget_zero(tmp_path, monkeypatch):
+    """DESCRIPTION_BACKFILL_PER_TICK=0 must disable the phase entirely — no
+    SELECT, no fetch, no DB write, no attempt-counter bump."""
+    import src.core.settings as settings_mod
+    import src.workers.tasks as tasks_mod
+
+    monkeypatch.setattr(settings_mod, "DESCRIPTION_BACKFILL_PER_TICK", 0, raising=False)
+
+    db = await _full_db(str(tmp_path / "t.db"))
+    try:
+        await db.insert_job(_mk_job(0, "greenhouse", "https://boards.greenhouse.io/deepmind/jobs/999"))
+        conn = db._db
+        user_id = _seed_user(str(tmp_path / "t.db"))
+        cur = await conn.execute("SELECT id FROM jobs LIMIT 1")
+        jid = (await cur.fetchone())[0]
+        await _seed_feed_row(conn, user_id, jid, 90)
+        await db.commit()
+
+        with aioresponses():  # no routes registered — any HTTP call fails loudly
+            result = await tasks_mod.enrichment_sweep({"db": conn})
+
+        assert result["attempted"] == 0, result
+        assert result["filled"] == 0, result
+        assert result["still_thin"] == 0, result
+        assert result["skipped_by_capability"] == 0, result
+        assert result["errors"] == 0, result
+
+        cur = await conn.execute("SELECT description FROM jobs WHERE id = ?", (jid,))
+        assert (await cur.fetchone())[0] == "short."
+        assert await _attempts(conn, jid) == 0
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_backfilled_job_reaches_enrichment_phase_same_tick(tmp_path, monkeypatch):
+    """A job whose description the BACKFILL phase just filled must be picked
+    up by the REPAIR phase in the SAME enrichment_sweep call — not the next
+    tick — because backfill runs first and commits before the repair query.
+    This scenario DOES need E2 on (repair/missing-coverage are still gated)."""
+    import src.core.settings as settings_mod
+    import src.workers.tasks as tasks_mod
+
+    monkeypatch.setattr(settings_mod, "ENGINE2_ENABLED", True, raising=False)
+    monkeypatch.setattr(settings_mod, "DESCRIPTION_BACKFILL_PER_TICK", 10, raising=False)
+    monkeypatch.setenv("ENRICHMENT_SWEEP_PER_TICK", "5")
+
+    db = await _full_db(str(tmp_path / "t.db"))
+    try:
+        await db.insert_job(_mk_job(0, "greenhouse", "https://boards.greenhouse.io/deepmind/jobs/321"))
+        conn = db._db
+        user_id = _seed_user(str(tmp_path / "t.db"))
+        cur = await conn.execute("SELECT id FROM jobs LIMIT 1")
+        jid = (await cur.fetchone())[0]
+        await _seed_feed_row(conn, user_id, jid, 90)
+        # A hollow enrichment row — the empty-text artifact the REPAIR phase
+        # targets (same shape as test_enrichment_sweep_task.py's repair test).
+        await conn.execute(
+            "INSERT INTO job_enrichment(job_id, title_canonical, category, visa_sponsorship, "
+            "seniority, workplace_type, enriched_at) VALUES (?,?,?,?,?,?,?)",
+            (jid, "Engineer", "software_engineering", "unknown", "unknown", "unknown", _NOW),
+        )
+        await db.commit()
+
+        calls = []
+
+        async def fake_enrich_batch(jobs, semaphore_limit=3, conn=None, skip_existing=True, **kw):
+            calls.append((sorted(j.id for j in jobs), skip_existing))
+            return [object()] * len(jobs)
+
+        with aioresponses() as m:
+            m.get(
+                re.compile(r"https://boards-api\.greenhouse\.io/v1/boards/deepmind/jobs/\d+\?content=true"),
+                payload={"content": _LONG_TEXT},
+            )
+            with patch("src.services.job_enrichment.enrich_batch", new=fake_enrich_batch):
+                result = await tasks_mod.enrichment_sweep({"db": conn})
+
+        assert result["filled"] == 1, result
+        cur = await conn.execute("SELECT description FROM jobs WHERE id = ?", (jid,))
+        assert "Deep learning research" in (await cur.fetchone())[0]
+
+        # REPAIR must have run in THIS SAME call, skip_existing=False (overwrite).
+        assert any(ids == [jid] and skip is False for ids, skip in calls), calls
+    finally:
+        await db.close()

--- a/backend/tests/test_enrichment_sweep_task.py
+++ b/backend/tests/test_enrichment_sweep_task.py
@@ -90,11 +90,26 @@ async def test_sweep_enriches_highest_value_candidates_within_budget(tmp_path, m
 
 @pytest.mark.asyncio
 async def test_sweep_noop_when_e2_off(tmp_path, monkeypatch):
+    """E2 off must mean zero LLM calls — but NOT zero everything.
+
+    2026-08-07 manager review: the BACKFILL phase (description-backfill)
+    was moved OUTSIDE the E2 gate on purpose. It makes no LLM call of its
+    own, and description text feeds Engine 1's keyword scorer and the
+    Engine 4 LLM judge, not just E2 enrichment — gating it behind E2 would
+    mean a keyword-only deployment (E2 off) never gets its thin-job text
+    fixed. So this test now needs a REAL db connection (backfill touches it
+    unconditionally) and asserts on `reason`/`called["n"]` rather than exact
+    dict equality, since backfill_stats keys are always merged into the
+    return value. Backfill itself is disabled here via
+    DESCRIPTION_BACKFILL_PER_TICK=0 so this test stays focused on the E2
+    gate — see test_description_backfill.py for backfill's own coverage.
+    """
     import src.core.settings as settings_mod
     import src.workers.tasks as tasks_mod
 
     monkeypatch.setattr(settings_mod, "ENGINE2_ENABLED", False, raising=False)
     monkeypatch.setattr(tasks_mod, "ENRICHMENT_ENABLED", False)
+    monkeypatch.setattr(settings_mod, "DESCRIPTION_BACKFILL_PER_TICK", 0, raising=False)
 
     called = {"n": 0}
 
@@ -102,11 +117,16 @@ async def test_sweep_noop_when_e2_off(tmp_path, monkeypatch):
         called["n"] += 1
         return []
 
-    with patch("src.services.job_enrichment.enrich_batch", new=fake_enrich_batch):
-        result = await tasks_mod.enrichment_sweep({"db": None})
+    db = await _full_db(str(tmp_path / "e2_off.db"))
+    try:
+        with patch("src.services.job_enrichment.enrich_batch", new=fake_enrich_batch):
+            result = await tasks_mod.enrichment_sweep({"db": db._db})
 
-    assert result == {"enriched": 0, "reason": "e2_off"}
-    assert called["n"] == 0, "E2 off must mean zero LLM calls (rule #18)"
+        assert result["reason"] == "e2_off"
+        assert result["enriched"] == 0
+        assert called["n"] == 0, "E2 off must mean zero LLM calls (rule #18)"
+    finally:
+        await db.close()
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_seniority_inference.py
+++ b/backend/tests/test_seniority_inference.py
@@ -1,0 +1,217 @@
+"""Tests for CV-derived seniority inference (services/profile/seniority.py)
+and its wiring into scoring_dimensions.resolve_experience_level.
+
+Covers the product design rule #29 guarantee explicitly: with BOTH the
+user-typed and the CV-inferred experience level empty, seniority_score must
+return the exact same neutral constant it always has — an inference module
+existing must never change behaviour for a profile it has nothing to say
+about.
+
+Also covers a manager-review regression (2026-08-07): the first cut of this
+module walked positions most-recent-first and returned the first title with
+a tier word, which let a short recent internship outrank years of sustained
+senior work — actively harmful given seniority_score's negative penalty
+tail. The fixtures below (anonymised from two real production profiles that
+both wrongly inferred "intern") pin the fix: a short recent internship must
+not outrank years of sustained senior work.
+"""
+from __future__ import annotations
+
+import datetime
+
+from src.core.settings import SENIORITY_WEIGHT
+from src.services.job_enrichment_schema import JobCategory, JobEnrichment, SeniorityLevel
+from src.services.profile.models import UserPreferences
+from src.services.profile.seniority import infer_experience_level
+from src.services.scoring_dimensions import resolve_experience_level, seniority_score
+
+# Pinned reference "today" so any fixture using an ongoing ("Present") role
+# is deterministic regardless of when the suite actually runs.
+_TODAY = datetime.date(2026, 1, 1)
+
+
+def _enrichment(**overrides) -> JobEnrichment:
+    base = dict(title_canonical="X", category=JobCategory.SOFTWARE_ENGINEERING)
+    base.update(overrides)
+    return JobEnrichment(**base)
+
+
+def _position(title: str, dates: str, **overrides) -> dict:
+    pos = {"company": "Acme", "title": title, "dates": dates, "location": "", "bullets": []}
+    pos.update(overrides)
+    return pos
+
+
+# ---------------------------------------------------------------------------
+# infer_experience_level — a sustained role's title/duration sets the floor
+# ---------------------------------------------------------------------------
+
+
+def test_title_word_on_a_sustained_role_wins():
+    positions = [_position("Senior Backend Engineer", "2021 - Present")]
+    assert infer_experience_level(positions, today=_TODAY) == "senior"
+
+
+def test_graduate_title_on_a_sustained_role_infers_junior_tier():
+    # job_signals' seniority_terms.txt maps "graduate" phrases to the JUNIOR
+    # tier (there is no separate SeniorityLevel.GRADUATE member) — so the
+    # legitimate output is "junior" (what the shared detector returns).
+    positions = [_position("Graduate Software Engineer", "2023 - 2024")]
+    assert infer_experience_level(positions, today=_TODAY) == "junior"
+
+
+def test_linkedin_position_shape_is_supported():
+    # LinkedIn positions use separate start/end keys instead of one "dates"
+    # string — both shapes must resolve through the same parser.
+    linkedin_positions = [
+        {"title": "Staff Engineer", "company": "Acme", "start": "2020", "end": "Present", "description": ""}
+    ]
+    assert infer_experience_level(None, linkedin_positions, today=_TODAY) == "staff"
+
+
+def test_sustained_floor_survives_a_later_short_role():
+    """The exact mechanism the manager-review fix protects: a role that
+    cleared the sustained bar (3 years here) must not be pulled back down by
+    a LATER role that never clears it — regardless of the later role's title
+    or how recent it is."""
+    positions = [
+        _position("Senior Manager", "2015 - 2018"),  # 3 years, sustained
+        _position("Freelance Helper", "Mar 2024 - May 2024"),  # ~3 months, short
+    ]
+    assert infer_experience_level(positions, today=_TODAY) == "senior"
+
+
+def test_duration_promotes_a_title_neutral_sustained_role():
+    # No seniority word in the title at all — the 3-year duration alone must
+    # still produce a non-empty, above-entry-level read.
+    positions = [_position("Software Development Engineer", "2019 - 2022")]
+    assert infer_experience_level(positions, today=_TODAY) == "mid"
+
+
+# ---------------------------------------------------------------------------
+# infer_experience_level — total-duration fallback (no role individually
+# sustained; the true last resort, signal 3)
+# ---------------------------------------------------------------------------
+
+
+def test_total_duration_fallback_when_no_single_role_sustains():
+    # Two short stints (4 months each), neither clears _SUSTAINED_MONTHS on
+    # its own; their SUM (~8 months) is banded instead. Must not be "intern".
+    positions = [
+        _position("Research Assistant", "Jan 2024 - Apr 2024"),
+        _position("Junior Analyst", "Jun 2024 - Sep 2024"),
+    ]
+    assert infer_experience_level(positions, today=_TODAY) == "junior"
+
+
+# ---------------------------------------------------------------------------
+# Regression fixtures — anonymised shapes from two real production profiles
+# that both wrongly inferred "intern" under the pre-fix most-recent-first
+# walk. Titles/dates only; no employer names or personal identifiers.
+# ---------------------------------------------------------------------------
+
+
+def test_real_profile_a_sustained_engineer_not_demoted_by_recent_internship():
+    """A short recent internship must not outrank years of sustained senior
+    work. This user held a plainly-titled engineering role for ~3 years
+    (2019-2022, no seniority word in the title) and, separately, a 3-month
+    internship in late 2024 and an earlier 13-month internship (2017-2018).
+    The pre-fix walk-back logic returned "intern" because that was the most
+    recent title with a tier word. The fix: only the 3-year role clears the
+    sustained-duration bar, and its own length alone (no title word needed)
+    earns "mid" — neither internship, however recent, can pull that back
+    down."""
+    positions = [
+        _position("Blockchain Engineer Intern", "Oct 2024 - December 2024"),
+        _position("Software Development Engineer", "June 2019 - August 2022"),
+        _position("Intern", "May 2017 - June 2018"),
+    ]
+    result = infer_experience_level(positions, today=_TODAY)
+    assert result != "intern"
+    assert result == "mid"
+
+
+def test_real_profile_b_short_stints_do_not_default_to_intern():
+    """A short recent internship must not outrank years of sustained senior
+    work — and, symmetrically, a lone short internship must not be the
+    default answer just because it's the only role with an explicit tier
+    word. This user has ~1 year of total experience across two ~4-month
+    roles (an internship, then a title-neutral R&D role); neither
+    individually clears the sustained bar, so the total (~8 months) is
+    banded instead. The pre-fix walk-back logic returned "intern" because
+    the most recent title had no tier word and the walk landed on the older
+    internship."""
+    positions = [
+        _position("AI Solutions Engineer - R&D", "June 2025 - September 2025"),
+        _position("AI/ML Engineer Intern", "October 2024 - January 2025"),
+    ]
+    result = infer_experience_level(positions, today=_TODAY)
+    assert result != "intern"
+    assert result == "junior"
+
+
+# ---------------------------------------------------------------------------
+# infer_experience_level — defensive behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_empty_positions_infer_nothing():
+    assert infer_experience_level([], []) == ""
+    assert infer_experience_level(None, None) == ""
+
+
+def test_unparseable_dates_do_not_raise():
+    positions = [_position("", "???## not a date at all")]
+    assert infer_experience_level(positions) == ""
+
+    positions_with_title = [_position("Widget Wrangler", "asdf glorp nonsense")]
+    # No exception, and no tier word / no parseable duration -> empty result.
+    assert infer_experience_level(positions_with_title) == ""
+
+
+def test_malformed_position_entries_do_not_raise():
+    # Not a dict, missing keys entirely, wrong types — none of this may crash.
+    garbage = ["not-a-dict", {}, {"title": None, "dates": None}, 42, None]
+    assert infer_experience_level(garbage) == ""
+
+
+# ---------------------------------------------------------------------------
+# resolve_experience_level — typed vs inferred precedence
+# ---------------------------------------------------------------------------
+
+
+def test_typed_value_always_beats_inferred():
+    prefs = UserPreferences(experience_level="mid", experience_level_inferred="senior")
+    assert resolve_experience_level(prefs) == "mid"
+
+
+def test_inferred_used_only_when_typed_is_empty():
+    prefs = UserPreferences(experience_level="", experience_level_inferred="senior")
+    assert resolve_experience_level(prefs) == "senior"
+
+
+def test_resolve_handles_none_profile():
+    assert resolve_experience_level(None) == ""
+
+
+# ---------------------------------------------------------------------------
+# THE RULE #29 PIN — both empty -> seniority_score is byte-identical to today
+# ---------------------------------------------------------------------------
+
+
+def test_both_empty_seniority_score_is_unchanged_neutral_constant():
+    """The guarantee this whole feature is not allowed to break.
+
+    With neither a typed nor an inferred experience level, resolving must
+    yield "" — the exact same input seniority_score has always accepted for
+    "user said nothing" — and the score must be the documented neutral
+    half-weight, identical to calling seniority_score(e, "") directly (the
+    behaviour before this module existed).
+    """
+    prefs = UserPreferences()  # both experience_level and _inferred are ""
+    resolved = resolve_experience_level(prefs)
+    assert resolved == ""
+
+    e = _enrichment(seniority=SeniorityLevel.SENIOR)
+    assert seniority_score(e, resolved) == SENIORITY_WEIGHT // 2
+    assert seniority_score(e, resolved) == seniority_score(e, "")


### PR DESCRIPTION
Two halves of the same gap. **Both were rejected on their first attempt for the same reason** — each would have reported success while being hollow — so the review history is in the commit rather than lost.

## Half 1 — description backfill (job side)

**1,311 active jobs (30%) carry under 200 chars of description**, and every enriched field tracks description length:

```
desc <200 chars    workplace 73% unknown, seniority 63%, visa 98%
desc 1,000-3,000   workplace 13% unknown
```

The enricher was never the problem — it was reading text that wasn't there. A BACKFILL phase now runs **first inside the existing sweep** (not a new worker), 50/tick, highest-user-value first, source-filtered in SQL. LinkedIn deliberately excluded — hammering the scraper risks blocking live search.

### The rejected first attempt
To dodge a migration, it padded still-thin descriptions with spaces until they passed the 200-char floor. Tested in review:

```python
job_has_value('skills', {'description': 'short text' + ' '*250})  →  True
```

Ten real words plus whitespace reported as **full skill coverage** — the exact bug [#254](https://github.com/Ranjith36963/job360/pull/254) killed hours earlier, reborn in a new column, and it would have fed blank space to the LLM judge and to users. Replaced by migration **0029**: a real attempt counter. `description` is now written *only* with genuinely fetched text.

Also fixed in review: the phase was gated behind `ENGINE2_ENABLED` (but text feeds keyword matching too), and the source filter moved into SQL.

**Forecast:** ~700–1,000 of 1,311 recovered; ~150–200 stay thin *by design*.

## Half 2 — seniority inference (user side)

Job side is 60% stocked; user side was empty for **100% of users**. A blank *preference* must never be guessed — but seniority is a **fact** in the CV's dated titles, so deriving it is reading, not inventing.

### The rejected first attempt
"Most recent title wins" returned **`intern` for both real profiles** — one of whom held a Software Development Engineer role for *three years* before a 3-month internship. `seniority_score` has a **negative tail** (−100% at 4 ranks), so that would have actively **penalised** every mid/senior job for someone who typed nothing.

Redesigned around a **duration-gated floor**: 6+ months to count, highest sustained rank wins (never the latest), duration alone can promote a title-neutral role, and the last-resort band starts at "junior" — never "intern".

**Verified on the real profiles:** `intern → mid` and `intern → junior`.

Rule #29 pinned: both values empty → `seniority_score` byte-identical to before.

+37 tests, 427 green across scoring/profile suites, migration round-trips up/down. Gate PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6DsQH5EUxJc3Vnqz9YHgQ
