### PR TITLE
fix(profile): a LinkedIn URL in the GitHub box says where LinkedIn actually goes

### DIFF
--- a/backend/src/api/routes/profile.py
+++ b/backend/src/api/routes/profile.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 import logging
 import os
+import re
 from dataclasses import asdict
 from datetime import datetime, timezone
 from typing import Any, cast
@@ -569,6 +570,24 @@ async def upload_github(
     """
     clean_username = normalize_github_username(username)
     if not clean_username:
+        # Name the mistake when we can recognise it. A LinkedIn URL in the
+        # GitHub box is the single most likely wrong paste — both boxes live in
+        # the same "Enrich Your Profile" card, and a CV lists both links side by
+        # side. Telling that user "that does not look like a GitHub username" is
+        # true and useless: it does not say where their LinkedIn DOES go, and
+        # LinkedIn cannot be read from a link at all (measured: linkedin.com
+        # answers a server with HTTP 999 and a sign-in wall, no profile data),
+        # which is exactly why the PDF export exists.
+        if re.search(r"linkedin\.com", username or "", re.IGNORECASE):
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "That is a LinkedIn URL, and this box is for GitHub. "
+                    "LinkedIn cannot be read from a link — use \"Enrich "
+                    "LinkedIn\" above and upload the PDF (on LinkedIn: your "
+                    "profile -> More -> Save to PDF)."
+                ),
+            )
         raise HTTPException(
             status_code=400,
             detail=(

--- a/backend/tests/test_profile_upload.py
+++ b/backend/tests/test_profile_upload.py
@@ -713,6 +713,34 @@ class TestUnusableHandleIsRejected:
         # AND no receipt — the page must not claim a connection that failed.
         assert got["github_connected_at"] == ""
 
+    @pytest.mark.parametrize(
+        "li",
+        [
+            "linkedin.com/in/ranjith-ai-engineer",
+            "https://www.linkedin.com/in/ranjith-ai-engineer/",
+        ],
+    )
+    def test_a_linkedin_url_says_where_linkedin_actually_goes(
+        self, api, monkeypatch, li
+    ) -> None:
+        """Name the mistake instead of restating the rule.
+
+        Both boxes sit in the same "Enrich Your Profile" card and a CV lists
+        both links side by side, so pasting the LinkedIn URL into the GitHub
+        box is the likeliest wrong paste there is. "That does not look like a
+        GitHub username" is true and useless — it never says where LinkedIn
+        DOES go, and LinkedIn cannot be read from a link at all (measured:
+        HTTP 999 + a sign-in wall for a server), which is why the PDF exists.
+        """
+        _stub(monkeypatch, {"username": "x", "languages": {}, "repos": []})
+        _register_and_login(api, f"gh-li-{abs(hash(li)) % 9999}@example.com")
+        _seed_cv(api)
+        r = api.post("/api/profile/github", data={"username": li})
+        assert r.status_code == 400, r.text
+        body = r.text.lower()
+        assert "linkedin" in body
+        assert "pdf" in body, "must point at the upload that actually works"
+
     def test_a_github_pages_url_now_resolves(self, api, monkeypatch) -> None:
         """The owner's own Portfolio URL must work — the handle is in it."""
         _stub(monkeypatch, {


### PR DESCRIPTION
## The report

The owner pasted his LinkedIn URL into the GitHub box and got *"That does not look like a GitHub username."* True, and useless — it never says where his LinkedIn **does** go, so he tried a second form and reported both as broken.

This isn't a user error, it's a **predictable** one: both boxes live in the same "Enrich Your Profile" card, and a CV lists both links side by side.

## The fix

Any input containing `linkedin.com` now gets a message that names the mistake and points at the control that works:

> *That is a LinkedIn URL, and this box is for GitHub. LinkedIn cannot be read from a link — use "Enrich LinkedIn" above and upload the PDF (on LinkedIn: your profile → More → Save to PDF).*

## Why LinkedIn genuinely cannot be read from a link

Measured, not assumed — I fetched the profile URL the way a server would:

```
plain server fetch    → HTTP 999      LinkedIn's anti-bot status
browser User-Agent    → HTTP 999      same, after a 301
body                  → 1,530 bytes   a sign-in wall
profile content       → 0 matches     no employers, no job title
```

So a URL field would either sit there doing nothing, or require scraping — which breaches LinkedIn's terms and is blocked regardless.

**GitHub is different only because it publishes a public API**: the same handle returns 14 repos. The PDF export isn't a workaround we invented — it's the one route LinkedIn sanctions to a person's own data, and it's what produced this profile's 13 LinkedIn skills.

**No URL field was added.** A field that cannot deliver is worse than no field.

## Test

Both URL forms the owner tried, asserting the response names **LinkedIn** *and* the **PDF** — so it can never regress to merely restating the rule.

Gate: **PASS**, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
