### PR TITLE
feat(profile): clear buttons — you cannot trust a test you cannot reset

### DIFF
--- a/backend/src/api/routes/profile.py
+++ b/backend/src/api/routes/profile.py
@@ -38,7 +38,7 @@ from src.services.profile.linkedin_parser import (
 from src.services.profile.linkedin_parser import (
     _looks_like_linkedin,
 )
-from src.services.profile.models import UserPreferences, UserProfile
+from src.services.profile.models import CVData, UserPreferences, UserProfile
 from src.services.profile.preferences import sanitize_preferences
 from src.services.profile.storage import (
     list_profile_versions,
@@ -610,6 +610,114 @@ async def upload_github(
         )
     await _extract_save_trigger(profile, user.id)
     return GitHubResponse(ok=True, merged=merged)
+
+
+# ── Clearing an input ────────────────────────────────────────────────────────
+#
+# WHY THIS EXISTS. You cannot trust a test you cannot reset. Every contamination
+# bug found on this profile (another person's GitHub, then their LinkedIn, then
+# their education/certs/titles merged into the CV fields) was hard to see
+# precisely because stale data lingered and every upload MERGED into it. Without
+# a reset, "upload a CV and check what came out" is never a clean experiment —
+# you are always reading the sum of every previous attempt.
+#
+# Each scope clears the fields that input OWNS, and nothing else, so clearing
+# LinkedIn cannot take the CV with it. Two details matter:
+#   * the matching ``llm_input_hashes`` entry is dropped, or a later re-upload of
+#     the SAME file would be treated as "already read" and skipped; and
+#   * every clear goes through ``save_profile``, which snapshots first — so a
+#     clear is undoable from the History drawer, which is what makes an
+#     irreversible-sounding button safe.
+
+_CLEAR_SCOPES = ("cv", "linkedin", "github", "preferences", "all")
+
+
+def _clear_cv(cv: CVData) -> None:
+    """Everything the CV owns, including its receipt and quality verdict."""
+    reset_cv_owned_fields(cv)  # the canonical "what the CV owns" list
+    cv.raw_text = ""
+    cv.cv_filename = ""
+    cv.cv_uploaded_at = ""
+    cv.extraction_score = {}
+    cv.llm_input_hashes.pop("cv", None)
+
+
+def _clear_linkedin(cv: CVData) -> None:
+    cv.linkedin_raw_text = ""
+    cv.linkedin_positions = []
+    cv.linkedin_skills = []
+    cv.linkedin_industry = ""
+    cv.linkedin_languages = []
+    cv.linkedin_projects = []
+    cv.linkedin_volunteer = []
+    cv.linkedin_courses = []
+    cv.linkedin_filename = ""
+    cv.linkedin_uploaded_at = ""
+    cv.llm_input_hashes.pop("linkedin", None)
+
+
+def _clear_github(cv: CVData, prefs: UserPreferences) -> None:
+    cv.github_languages = {}
+    cv.github_topics = []
+    cv.github_skills_inferred = []
+    cv.github_frameworks = []
+    cv.github_llm_skills = []
+    cv.github_repos_brief = []
+    cv.github_bio = ""
+    cv.github_profile_readme = ""
+    cv.github_connected_at = ""
+    cv.llm_input_hashes.pop("github", None)
+    prefs.github_username = ""  # the handle belongs to this section
+
+
+@router.post("/profile/clear", response_model=ProfileResponse)
+async def clear_profile_section(
+    section: str = Form(...),  # noqa: B008 — FastAPI dependency-injection idiom
+    user: CurrentUser = Depends(require_user),  # noqa: B008
+) -> ProfileResponse:
+    """Empty ONE input (or the whole profile), so the next upload starts clean.
+
+    ``section``: cv | linkedin | github | preferences | all.
+
+    Deliberately does NOT re-run extraction: there is nothing to extract, and a
+    paid LLM round-trip to rebuild an empty profile would be waste. The stored
+    snapshot taken by ``save_profile`` is what makes this reversible.
+    """
+    if section not in _CLEAR_SCOPES:
+        raise HTTPException(
+            status_code=400,
+            detail=f"section must be one of: {', '.join(_CLEAR_SCOPES)}",
+        )
+    profile = load_profile(user.id)
+    if profile is None:
+        raise HTTPException(status_code=404, detail="No profile to clear")
+
+    cv = profile.cv_data
+    prefs = profile.preferences or UserPreferences()
+
+    if section in ("cv", "all"):
+        _clear_cv(cv)
+    if section in ("linkedin", "all"):
+        _clear_linkedin(cv)
+    if section in ("github", "all"):
+        _clear_github(cv, prefs)
+    if section in ("preferences", "all"):
+        # A fresh preferences object — but the GitHub handle is owned by the
+        # GitHub section, so clearing PREFERENCES alone must not disconnect it.
+        keep_handle = "" if section == "all" else prefs.github_username
+        prefs = UserPreferences(github_username=keep_handle)
+    if section == "all":
+        # about_me-derived skills live on the CV object but are owned by the
+        # preferences the user typed, so a full clear takes them too.
+        cv.about_me_inferred_skills = []
+        cv.llm_input_hashes.pop("about_me", None)
+
+    profile.preferences = prefs
+    save_profile(profile, user.id, f"clear_{section}")
+    logger.info(
+        "profile_cleared", extra={"event": "profile_cleared", "section": section}
+    )
+    return _build_profile_response(profile)
 
 
 # ── Step-1.5 S3-A,B,C — profile version + JSON Resume endpoints. ──

--- a/backend/tests/test_profile_upload.py
+++ b/backend/tests/test_profile_upload.py
@@ -767,3 +767,153 @@ class TestRealDataStillWorks:
         assert api.get("/api/profile").json()["summary"]["github_username"] == (
             "Ranjith36963"
         )
+
+
+# ---------------------------------------------------------------------------
+# Clearing an input — you cannot trust a test you cannot reset
+# ---------------------------------------------------------------------------
+# Every contamination bug found on the owner's live profile (another person's
+# GitHub, then their LinkedIn, then their education/certs/titles merged into the
+# CV fields) was hard to SEE because stale data lingered and each upload merged
+# into it. These pin the two properties that make a reset trustworthy:
+#   1. a scope clears what that input OWNS and nothing else, and
+#   2. the cached LLM hash goes with it, so re-uploading the SAME file really
+#      re-extracts instead of being skipped as "already read".
+
+
+def _seed_full_profile(api_client, monkeypatch):
+    """A profile carrying CV + LinkedIn + GitHub + typed preferences."""
+    import json as _json
+
+    import src.api.routes.profile as profile_route
+
+    _stub(monkeypatch, {
+        "username": "octocat",
+        "languages": {"Python": 10},
+        "repos": [{"name": "r", "language": "Python"}],
+        "repos_brief": [{"name": "r", "language": "Python"}],
+    })
+    monkeypatch.setattr(profile_route, "extract_linkedin_text", lambda p: "LinkedIn text")
+    monkeypatch.setattr(profile_route, "_looks_like_linkedin", lambda t: True)
+
+    api_client.post(
+        "/api/profile/cv",
+        files={"cv": ("my_cv.pdf", io.BytesIO(b"%PDF-1.4\n%%EOF"), "application/pdf")},
+    )
+    api_client.post(
+        "/api/profile/linkedin",
+        files={"file": ("li.pdf", io.BytesIO(b"%PDF-1.4\n%%EOF"), "application/pdf")},
+    )
+    api_client.post("/api/profile/github", data={"username": "octocat"})
+    api_client.post(
+        "/api/profile/preferences",
+        data={"preferences": _json.dumps({"additional_skills": ["Rust"],
+                                          "target_job_titles": ["SRE"]})},
+    )
+
+
+class TestClearSectionRemovesOnlyThatSection:
+    def test_clearing_the_cv_leaves_linkedin_and_github(self, api, monkeypatch) -> None:
+        _register_and_login(api, "clear-cv@example.com")
+        _seed_full_profile(api, monkeypatch)
+        r = api.post("/api/profile/clear", data={"section": "cv"})
+        assert r.status_code == 200, r.text
+        s = r.json()["summary"]
+        assert s["cv_length"] == 0
+        assert s["cv_filename"] == ""
+        # The OTHER inputs survive. Asserted on the RECEIPT, not on
+        # `has_linkedin`: that flag is derived from EXTRACTED skills/positions,
+        # and extraction is stubbed here — so it is false even before the clear
+        # and would pass this test for the wrong reason.
+        assert s["linkedin_filename"] == "li.pdf", "clearing the CV took LinkedIn too"
+        assert s["has_github"] is True
+        assert s["github_username"] == "octocat"
+
+    def test_clearing_linkedin_leaves_the_cv(self, api, monkeypatch) -> None:
+        _register_and_login(api, "clear-li@example.com")
+        _seed_full_profile(api, monkeypatch)
+        r = api.post("/api/profile/clear", data={"section": "linkedin"})
+        assert r.status_code == 200, r.text
+        s = r.json()["summary"]
+        assert s["has_linkedin"] is False
+        assert s["linkedin_filename"] == ""
+        assert s["cv_length"] > 0, "clearing LinkedIn destroyed the CV"
+        assert s["has_github"] is True
+
+    def test_clearing_github_drops_the_handle_and_receipt(self, api, monkeypatch) -> None:
+        _register_and_login(api, "clear-gh@example.com")
+        _seed_full_profile(api, monkeypatch)
+        r = api.post("/api/profile/clear", data={"section": "github"})
+        assert r.status_code == 200, r.text
+        s = r.json()["summary"]
+        assert s["has_github"] is False
+        assert s["github_username"] == ""
+        assert s["github_connected_at"] == ""
+        assert s["cv_length"] > 0
+
+    def test_clearing_preferences_keeps_the_github_handle(self, api, monkeypatch) -> None:
+        # The handle is owned by the GitHub section — clearing PREFERENCES
+        # alone must not silently disconnect GitHub.
+        _register_and_login(api, "clear-prefs@example.com")
+        _seed_full_profile(api, monkeypatch)
+        r = api.post("/api/profile/clear", data={"section": "preferences"})
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["preferences"].get("additional_skills") in ([], None)
+        assert body["preferences"].get("target_job_titles") in ([], None)
+        assert body["summary"]["github_username"] == "octocat"
+        assert body["summary"]["cv_length"] > 0
+
+    def test_clear_all_empties_everything(self, api, monkeypatch) -> None:
+        _register_and_login(api, "clear-all@example.com")
+        _seed_full_profile(api, monkeypatch)
+        r = api.post("/api/profile/clear", data={"section": "all"})
+        assert r.status_code == 200, r.text
+        s = r.json()["summary"]
+        assert s["cv_length"] == 0
+        assert s["has_linkedin"] is False
+        assert s["has_github"] is False
+        assert s["github_username"] == ""
+        assert s["skills_count"] == 0
+        assert r.json()["preferences"].get("additional_skills") in ([], None)
+
+
+class TestClearIsSafeAndReversible:
+    def test_an_unknown_section_is_rejected(self, api, monkeypatch) -> None:
+        _register_and_login(api, "clear-bad@example.com")
+        _seed_full_profile(api, monkeypatch)
+        r = api.post("/api/profile/clear", data={"section": "everything"})
+        assert r.status_code == 400
+        assert "cv" in r.text and "all" in r.text
+
+    def test_clearing_snapshots_first_so_it_can_be_undone(
+        self, api, monkeypatch
+    ) -> None:
+        _register_and_login(api, "clear-undo@example.com")
+        _seed_full_profile(api, monkeypatch)
+        api.post("/api/profile/clear", data={"section": "all"})
+        versions = api.get("/api/profile/versions").json()["versions"]
+        # The pre-clear state is still recoverable from History.
+        assert any(v.get("source_action") == "clear_all" for v in versions)
+        assert len(versions) >= 2, "no snapshot to roll back to"
+
+    def test_re_uploading_the_same_cv_after_a_clear_really_re_extracts(
+        self, api, monkeypatch
+    ) -> None:
+        """The cached LLM hash must go with the cleared input.
+
+        Otherwise the identical file is treated as "already read", the passes
+        are skipped, and the profile stays empty — a reset that does not reset.
+        """
+        _register_and_login(api, "clear-rerun@example.com")
+        _seed_full_profile(api, monkeypatch)
+        api.post("/api/profile/clear", data={"section": "cv"})
+        r = api.post(
+            "/api/profile/cv",
+            files={"cv": ("my_cv.pdf", io.BytesIO(b"%PDF-1.4\n%%EOF"),
+                          "application/pdf")},
+        )
+        assert r.status_code == 200, r.text
+        s = r.json()["summary"]
+        assert s["cv_length"] > 0, "the same CV did not re-extract after a clear"
+        assert s["cv_filename"] == "my_cv.pdf"

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -92,6 +92,19 @@
         "title": "ApplicationTimelineResponse",
         "type": "object"
       },
+      "Body_clear_profile_section_api_profile_clear_post": {
+        "properties": {
+          "section": {
+            "title": "Section",
+            "type": "string"
+          }
+        },
+        "required": [
+          "section"
+        ],
+        "title": "Body_clear_profile_section_api_profile_clear_post",
+        "type": "object"
+      },
       "Body_upload_cv_api_profile_cv_post": {
         "properties": {
           "cv": {
@@ -4619,6 +4632,66 @@
           }
         },
         "summary": "Upsert Profile",
+        "tags": [
+          "profile"
+        ]
+      }
+    },
+    "/api/profile/clear": {
+      "post": {
+        "description": "Empty ONE input (or the whole profile), so the next upload starts clean.\n\n``section``: cv | linkedin | github | preferences | all.\n\nDeliberately does NOT re-run extraction: there is nothing to extract, and a\npaid LLM round-trip to rebuild an empty profile would be waste. The stored\nsnapshot taken by ``save_profile`` is what makes this reversible.",
+        "operationId": "clear_profile_section_api_profile_clear_post",
+        "parameters": [
+          {
+            "in": "cookie",
+            "name": "job360_session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Job360 Session"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_clear_profile_section_api_profile_clear_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProfileResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Clear Profile Section",
         "tags": [
           "profile"
         ]

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -12,14 +12,26 @@ import { CVViewer } from "@/components/profile/CVViewer";
 import { PreferencesForm } from "@/components/profile/PreferencesForm";
 import { VersionHistoryDrawer } from "@/components/profile/VersionHistoryDrawer";
 import { JsonResumeExportButton } from "@/components/profile/JsonResumeExportButton";
+import { ClearButton } from "@/components/profile/ClearButton";
 import {
   getProfile,
   uploadProfile,
   uploadLinkedin,
   uploadGithub,
+  clearProfileSection,
+  type ClearSection,
 } from "@/lib/api";
 import { ApiError, apiErrorMessage } from "@/lib/api-error";
 import type { ProfileResponse, PreferencesRequest } from "@/lib/types";
+
+/** Human names for the clear toasts — "cv" is not what a person calls it. */
+const SECTION_LABEL: Record<ClearSection, string> = {
+  cv: "CV",
+  linkedin: "LinkedIn",
+  github: "GitHub",
+  preferences: "Preferences",
+  all: "Profile",
+};
 
 // ── Completeness calculation ────────────────────────────────
 
@@ -163,6 +175,25 @@ export default function ProfilePage() {
     [fetchProfile]
   );
 
+  // One handler for all five clear buttons — the section is the only thing
+  // that differs. The response IS the rebuilt profile, so the page updates from
+  // it directly rather than re-fetching.
+  const handleClear = useCallback(async (section: ClearSection) => {
+    setError(null);
+    try {
+      const data = await clearProfileSection(section);
+      setProfile(data);
+      toast.success(
+        section === "all" ? "Profile cleared" : `${SECTION_LABEL[section]} cleared`,
+        { description: "Undo it from History if that was a mistake." }
+      );
+    } catch (err: unknown) {
+      const msg = apiErrorMessage(err, "Failed to clear");
+      setError(msg);
+      toast.error(msg);
+    }
+  }, []);
+
   const handleSavePreferences = useCallback(
     async (prefs: PreferencesRequest) => {
       setError(null);
@@ -234,6 +265,17 @@ export default function ProfilePage() {
                 <History className="h-3.5 w-3.5" />
                 History
               </Button>
+              {/* Sits next to History deliberately: History is the undo for it.
+                  A profile you can empty in one click is what makes "upload a
+                  CV and see exactly what came out" a clean experiment instead
+                  of a reading of everything ever uploaded. */}
+              {profile && (
+                <ClearButton
+                  label="Clear profile"
+                  confirmLabel="Click again to clear everything"
+                  onConfirm={() => handleClear("all")}
+                />
+              )}
             </div>
 
             {/* Completeness badge */}
@@ -318,6 +360,7 @@ export default function ProfilePage() {
                 onUpload={handleCVUpload}
                 onLinkedinUpload={handleLinkedinUpload}
                 onGithubEnrich={handleGithubEnrich}
+                onClearSection={handleClear}
                 profile={profile?.summary ?? null}
                 cvDetail={profile?.cv_detail ?? null}
                 loading={loadingProfile}
@@ -327,6 +370,7 @@ export default function ProfilePage() {
               <PreferencesForm
                 preferences={profile?.preferences ?? {}}
                 onSave={handleSavePreferences}
+                onClear={profile ? () => handleClear("preferences") : undefined}
                 loading={loadingProfile}
               />
             </div>

--- a/frontend/src/components/profile/CVUpload.tsx
+++ b/frontend/src/components/profile/CVUpload.tsx
@@ -18,12 +18,15 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
+import { ClearButton } from "@/components/profile/ClearButton";
 import type { ProfileSummary, CVDetail } from "@/lib/types";
 
 interface CVUploadProps {
   onUpload: (file: File) => Promise<void>;
   onLinkedinUpload?: (file: File) => Promise<void>;
   onGithubEnrich?: (username: string) => Promise<void>;
+  /** Empty ONE input so the next upload starts from nothing. Undoable via History. */
+  onClearSection?: (section: "cv" | "linkedin" | "github") => Promise<void>;
   profile: ProfileSummary | null;
   cvDetail?: CVDetail | null;
   loading: boolean;
@@ -168,6 +171,7 @@ export function CVUpload({
   onUpload,
   onLinkedinUpload,
   onGithubEnrich,
+  onClearSection,
   profile,
   cvDetail,
   loading,
@@ -514,17 +518,28 @@ export function CVUpload({
               </span>
             </div>
 
-            {/* Re-upload button */}
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => fileInputRef.current?.click()}
-              disabled={uploading || loading}
-              className="gap-2"
-            >
-              <Upload className="h-3.5 w-3.5" />
-              Re-upload CV
-            </Button>
+            {/* Re-upload + clear, side by side: the two things you do to a CV
+                that is already here. */}
+            <div className="flex flex-wrap items-center gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => fileInputRef.current?.click()}
+                disabled={uploading || loading}
+                className="gap-2"
+              >
+                <Upload className="h-3.5 w-3.5" />
+                Re-upload CV
+              </Button>
+              {onClearSection && (
+                <ClearButton
+                  label="Clear CV"
+                  confirmLabel="Click again to clear the CV"
+                  disabled={uploading || loading}
+                  onConfirm={() => onClearSection("cv")}
+                />
+              )}
+            </div>
             <input
               ref={fileInputRef}
               type="file"
@@ -585,10 +600,21 @@ export function CVUpload({
             </Button>
           </div>
           {profile?.has_linkedin && (
-            <UploadReceipt
-              name={profile.linkedin_filename || "LinkedIn profile on file"}
-              at={profile.linkedin_uploaded_at}
-            />
+            <>
+              <UploadReceipt
+                name={profile.linkedin_filename || "LinkedIn profile on file"}
+                at={profile.linkedin_uploaded_at}
+              />
+              {onClearSection && (
+                <ClearButton
+                  label="Clear LinkedIn"
+                  confirmLabel="Click again to clear LinkedIn"
+                  disabled={linkedinLoading}
+                  onConfirm={() => onClearSection("linkedin")}
+                  className="w-full"
+                />
+              )}
+            </>
           )}
         </div>
 
@@ -642,21 +668,32 @@ export function CVUpload({
               count as proof of what we actually read. This card previously had
               NO confirmation of any kind after a successful enrich. */}
           {profile?.has_github && (
-            <UploadReceipt
-              name={
-                profile.github_username
-                  ? `@${profile.github_username}`
-                  : "GitHub connected"
-              }
-              at={profile.github_connected_at}
-              meta={
-                profile.github_repo_count
-                  ? `${profile.github_repo_count} public ${
-                      profile.github_repo_count === 1 ? "repo" : "repos"
-                    } read`
-                  : undefined
-              }
-            />
+            <>
+              <UploadReceipt
+                name={
+                  profile.github_username
+                    ? `@${profile.github_username}`
+                    : "GitHub connected"
+                }
+                at={profile.github_connected_at}
+                meta={
+                  profile.github_repo_count
+                    ? `${profile.github_repo_count} public ${
+                        profile.github_repo_count === 1 ? "repo" : "repos"
+                      } read`
+                    : undefined
+                }
+              />
+              {onClearSection && (
+                <ClearButton
+                  label="Clear GitHub"
+                  confirmLabel="Click again to clear GitHub"
+                  disabled={githubLoading}
+                  onConfirm={() => onClearSection("github")}
+                  className="w-full"
+                />
+              )}
+            </>
           )}
         </div>
 

--- a/frontend/src/components/profile/ClearButton.test.tsx
+++ b/frontend/src/components/profile/ClearButton.test.tsx
@@ -1,0 +1,85 @@
+/**
+ * A destructive button must not fire on one stray click.
+ *
+ * Clearing is offered precisely so profile state can be reset OFTEN (you cannot
+ * trust a test you cannot reset), which means the button sits next to controls
+ * the user clicks all the time. The safety property is therefore: ONE click
+ * arms, a SECOND click acts, and an armed button disarms itself so it is never
+ * left primed to fire on an unrelated click minutes later.
+ *
+ * Uses fireEvent + real timers deliberately: userEvent's own timer plumbing
+ * fights vi.useFakeTimers, and the behaviour under test is plain click
+ * sequencing, not typing or pointer nuance.
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, act, cleanup, waitFor } from "@testing-library/react";
+import { ClearButton } from "./ClearButton";
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+function setup(onConfirm = vi.fn().mockResolvedValue(undefined)) {
+  render(<ClearButton onConfirm={onConfirm} label="Clear CV" />);
+  return { onConfirm, btn: screen.getByTestId("clear-button") };
+}
+
+describe("ClearButton", () => {
+  it("does NOT clear on the first click", () => {
+    const { onConfirm, btn } = setup();
+    fireEvent.click(btn);
+    expect(onConfirm).not.toHaveBeenCalled();
+    expect(btn.getAttribute("data-armed")).toBe("true");
+  });
+
+  it("clears on the second click", async () => {
+    const { onConfirm, btn } = setup();
+    fireEvent.click(btn);
+    fireEvent.click(btn);
+    await waitFor(() => expect(onConfirm).toHaveBeenCalledTimes(1));
+  });
+
+  it("asks before it acts, in words", () => {
+    const { btn } = setup();
+    expect(btn.textContent).toContain("Clear CV");
+    fireEvent.click(btn);
+    expect(btn.textContent).toMatch(/click again/i);
+  });
+
+  it("disarms itself so it cannot fire on a later unrelated click", () => {
+    vi.useFakeTimers();
+    const { onConfirm, btn } = setup();
+    fireEvent.click(btn);
+    expect(btn.getAttribute("data-armed")).toBe("true");
+    act(() => {
+      vi.advanceTimersByTime(4500);
+    });
+    expect(btn.getAttribute("data-armed")).toBe("false");
+    fireEvent.click(btn); // a FIRST click again, not a confirm
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it("cannot be double-fired while the clear is in flight", async () => {
+    let release!: () => void;
+    const onConfirm = vi.fn(
+      () =>
+        new Promise<void>((r) => {
+          release = r;
+        })
+    );
+    const { btn } = setup(onConfirm);
+    fireEvent.click(btn);
+    fireEvent.click(btn);
+    await waitFor(() => expect(onConfirm).toHaveBeenCalledTimes(1));
+    await waitFor(() =>
+      expect((btn as HTMLButtonElement).disabled).toBe(true)
+    );
+    fireEvent.click(btn); // ignored — the button is disabled mid-flight
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      release();
+    });
+  });
+});

--- a/frontend/src/components/profile/ClearButton.tsx
+++ b/frontend/src/components/profile/ClearButton.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Trash2, Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+/**
+ * A destructive action that asks once, inline.
+ *
+ * WHY TWO-STEP AND NOT A MODAL. Clearing is recoverable — the server snapshots
+ * the profile before every clear, so History can restore it. A full modal for
+ * an undoable action is friction the user pays on every test cycle, and this
+ * button exists precisely so profile state can be reset OFTEN. One deliberate
+ * second click is proportionate; a stray click still cannot wipe anything.
+ *
+ * The armed state self-disarms after 4s so a half-pressed button never sits
+ * there waiting to fire on an unrelated click later.
+ */
+export function ClearButton({
+  onConfirm,
+  label = "Clear",
+  confirmLabel = "Click again to clear",
+  size = "sm",
+  className = "",
+  disabled = false,
+}: {
+  onConfirm: () => Promise<void>;
+  label?: string;
+  confirmLabel?: string;
+  size?: "sm" | "default";
+  className?: string;
+  disabled?: boolean;
+}) {
+  const [armed, setArmed] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timer.current) clearTimeout(timer.current);
+    };
+  }, []);
+
+  const handle = useCallback(async () => {
+    if (!armed) {
+      setArmed(true);
+      timer.current = setTimeout(() => setArmed(false), 4000);
+      return;
+    }
+    if (timer.current) clearTimeout(timer.current);
+    setArmed(false);
+    setBusy(true);
+    try {
+      await onConfirm();
+    } finally {
+      setBusy(false);
+    }
+  }, [armed, onConfirm]);
+
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      size={size}
+      onClick={handle}
+      disabled={disabled || busy}
+      aria-label={armed ? confirmLabel : label}
+      data-testid="clear-button"
+      data-armed={armed ? "true" : "false"}
+      className={`gap-1.5 ${
+        armed
+          ? "border-destructive/60 text-destructive hover:text-destructive"
+          : "text-muted-foreground hover:text-foreground"
+      } ${className}`}
+    >
+      {busy ? (
+        <Loader2 className="h-3.5 w-3.5 animate-spin" />
+      ) : (
+        <Trash2 className="h-3.5 w-3.5" />
+      )}
+      {busy ? "Clearing..." : armed ? confirmLabel : label}
+    </Button>
+  );
+}

--- a/frontend/src/components/profile/PreferencesForm.tsx
+++ b/frontend/src/components/profile/PreferencesForm.tsx
@@ -23,11 +23,15 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Separator } from "@/components/ui/separator";
+import { ClearButton } from "@/components/profile/ClearButton";
 import type { PreferencesRequest } from "@/lib/types";
 
 interface PreferencesFormProps {
   preferences: Record<string, unknown>;
   onSave: (prefs: PreferencesRequest) => Promise<void>;
+  /** Empty every typed preference. Undoable from History. Omitted when there
+   *  is no profile yet — there is nothing to clear. */
+  onClear?: () => Promise<void>;
   loading: boolean;
 }
 
@@ -193,6 +197,7 @@ const AUTOSAVE_DELAY_MS = 800;
 export function PreferencesForm({
   preferences,
   onSave,
+  onClear,
   loading,
 }: PreferencesFormProps) {
   const [targetTitles, setTargetTitles] = useState<string[]>([]);
@@ -317,6 +322,19 @@ export function PreferencesForm({
             Customize your job search criteria
           </p>
         </div>
+        {/* In the card header, not at the bottom: this form autosaves, so there
+            is no "Save" row to sit beside, and the header is where a
+            card-scoped action belongs. */}
+        {onClear && (
+          <div className="ml-auto">
+            <ClearButton
+              label="Clear"
+              confirmLabel="Click again to clear"
+              disabled={loading}
+              onConfirm={onClear}
+            />
+          </div>
+        )}
       </div>
 
       <div className="space-y-6">

--- a/frontend/src/lib/api-types.ts
+++ b/frontend/src/lib/api-types.ts
@@ -764,6 +764,32 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/profile/clear": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Clear Profile Section
+         * @description Empty ONE input (or the whole profile), so the next upload starts clean.
+         *
+         *     ``section``: cv | linkedin | github | preferences | all.
+         *
+         *     Deliberately does NOT re-run extraction: there is nothing to extract, and a
+         *     paid LLM round-trip to rebuild an empty profile would be waste. The stored
+         *     snapshot taken by ``save_profile`` is what makes this reversible.
+         */
+        post: operations["clear_profile_section_api_profile_clear_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/profile/cv": {
         parameters: {
             query?: never;
@@ -1468,6 +1494,11 @@ export interface components {
             job_id: number;
             /** Timeline */
             timeline: components["schemas"]["TimelineEntry"][];
+        };
+        /** Body_clear_profile_section_api_profile_clear_post */
+        Body_clear_profile_section_api_profile_clear_post: {
+            /** Section */
+            section: string;
         };
         /** Body_upload_cv_api_profile_cv_post */
         Body_upload_cv_api_profile_cv_post: {
@@ -3682,6 +3713,41 @@ export interface operations {
         requestBody?: {
             content: {
                 "multipart/form-data": components["schemas"]["Body_upsert_profile_api_profile_post"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProfileResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    clear_profile_section_api_profile_clear_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: {
+                job360_session?: string | null;
+            };
+        };
+        requestBody: {
+            content: {
+                "application/x-www-form-urlencoded": components["schemas"]["Body_clear_profile_section_api_profile_clear_post"];
             };
         };
         responses: {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -275,6 +275,27 @@ export async function uploadGithub(
   });
 }
 
+/** Which part of the profile to empty. "all" wipes the lot. */
+export type ClearSection = "cv" | "linkedin" | "github" | "preferences" | "all";
+
+/**
+ * Empty one input (or the whole profile) so the next upload starts clean.
+ *
+ * Every clear is snapshotted server-side before it writes, so it is undoable
+ * from the History drawer — that is what makes a destructive-looking button
+ * safe to offer.
+ */
+export async function clearProfileSection(
+  section: ClearSection
+): Promise<ProfileResponse> {
+  const form = new FormData();
+  form.append("section", section);
+  return request<ProfileResponse>("/api/profile/clear", {
+    method: "POST",
+    body: form,
+  });
+}
+
 // ---- Profile version management (Step-2 A1, S3-MVP endpoints) ----
 
 export async function getProfileVersions(): Promise<ProfileVersionsListResponse> {


### PR DESCRIPTION
## Why

Every contamination bug found on the live profile this week was hard to **see** for the same reason: uploads **merge** into what's already stored. So *"upload a CV and check what came out"* never reads that CV — it reads the sum of every upload ever made.

Another person's GitHub, then their LinkedIn, then their education / certifications / job titles that had **already merged into the CV fields** and survived deleting the LinkedIn block. Each one took a live DB query to find, because the UI couldn't distinguish new data from residue.

A reset makes each upload a clean experiment. That's the whole feature.

## What ships

`POST /api/profile/clear` with `section = cv | linkedin | github | preferences | all`. Each scope clears the fields that input **owns** and nothing else — clearing LinkedIn cannot take the CV with it.

```
Profile   [Export JSON Resume] [History] [🗑 Clear profile]   ← History is its undo
CV card               [Re-upload CV] [🗑 Clear CV]
LinkedIn   receipt →  [🗑 Clear LinkedIn]
GitHub     receipt →  [🗑 Clear GitHub]
Preferences header →  [🗑 Clear]
```

## Three decisions worth knowing

**1. The cached LLM hash goes with the cleared input.** Without it, re-uploading the *same* file would be treated as "already read", every pass skipped, and the profile would stay empty — **a reset that doesn't reset**. Pinned by a test that clears the CV, re-uploads the identical file, and asserts it re-extracted.

**2. Clearing preferences keeps the GitHub handle.** The handle is owned by the GitHub section; wiping it from a preferences clear would silently disconnect GitHub — the same class of invisible state change this feature exists to prevent.

**3. Two-step confirm, not a modal.** Every clear is snapshotted by `save_profile` **before** it writes, so it's undoable from History. A modal on an undoable action is friction paid on every test cycle, and this button exists to be used often. One click arms, a second acts, and the armed state self-disarms after 4s so a half-pressed button is never left primed to fire on an unrelated click later.

Deliberately does **not** re-run extraction: there's nothing to extract from an emptied input, and a paid LLM round-trip to rebuild an empty profile is waste.

## Tests

| Layer | Count | What it proves |
|---|---|---|
| Backend | 8 | each scope clears only its own section · unknown section → 400 · a snapshot exists to undo from · the same file really re-extracts after a clear |
| Component | 5 | first click never fires · second does · it says what it will do · it self-disarms · it can't double-fire mid-flight |

231 frontend unit tests · type-check + lint clean · api-types regenerated · Gate **PASS**, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
