### PR TITLE
fix(profile): a better prompt must reach users who already uploaded

### DIFF
--- a/backend/src/services/profile/two_pass.py
+++ b/backend/src/services/profile/two_pass.py
@@ -61,18 +61,49 @@ async def _none() -> None:
     return None
 
 
+EXTRACTOR_VERSION = "2"
+"""Bump this whenever an LLM extraction PROMPT changes in a way that should
+re-read inputs the system has already seen.
+
+WHY IT EXISTS (measured on a live profile, 2026-08-08). The cost cache keyed on
+the INPUT alone: same CV text -> skip the paid pass. Correct for cost, wrong for
+correctness — because it silently means **a prompt improvement never reaches an
+existing user**. Their extraction is frozen at whatever the prompt produced the
+last time their input changed, and re-uploading the same CV cannot fix it (the
+text is identical, so the hash still matches).
+
+Proof: the CV prompt already instructs the LLM to mine skills demonstrated in
+prose ("inside a project, an experience bullet...", ``cv_parser`` RULE 9). A real
+profile's CV names predictive maintenance, fraud detection, IoT, RUL and
+multi-agent workflow in its experience bullets, yet none reached ``cv.skills`` —
+the improved prompt had never run over that CV, because the hash matched.
+
+Including this version in the digest makes a prompt change invalidate the cache
+exactly once per user, which is the intended cost: pay again only when the
+extractor genuinely got better.
+
+Version log — 1: input-only hash (pre-2026-08-08). 2: prose-mining CV prompt.
+"""
+
+
 def _input_hash(raw: Any) -> str:
-    """Stable fingerprint of one extraction input.
+    """Stable fingerprint of one extraction input AND the extractor that read it.
 
     Accepts whatever the four inputs actually are — CV/LinkedIn text are strings,
     ``github_repos_brief`` may be a list of dicts — so a non-string is serialised
     with sorted keys to keep the digest stable across runs (Python dict order is
     insertion-ordered, and a re-fetch could reorder it without the content
     changing, which would look like a change and re-bill the user).
