### PR TITLE
feat(profile): upload receipts, one copy of the CV text, fewer preference boxes

### DIFF
--- a/backend/scripts/reset_polluted_additional_skills.py
+++ b/backend/scripts/reset_polluted_additional_skills.py
@@ -1,0 +1,115 @@
+"""One-time: empty the "Added by you" box for a user whose entries are NOT his.
+
+WHY THIS IS CLEANUP, NOT DATA DELETION.
+
+An old extraction bug wrote CV content into ``preferences.additional_skills``
+(the "Added by you" box). The sanitizer in ``save_profile`` removes entries that
+are verbatim duplicates of an extracted skill, which took one live profile from
+131 -> 103 -> 24. The residual 24 survive only because they are not EXACT
+matches — they are the SPLIT HALVES of skills the CV holds joined:
+
+    cv.skills            "Audio Processing"  "Transfer Learning"  "CI/CD Pipelines"
+    additional_skills    "Audio" "Processing" "Transfer" "Learning" "CI" "CD Pipelines"
+
+plus a location ("Remote", from a position location "United Kingdom (Remote)")
+and a past job title ("ML Engineer Intern", a substring of "AI/ML Engineer
+Intern"). The mechanism, the provenance, and the owner's own testimony ("did you
+add that or is it just populating on its own?" — he typed none of them) all
+agree: this is bug output, not user input.
+
+WHY NOT A CLEVER RULE INSTEAD. A "drop anything that is a sub-phrase of an
+extracted skill" heuristic would catch these, but it is NOT zero-loss: if
+``cv.skills`` held "Docker Compose" and the user genuinely typed "Docker", it
+would delete a real, distinct skill. It would also be a permanent heuristic
+guarding a box that extraction can no longer write to — cleverness defending
+against a threat that is already dead. A targeted one-time reset is the honest
+tool for a one-time mess.
+
+SAFETY.
+  * Writes via ``save_profile``, which appends a version snapshot first — the
+    previous list stays in ``user_profile_versions``, so this is reversible.
+  * Requires an explicit --email. Refuses to run across all users: the
+    justification is one user's testimony, and nobody else has given it.
+  * Does NOT touch cv_data. Every skill remains visible under its real source
+    (CV / LinkedIn / GitHub) and keeps feeding matching from there.
+  * Idempotent — an already-empty box is a no-op.
+
+Usage:
+    railway run -s Postgres bash -c \
+      'export DATABASE_URL="$DATABASE_PUBLIC_URL"; \
+       python scripts/reset_polluted_additional_skills.py --email X --apply'
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+def main(email: str, apply: bool) -> int:
+    import psycopg
+
+    from src.services.profile.models import CVData, UserPreferences, UserProfile
+    from src.services.profile.storage import _filter_fields, save_profile
+
+    dsn = os.environ.get("DATABASE_PUBLIC_URL") or os.environ.get("DATABASE_URL")
+    if not dsn:
+        raise SystemExit("set DATABASE_PUBLIC_URL or DATABASE_URL")
+    conn = psycopg.connect(dsn)
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT u.id, p.cv_data, p.preferences FROM user_profiles p "
+        "JOIN users u ON u.id = p.user_id WHERE u.email = %s",
+        (email,),
+    )
+    row = cur.fetchone()
+    conn.close()
+    if not row:
+        raise SystemExit(f"no profile for {email}")
+
+    uid, cv_json, pref_json = row
+    cv = CVData(**_filter_fields(json.loads(cv_json), CVData))
+    prefs = UserPreferences(**_filter_fields(json.loads(pref_json), UserPreferences))
+    before = list(prefs.additional_skills or [])
+    if not before:
+        print("already empty — nothing to do")
+        return 0
+
+    # Show the evidence, so the operator sees WHAT is being dropped and can
+    # confirm each entry is reachable elsewhere before agreeing to the write.
+    extracted = set()
+    for f in ("skills", "linkedin_skills", "github_llm_skills", "github_skills_inferred"):
+        for s in getattr(cv, f, []) or []:
+            if isinstance(s, str):
+                extracted.add(s.strip().lower())
+    print(f"{email}: additional_skills = {len(before)}")
+    for s in before:
+        low = s.strip().lower()
+        covered = [e for e in extracted if low in e and low != e]
+        note = f"fragment of: {covered[0]}" if covered else "no joined form found"
+        print(f"  - {s:<28} ({note})")
+
+    if not apply:
+        print(f"\nDRY RUN — would clear all {len(before)}. Re-run with --apply.")
+        return 0
+
+    prefs.additional_skills = []
+    save_profile(
+        UserProfile(cv_data=cv, preferences=prefs),
+        uid,
+        "additional_skills_pollution_reset",
+    )
+    print(f"\nCLEARED {len(before)} entries. Previous list is preserved in "
+          "user_profile_versions (rollback available).")
+    return 0
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--email", required=True, help="the ONE user to reset")
+    ap.add_argument("--apply", action="store_true")
+    a = ap.parse_args()
+    raise SystemExit(main(a.email, a.apply))

--- a/backend/src/api/models.py
+++ b/backend/src/api/models.py
@@ -178,6 +178,18 @@ class ProfileSummary(BaseModel):
     has_github: bool
     education: list[str]
     experience_level: str
+    # Upload receipts — what the user gave us and when, per input. Defaults
+    # keep every existing caller and old stored profile valid (a profile saved
+    # before 2026-08-08 has no receipt, and the UI falls back to a plain
+    # "uploaded" state). ``github_repo_count`` is the GitHub equivalent of a
+    # filename: proof of what we actually read.
+    cv_filename: str = ""
+    cv_uploaded_at: str = ""
+    linkedin_filename: str = ""
+    linkedin_uploaded_at: str = ""
+    github_username: str = ""
+    github_connected_at: str = ""
+    github_repo_count: int = 0
 
 
 class CVDetail(BaseModel):

--- a/backend/src/api/routes/profile.py
+++ b/backend/src/api/routes/profile.py
@@ -7,6 +7,7 @@ import json
 import logging
 import os
 from dataclasses import asdict
+from datetime import datetime, timezone
 from typing import Any, cast
 
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, UploadFile
@@ -113,6 +114,15 @@ def _build_profile_response(profile: UserProfile) -> ProfileResponse:
         has_github=bool(profile.cv_data.github_languages),
         education=profile.cv_data.education,
         experience_level=profile.preferences.experience_level,
+        # Upload receipts (2026-08-08) — getattr so a CVData loaded from a row
+        # saved before these fields existed still renders.
+        cv_filename=getattr(profile.cv_data, "cv_filename", "") or "",
+        cv_uploaded_at=getattr(profile.cv_data, "cv_uploaded_at", "") or "",
+        linkedin_filename=getattr(profile.cv_data, "linkedin_filename", "") or "",
+        linkedin_uploaded_at=getattr(profile.cv_data, "linkedin_uploaded_at", "") or "",
+        github_username=profile.preferences.github_username or "",
+        github_connected_at=getattr(profile.cv_data, "github_connected_at", "") or "",
+        github_repo_count=len(getattr(profile.cv_data, "github_repos_brief", []) or []),
     )
     cv = profile.cv_data
     cv_detail = CVDetail(
@@ -321,6 +331,13 @@ async def _capture_cv_raw(content: bytes, filename: str | None, profile: UserPro
         # the new one is known to be readable.
         reset_cv_owned_fields(profile.cv_data)
         profile.cv_data.raw_text = raw_text
+        # Upload receipt — WHAT was uploaded and WHEN. Set here, right where the
+        # new CV replaces the old one, so a re-upload always names the CURRENT
+        # file (a stale name would be worse than none: it would confirm the
+        # wrong document). Only the base name is kept — a browser can send a
+        # path-ish value, and the directory part is neither useful nor ours.
+        profile.cv_data.cv_filename = os.path.basename(filename or "")[:255]
+        profile.cv_data.cv_uploaded_at = datetime.now(timezone.utc).isoformat()
     finally:
         try:
             os.unlink(tmp_path)
@@ -512,6 +529,11 @@ async def upload_linkedin(
         if merged:
             profile = load_profile(user.id) or UserProfile()
             profile.cv_data.linkedin_raw_text = text
+            # Upload receipt — see the CV path. Recorded only on a MERGED
+            # upload: a PDF we could not read as LinkedIn changes nothing, so
+            # claiming a successful upload would be a lie on screen.
+            profile.cv_data.linkedin_filename = os.path.basename(file.filename or "")[:255]
+            profile.cv_data.linkedin_uploaded_at = datetime.now(timezone.utc).isoformat()
             await _extract_save_trigger(profile, user.id)
     finally:
         try:
@@ -539,6 +561,9 @@ async def upload_github(
     # the GitHub LLM pass and re-runs the others from stored raw.
     profile.cv_data = enrich_cv_from_github(profile.cv_data, github_data)
     profile.preferences.github_username = clean_username
+    # Connection receipt — GitHub has no file, so the handle + when we read it
+    # is the receipt (repo count comes from len(github_repos_brief)).
+    profile.cv_data.github_connected_at = datetime.now(timezone.utc).isoformat()
     await _extract_save_trigger(profile, user.id)
     return GitHubResponse(ok=True, merged=True)
 

--- a/backend/src/services/profile/models.py
+++ b/backend/src/services/profile/models.py
@@ -101,6 +101,27 @@ class CVData:
     # JSON blob, no migration (storage._filter_fields drops unknown keys, so
     # old rows load with an empty list).
     cv_positions: list[dict[str, Any]] = field(default_factory=list)
+    # ── Upload receipts (2026-08-08) ────────────────────────────────────────
+    # WHAT the user gave us and WHEN. Found on a live smoke test: after
+    # uploading, the only feedback was a small tick the owner said he "didn't
+    # catch", and nothing anywhere named the file — so a user could not tell
+    # WHICH CV was on file, whether a re-upload had actually replaced it, or
+    # when any of it happened. GitHub had no confirmation at all.
+    #
+    # Storing the original filename is consistent with what is already kept:
+    # the full CV text (far more sensitive) lives in ``raw_text``. Keeping the
+    # receipt inside this same blob means the existing account-deletion and
+    # version-snapshot paths carry it automatically — no separate lifecycle.
+    # JSON blob, so no migration (storage._filter_fields drops unknown keys;
+    # old rows load with empty strings and the UI falls back to "uploaded").
+    # Timestamps are ISO-8601 UTC strings, matching the rest of storage.
+    cv_filename: str = ""
+    cv_uploaded_at: str = ""
+    linkedin_filename: str = ""
+    linkedin_uploaded_at: str = ""
+    # GitHub has no file — the handle IS the receipt, alongside when it was
+    # connected and how many repos were read (len(github_repos_brief)).
+    github_connected_at: str = ""
     # Batch 1.1 — archetype classification (CareerDomain enum value).
     # Optional; None means "LLM did not classify". Consumed by
     # archetype-aware scoring (Pillar 1 #10 / Pillar 2).

--- a/backend/tests/test_profile_upload.py
+++ b/backend/tests/test_profile_upload.py
@@ -513,3 +513,135 @@ class TestCapturedCvReplacesRatherThanBlends:
         assert profile.cv_data.raw_text == "ORIGINAL CV TEXT"
         assert profile.cv_data.name == "Alice Anderson"
         assert profile.cv_data.skills == ["Airflow", "Spark"]
+
+
+# ---------------------------------------------------------------------------
+# Upload receipts — WHAT was uploaded, and WHEN
+# ---------------------------------------------------------------------------
+# Found on a live smoke test 2026-08-08. After uploading, the only feedback was
+# a small tick the owner said he "didn't catch", and nothing named the file, so
+# a user could not tell WHICH CV was on file or whether a re-upload replaced it.
+# GitHub had no confirmation at all.
+#
+# VALUE-presence tests, not schema-presence (rule #21): every receipt field
+# defaults to "", so `assert "cv_filename" in body` would pass against a
+# serializer that never reads it. Each test runs a real upload end-to-end and
+# asserts the ACTUAL filename.
+#
+# These live HERE rather than in their own file on purpose: the `api` fixture
+# gives each test its own DB path (hence its own Postgres schema). Importing it
+# into another module double-imports this one, and registration then lands in a
+# different schema than the login reads — every auth call fails with "invalid
+# credentials". Same-file tests share the fixture correctly.
+
+def _stub_extraction(monkeypatch, text: str = "cv text") -> None:
+    """Mock the parser + the paid two-pass extraction (offline, rule #4)."""
+    import src.api.routes.profile as profile_route
+
+    monkeypatch.setattr(profile_route, "extract_text", lambda path: text)
+
+    async def _fake_extract(profile):
+        profile.cv_data.skills = ["python"]
+        profile.cv_data.job_titles = ["Engineer"]
+        return profile
+
+    monkeypatch.setattr(profile_route, "run_two_pass_extraction", _fake_extract)
+
+
+class TestCVReceipt:
+    def test_upload_records_the_real_filename_and_a_timestamp(self, api, monkeypatch) -> None:
+        _stub_extraction(monkeypatch)
+        _register_and_login(api, "receipt1@example.com")
+        r = api.post(
+            "/api/profile/cv",
+            files={"cv": ("Ranjith_CV_2026.pdf", io.BytesIO(b"%PDF-1.4\n%%EOF"),
+                          "application/pdf")},
+        )
+        assert r.status_code == 200, r.text
+        summary = r.json()["summary"]
+        # VALUE presence — the actual name the user uploaded, not a default.
+        assert summary["cv_filename"] == "Ranjith_CV_2026.pdf"
+        assert summary["cv_uploaded_at"], "no upload timestamp recorded"
+        assert summary["cv_uploaded_at"].startswith("20"), summary["cv_uploaded_at"]
+
+    def test_reupload_replaces_the_receipt(self, api, monkeypatch) -> None:
+        """A stale name is worse than none — it confirms the WRONG document."""
+        _stub_extraction(monkeypatch)
+        _register_and_login(api, "receipt2@example.com")
+        api.post(
+            "/api/profile/cv",
+            files={"cv": ("old_cv.pdf", io.BytesIO(b"%PDF-1.4\n%%EOF"), "application/pdf")},
+        )
+        r = api.post(
+            "/api/profile/cv",
+            files={"cv": ("new_cv.pdf", io.BytesIO(b"%PDF-1.4\n%%EOF"), "application/pdf")},
+        )
+        assert r.json()["summary"]["cv_filename"] == "new_cv.pdf"
+
+    def test_rejected_upload_does_not_touch_the_existing_receipt(
+        self, api, monkeypatch
+    ) -> None:
+        """A 415 must not claim we hold a file we never read.
+
+        Stronger than asserting an empty receipt: it proves a REJECTED upload
+        cannot overwrite the good one already on file. The route's own ordering
+        guard (every 413/415/503 raises before the profile is touched) is what
+        makes this hold.
+        """
+        _stub_extraction(monkeypatch)
+        _register_and_login(api, "receipt3@example.com")
+        api.post(
+            "/api/profile/cv",
+            files={"cv": ("good_cv.pdf", io.BytesIO(b"%PDF-1.4\n%%EOF"), "application/pdf")},
+        )
+        bad = api.post(
+            "/api/profile/cv",
+            files={"cv": ("notes.txt", io.BytesIO(b"plain text"), "text/plain")},
+        )
+        assert bad.status_code == 415
+        got = api.get("/api/profile").json()["summary"]
+        assert got["cv_filename"] == "good_cv.pdf", "a rejected upload clobbered the receipt"
+
+    def test_only_the_basename_is_kept(self, api, monkeypatch) -> None:
+        """A browser can send a path-ish value; the directory is not ours."""
+        _stub_extraction(monkeypatch)
+        _register_and_login(api, "receipt4@example.com")
+        r = api.post(
+            "/api/profile/cv",
+            files={"cv": ("C:/Users/secret/Documents/cv.pdf",
+                          io.BytesIO(b"%PDF-1.4\n%%EOF"), "application/pdf")},
+        )
+        assert r.json()["summary"]["cv_filename"] == "cv.pdf"
+
+
+class TestGitHubReceipt:
+    def test_github_connect_records_handle_and_time(self, api, monkeypatch) -> None:
+        """GitHub has no file — the handle IS the receipt."""
+        import src.api.routes.profile as profile_route
+
+        _stub_extraction(monkeypatch)
+
+        async def _fake_fetch(username):
+            return {"username": username, "languages": {"Python": 100}, "repos": []}
+
+        monkeypatch.setattr(profile_route, "fetch_github_profile", _fake_fetch)
+        _register_and_login(api, "receipt5@example.com")
+        r = api.post("/api/profile/github", data={"username": "Ranjith36963"})
+        assert r.status_code == 200, r.text
+        got = api.get("/api/profile").json()["summary"]
+        assert got["github_username"] == "Ranjith36963"
+        assert got["github_connected_at"], "no connection timestamp recorded"
+
+
+class TestReceiptsSurviveOldRows:
+    def test_profile_saved_before_receipts_existed_still_loads(self) -> None:
+        """Old rows have no receipt fields — they must default, never crash."""
+        from src.services.profile.models import CVData
+        from src.services.profile.storage import _filter_fields
+
+        legacy_blob = {"raw_text": "old cv", "skills": ["Python"], "unknown_old_key": 1}
+        cv = CVData(**_filter_fields(legacy_blob, CVData))
+        assert cv.cv_filename == ""
+        assert cv.cv_uploaded_at == ""
+        assert cv.linkedin_filename == ""
+        assert cv.github_connected_at == ""

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -1610,9 +1610,19 @@
       },
       "ProfileSummary": {
         "properties": {
+          "cv_filename": {
+            "default": "",
+            "title": "Cv Filename",
+            "type": "string"
+          },
           "cv_length": {
             "title": "Cv Length",
             "type": "integer"
+          },
+          "cv_uploaded_at": {
+            "default": "",
+            "title": "Cv Uploaded At",
+            "type": "string"
           },
           "education": {
             "items": {
@@ -1623,6 +1633,21 @@
           },
           "experience_level": {
             "title": "Experience Level",
+            "type": "string"
+          },
+          "github_connected_at": {
+            "default": "",
+            "title": "Github Connected At",
+            "type": "string"
+          },
+          "github_repo_count": {
+            "default": 0,
+            "title": "Github Repo Count",
+            "type": "integer"
+          },
+          "github_username": {
+            "default": "",
+            "title": "Github Username",
             "type": "string"
           },
           "has_github": {
@@ -1643,6 +1668,16 @@
             },
             "title": "Job Titles",
             "type": "array"
+          },
+          "linkedin_filename": {
+            "default": "",
+            "title": "Linkedin Filename",
+            "type": "string"
+          },
+          "linkedin_uploaded_at": {
+            "default": "",
+            "title": "Linkedin Uploaded At",
+            "type": "string"
           },
           "skills_count": {
             "title": "Skills Count",

--- a/frontend/src/components/profile/CVUpload.tsx
+++ b/frontend/src/components/profile/CVUpload.tsx
@@ -29,9 +29,65 @@ interface CVUploadProps {
   loading: boolean;
 }
 
+// ── Upload receipt ────────────────────────────────────────
+// WHAT we hold and WHEN we got it, per input.
+//
+// Before this, a successful upload showed only a small tick in the card
+// header. The owner's words on a live smoke test: "I get a neon colour tick
+// mark but I didn't catch that". Worse, nothing anywhere named the file — so
+// you could not tell WHICH CV was on file, or whether a re-upload had actually
+// replaced it. GitHub had no confirmation at all.
+//
+// A tick says "something worked". A receipt says "we have Ranjith_CV.pdf, added
+// 8 Aug 2026" — which is the question a user actually asks. Same component for
+// all three inputs; GitHub passes its handle as the name, since it has no file.
+
+function formatReceiptDate(iso: string | undefined): string {
+  if (!iso) return "";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "";
+  return d.toLocaleDateString(undefined, {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  });
+}
+
+function UploadReceipt({
+  name,
+  at,
+  meta,
+}: {
+  name: string;
+  at?: string;
+  meta?: string;
+}) {
+  const when = formatReceiptDate(at);
+  const sub = [meta, when && `added ${when}`].filter(Boolean).join(" · ");
+  return (
+    <div
+      data-testid="upload-receipt"
+      className="flex items-center gap-2 rounded-lg border border-score-high/30 bg-score-high/5 px-3 py-2"
+    >
+      <CheckCircle className="h-4 w-4 shrink-0 text-score-high" />
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-xs font-medium text-foreground" title={name}>
+          {name}
+        </p>
+        {sub && <p className="text-[11px] text-muted-foreground">{sub}</p>}
+      </div>
+    </div>
+  );
+}
+
 // ── Highlight engine ──────────────────────────────────────
 // Marks extracted terms inline within the full CV text using
 // neon-colored backgrounds by category.
+//
+// THIS card is the single home of the full CV text (owner decision
+// 2026-08-08). The duplicate copy inside CVViewer's "Full CV Text" panel was
+// removed — same wall of text twice on one page, and this is the card where a
+// user looks for the CV they just uploaded.
 
 interface HighlightTerm {
   text: string;
@@ -418,7 +474,17 @@ export function CVUpload({
               )}
             </div>
 
-            {/* Full CV text with inline highlights */}
+            {/* Receipt — the file we actually hold, and when it arrived. */}
+            <UploadReceipt
+              name={profile.cv_filename || "CV on file"}
+              at={profile.cv_uploaded_at}
+            />
+
+            {/* Full CV text with inline highlights.
+                THE single copy on the page (owner decision 2026-08-08): the
+                identical panel inside CVViewer ("Full CV Text") was removed
+                rather than this one, because this is the card a user looks at
+                for the CV they just uploaded. */}
             {cvDetail && cvDetail.raw_text && (
               <div className="rounded-lg bg-muted/20 border border-border/40 p-4 max-h-[500px] overflow-y-auto">
                 <pre className="whitespace-pre-wrap font-sans text-[13px] leading-relaxed text-foreground/85">
@@ -518,6 +584,12 @@ export function CVUpload({
               {profile?.has_linkedin ? "Re-enrich" : "Enrich"} LinkedIn
             </Button>
           </div>
+          {profile?.has_linkedin && (
+            <UploadReceipt
+              name={profile.linkedin_filename || "LinkedIn profile on file"}
+              at={profile.linkedin_uploaded_at}
+            />
+          )}
         </div>
 
         <Separator className="my-4" />
@@ -566,6 +638,26 @@ export function CVUpload({
               Enrich GitHub
             </Button>
           </div>
+          {/* GitHub has no file — the handle IS the receipt, with the repo
+              count as proof of what we actually read. This card previously had
+              NO confirmation of any kind after a successful enrich. */}
+          {profile?.has_github && (
+            <UploadReceipt
+              name={
+                profile.github_username
+                  ? `@${profile.github_username}`
+                  : "GitHub connected"
+              }
+              at={profile.github_connected_at}
+              meta={
+                profile.github_repo_count
+                  ? `${profile.github_repo_count} public ${
+                      profile.github_repo_count === 1 ? "repo" : "repos"
+                    } read`
+                  : undefined
+              }
+            />
+          )}
         </div>
 
         {/* Hint if neither enrichment */}

--- a/frontend/src/components/profile/CVViewer.extracted-sections.test.tsx
+++ b/frontend/src/components/profile/CVViewer.extracted-sections.test.tsx
@@ -181,7 +181,14 @@ describe("CVViewer — extracted sections", () => {
     expect(screen.queryByText("LinkedIn detail")).not.toBeInTheDocument();
     expect(screen.queryByText("GitHub detail")).not.toBeInTheDocument();
     expect(screen.queryByText(/Skills Extracted/)).not.toBeInTheDocument();
-    // The always-present "Full CV Text" toggle still renders.
-    expect(screen.getByText("Full CV Text")).toBeInTheDocument();
+    // The "Full CV Text" panel was REMOVED from this view on 2026-08-08 (owner
+    // decision): the identical text already renders in the "CV Uploaded" card
+    // on the same page, and showing the same wall of text twice is noise. This
+    // assertion is inverted deliberately — it now guards against the duplicate
+    // coming back, and the section header below proves the view still renders.
+    expect(screen.queryByText("Full CV Text")).not.toBeInTheDocument();
+    expect(
+      screen.getByText("What we extracted from your profile")
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/profile/CVViewer.tsx
+++ b/frontend/src/components/profile/CVViewer.tsx
@@ -1,10 +1,7 @@
 "use client";
 
-import { useState } from "react";
 import {
   FileText,
-  ChevronDown,
-  ChevronUp,
   Briefcase,
   GraduationCap,
   Award,
@@ -36,48 +33,6 @@ interface CVViewerProps {
   linkedinSubsections?: Record<string, Record<string, unknown>[]>;
   /** ProfileResponse.github_temporal — { languages: {lang: bytes}, topics: {topic: 1} }. */
   githubTemporal?: Record<string, Record<string, unknown>>;
-}
-
-/** Highlight extracted terms within the full CV text. */
-function highlightText(
-  text: string,
-  terms: string[],
-  className: string
-): React.ReactNode[] {
-  if (!terms.length) return [text];
-
-  // A skill can wrap across a line in the PDF text ("Machine" end of one line,
-  // "Learning" start of the next), so the space inside a term must match ANY
-  // whitespace — including a newline. Escape regex specials first, then turn each
-  // run of spaces into \s+ so "Machine Learning" also matches "Machine\nLearning".
-  const escaped = terms
-    .filter((t) => t.trim().length > 2)
-    .map((t) =>
-      t.replace(/[.*+?^${}()|[\]\\]/g, "\\$&").replace(/\s+/g, "\\s+")
-    )
-    .sort((a, b) => b.length - a.length);
-
-  if (!escaped.length) return [text];
-
-  // Compare on whitespace-collapsed, lower-cased forms so a wrapped match
-  // ("Machine\nLearning") still equals its term ("Machine Learning").
-  const norm = (s: string) => s.replace(/\s+/g, " ").trim().toLowerCase();
-  const termSet = new Set(terms.map(norm));
-
-  const pattern = new RegExp(`(${escaped.join("|")})`, "gi");
-  const parts = text.split(pattern);
-
-  return parts.map((part, i) => {
-    const isMatch = termSet.has(norm(part));
-    if (isMatch) {
-      return (
-        <mark key={i} className={className}>
-          {part}
-        </mark>
-      );
-    }
-    return <span key={i}>{part}</span>;
-  });
 }
 
 // ── Dict helpers — cv_positions / linkedin subsections arrive as loosely
@@ -202,13 +157,8 @@ export function CVViewer({
   linkedinSubsections,
   githubTemporal,
 }: CVViewerProps) {
-  const [showFullCV, setShowFullCV] = useState(false);
-
-  // All terms to highlight (combine skills + titles for unified highlighting)
-  const allHighlightTerms = [
-    ...cv.skills,
-    ...cv.job_titles,
-  ];
+  // (The showFullCV toggle and its highlight terms went with the "Full CV
+  // Text" panel — that text now lives only in the CV Uploaded card.)
 
   const positions = (cv.cv_positions ?? [])
     .map((raw) => normalizePosition(raw as Record<string, unknown>))
@@ -435,44 +385,12 @@ export function CVViewer({
         )}
       </div>
 
-      {/* ── Full CV with highlights toggle ────────────── */}
-      <div className="glass-card rounded-xl p-6">
-        <button
-          onClick={() => setShowFullCV(!showFullCV)}
-          className="w-full flex items-center justify-between gap-2 group"
-        >
-          <div className="flex items-center gap-2">
-            <FileText className="h-4 w-4 text-primary" />
-            <h3 className="font-heading text-base font-semibold">
-              Full CV Text
-            </h3>
-            <span className="text-xs text-muted-foreground">
-              (extracted skills are{" "}
-              <mark className="bg-primary/20 text-primary px-1 rounded text-xs">
-                highlighted
-              </mark>
-              )
-            </span>
-          </div>
-          {showFullCV ? (
-            <ChevronUp className="h-4 w-4 text-muted-foreground group-hover:text-foreground transition-colors" />
-          ) : (
-            <ChevronDown className="h-4 w-4 text-muted-foreground group-hover:text-foreground transition-colors" />
-          )}
-        </button>
-
-        {showFullCV && (
-          <div className="mt-4 rounded-lg bg-muted/30 border border-border/50 p-4 max-h-[600px] overflow-y-auto">
-            <pre className="whitespace-pre-wrap font-sans text-sm leading-relaxed text-foreground/85">
-              {highlightText(
-                cv.raw_text,
-                allHighlightTerms,
-                "bg-primary/20 text-primary rounded px-0.5"
-              )}
-            </pre>
-          </div>
-        )}
-      </div>
+      {/* The "Full CV Text" panel used to sit here. REMOVED 2026-08-08 (owner
+          decision): the identical full CV text is already rendered in the "CV
+          Uploaded" card at the top of this same page, with the same
+          highlighting — the same wall of text twice on one screen. The card
+          keeps it, because that is where a user looks for the CV they just
+          uploaded; this view stays focused on what we EXTRACTED from it. */}
 
       {/* ── LinkedIn detail ────────────────────────────── */}
       {hasLinkedinDetail && (

--- a/frontend/src/components/profile/PreferencesForm.tsx
+++ b/frontend/src/components/profile/PreferencesForm.tsx
@@ -339,15 +339,10 @@ export function PreferencesForm({
           description="Skills beyond what your CV contains"
         />
 
-        {/* ── Excluded Skills ────────────────────── */}
-        <TagInput
-          label="Excluded Skills"
-          tags={excludedSkills}
-          onChange={setExcludedSkills}
-          placeholder="e.g. COBOL, Fortran"
-          description="Skills you don't want to work with (penalized in scoring)"
-          variant="destructive"
-        />
+        {/* Excluded Skills input removed from UI (owner, 2026-08-08) — the
+            excluded_skills field, scoring penalty, and payload key are kept
+            fully intact; every existing user's value is empty in prod, so
+            hiding the control drops no data and changes no live score. */}
 
         <Separator />
 
@@ -462,16 +457,10 @@ export function PreferencesForm({
 
         <Separator />
 
-        {/* ── Negative Keywords ──────────────────── */}
-        <TagInput
-          label="Negative Keywords"
-          icon={<AlertCircle className="h-3.5 w-3.5" />}
-          tags={negativeKeywords}
-          onChange={setNegativeKeywords}
-          placeholder="e.g. intern, junior, volunteer"
-          description="Job title keywords to penalize"
-          variant="destructive"
-        />
+        {/* Negative Keywords input removed from UI (owner, 2026-08-08) — the
+            negative_keywords field, scoring penalty, and payload key are kept
+            fully intact; every existing user's value is empty in prod, so
+            hiding the control drops no data and changes no live score. */}
 
         {/* ── About Me ───────────────────────────── */}
         <div className="space-y-2">
@@ -487,16 +476,10 @@ export function PreferencesForm({
           />
         </div>
 
-        {/* ── Excluded Companies ──────────────────── */}
-        <TagInput
-          label="Excluded Companies"
-          icon={<Building2 className="h-3.5 w-3.5" />}
-          tags={excludedCompanies}
-          onChange={setExcludedCompanies}
-          placeholder="e.g. Acme Corp"
-          description="Companies to zero-out from results"
-          variant="destructive"
-        />
+        {/* Excluded Companies input removed from UI (owner, 2026-08-08) — the
+            excluded_companies field, scoring zero-out, and payload key are kept
+            fully intact; every existing user's value is empty in prod, so
+            hiding the control drops no data and changes no live score. */}
 
         {/* ── Auto-save status ───────────────────────
             No "Save" button — preferences save automatically a moment after

--- a/frontend/src/lib/api-types.ts
+++ b/frontend/src/lib/api-types.ts
@@ -2119,12 +2119,37 @@ export interface components {
         };
         /** ProfileSummary */
         ProfileSummary: {
+            /**
+             * Cv Filename
+             * @default
+             */
+            cv_filename: string;
             /** Cv Length */
             cv_length: number;
+            /**
+             * Cv Uploaded At
+             * @default
+             */
+            cv_uploaded_at: string;
             /** Education */
             education: string[];
             /** Experience Level */
             experience_level: string;
+            /**
+             * Github Connected At
+             * @default
+             */
+            github_connected_at: string;
+            /**
+             * Github Repo Count
+             * @default 0
+             */
+            github_repo_count: number;
+            /**
+             * Github Username
+             * @default
+             */
+            github_username: string;
             /** Has Github */
             has_github: boolean;
             /** Has Linkedin */
@@ -2133,6 +2158,16 @@ export interface components {
             is_complete: boolean;
             /** Job Titles */
             job_titles: string[];
+            /**
+             * Linkedin Filename
+             * @default
+             */
+            linkedin_filename: string;
+            /**
+             * Linkedin Uploaded At
+             * @default
+             */
+            linkedin_uploaded_at: string;
             /** Skills Count */
             skills_count: number;
         };


### PR DESCRIPTION
Five owner-reported fixes from a live smoke test, each verified against live prod or a real test run.

## 1. Upload receipts — "I didn't catch that tick"

A successful upload showed only a small tick in the card header, and **nothing named the file**. You couldn't tell *which* CV was on file, or whether a re-upload had actually replaced it. GitHub had no confirmation at all.

Now each of **CV / LinkedIn / GitHub** shows a persistent receipt row — what we hold, and when it arrived. GitHub has no file, so its handle is the receipt: `@ranjith36963 · 14 public repos read · added 8 Aug 2026`.

- New `CVData` fields + 7 `ProfileSummary` fields. **No migration** — JSON blob, `_filter_fields` drops unknown keys, old rows load with empty strings and render a plain "on file" state.
- The CV receipt is written exactly where the new CV replaces the old one, so a re-upload always names the **current** file. A stale name would be worse than none — it would confirm the wrong document.
- Storing the filename is consistent with what's already kept: the full CV text lives in the same blob, so existing deletion + version-snapshot paths carry it automatically.

## 2. Full CV text was on the page twice

Once in the "CV Uploaded" card, once in CVViewer's "Full CV Text" panel — the same wall of text on one screen. Owner picked the card. CVViewer's panel (plus its orphaned highlighter, toggle state and chevron imports) is removed. The CVViewer test assertion is **inverted deliberately** so the duplicate can't silently return.

## 3. Three preference boxes removed from the UI

Excluded Skills, Negative Keywords, Excluded Companies. **UI only** — backend fields, payload keys and scoring untouched, reversible in one commit.

Verified against prod *before* hiding: all three are empty for **every** existing profile (3/3), so this leaves no invisible penalty on anyone.

## Tests

6 **value-presence** tests (rule #21 — these fields default to `""`, so a schema-presence assert would pass against a serializer that never reads them). Each runs a real upload end-to-end and asserts the actual filename, including that a rejected 415 upload cannot clobber the receipt already on file.

They live **inside** `test_profile_upload.py` on purpose. The `api` fixture gives each test its own DB path (hence its own Postgres schema); importing it across modules double-imports the module, so registration lands in a different schema than the login reads and every auth call fails with `invalid credentials` — including in a **pre-existing** test. Caught by the local gate, not by CI.

- Backend: 23/23 in that file
- Frontend: 219 unit tests, type-check + lint clean
- api-types regenerated · Gate: **PASS**

🤖 Generated with [Claude Code](https://claude.com/claude-code)