### PR TITLE
fix(profile): github_username self-validates; extracted view labelled 'profile' not 'CV'

### DIFF
--- a/backend/src/api/routes/profile.py
+++ b/backend/src/api/routes/profile.py
@@ -364,7 +364,14 @@ def _apply_preferences(preferences_json: str, profile: UserProfile) -> None:
         experience_level=pref_dict.get("experience_level", ""),
         negative_keywords=pref_dict.get("negative_keywords", []),
         about_me=pref_dict.get("about_me", ""),
-        github_username=pref_dict.get("github_username", existing.github_username),
+        # normalize_github_username here too, not only in the dedicated GitHub
+        # route: a raw value reaching this fallback path stored "https:" for a
+        # real user (2026-08-08), which silently broke GitHub enrichment. A
+        # value that doesn't reduce to a valid handle normalizes to "" — better
+        # an empty handle than a poisoned one.
+        github_username=normalize_github_username(
+            pref_dict.get("github_username") or existing.github_username or ""
+        ),
         # Explicit value wins (a future dedicated control); otherwise derive
         # from work_arrangement; only then fall back to the stored value.
         preferred_workplace=pref_dict.get("preferred_workplace")

--- a/backend/src/services/profile/github_enricher.py
+++ b/backend/src/services/profile/github_enricher.py
@@ -58,9 +58,15 @@ def normalize_github_username(raw: str) -> str:
     match = re.search(r"github\.com/+([^/?#\s]+)", s, re.IGNORECASE)
     if match:
         return match.group(1)
-    # Otherwise treat the whole thing as a handle, but still strip any
-    # stray path/query so "torvalds/repo" -> "torvalds".
-    return re.split(r"[/?#\s]", s, maxsplit=1)[0]
+    else:
+        # Otherwise treat the whole thing as a handle, but still strip any
+        # stray path/query so "torvalds/repo" -> "torvalds".
+        s = re.split(r"[/?#\s]", s, maxsplit=1)[0]
+    # SELF-VALIDATE. The old contract left validation "to the caller", so a
+    # caller that forgot (the _apply_preferences fallback) stored "https:" for a
+    # real user and silently broke GitHub enrichment. A handle that fails the
+    # GitHub rule is not a handle — return "" so no caller can persist poison.
+    return s if _GITHUB_USERNAME_RE.match(s) else ""
 
 
 from src.core.settings import GITHUB_TOKEN

--- a/backend/tests/test_pillar1_data_loss.py
+++ b/backend/tests/test_pillar1_data_loss.py
@@ -250,3 +250,34 @@ class TestNeedsVisaRoundTripsThroughTheRoute:
         out = self._apply({"target_job_titles": ["ML"]},
                           existing=UserPreferences(needs_visa=True))
         assert out.needs_visa is True
+
+
+class TestGithubUsernameFallbackIsNormalized:
+    """github_username reaching the _apply_preferences fallback path was stored
+    raw — a real user ended up with 'https:' (2026-08-08), which silently broke
+    GitHub enrichment (0 languages/skills, no GitHub bucket). The dedicated
+    GitHub route already normalized; this pins the fallback path too."""
+
+    def _apply(self, form: dict, existing_username: str = ""):
+        import json
+
+        from src.api.routes.profile import _apply_preferences
+        from src.services.profile.models import CVData, UserPreferences, UserProfile
+
+        p = UserProfile(
+            cv_data=CVData(),
+            preferences=UserPreferences(github_username=existing_username),
+        )
+        _apply_preferences(json.dumps(form), p)
+        return p.preferences.github_username
+
+    def test_a_url_is_reduced_to_a_handle(self) -> None:
+        assert self._apply({"github_username": "https://github.com/Ranjith36963"}) == "Ranjith36963"
+
+    def test_a_stored_bad_value_is_scrubbed_on_next_save(self) -> None:
+        # 'https:' can never be a valid handle -> normalizes to "" rather than
+        # persisting the poison.
+        assert self._apply({}, existing_username="https:") == ""
+
+    def test_a_clean_handle_survives(self) -> None:
+        assert self._apply({"github_username": "torvalds"}) == "torvalds"

--- a/frontend/src/components/profile/CVViewer.tsx
+++ b/frontend/src/components/profile/CVViewer.tsx
@@ -244,7 +244,7 @@ export function CVViewer({
       <div className="glass-card rounded-xl p-6">
         <h3 className="font-heading text-base font-semibold mb-4 flex items-center gap-2">
           <FileText className="h-4 w-4 text-primary" />
-          What we extracted from your CV
+          What we extracted from your profile
         </h3>
 
         {/* Identity */}


### PR DESCRIPTION
Two small fixes from the same live smoke test as #266.

**P1 — github_username stored as `'https:'`** for a real user, silently breaking all GitHub enrichment (0 skills, no FROM-GITHUB bucket). `normalize_github_username` reduced a URL to a handle but **never validated the result** — its docstring said validation was 'left to the caller', and the `_apply_preferences` fallback didn't. Now it **self-validates** (returns `''` for non-handles), so no caller can persist poison. `'https:'` → `''`; `https://github.com/Ranjith36963` → `Ranjith36963`; scrubbed on next save.

**P2 — label** 'What we extracted from your **CV**' → '…your **profile**' (it includes LinkedIn + GitHub; per-source badges already sit below it).

+3 tests, 67 green. Gate PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6DsQH5EUxJc3Vnqz9YHgQ