### PR TITLE
feat(pillar1-ui): give needs_visa a front door — the visa dimension can finally fire

### DIFF
--- a/backend/tests/test_pillar1_data_loss.py
+++ b/backend/tests/test_pillar1_data_loss.py
@@ -210,3 +210,43 @@ class TestWorkplaceBridge:
         neutral score), never a manufactured value."""
         assert self._apply({"work_arrangement": ""}).preferred_workplace is None
         assert self._apply({}).preferred_workplace is None
+
+
+class TestNeedsVisaRoundTripsThroughTheRoute:
+    """needs_visa gates the VISA scoring dimension (weight 6) but had NO UI
+    control until 2026-08-08. The frontend form now sends it; this pins the
+    BACKEND half — that _apply_preferences stores what the form sends, and that
+    a save which omits it (an older client) does not silently wipe a stored
+    True (the preferences-wipe class this file's first test covers).
+    """
+
+    def _apply(self, form: dict, existing=None):
+        import json
+
+        from src.api.routes.profile import _apply_preferences
+        from src.services.profile.models import CVData, UserPreferences, UserProfile
+
+        p = UserProfile(
+            cv_data=CVData(),
+            preferences=existing or UserPreferences(),
+        )
+        _apply_preferences(json.dumps(form), p)
+        return p.preferences
+
+    def test_form_sending_true_is_stored(self) -> None:
+        assert self._apply({"needs_visa": True}).needs_visa is True
+
+    def test_form_sending_false_is_stored(self) -> None:
+        from src.services.profile.models import UserPreferences
+
+        out = self._apply({"needs_visa": False},
+                          existing=UserPreferences(needs_visa=True))
+        assert out.needs_visa is False
+
+    def test_a_save_that_omits_it_preserves_the_stored_value(self) -> None:
+        """An older client that never sends the key must not wipe a stored True."""
+        from src.services.profile.models import UserPreferences
+
+        out = self._apply({"target_job_titles": ["ML"]},
+                          existing=UserPreferences(needs_visa=True))
+        assert out.needs_visa is True

--- a/frontend/src/components/profile/PreferencesForm.tsx
+++ b/frontend/src/components/profile/PreferencesForm.tsx
@@ -160,6 +160,7 @@ function prefsFromRaw(raw: Record<string, unknown>): PreferencesRequest {
     negative_keywords: asArr(raw.negative_keywords),
     about_me: typeof raw.about_me === "string" ? raw.about_me : "",
     excluded_companies: asArr(raw.excluded_companies),
+    needs_visa: raw.needs_visa === true,
   };
 }
 
@@ -179,6 +180,7 @@ function serializePrefs(p: PreferencesRequest): string {
     p.negative_keywords,
     p.about_me,
     p.excluded_companies,
+    p.needs_visa,
   ]);
 }
 
@@ -205,6 +207,7 @@ export function PreferencesForm({
   const [negativeKeywords, setNegativeKeywords] = useState<string[]>([]);
   const [aboutMe, setAboutMe] = useState("");
   const [excludedCompanies, setExcludedCompanies] = useState<string[]>([]);
+  const [needsVisa, setNeedsVisa] = useState(false);
   const [saving, setSaving] = useState(false);
   // Distinct from `saving`: a failed auto-save used to fall back to the same
   // green "Changes save automatically" line as a successful one, so once the
@@ -231,6 +234,7 @@ export function PreferencesForm({
     setSalaryMax(p.salary_max != null ? String(p.salary_max) : "");
     setWorkArrangement(p.work_arrangement ?? "any");
     setExperienceLevel(p.experience_level ?? "mid");
+    setNeedsVisa(p.needs_visa === true);
     setNegativeKeywords(p.negative_keywords ?? []);
     setAboutMe(p.about_me ?? "");
     setExcludedCompanies(p.excluded_companies ?? []);
@@ -253,6 +257,7 @@ export function PreferencesForm({
       negative_keywords: negativeKeywords,
       about_me: aboutMe,
       excluded_companies: excludedCompanies,
+      needs_visa: needsVisa,
     }),
     [
       targetTitles,
@@ -267,6 +272,7 @@ export function PreferencesForm({
       negativeKeywords,
       aboutMe,
       excludedCompanies,
+      needsVisa,
     ]
   );
 
@@ -438,6 +444,21 @@ export function PreferencesForm({
             </Select>
           </div>
         </div>
+
+        {/* ── Visa sponsorship ──────────────────────
+            Gates the backend VISA scoring dimension. Before this control
+            existed the field was always the default False, so sponsors could
+            never be ranked up for the people who need them. Empty/unchecked is
+            a real answer ("I don't need sponsorship"), not a missing one. */}
+        <label className="flex items-center gap-2 text-sm font-medium cursor-pointer">
+          <input
+            type="checkbox"
+            className="h-4 w-4 rounded border-input"
+            checked={needsVisa}
+            onChange={(e) => setNeedsVisa(e.target.checked)}
+          />
+          I need visa sponsorship to work in the UK
+        </label>
 
         <Separator />
 

--- a/frontend/src/components/profile/PreferencesForm.visa.test.tsx
+++ b/frontend/src/components/profile/PreferencesForm.visa.test.tsx
@@ -1,0 +1,72 @@
+/**
+ * PreferencesForm — visa sponsorship control.
+ *
+ * needs_visa gates the backend VISA scoring dimension (weight 6). It had NO UI
+ * control anywhere until 2026-08-08, so the field the scorer reads was always
+ * the default False and sponsors could never be ranked up for the people who
+ * need them. These tests pin the round-trip: the checkbox must hydrate from a
+ * saved value AND send its new value on change — and, per the serialize/hydrate
+ * symmetry the component depends on, hydration alone must NOT fire a save.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { PreferencesForm } from "./PreferencesForm";
+
+const VISA_LABEL = /i need visa sponsorship/i;
+
+describe("PreferencesForm — visa sponsorship", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("renders a visa control (the dimension had no front door before)", () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    render(<PreferencesForm preferences={{}} onSave={onSave} loading={false} />);
+    expect(screen.getByLabelText(VISA_LABEL)).toBeTruthy();
+  });
+
+  it("hydrates as checked from a saved needs_visa=true", () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    render(
+      <PreferencesForm
+        preferences={{ needs_visa: true }}
+        onSave={onSave}
+        loading={false}
+      />
+    );
+    expect((screen.getByLabelText(VISA_LABEL) as HTMLInputElement).checked).toBe(true);
+  });
+
+  it("does NOT save on hydration (serialize/hydrate symmetry)", async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    render(
+      <PreferencesForm
+        preferences={{ needs_visa: true }}
+        onSave={onSave}
+        loading={false}
+      />
+    );
+    await act(async () => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it("sends needs_visa=true when the user ticks the box", async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    render(<PreferencesForm preferences={{}} onSave={onSave} loading={false} />);
+
+    fireEvent.click(screen.getByLabelText(VISA_LABEL));
+    expect(onSave).not.toHaveBeenCalled(); // debounced
+
+    await act(async () => {
+      vi.advanceTimersByTime(900);
+    });
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({ needs_visa: true })
+    );
+  });
+});

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -130,6 +130,11 @@ export interface PreferencesRequest {
   negative_keywords?: string[];
   about_me?: string;
   excluded_companies?: string[];
+  // Whether the user needs visa sponsorship. Gates the VISA scoring dimension
+  // (weight 6) on the backend. Had no UI control until 2026-08-08, so the
+  // dimension could never fire for anyone — the field the scorer reads was
+  // always the default False because no screen could set it.
+  needs_visa?: boolean;
 }
 
 // ---- Skill tier / provenance — frontend structuring of profile fields ----


### PR DESCRIPTION
The last audit found the **VISA scoring dimension (weight 6) had no UI control anywhere**. I wrongly deferred it as "an owner decision" — but the directive was explicit: *no restrictions from the user side*. So `needs_visa` was always the default `False` and sponsors could never be ranked up for the people who need them.

Root cause was deeper than a missing checkbox: **`needs_visa` wasn't in the frontend `PreferencesRequest` type at all**, so nothing could send it. The backend already accepts it — this is a frontend completion across all 7 touchpoints: type → parse → serialize → state → hydrate → payload → checkbox.

## Verified (every method short of a pixel render)
- `tsc --noEmit` clean
- **4 component render tests** (jsdom): renders · hydrates *checked* from saved `true` · no save on hydration · sends `true` on tick
- **3 backend route tests**: stores true · stores false · an old client can't wipe a stored true
- existing autosave suite still green
- production build compiles (108s) + serves

## Honest bound
I could **not** capture a pixel screenshot of the control. The prod server runs and the header authenticates via a mocked `/api/auth/me`, but the profile body has a deeper signed-session gate route-mocking doesn't satisfy — and I won't fake a session cookie to manufacture a screenshot. Function is proven; visual layout on the real page is the one thing unconfirmed.

Combined with the workplace bridge (#262), **both previously-dead scoring dimensions now have a working front door.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6DsQH5EUxJc3Vnqz9YHgQ