### PR TITLE
feat(pillar1-ui): show every extracted shelf — the profile page stops hiding the data

### DIFF
--- a/backend/src/api/models.py
+++ b/backend/src/api/models.py
@@ -196,6 +196,11 @@ class CVDetail(BaseModel):
     headline: str = ""
     location: str = ""
     achievements: list[str] = []
+    # Dated work history {company, title, dates, location, bullets}. Stored
+    # since 2026-08-06 but never exposed to the frontend, so the user could
+    # never SEE their parsed experience — only a "Roles: N" count. Part of
+    # the "stored but not shown" gap closed 2026-08-08.
+    cv_positions: list[dict[str, Any]] = []
     # Aggregated highlights for the CV viewer — merges skills + titles +
     # companies + achievements + name/headline/location for in-text highlighting
     highlights: list[str] = []

--- a/backend/src/api/routes/profile.py
+++ b/backend/src/api/routes/profile.py
@@ -128,6 +128,7 @@ def _build_profile_response(profile: UserProfile) -> ProfileResponse:
         headline=getattr(cv, "headline", ""),
         location=getattr(cv, "location", ""),
         achievements=getattr(cv, "achievements", []),
+        cv_positions=getattr(cv, "cv_positions", []) or [],
         highlights=cv.highlights if hasattr(cv, "highlights") else cv.skills,
     )
 
@@ -193,6 +194,11 @@ def _build_profile_response(profile: UserProfile) -> ProfileResponse:
 
     # Step-1.5 S3-E — LinkedIn sub-sections + GitHub temporal map.
     linkedin_subsections: dict[str, list[dict[str, Any]]] = {
+        # LinkedIn work history — parsed and stored since Batch 1.5 but never
+        # exposed here, so it drove only the has_linkedin boolean and the user
+        # could never SEE their LinkedIn experience. Same "stored but not shown"
+        # gap as cv_positions, closed 2026-08-08.
+        "positions": list(getattr(cv, "linkedin_positions", []) or []),
         "languages": list(getattr(cv, "linkedin_languages", []) or []),
         "projects": list(getattr(cv, "linkedin_projects", []) or []),
         "volunteer": list(getattr(cv, "linkedin_volunteer", []) or []),

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -188,6 +188,15 @@
             "title": "Companies",
             "type": "array"
           },
