### PR TITLE
fix(devitjobs): we were telling users 1,977 jobs sponsor visas — the API says 2

### DIFF
--- a/backend/scripts/repair_devitjobs_visa.py
+++ b/backend/scripts/repair_devitjobs_visa.py
@@ -1,0 +1,124 @@
+"""Repair the false "Visa sponsorship available" claim on stored devitjobs rows.
+
+THE BUG (fixed in sources/apis_free/devitjobs.py, this repairs its damage).
+`hasVisaSponsorship` arrives from the API as the STRING "Yes"/"No", and
+`bool("No")` is True in Python. So `visa_flag = bool(item.get(...))` marked
+EVERY devitjobs row as sponsoring, and the description this source composes
+itself then had "Visa sponsorship available" appended to it.
+
+Measured on prod 2026-08-07: 1,977 active rows carried that sentence while the
+API reports exactly 2 of 2,377 jobs actually offering sponsorship.
+
+WHY IT MATTERS MORE THAN A WRONG FLAG. A user with `needs_visa=True` gets the
+FULL visa weight on a job that "sponsors", so ~1,975 jobs that explicitly
+refuse sponsorship were being ranked UP for exactly the users who cannot take
+them. Worse, `visa_signal.detect_visa_status` reads description text — so it
+read our own fabricated sentence back as evidence, inflating measured visa
+coverage. A fabricated fact that a detector then "confirms" is the most
+expensive kind of wrong.
+
+WHAT THIS DOES. Re-reads the live API (the authority), and for every stored
+devitjobs row: sets `visa_flag` to the correctly-parsed value and strips the
+"Visa sponsorship available" sentence from the description unless the API
+actually says Yes. Descriptions are otherwise untouched.
+
+Idempotent. Pass --apply to write; default is a dry run.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import re
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+if os.name == "nt":
+    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+
+_CLAIM = re.compile(r"\.?\s*Visa sponsorship available\.?", re.IGNORECASE)
+
+
+def _sponsors(raw: object) -> bool:
+    """The parse the source should always have used."""
+    return str(raw or "").strip().lower() in ("yes", "true", "1")
+
+
+async def main(apply: bool) -> int:
+    import aiohttp
+    import psycopg
+
+    dsn = os.environ.get("DATABASE_PUBLIC_URL") or os.environ.get("DATABASE_URL")
+    if not dsn:
+        raise SystemExit("set DATABASE_PUBLIC_URL or DATABASE_URL")
+
+    async with aiohttp.ClientSession() as session:
+        async with session.get("https://devitjobs.uk/api/jobsLight") as resp:
+            live = await resp.json(content_type=None)
+
+    # Key by (company, title) — the same pair the catalog dedupes on, since the
+    # API's own id is not stored on our rows.
+    truth: dict[tuple[str, str], bool] = {}
+    for item in live:
+        key = (
+            str(item.get("company") or "").strip().lower(),
+            str(item.get("name") or "").strip().lower(),
+        )
+        truth[key] = _sponsors(item.get("hasVisaSponsorship"))
+    print(f"live API rows: {len(live)}; genuinely sponsoring: {sum(truth.values())}")
+
+    conn = psycopg.connect(dsn)
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT id, company, title, description, visa_flag FROM jobs "
+        "WHERE source = 'devitjobs'"
+    )
+    rows = cur.fetchall()
+
+    fixes: list[tuple[int, str, int]] = []
+    unmatched = 0
+    for jid, company, title, desc, flag in rows:
+        key = (str(company or "").strip().lower(), str(title or "").strip().lower())
+        if key not in truth:
+            # Not in the live feed any more (expired listing). Its stored claim
+            # is still unverifiable, so strip it rather than leave a fabricated
+            # fact standing.
+            unmatched += 1
+            sponsors = False
+        else:
+            sponsors = truth[key]
+        new_desc = desc or ""
+        if not sponsors:
+            new_desc = _CLAIM.sub("", new_desc).strip()
+        new_flag = 1 if sponsors else 0
+        if new_desc != (desc or "") or int(flag or 0) != new_flag:
+            fixes.append((jid, new_desc, new_flag))
+
+    print(f"stored devitjobs rows: {len(rows)}  (not in live feed: {unmatched})")
+    print(f"rows needing repair: {len(fixes)}")
+    if not apply:
+        print("\nDRY RUN — nothing written. Re-run with --apply.")
+        conn.close()
+        return 0
+
+    # Batched: ~2,000 individual round-trips over a public DSN exceeded a
+    # 250s ceiling on the first run. executemany pipelines them.
+    BATCH = 200
+    for i in range(0, len(fixes), BATCH):
+        chunk = fixes[i:i + BATCH]
+        cur.executemany(
+            "UPDATE jobs SET description = %s, visa_flag = %s WHERE id = %s",
+            [(d, f, j) for j, d, f in chunk],
+        )
+        conn.commit()
+        print(f"  ...{min(i + BATCH, len(fixes))}/{len(fixes)}", flush=True)
+    print(f"\nREPAIRED {len(fixes)} rows.")
+    conn.close()
+    return 0
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--apply", action="store_true")
+    raise SystemExit(asyncio.run(main(ap.parse_args().apply)))

--- a/backend/src/sources/apis_free/devitjobs.py
+++ b/backend/src/sources/apis_free/devitjobs.py
@@ -51,7 +51,19 @@ class DevITJobsSource(BaseJobSource):
                 except (ValueError, TypeError):
                     salary_max = None
 
-            visa_flag = bool(item.get("hasVisaSponsorship", False))
+            # `hasVisaSponsorship` arrives as the STRING "Yes"/"No", never a
+            # boolean — and `bool("No")` is True in Python. That one-word bug
+            # marked EVERY devitjobs row as sponsoring and then wrote
+            # "Visa sponsorship available" into the description we compose
+            # below. Measured in prod 2026-08-07: 1,977 active rows claimed
+            # sponsorship while the API says exactly 2 of 2,377 actually
+            # offer it. Users who need sponsorship were being shown - and
+            # ranked UP on - jobs that explicitly refuse it, and the visa text
+            # detector then read our own fabricated sentence back as evidence.
+            # Parse the value; never trust a non-empty string to mean "true".
+            visa_flag = str(item.get("hasVisaSponsorship") or "").strip().lower() in (
+                "yes", "true", "1",
+            )
             exp_level = item.get("expLevel", "")
 
             # Job-understanding fix (2026-08-05): jobsLight has NO prose
@@ -74,7 +86,12 @@ class DevITJobsSource(BaseJobSource):
                 ("Tech category", "techCategory"),
                 ("Category", "metaCategory"),
                 ("Job type", "jobType"),
-                ("Workplace", "remoteType"),
+                # `workplace` (office/hybrid/remote), NOT `remoteType`:
+                # measured live, remoteType is null on 2,324 of 2,377 rows
+                # while workplace is populated on all of them. Reading the
+                # empty one threw away a structured workplace signal for the
+                # single largest source in the catalog.
+                ("Workplace", "workplace"),
                 ("Experience level", "expLevel"),
                 ("Company size", "companySize"),
             ):

--- a/backend/tests/test_devitjobs.py
+++ b/backend/tests/test_devitjobs.py
@@ -1,0 +1,32 @@
+
+
+class TestVisaSponsorshipIsParsedNotCoerced:
+    """`hasVisaSponsorship` arrives as the STRING "Yes"/"No", and bool("No")
+    is True in Python. That one-word bug marked EVERY devitjobs row as
+    sponsoring and wrote "Visa sponsorship available" into the description we
+    compose ourselves.
+
+    Measured in prod 2026-08-07: 1,977 active rows claimed sponsorship while
+    the API says exactly 2 of 2,377 offer it. A user who needs sponsorship was
+    shown - and ranked UP on - jobs that explicitly refuse it, and the visa
+    text detector read our own fabricated sentence back as evidence.
+    """
+
+    @staticmethod
+    def _parse(raw: object) -> bool:
+        return str(raw or "").strip().lower() in ("yes", "true", "1")
+
+    def test_the_string_no_is_falsey(self) -> None:
+        assert self._parse("No") is False
+        assert bool("No") is True, "the trap itself: a non-empty string is truthy"
+
+    def test_the_string_yes_is_truthy(self) -> None:
+        assert self._parse("Yes") is True
+
+    def test_absent_or_empty_is_false(self) -> None:
+        for raw in (None, "", "  "):
+            assert self._parse(raw) is False
+
+    def test_real_booleans_still_work(self) -> None:
+        assert self._parse(True) is True
+        assert self._parse(False) is False

--- a/backend/tests/test_sources.py
+++ b/backend/tests/test_sources.py
@@ -1051,7 +1051,11 @@ DEVITJOBS_PAYLOAD = [
         "actualCity": "London",
         "annualSalaryFrom": 65000,
         "annualSalaryTo": 95000,
-        "hasVisaSponsorship": True,
+        # STRINGS, not booleans — this is what the live API actually
+        # sends, and the mismatch is why a `bool("No") is True` bug
+        # survived here for months: the fixture encoded a shape the
+        # upstream never produced, so the test could not catch it.
+        "hasVisaSponsorship": "Yes",
         "expLevel": "Senior",
         "jobUrl": "https://devitjobs.uk/jobs/revolut-ml-engineer",
         "publishedAt": "2024-01-15",
@@ -1061,7 +1065,10 @@ DEVITJOBS_PAYLOAD = [
         "filterTags": ["machine-learning", "mlops"],
         "techCategory": "Data Science",
         "jobType": "Full-time",
-        "remoteType": "Hybrid",
+        # `workplace` is the field the live API populates (2,377/2,377);
+        # `remoteType` is null on 2,324 of them. Verified 2026-08-07.
+        "workplace": "Hybrid",
+        "remoteType": None,
         "companySize": "1000+",
     },
     {
@@ -1070,7 +1077,7 @@ DEVITJOBS_PAYLOAD = [
         "actualCity": "London",
         "annualSalaryFrom": 40000,
         "annualSalaryTo": 55000,
-        "hasVisaSponsorship": False,
+        "hasVisaSponsorship": "No",
         "expLevel": "Mid",
         "jobUrl": "https://devitjobs.uk/jobs/someco-marketing",
     },


### PR DESCRIPTION
### `bool("No")` is `True` in Python.

`hasVisaSponsorship` arrives from the devitjobs API as the **string** `"Yes"`/`"No"`, and the source did `visa_flag = bool(item.get("hasVisaSponsorship", False))`. Every non-empty string is truthy, so **every** row was marked as sponsoring — and because this source composes its own description text, we wrote *"Visa sponsorship available"* into our own catalog.

```
Rows claiming "Visa sponsorship available":   1,977
Rows the live API says actually sponsor:          2
```

## Why this is worse than a wrong boolean

Real users have `needs_visa=True`. `visa_score` awards **full weight** to a sponsoring job — so ~1,975 jobs that explicitly **refuse** sponsorship were ranked **up** for exactly the people who cannot take them.

**And it corrupted the measurement of itself.** `detect_visa_status` reads description text, so it read our own fabricated sentence back as evidence. The *"visa coverage 3% → 49%"* figure I reported earlier today was built almost entirely on it. **The honest number after repair is 4%.** The detector was never wrong — it was being fed a lie by its own catalog.

> A fabricated fact that a detector then "confirms" is the most expensive kind of wrong, because every downstream check agrees with it.

## Second bug, found while fixing the first
The description composer read `remoteType` for its Workplace line — null on **2,324 of 2,377** live rows — while `workplace` (office/hybrid/remote) is populated on all of them. A structured workplace signal on the largest source in the catalog, discarded. Now reads `workplace`.

## Fix + repair
Parse the value, never coerce the string. `scripts/repair_devitjobs_visa.py` re-reads the live API as the authority and corrects stored rows. **Already run against prod: 1,996 rows repaired, verified 1,977 → 2.**

+4 tests, including an explicit `assert bool("No") is True` so the next reader sees the trap itself. Gate PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6DsQH5EUxJc3Vnqz9YHgQ
