### PR TITLE
test(profile): prove the upload receipts actually reach the screen

### DIFF
--- a/frontend/src/components/profile/CVUpload.receipts.test.tsx
+++ b/frontend/src/components/profile/CVUpload.receipts.test.tsx
@@ -1,0 +1,150 @@
+/**
+ * Upload receipts must REACH THE SCREEN.
+ *
+ * The backend tests prove the API returns cv_filename / linkedin_filename /
+ * github_username. They cannot prove the page renders them — and "a value
+ * stored, returned, and shown to nobody" is the exact failure this repo has hit
+ * before (CLAUDE.md rule #21, value-presence over schema-presence).
+ *
+ * Found on a live smoke test 2026-08-08: after an upload the only feedback was
+ * a small tick in the card header. The owner's words: "I get a neon colour tick
+ * mark but I didn't catch that" — and nothing named the file, so he could not
+ * tell WHICH CV was on file or whether a re-upload had replaced it. GitHub had
+ * no confirmation at all.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import { CVUpload } from "./CVUpload";
+import type { ProfileSummary, CVDetail } from "@/lib/types";
+
+const RAW_CV = "Ada Lovelace\nMachine Learning Engineer\nBuilds production ML.";
+
+function summary(over: Partial<ProfileSummary> = {}): ProfileSummary {
+  return {
+    is_complete: true,
+    job_titles: ["ML Engineer"],
+    skills_count: 2,
+    cv_length: RAW_CV.length,
+    has_linkedin: true,
+    has_github: true,
+    education: [],
+    experience_level: "senior",
+    cv_filename: "Ada_Lovelace_CV_2026.pdf",
+    cv_uploaded_at: "2026-08-08T10:30:00+00:00",
+    linkedin_filename: "Profile_Ada.pdf",
+    linkedin_uploaded_at: "2026-08-07T09:00:00+00:00",
+    github_username: "adalovelace",
+    github_connected_at: "2026-08-06T08:00:00+00:00",
+    github_repo_count: 14,
+    ...over,
+  } as ProfileSummary;
+}
+
+const cvDetail = {
+  raw_text: RAW_CV,
+  skills: ["Python", "PyTorch"],
+  job_titles: ["ML Engineer"],
+  companies: [],
+  education: [],
+  certifications: [],
+  summary_text: "Builds production ML.",
+  experience_text: "",
+  name: "Ada Lovelace",
+  headline: "Machine Learning Engineer",
+  location: "London",
+  achievements: [],
+} as unknown as CVDetail;
+
+function renderCard(s: ProfileSummary) {
+  return render(
+    <CVUpload
+      onUpload={vi.fn()}
+      onLinkedinUpload={vi.fn()}
+      onGithubEnrich={vi.fn()}
+      profile={s}
+      cvDetail={cvDetail}
+      loading={false}
+    />
+  );
+}
+
+describe("upload receipts reach the screen", () => {
+  it("names the actual CV file and when it arrived", () => {
+    renderCard(summary());
+    const receipts = screen.getAllByTestId("upload-receipt");
+    // One per input: CV, LinkedIn, GitHub.
+    expect(receipts).toHaveLength(3);
+    expect(within(receipts[0]).getByText("Ada_Lovelace_CV_2026.pdf")).toBeTruthy();
+    // The date is rendered in the viewer's locale — assert the YEAR, not an
+    // exact format string, so this does not break on a different locale.
+    expect(receipts[0].textContent).toMatch(/added/i);
+    expect(receipts[0].textContent).toContain("2026");
+  });
+
+  it("names the LinkedIn file", () => {
+    renderCard(summary());
+    const receipts = screen.getAllByTestId("upload-receipt");
+    expect(within(receipts[1]).getByText("Profile_Ada.pdf")).toBeTruthy();
+  });
+
+  it("shows the GitHub handle and repo count — its receipt has no file", () => {
+    renderCard(summary());
+    const receipts = screen.getAllByTestId("upload-receipt");
+    expect(within(receipts[2]).getByText("@adalovelace")).toBeTruthy();
+    expect(receipts[2].textContent).toContain("14 public repos read");
+  });
+
+  it("a re-upload shows the NEW name, never the old one", () => {
+    const { rerender } = renderCard(summary());
+    rerender(
+      <CVUpload
+        onUpload={vi.fn()}
+        onLinkedinUpload={vi.fn()}
+        onGithubEnrich={vi.fn()}
+        profile={summary({ cv_filename: "Ada_CV_v2.pdf" })}
+        cvDetail={cvDetail}
+        loading={false}
+      />
+    );
+    const receipts = screen.getAllByTestId("upload-receipt");
+    expect(receipts[0].textContent).toContain("Ada_CV_v2.pdf");
+    expect(receipts[0].textContent).not.toContain("Ada_Lovelace_CV_2026.pdf");
+  });
+
+  it("a profile saved before receipts existed degrades to a plain state", () => {
+    // Old rows load with empty strings. They must read as "on file" and must
+    // NEVER render undefined / NaN / Invalid Date.
+    renderCard(
+      summary({
+        cv_filename: "",
+        cv_uploaded_at: "",
+        linkedin_filename: "",
+        linkedin_uploaded_at: "",
+        github_username: "",
+        github_connected_at: "",
+        github_repo_count: 0,
+      })
+    );
+    const receipts = screen.getAllByTestId("upload-receipt");
+    expect(receipts[0].textContent).toContain("CV on file");
+    expect(receipts[1].textContent).toContain("LinkedIn profile on file");
+    expect(receipts[2].textContent).toContain("GitHub connected");
+    for (const r of receipts) {
+      expect(r.textContent).not.toMatch(/undefined|NaN|Invalid Date/);
+    }
+  });
+
+  it("a bad timestamp never renders 'Invalid Date'", () => {
+    renderCard(summary({ cv_uploaded_at: "not-a-date" }));
+    const receipts = screen.getAllByTestId("upload-receipt");
+    expect(receipts[0].textContent).toContain("Ada_Lovelace_CV_2026.pdf");
+    expect(receipts[0].textContent).not.toMatch(/Invalid Date/);
+  });
+
+  it("no receipt is shown for an input that was never provided", () => {
+    renderCard(summary({ has_linkedin: false, has_github: false }));
+    // Only the CV receipt remains — an absent input stays silent (rule #29).
+    expect(screen.getAllByTestId("upload-receipt")).toHaveLength(1);
+  });
+});

--- a/frontend/tests/e2e/upload-receipts.spec.ts
+++ b/frontend/tests/e2e/upload-receipts.spec.ts
@@ -1,0 +1,167 @@
+import { test, expect, type Page } from "@playwright/test";
+
+/**
+ * Can the user SEE what we hold, and when we got it?
+ *
+ * WHY THIS EXISTS. After an upload the only feedback was a small tick in the
+ * card header. The owner's words on a live smoke test: "I get a neon colour
+ * tick mark but I didn't catch that" — and nothing anywhere NAMED the file, so
+ * he could not tell which CV was on file or whether a re-upload had actually
+ * replaced it. GitHub had no confirmation at all.
+ *
+ * The backend tests prove the API RETURNS the filename. They cannot prove the
+ * page RENDERS it — and a value stored, returned, and shown to nobody is the
+ * exact failure shape this repo has hit before. So this spec drives a real
+ * browser and reads the receipt with the same eyes the user does.
+ *
+ * Hermetic: fake the session cookie (middleware only checks presence) and mock
+ * the API, same as the other specs.
+ */
+
+const SESSION_COOKIE = {
+  name: "job360_session",
+  value: "e2e-token",
+  domain: "localhost",
+  path: "/",
+};
+
+const RAW_CV = `Ada Lovelace
+Machine Learning Engineer
+SUMMARY
+Builds production ML systems.`;
+
+/** A profile whose three inputs all carry a receipt. */
+function profileWithReceipts(over: Record<string, unknown> = {}) {
+  return {
+    summary: {
+      is_complete: true,
+      job_titles: ["ML Engineer"],
+      skills_count: 2,
+      cv_length: RAW_CV.length,
+      has_linkedin: true,
+      has_github: true,
+      education: [],
+      experience_level: "senior",
+      cv_filename: "Ada_Lovelace_CV_2026.pdf",
+      cv_uploaded_at: "2026-08-08T10:30:00+00:00",
+      linkedin_filename: "Profile_Ada.pdf",
+      linkedin_uploaded_at: "2026-08-07T09:00:00+00:00",
+      github_username: "adalovelace",
+      github_connected_at: "2026-08-06T08:00:00+00:00",
+      github_repo_count: 14,
+      ...over,
+    },
+    preferences: { target_job_titles: [], additional_skills: [] },
+    cv_detail: {
+      raw_text: RAW_CV,
+      skills: ["Python", "PyTorch"],
+      job_titles: ["ML Engineer"],
+      companies: [],
+      education: [],
+      certifications: [],
+      summary_text: "Builds production ML systems.",
+      experience_text: "",
+      name: "Ada Lovelace",
+      headline: "Machine Learning Engineer",
+      location: "London",
+      achievements: [],
+      highlights: ["Python", "PyTorch"],
+    },
+    skill_tiers: {},
+  };
+}
+
+async function mockProfile(page: Page, payload: unknown) {
+  await page.route("**/api/auth/me**", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ id: "e2e-user", email: "e2e@example.com" }),
+    })
+  );
+  await page.route("**/api/profile**", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(payload),
+    })
+  );
+}
+
+test.describe("Upload receipts — what we hold, and when", () => {
+  test("names the actual CV, LinkedIn file and GitHub handle on screen", async ({
+    page,
+    context,
+  }) => {
+    await context.addCookies([SESSION_COOKIE]);
+    await mockProfile(page, profileWithReceipts());
+    await page.goto("/profile");
+
+    const receipts = page.getByTestId("upload-receipt");
+    await expect(receipts.first()).toBeVisible({ timeout: 30_000 });
+    // One per input: CV, LinkedIn, GitHub.
+    await expect(receipts).toHaveCount(3);
+
+    // The CV receipt names the REAL file — this is the whole point. A generic
+    // "uploaded" tick is what we are replacing.
+    await expect(receipts.nth(0)).toContainText("Ada_Lovelace_CV_2026.pdf");
+    await expect(receipts.nth(0)).toContainText(/added/i);
+    await expect(receipts.nth(0)).toContainText("2026");
+
+    await expect(receipts.nth(1)).toContainText("Profile_Ada.pdf");
+
+    // GitHub has no file, so the handle is the receipt and the repo count is
+    // the proof of what was actually read.
+    await expect(receipts.nth(2)).toContainText("@adalovelace");
+    await expect(receipts.nth(2)).toContainText("14 public repos read");
+  });
+
+  test("an older profile with no stored receipt still shows a sane state", async ({
+    page,
+    context,
+  }) => {
+    // Rows saved before the receipt fields existed load with empty strings.
+    // They must degrade to a plain "on file", never render "undefined" or a
+    // blank chip.
+    await context.addCookies([SESSION_COOKIE]);
+    await mockProfile(
+      page,
+      profileWithReceipts({
+        cv_filename: "",
+        cv_uploaded_at: "",
+        linkedin_filename: "",
+        linkedin_uploaded_at: "",
+        github_username: "",
+        github_connected_at: "",
+        github_repo_count: 0,
+      })
+    );
+    await page.goto("/profile");
+
+    const receipts = page.getByTestId("upload-receipt");
+    await expect(receipts.first()).toBeVisible({ timeout: 30_000 });
+    await expect(receipts.nth(0)).toContainText("CV on file");
+    await expect(receipts.nth(1)).toContainText("LinkedIn profile on file");
+    await expect(receipts.nth(2)).toContainText("GitHub connected");
+    for (const t of ["undefined", "NaN", "Invalid Date"]) {
+      await expect(page.getByTestId("upload-receipt").first()).not.toContainText(t);
+    }
+  });
+
+  test("the full CV text appears exactly ONCE on the page", async ({
+    page,
+    context,
+  }) => {
+    // It used to render in the CV card AND in CVViewer's "Full CV Text" panel.
+    // The panel was removed; this guards the duplicate from returning.
+    await context.addCookies([SESSION_COOKIE]);
+    await mockProfile(page, profileWithReceipts());
+    await page.goto("/profile");
+
+    await expect(page.getByText("What we extracted from your profile")).toBeVisible({
+      timeout: 30_000,
+    });
+    await expect(page.getByText("Full CV Text")).toHaveCount(0);
+    await expect(page.getByText("Builds production ML systems.").first()).toBeVisible();
+  });
+});