+
+    ``EXTRACTOR_VERSION`` is folded in so improving a prompt re-reads inputs the
+    system has already seen — see the note on that constant. Old stored digests
+    were computed WITHOUT it, so they simply stop matching and every profile
+    re-extracts once, which is the desired behaviour.
     """
     if not isinstance(raw, str):
         raw = json.dumps(raw, sort_keys=True, default=str)
-    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+    payload = f"v{EXTRACTOR_VERSION}\x00{raw}"
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
 
 def _pass_produced_data(key: str, res: Any) -> bool:

--- a/backend/tests/test_extractor_version_cache.py
+++ b/backend/tests/test_extractor_version_cache.py
@@ -1,0 +1,66 @@
+"""A prompt improvement must reach users who already uploaded.
+
+MEASURED ON A LIVE PROFILE, 2026-08-08. The LLM cost cache keyed on the INPUT
+alone: same CV text -> skip the paid pass. Correct for cost, wrong for
+correctness — a prompt fix could never reach an existing user, and re-uploading
+the same CV could not help either (identical text, identical hash).
+
+The damage was real and visible: the CV prompt already tells the LLM to mine
+skills demonstrated in prose, yet a real CV naming "predictive maintenance",
+"fraud detection", "IoT", "RUL" and "multi-agent workflow" in its experience
+bullets had NONE of them in cv.skills. The improved prompt had simply never run
+over that CV.
+
+Folding EXTRACTOR_VERSION into the digest fixes it: bumping the version
+invalidates every cached hash exactly once, so each profile re-extracts under
+the better prompt and then caches again.
+"""
+from __future__ import annotations
+
+from src.services.profile import two_pass
+from src.services.profile.models import CVData
+
+
+class TestExtractorVersionIsPartOfTheCacheKey:
+    def test_same_input_same_version_is_cached(self) -> None:
+        """The cost guard must still work — this is the whole point of caching."""
+        cv = CVData(raw_text="CV TEXT")
+        cv.llm_input_hashes["cv"] = two_pass._input_hash("CV TEXT")
+        assert two_pass._already_read(cv, "cv", "CV TEXT") is True
+
+    def test_bumping_the_version_invalidates_the_cache(self, monkeypatch) -> None:
+        """A prompt improvement re-reads inputs the system has already seen."""
+        cv = CVData(raw_text="CV TEXT")
+        cv.llm_input_hashes["cv"] = two_pass._input_hash("CV TEXT")
+        assert two_pass._already_read(cv, "cv", "CV TEXT") is True
+
+        monkeypatch.setattr(two_pass, "EXTRACTOR_VERSION", "999")
+        assert two_pass._already_read(cv, "cv", "CV TEXT") is False, (
+            "a prompt bump must re-run the pass, or improvements never reach "
+            "existing users"
+        )
+
+    def test_a_digest_stored_before_versioning_no_longer_matches(self) -> None:
+        """Legacy rows re-extract exactly once — the intended migration."""
+        import hashlib
+
+        legacy = hashlib.sha256(b"CV TEXT").hexdigest()  # the OLD formula
+        cv = CVData(raw_text="CV TEXT")
+        cv.llm_input_hashes["cv"] = legacy
+        assert two_pass._already_read(cv, "cv", "CV TEXT") is False
+
+    def test_changed_input_still_invalidates(self) -> None:
+        """The original behaviour is untouched: new text -> re-read."""
+        cv = CVData(raw_text="OLD")
+        cv.llm_input_hashes["cv"] = two_pass._input_hash("OLD")
+        assert two_pass._already_read(cv, "cv", "NEW TEXT") is False
+
+    def test_empty_input_is_never_considered_read(self) -> None:
+        cv = CVData()
+        assert two_pass._already_read(cv, "cv", "") is False
+
+    def test_non_string_inputs_stay_stable(self) -> None:
+        """github_repos_brief is a list of dicts; key order must not matter."""
+        a = [{"name": "r1", "language": "Python"}]
+        b = [{"language": "Python", "name": "r1"}]
+        assert two_pass._input_hash(a) == two_pass._input_hash(b)


### PR DESCRIPTION
## The bug (measured on a live profile)

The LLM cost cache keyed on the **input alone**:

```
cache key = sha256(cv_text)        same text -> skip the paid pass
```

Correct for cost, wrong for correctness — it silently means **a prompt improvement never reaches an existing user**. Their extraction is frozen at whatever the prompt produced the last time their input changed. Re-uploading the same CV can't fix it either: identical text -> identical hash -> still skipped.

## The damage, on a real profile today

The CV prompt **already** instructs the LLM to mine skills demonstrated in prose (`cv_parser.py:86-93`, RULE 9 — *"inside a project, an experience bullet... demonstrates that skill"*).

That user's CV names **predictive maintenance, fraud detection, IoT, RUL, multi-agent workflow** in its `PROFESSIONAL EXPERIENCE` bullets. None reached `cv.skills` — all 80 entries come from the `CORE SKILLS` section that the *deterministic* pass reads.

**The improved prompt had never run over that CV.** The only place those skills survived was old preference-pollution — which is why cleaning the pollution appeared to "lose" real skills.

## The fix

```
cache key = sha256("v<EXTRACTOR_VERSION>\0" + input)
```

Bumping `EXTRACTOR_VERSION` invalidates every cached digest **exactly once**, so each profile re-extracts under the better prompt and then caches again. Cost stays bounded; correctness stops being frozen.

Old digests were computed without the prefix, so they simply stop matching — **no backfill or migration needed**. Set to `"2"` (1 = the historical input-only hash), with a version log in the docstring so the next prompt change knows to bump it.

## Tests (6 new)

| assertion | why it matters |
|---|---|
| a version bump invalidates | the fix itself |
| same version still caches | the cost guard is intact |
| a pre-versioning digest re-extracts once | the migration |
| a changed input still invalidates | original behaviour untouched |
| empty input is never "read" | no spurious billing |
| dict key-order stays stable | a `github_repos_brief` re-fetch doesn't re-bill |

144 related tests pass · ruff clean · gate **PASS**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