+          "cv_positions": {
+            "default": [],
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "title": "Cv Positions",
+            "type": "array"
+          },
           "education": {
             "default": [],
             "items": {

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -8,6 +8,7 @@ import { User, CheckCircle, AlertCircle, History, Search } from "lucide-react";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
 import { CVUpload } from "@/components/profile/CVUpload";
+import { CVViewer } from "@/components/profile/CVViewer";
 import { PreferencesForm } from "@/components/profile/PreferencesForm";
 import { VersionHistoryDrawer } from "@/components/profile/VersionHistoryDrawer";
 import { JsonResumeExportButton } from "@/components/profile/JsonResumeExportButton";
@@ -329,6 +330,20 @@ export default function ProfilePage() {
                 loading={loadingProfile}
               />
             </div>
+
+            {/* ── What we extracted (readable content, not just counts) ──
+                The API already returns name/summary/skills/dated work
+                history/education/certs/LinkedIn detail/GitHub detail — this
+                was the only place none of it was ever rendered. Each
+                sub-section inside CVViewer renders only when it has data. */}
+            {profile?.cv_detail && (
+              <CVViewer
+                cv={profile.cv_detail}
+                skillProvenance={profile.skill_provenance}
+                linkedinSubsections={profile.linkedin_subsections}
+                githubTemporal={profile.github_temporal}
+              />
+            )}
 
             {/* ── Your Skills (grouped by source) ────────── */}
             {(() => {

--- a/frontend/src/components/profile/CVViewer.extracted-sections.test.tsx
+++ b/frontend/src/components/profile/CVViewer.extracted-sections.test.tsx
@@ -1,0 +1,187 @@
+/**
+ * CVViewer — "What we extracted" sections.
+ *
+ * CVViewer rendered the CV summary/skills/titles/education/certifications
+ * but was wired into NOWHERE in the app (a dead component). This batch wires
+ * it into the profile page and extends it with sections the backend already
+ * returned but nothing ever rendered: dated CV work history (cv_positions),
+ * LinkedIn detail (linkedin_subsections — including LinkedIn's own dated
+ * work history via `positions`), GitHub detail (github_temporal), and
+ * achievements (cv_detail.achievements). These tests pin: (1) a full profile
+ * renders every new section with real content, and (2) an empty/older
+ * profile renders none of them — no crash, no empty-section noise.
+ */
+
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { CVViewer } from "./CVViewer";
+import type { CVDetail } from "@/lib/types";
+
+const FULL_CV: CVDetail = {
+  raw_text: "Jane Doe — Senior Engineer at Acme. Python, TypeScript.",
+  skills: ["Python", "TypeScript"],
+  job_titles: ["Senior Engineer"],
+  companies: ["Acme"],
+  education: ["BSc Computer Science, Imperial College London"],
+  certifications: ["AWS Certified Solutions Architect"],
+  summary_text: "Senior engineer with 8 years building distributed systems.",
+  experience_text: "",
+  name: "Jane Doe",
+  headline: "Senior Engineer @ Acme",
+  location: "London, UK",
+  achievements: [
+    "Won the internal hackathon 2023",
+    "Published a paper at a NeurIPS workshop",
+  ],
+  cv_positions: [
+    {
+      company: "Acme",
+      title: "Senior Engineer",
+      dates: "2021 – Present",
+      location: "Shoreditch, London",
+      bullets: ["Led the payments migration", "Mentored 4 engineers"],
+    },
+    {
+      company: "Beta Corp",
+      title: "Software Engineer",
+      dates: "2018 – 2021",
+      location: "Remote",
+      bullets: [],
+    },
+  ],
+  highlights: ["Python", "TypeScript", "Senior Engineer"],
+  extraction_score: { verdict: "good", coverage: 0.9 },
+};
+
+const SKILL_PROVENANCE = {
+  Python: ["cv_explicit", "github_llm"],
+  TypeScript: ["linkedin"],
+};
+
+const LINKEDIN_SUBSECTIONS = {
+  positions: [
+    {
+      title: "Product Engineer",
+      company: "Widgets Ltd",
+      start: "2019",
+      end: "2021",
+      description: "Owned the checkout flow end to end.",
+    },
+  ],
+  languages: [{ language: "French", proficiency: "Professional working" }],
+  projects: [
+    {
+      title: "Open Source Router",
+      description: "A tiny HTTP router.",
+      start: "2022",
+      end: "2023",
+      url: "https://example.com",
+    },
+  ],
+  volunteer: [
+    { role: "Mentor", organisation: "CodeBar", cause: "Education" },
+  ],
+  courses: [{ title: "Distributed Systems", institution: "Coursera" }],
+};
+
+const GITHUB_TEMPORAL = {
+  languages: { TypeScript: 8000, Python: 2000 },
+  topics: { fastapi: 1, nextjs: 1 },
+};
+
+describe("CVViewer — extracted sections", () => {
+  it("renders identity, work history, LinkedIn detail, and GitHub detail with real content", () => {
+    render(
+      <CVViewer
+        cv={FULL_CV}
+        skillProvenance={SKILL_PROVENANCE}
+        linkedinSubsections={LINKEDIN_SUBSECTIONS}
+        githubTemporal={GITHUB_TEMPORAL}
+      />
+    );
+
+    // Identity
+    expect(screen.getByText("Jane Doe")).toBeInTheDocument();
+    expect(screen.getByText("Senior Engineer @ Acme")).toBeInTheDocument();
+    expect(screen.getByText("London, UK")).toBeInTheDocument();
+
+    // Work history — dated positions, the headline new capability
+    expect(screen.getByText(/Work History \(2\)/)).toBeInTheDocument();
+    expect(screen.getByText("Led the payments migration")).toBeInTheDocument();
+    expect(screen.getByText("Beta Corp", { exact: false })).toBeInTheDocument();
+    expect(screen.getByText("2021 – Present")).toBeInTheDocument();
+
+    // Skills carry a provenance tooltip
+    const pythonBadge = screen.getByText("Python");
+    expect(pythonBadge).toHaveAttribute("title", "Found in: CV, GitHub");
+
+    // LinkedIn detail
+    expect(screen.getByText("LinkedIn detail")).toBeInTheDocument();
+    expect(screen.getByText(/French/)).toBeInTheDocument();
+    expect(screen.getByText("Open Source Router")).toBeInTheDocument();
+    expect(screen.getByText("Mentor")).toBeInTheDocument();
+    expect(screen.getByText(/CodeBar/)).toBeInTheDocument();
+    expect(screen.getByText(/Distributed Systems/)).toBeInTheDocument();
+
+    // LinkedIn Work History — LinkedIn's own dated positions, separate from
+    // the CV's cv_positions
+    expect(screen.getByText(/Work History \(1\)/)).toBeInTheDocument();
+    expect(screen.getByText("Product Engineer")).toBeInTheDocument();
+    expect(screen.getByText(/Widgets Ltd/)).toBeInTheDocument();
+    expect(screen.getByText("2019 – 2021")).toBeInTheDocument();
+    expect(
+      screen.getByText("Owned the checkout flow end to end.")
+    ).toBeInTheDocument();
+
+    // GitHub detail
+    expect(screen.getByText("GitHub detail")).toBeInTheDocument();
+    expect(screen.getByText(/TypeScript · 80%/)).toBeInTheDocument();
+    expect(screen.getByText("fastapi")).toBeInTheDocument();
+
+    // Achievements
+    expect(screen.getByText(/Achievements \(2\)/)).toBeInTheDocument();
+    expect(screen.getByText("Won the internal hackathon 2023")).toBeInTheDocument();
+    expect(
+      screen.getByText("Published a paper at a NeurIPS workshop")
+    ).toBeInTheDocument();
+  });
+
+  it("renders no new sections (and does not crash) for an older/empty profile", () => {
+    const emptyCV: CVDetail = {
+      raw_text: "",
+      skills: [],
+      job_titles: [],
+      companies: [],
+      education: [],
+      certifications: [],
+      summary_text: "",
+      experience_text: "",
+      name: "",
+      headline: "",
+      location: "",
+      achievements: [],
+      cv_positions: [],
+      highlights: [],
+      extraction_score: {},
+    };
+
+    // Also pass linkedinSubsections/githubTemporal with an empty `positions`
+    // array (as an older cached response would), to pin that an empty
+    // positions list doesn't crash or render a Work History block either.
+    render(
+      <CVViewer
+        cv={emptyCV}
+        linkedinSubsections={{ positions: [] }}
+        githubTemporal={{}}
+      />
+    );
+
+    expect(screen.queryByText(/Work History/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Achievements/)).not.toBeInTheDocument();
+    expect(screen.queryByText("LinkedIn detail")).not.toBeInTheDocument();
+    expect(screen.queryByText("GitHub detail")).not.toBeInTheDocument();
+    expect(screen.queryByText(/Skills Extracted/)).not.toBeInTheDocument();
+    // The always-present "Full CV Text" toggle still renders.
+    expect(screen.getByText("Full CV Text")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/profile/CVViewer.tsx
+++ b/frontend/src/components/profile/CVViewer.tsx
@@ -11,12 +11,31 @@ import {
   Wrench,
   User,
   Building,
+  MapPin,
+  Calendar,
+  Link2,
+  Languages,
+  FolderKanban,
+  HeartHandshake,
+  BookOpen,
+  GitBranch,
+  Code2,
+  Hash,
+  Trophy,
 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import type { CVDetail } from "@/lib/types";
 
 interface CVViewerProps {
   cv: CVDetail;
+  /** skill -> list of raw provenance source labels (e.g. "cv_explicit", "linkedin").
+   *  Optional — when absent, skills render as a plain list with no source hint. */
+  skillProvenance?: Record<string, string[]>;
+  /** ProfileResponse.linkedin_subsections — { languages, projects, volunteer, courses }.
+   *  Each entry is a loosely-typed dict from the LLM parse; fields are read defensively. */
+  linkedinSubsections?: Record<string, Record<string, unknown>[]>;
+  /** ProfileResponse.github_temporal — { languages: {lang: bytes}, topics: {topic: 1} }. */
+  githubTemporal?: Record<string, Record<string, unknown>>;
 }
 
 /** Highlight extracted terms within the full CV text. */
@@ -61,7 +80,128 @@ function highlightText(
   });
 }
 
-export function CVViewer({ cv }: CVViewerProps) {
+// ── Dict helpers — cv_positions / linkedin subsections arrive as loosely
+// typed `{[key: string]: unknown}` records (LLM output, no strict schema on
+// the wire), so every field read is defensive: wrong type or missing key
+// just renders as empty rather than crashing. ──────────────────────────────
+
+function strField(obj: Record<string, unknown>, key: string): string {
+  const v = obj[key];
+  return typeof v === "string" ? v : "";
+}
+
+function strArrField(obj: Record<string, unknown>, key: string): string[] {
+  const v = obj[key];
+  return Array.isArray(v)
+    ? v.filter((x): x is string => typeof x === "string")
+    : [];
+}
+
+interface CVPositionEntry {
+  company: string;
+  title: string;
+  dates: string;
+  location: string;
+  bullets: string[];
+}
+
+function normalizePosition(raw: Record<string, unknown>): CVPositionEntry {
+  return {
+    company: strField(raw, "company"),
+    title: strField(raw, "title"),
+    dates: strField(raw, "dates"),
+    location: strField(raw, "location"),
+    bullets: strArrField(raw, "bullets"),
+  };
+}
+
+interface LinkedinPositionEntry {
+  title: string;
+  company: string;
+  start: string;
+  end: string;
+  description: string;
+}
+
+function normalizeLinkedinPosition(raw: Record<string, unknown>): LinkedinPositionEntry {
+  return {
+    title: strField(raw, "title"),
+    company: strField(raw, "company"),
+    start: strField(raw, "start"),
+    end: strField(raw, "end"),
+    description: strField(raw, "description"),
+  };
+}
+
+// ── Skill provenance — map raw evidence-source labels (skill_tiering.py's
+// `_SOURCE_WEIGHTS` keys) to the same 4 user-facing buckets the "Your Skills"
+// section on the profile page already groups by, so the colour language
+// stays consistent across the page. ─────────────────────────────────────────
+
+const SOURCE_BUCKET: Record<string, "cv" | "linkedin" | "github" | "preferences"> = {
+  cv_explicit: "cv",
+  linkedin: "linkedin",
+  github_llm: "github",
+  github_lang: "github",
+  github_dep: "github",
+  user_declared: "preferences",
+  about_me_llm: "preferences",
+};
+
+const BUCKET_LABEL: Record<string, string> = {
+  cv: "CV",
+  linkedin: "LinkedIn",
+  github: "GitHub",
+  preferences: "you added",
+};
+
+/** Human-readable "Found in: CV, LinkedIn" string for a skill badge's title
+ * tooltip, or null when there's no provenance to show. Matches case- and
+ * whitespace-insensitively since evidence names aren't guaranteed to be the
+ * exact same string casing as `cv.skills`. */
+function provenanceTooltip(
+  skill: string,
+  provenance: Record<string, string[]> | undefined
+): string | null {
+  if (!provenance) return null;
+  const norm = (s: string) => s.trim().toLowerCase();
+  const key = Object.keys(provenance).find((k) => norm(k) === norm(skill));
+  if (!key) return null;
+  const buckets = Array.from(
+    new Set(
+      provenance[key]
+        .map((s) => SOURCE_BUCKET[s])
+        .filter((b): b is "cv" | "linkedin" | "github" | "preferences" => Boolean(b))
+    )
+  );
+  if (!buckets.length) return null;
+  return `Found in: ${buckets.map((b) => BUCKET_LABEL[b]).join(", ")}`;
+}
+
+/** Small "icon + uppercase label" header used by every extracted section. */
+function SectionLabel({
+  icon: Icon,
+  text,
+}: {
+  icon: React.ComponentType<{ className?: string }>;
+  text: string;
+}) {
+  return (
+    <div className="flex items-center gap-2 mb-2">
+      <Icon className="h-3.5 w-3.5 text-primary" />
+      <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+        {text}
+      </span>
+    </div>
+  );
+}
+
+export function CVViewer({
+  cv,
+  skillProvenance,
+  linkedinSubsections,
+  githubTemporal,
+}: CVViewerProps) {
   const [showFullCV, setShowFullCV] = useState(false);
 
   // All terms to highlight (combine skills + titles for unified highlighting)
@@ -69,6 +209,34 @@ export function CVViewer({ cv }: CVViewerProps) {
     ...cv.skills,
     ...cv.job_titles,
   ];
+
+  const positions = (cv.cv_positions ?? [])
+    .map((raw) => normalizePosition(raw as Record<string, unknown>))
+    .filter((p) => p.company || p.title);
+
+  // ── LinkedIn subsections ──────────────────────────────────
+  const liPositions = (linkedinSubsections?.positions ?? [])
+    .map((raw) => normalizeLinkedinPosition(raw))
+    .filter((p) => p.title || p.company);
+  const liLanguages = linkedinSubsections?.languages ?? [];
+  const liProjects = linkedinSubsections?.projects ?? [];
+  const liVolunteer = linkedinSubsections?.volunteer ?? [];
+  const liCourses = linkedinSubsections?.courses ?? [];
+  const hasLinkedinDetail =
+    liPositions.length > 0 ||
+    liLanguages.length > 0 ||
+    liProjects.length > 0 ||
+    liVolunteer.length > 0 ||
+    liCourses.length > 0;
+
+  // ── GitHub temporal (languages by byte share + topics) ─────
+  const ghLanguages = Object.entries(githubTemporal?.languages ?? {}).filter(
+    (entry): entry is [string, number] => typeof entry[1] === "number"
+  );
+  const ghLanguageTotal = ghLanguages.reduce((sum, [, bytes]) => sum + bytes, 0);
+  const ghLanguagesSorted = [...ghLanguages].sort((a, b) => b[1] - a[1]);
+  const ghTopics = Object.keys(githubTemporal?.topics ?? {});
+  const hasGithubDetail = ghLanguagesSorted.length > 0 || ghTopics.length > 0;
 
   return (
     <div className="space-y-6 animate-fade-in-up stagger-2">
@@ -78,6 +246,28 @@ export function CVViewer({ cv }: CVViewerProps) {
           <FileText className="h-4 w-4 text-primary" />
           What we extracted from your CV
         </h3>
+
+        {/* Identity */}
+        {(cv.name || cv.headline || cv.location) && (
+          <div className="mb-5 pb-4 border-b border-border/40">
+            {cv.name && (
+              <h4 className="font-heading text-lg font-semibold text-foreground">
+                {cv.name}
+              </h4>
+            )}
+            {cv.headline && (
+              <p className="mt-0.5 text-sm text-muted-foreground">
+                {cv.headline}
+              </p>
+            )}
+            {cv.location && (
+              <p className="mt-1.5 flex items-center gap-1 text-xs text-muted-foreground">
+                <MapPin className="h-3 w-3" />
+                {cv.location}
+              </p>
+            )}
+          </div>
+        )}
 
         {/* Professional Summary */}
         {cv.summary_text && (
@@ -109,6 +299,7 @@ export function CVViewer({ cv }: CVViewerProps) {
                   key={skill}
                   variant="secondary"
                   className="text-xs skill-matched"
+                  title={provenanceTooltip(skill, skillProvenance) ?? undefined}
                 >
                   {skill}
                 </Badge>
@@ -135,6 +326,55 @@ export function CVViewer({ cv }: CVViewerProps) {
                   <Building className="mr-1.5 h-3 w-3" />
                   {title}
                 </span>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Work History — dated positions (company · title · dates · location + bullets).
+            Stored server-side since 2026-08-06 but never shown until now — the only
+            place a user can see WHEN and WHERE they worked, not just a role-title bag. */}
+        {positions.length > 0 && (
+          <div className="mb-5">
+            <SectionLabel icon={Calendar} text={`Work History (${positions.length})`} />
+            <div className="space-y-3 pl-5">
+              {positions.map((pos, i) => (
+                <div
+                  key={i}
+                  className="rounded-lg border border-border/50 bg-muted/10 p-3"
+                >
+                  <div className="flex flex-wrap items-baseline justify-between gap-x-3 gap-y-0.5">
+                    <p className="text-sm font-medium text-foreground">
+                      {pos.title || "Role"}
+                      {pos.company && (
+                        <span className="font-normal text-muted-foreground">
+                          {" "}
+                          · {pos.company}
+                        </span>
+                      )}
+                    </p>
+                    {pos.dates && (
+                      <span className="shrink-0 text-xs text-muted-foreground">
+                        {pos.dates}
+                      </span>
+                    )}
+                  </div>
+                  {pos.location && (
+                    <p className="mt-0.5 flex items-center gap-1 text-xs text-muted-foreground">
+                      <MapPin className="h-3 w-3" />
+                      {pos.location}
+                    </p>
+                  )}
+                  {pos.bullets.length > 0 && (
+                    <ul className="mt-2 list-disc space-y-1 pl-4 text-xs text-foreground/80">
+                      {pos.bullets.map((bullet, bi) => (
+                        <li key={bi} className="leading-relaxed">
+                          {bullet}
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </div>
               ))}
             </div>
           </div>
@@ -172,6 +412,22 @@ export function CVViewer({ cv }: CVViewerProps) {
               {cv.certifications.map((cert, i) => (
                 <li key={i} className="leading-relaxed">
                   {cert}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {/* Achievements — returned by the API since day one, rendered
+            nowhere until now. Same "stored but not shown" shape as
+            cv_positions was. */}
+        {cv.achievements.length > 0 && (
+          <div className="mb-5">
+            <SectionLabel icon={Trophy} text={`Achievements (${cv.achievements.length})`} />
+            <ul className="space-y-1 pl-5 text-sm text-foreground/80">
+              {cv.achievements.map((achievement, i) => (
+                <li key={i} className="leading-relaxed">
+                  {achievement}
                 </li>
               ))}
             </ul>
@@ -217,6 +473,205 @@ export function CVViewer({ cv }: CVViewerProps) {
           </div>
         )}
       </div>
+
+      {/* ── LinkedIn detail ────────────────────────────── */}
+      {hasLinkedinDetail && (
+        <div className="glass-card rounded-xl p-6">
+          <h3 className="font-heading text-base font-semibold mb-4 flex items-center gap-2">
+            <Link2 className="h-4 w-4 text-[#0A66C2]" />
+            LinkedIn detail
+          </h3>
+
+          {/* Work History — parsed and stored since Batch 1.5 but never
+              exposed until now; same visual style as the CV Work History
+              section above (title · company · dates, description under
+              each — LinkedIn positions carry one description, not bullets). */}
+          {liPositions.length > 0 && (
+            <div className="mb-5">
+              <SectionLabel icon={Calendar} text={`Work History (${liPositions.length})`} />
+              <div className="space-y-3 pl-5">
+                {liPositions.map((pos, i) => (
+                  <div
+                    key={i}
+                    className="rounded-lg border border-border/50 bg-muted/10 p-3"
+                  >
+                    <div className="flex flex-wrap items-baseline justify-between gap-x-3 gap-y-0.5">
+                      <p className="text-sm font-medium text-foreground">
+                        {pos.title || "Role"}
+                        {pos.company && (
+                          <span className="font-normal text-muted-foreground">
+                            {" "}
+                            · {pos.company}
+                          </span>
+                        )}
+                      </p>
+                      {(pos.start || pos.end) && (
+                        <span className="shrink-0 text-xs text-muted-foreground">
+                          {[pos.start, pos.end].filter(Boolean).join(" – ")}
+                        </span>
+                      )}
+                    </div>
+                    {pos.description && (
+                      <p className="mt-1 text-xs text-foreground/80 leading-relaxed">
+                        {pos.description}
+                      </p>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {liLanguages.length > 0 && (
+            <div className="mb-5">
+              <SectionLabel icon={Languages} text={`Languages (${liLanguages.length})`} />
+              <ul className="flex flex-wrap gap-1.5 pl-5">
+                {liLanguages.map((item, i) => {
+                  const lang = strField(item, "language");
+                  const prof = strField(item, "proficiency");
+                  if (!lang) return null;
+                  return (
+                    <li
+                      key={i}
+                      className="rounded-full bg-sky-500/10 text-sky-400 px-2.5 py-0.5 text-xs font-medium"
+                    >
+                      {lang}
+                      {prof ? ` · ${prof}` : ""}
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+          )}
+
+          {liProjects.length > 0 && (
+            <div className="mb-5">
+              <SectionLabel icon={FolderKanban} text={`Projects (${liProjects.length})`} />
+              <div className="space-y-2 pl-5">
+                {liProjects.map((item, i) => {
+                  const title = strField(item, "title");
+                  const description = strField(item, "description");
+                  const start = strField(item, "start");
+                  const end = strField(item, "end");
+                  const dateRange = [start, end].filter(Boolean).join(" – ");
+                  if (!title) return null;
+                  return (
+                    <div key={i} className="text-sm">
+                      <p className="font-medium text-foreground">
+                        {title}
+                        {dateRange && (
+                          <span className="ml-2 text-xs font-normal text-muted-foreground">
+                            {dateRange}
+                          </span>
+                        )}
+                      </p>
+                      {description && (
+                        <p className="text-xs text-foreground/70 leading-relaxed">
+                          {description}
+                        </p>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+
+          {liVolunteer.length > 0 && (
+            <div className="mb-5">
+              <SectionLabel icon={HeartHandshake} text={`Volunteer (${liVolunteer.length})`} />
+              <div className="space-y-2 pl-5">
+                {liVolunteer.map((item, i) => {
+                  const role = strField(item, "role");
+                  const org = strField(item, "organisation");
+                  const cause = strField(item, "cause");
+                  if (!role && !org) return null;
+                  return (
+                    <div key={i} className="text-sm">
+                      <p className="font-medium text-foreground">
+                        {role || "Volunteer"}
+                        {org && (
+                          <span className="font-normal text-muted-foreground">
+                            {" "}
+                            · {org}
+                          </span>
+                        )}
+                      </p>
+                      {cause && (
+                        <p className="text-xs text-foreground/70">{cause}</p>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+
+          {liCourses.length > 0 && (
+            <div>
+              <SectionLabel icon={BookOpen} text={`Courses (${liCourses.length})`} />
+              <ul className="space-y-1 pl-5 text-sm text-foreground/80">
+                {liCourses.map((item, i) => {
+                  const title = strField(item, "title");
+                  const institution = strField(item, "institution");
+                  if (!title) return null;
+                  return (
+                    <li key={i} className="leading-relaxed">
+                      {title}
+                      {institution ? ` — ${institution}` : ""}
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* ── GitHub detail ──────────────────────────────── */}
+      {hasGithubDetail && (
+        <div className="glass-card rounded-xl p-6">
+          <h3 className="font-heading text-base font-semibold mb-4 flex items-center gap-2">
+            <GitBranch className="h-4 w-4 text-[#8B5CF6]" />
+            GitHub detail
+          </h3>
+
+          {ghLanguagesSorted.length > 0 && (
+            <div className="mb-5">
+              <SectionLabel icon={Code2} text={`Languages (${ghLanguagesSorted.length})`} />
+              <ul className="flex flex-wrap gap-1.5 pl-5">
+                {ghLanguagesSorted.map(([lang, bytes]) => {
+                  const pct = ghLanguageTotal > 0 ? Math.round((bytes / ghLanguageTotal) * 100) : 0;
+                  return (
+                    <li
+                      key={lang}
+                      className="rounded-full bg-violet-500/10 text-violet-400 px-2.5 py-0.5 text-xs font-medium"
+                    >
+                      {lang} {pct > 0 ? `· ${pct}%` : ""}
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+          )}
+
+          {ghTopics.length > 0 && (
+            <div>
+              <SectionLabel icon={Hash} text={`Topics (${ghTopics.length})`} />
+              <ul className="flex flex-wrap gap-1.5 pl-5">
+                {ghTopics.map((topic) => (
+                  <li
+                    key={topic}
+                    className="rounded-full bg-muted/40 text-muted-foreground px-2.5 py-0.5 text-xs font-medium"
+                  >
+                    {topic}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/lib/api-types.ts
+++ b/frontend/src/lib/api-types.ts
@@ -1512,6 +1512,13 @@ export interface components {
              */
             companies: string[];
             /**
+             * Cv Positions
+             * @default []
+             */
+            cv_positions: {
+                [key: string]: unknown;
+            }[];
+            /**
              * Education
              * @default []
              */


### PR DESCRIPTION
The profile page rendered only **counts** ("Skills: 24, Roles: 2") plus a wall of raw CV text. A user could never *see* their extracted name, summary, skills list, dated work history, education, certs, achievements, or any LinkedIn/GitHub detail — the *"hiding / blind spots"* the owner asked to find. A 222-line `CVViewer` that renders these as real lists existed but was **imported nowhere**.

## Three fields were 'stored but not shown' at different layers — all closed
- **cv_positions** (dated CV work history) — stored since Aug 6, never in the API response. Added to `CVDetail` + route.
- **linkedin_positions** (LinkedIn work history) — parsed + stored, only drove `has_linkedin`. Added to `linkedin_subsections`.
- **achievements** — returned, drawn nowhere. Now rendered.

## The new view
`CVViewer` wired into the page and extended into **"What we extracted from your CV"**: identity · summary · full skills list (with per-source provenance tooltips) · **dated Work History with bullets** · education · certifications · achievements — plus a **LinkedIn detail** card (work history, languages, projects, volunteer, courses) and a **GitHub detail** card (languages by %, topics). Every section renders **only when it has data** — no empty noise, no false emptiness.

## Verified by screenshot, not assertion
Built the prod bundle, served it, authenticated with the **repo's own e2e recipe** (`job360_session` cookie + `E2E_TEST_MODE`) — not invented route-mocks — and captured the real page at 1440×900 and 390×844. Inspected the images directly: all sections render with real content, **mobile `scrollWidth == 390` (no overflow)**, 0 console errors. This is the pixel proof the earlier needs_visa PR couldn't produce; the session gate was cracked by reading how the project's existing Playwright specs log in.

+CVViewer tests (present with data · absent + no-crash when empty). type-check clean, 19 component tests pass, api-types regenerated. Gate PASS.

Deliberately left (dead weight per the shelf manifest, would be noise): `career_domain`, `cv_languages`, `llm_input_hashes` — no reader.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6DsQH5EUxJc3Vnqz9YHgQ