### PR DESCRIPTION
## The gap this closes

The receipts shipped in #272 with backend tests proving the API **returns** `cv_filename` / `linkedin_filename` / `github_username`. Nothing proved the page **renders** them — and "a value stored, returned, and shown to nobody" is the exact failure shape this repo has hit before (rule #21).

Not academic: the owner's live profile predates those fields, so the only state ever seen on screen was the empty-string fallback (`CV on file`). **The filename path — the whole point of the feature — was unverified.**

## Two layers

**1. `CVUpload.receipts.test.tsx` — 7 tests, verified locally (7/7 pass)**

- the real CV filename + "added" + the year reach the DOM
- the LinkedIn filename reaches the DOM
- GitHub (no file) shows `@handle` + `14 public repos read`
- a **re-upload** renders the new name and **not** the stale one — a stale name is worse than none, it confirms the wrong document
- a pre-receipt row degrades to `CV on file`, never `undefined` / `NaN` / `Invalid Date`
- a malformed timestamp never renders `Invalid Date`
- an input never provided shows **no** receipt (rule #29 — empty shelves stay silent)

**2. `tests/e2e/upload-receipts.spec.ts` — same assertions in a real browser**, plus a guard that the full CV text appears **exactly once** on the page (it used to render in both the CV card and CVViewer's "Full CV Text" panel; the panel was removed in #272 and this stops the duplicate returning).

## Honest note on the e2e spec

It **cannot run on my machine**: local Playwright needs the backend up for the server-side session check, so `/profile` redirects to login (*"We couldn't reach the server to verify your session"*). The pre-existing profile specs fail locally for the same reason. **CI runs it with a backend — this PR is where it gets verified in a real browser.**

Gate: **PASS**, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)