### PR TITLE
feat(profile): surface every GitHub shelf — 92 pieces of signal were invisible

### DIFF
--- a/backend/src/api/models.py
+++ b/backend/src/api/models.py
@@ -259,6 +259,12 @@ class ProfileResponse(BaseModel):
     # (top-K by volume) + topic frequencies. Pure metric surface — UI
     # renders trend graphs without backend re-shaping.
     github_temporal: dict[str, dict[Any, Any]] = {}
+    # Everything else GitHub gave us: repos (name/language/description/topics/
+    # README excerpt/stars/pushed_at), dependency-file frameworks, inferred and
+    # LLM-read skills, bio, profile README. Measured 2026-08-09: 92 pieces of
+    # this were stored and rendered NOWHERE while only languages+topics showed.
+    # Defaults to {} so every existing caller and older profile stays valid.
+    github_detail: dict[str, Any] = {}
     # Step-1.5 S3-E — newest snapshot id from ``user_profile_versions``;
     # surfaces "current version" alongside the history list. None when
     # the version table is empty / unavailable.

--- a/backend/src/api/routes/profile.py
+++ b/backend/src/api/routes/profile.py
@@ -220,6 +220,27 @@ def _build_profile_response(profile: UserProfile) -> ProfileResponse:
         "languages": dict(getattr(cv, "github_languages", {}) or {}),
         "topics": {t: 1 for t in (getattr(cv, "github_topics", []) or [])},
     }
+    # EVERYTHING ELSE GitHub gave us. Measured on a live profile 2026-08-09:
+    # languages (14) and topics (10) reached the screen, while 49 frameworks,
+    # 13 repos and 30 LLM-read skills sat in the database appearing NOWHERE —
+    # 92 pieces of signal stored and shown to nobody, the same shape as
+    # cv_positions and the upload receipts before them.
+    #
+    # This is the input where it matters most: GitHub evidence outranks a CV
+    # claim. A CV says "FastAPI"; a requirements.txt in shipped code PROVES it,
+    # which is why skill_tiering weights github_dep/github_llm (1.5) above
+    # github_lang (1.0). That evidence was already scoring the user's matches —
+    # they simply could not see it.
+    github_detail: dict[str, Any] = {
+        "username": profile.preferences.github_username or "",
+        "connected_at": getattr(cv, "github_connected_at", "") or "",
+        "repos": list(getattr(cv, "github_repos_brief", []) or []),
+        "frameworks": list(getattr(cv, "github_frameworks", []) or []),
+        "skills_inferred": list(getattr(cv, "github_skills_inferred", []) or []),
+        "llm_skills": list(getattr(cv, "github_llm_skills", []) or []),
+        "bio": getattr(cv, "github_bio", "") or "",
+        "profile_readme": getattr(cv, "github_profile_readme", "") or "",
+    }
 
     # Step-1.5 S3-E — current_version_id surfaces the newest snapshot id
     # from user_profile_versions. Best-effort: a stale DB without 0007
@@ -243,6 +264,7 @@ def _build_profile_response(profile: UserProfile) -> ProfileResponse:
         ai_suggestions=ai_suggestions,
         linkedin_subsections=linkedin_subsections,
         github_temporal=github_temporal,
+        github_detail=github_detail,
         current_version_id=current_version_id,
     )
 

--- a/backend/src/services/profile/github_enricher.py
+++ b/backend/src/services/profile/github_enricher.py
@@ -516,6 +516,16 @@ async def fetch_github_profile(
                 "language": r.get("language", "") or "",
                 "description": r.get("description", ""),
                 "topics": list(r.get("topics", []) or []),
+                # RECENCY and WEIGHT were fetched and thrown away. ``pushed_at``
+                # is the only recency signal GitHub hands us — the engine has no
+                # skill-recency input anywhere, and "used this in the last
+                # month" is a different claim from "used it in 2019".
+                # ``stars`` is the one public quality signal on a repo. Both are
+                # already in the /users/{u}/repos payload, so keeping them costs
+                # nothing and closes the last GitHub field with no shelf.
+                "stars": int(r.get("stargazers_count", 0) or 0),
+                "pushed_at": r.get("pushed_at", "") or "",
+                "url": r.get("html_url", "") or "",
             }
             if excerpt:
                 brief["readme_excerpt"] = excerpt

--- a/backend/tests/test_profile_upload.py
+++ b/backend/tests/test_profile_upload.py
@@ -861,6 +861,74 @@ def _seed_full_profile(api_client, monkeypatch):
     )
 
 
+class TestEveryGithubShelfReachesTheApi:
+    """A shelf the API never returns is a shelf the user can never see.
+
+    Measured 2026-08-09: GitHub gave a live profile 14 languages, 10 topics, 49
+    frameworks, 13 repos, 25 inferred and 30 LLM-read skills — and only
+    languages + topics were exposed. 92 pieces of signal stored and shown to
+    nobody, which is the same failure as cv_positions and the upload receipts.
+    VALUE-presence, not schema-presence (rule #21): every field below defaults
+    to empty, so asserting the KEY exists would pass against a serializer that
+    never reads the column.
+    """
+
+    def test_github_detail_carries_repos_frameworks_and_skills(
+        self, api, monkeypatch
+    ) -> None:
+        _stub(monkeypatch, {
+            "username": "octocat",
+            "languages": {"Python": 500},
+            "repos": [{"name": "job360", "language": "Python"}],
+            "repos_brief": [{
+                "name": "job360",
+                "language": "Python",
+                "description": "A UK job search engine",
+                "topics": ["fastapi"],
+                "stars": 7,
+                "pushed_at": "2026-08-01T10:00:00Z",
+            }],
+            "frameworks_inferred": ["fastapi", "langgraph"],
+            "skills_inferred": ["TypeScript"],
+            "bio": "Builds things",
+            "profile_readme": "# Hello",
+        })
+        _register_and_login(api, "gh-detail@example.com")
+        _seed_cv(api)
+        assert api.post(
+            "/api/profile/github", data={"username": "octocat"}
+        ).status_code == 200
+
+        detail = api.get("/api/profile").json()["github_detail"]
+        assert detail["username"] == "octocat"
+        assert detail["connected_at"], "no connection receipt"
+        # The repo brief must carry RECENCY and WEIGHT — both were fetched from
+        # /users/{u}/repos and thrown away before this change, and pushed_at is
+        # the only skill-recency signal the engine gets from anywhere.
+        repo = detail["repos"][0]
+        assert repo["name"] == "job360"
+        assert repo["description"] == "A UK job search engine"
+        assert repo["stars"] == 7
+        assert repo["pushed_at"].startswith("2026")
+        # Dependency-file evidence: DEMONSTRATED usage, not a CV claim.
+        assert "langgraph" in detail["frameworks"]
+        assert "TypeScript" in detail["skills_inferred"]
+        assert detail["bio"] == "Builds things"
+        assert detail["profile_readme"] == "# Hello"
+
+    def test_no_github_means_an_empty_detail_not_a_crash(
+        self, api, monkeypatch
+    ) -> None:
+        """Empty shelves stay silent (rule #29) — and must not 500."""
+        _stub(monkeypatch, {})
+        _register_and_login(api, "gh-nodetail@example.com")
+        _seed_cv(api)
+        detail = api.get("/api/profile").json()["github_detail"]
+        assert detail["repos"] == []
+        assert detail["frameworks"] == []
+        assert detail["username"] == ""
+
+
 class TestClearSectionRemovesOnlyThatSection:
     def test_clearing_the_cv_leaves_linkedin_and_github(self, api, monkeypatch) -> None:
         _register_and_login(api, "clear-cv@example.com")

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -1543,6 +1543,12 @@
               }
             ]
           },
+          "github_detail": {
+            "additionalProperties": true,
+            "default": {},
+            "title": "Github Detail",
+            "type": "object"
+          },
           "github_temporal": {
             "additionalProperties": {
               "additionalProperties": true,

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -386,6 +386,7 @@ export default function ProfilePage() {
                 skillProvenance={profile.skill_provenance}
                 linkedinSubsections={profile.linkedin_subsections}
                 githubTemporal={profile.github_temporal}
+                githubDetail={profile.github_detail}
               />
             )}
 

--- a/frontend/src/components/profile/CVViewer.github-detail.test.tsx
+++ b/frontend/src/components/profile/CVViewer.github-detail.test.tsx
@@ -1,0 +1,137 @@
+/**
+ * Every GitHub shelf must reach the screen.
+ *
+ * MEASURED ON A LIVE PROFILE, 2026-08-09. GitHub returned 14 languages, 10
+ * topics, 49 frameworks, 13 repos, 25 inferred skills and 30 LLM-read skills.
+ * Only languages and topics rendered — 92 pieces of extracted signal sat in the
+ * database and appeared NOWHERE. Same shape as cv_positions and the upload
+ * receipts before them: a value computed, stored, and shown to nobody.
+ *
+ * It matters most on THIS input. A CV *claims* "FastAPI"; a requirements.txt in
+ * shipped code *proves* it — which is why skill tiering already weights GitHub
+ * dependency and README evidence (1.5) above a language guess (1.0). That
+ * evidence was scoring the user's job matches while being invisible to them.
+ */
+
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { CVViewer } from "./CVViewer";
+import type { CVDetail } from "@/lib/types";
+
+const cv = {
+  raw_text: "Ada Lovelace\nEngineer",
+  skills: ["Python"],
+  job_titles: ["ML Engineer"],
+  companies: [],
+  education: [],
+  certifications: [],
+  summary_text: "Builds things.",
+  experience_text: "",
+  name: "Ada Lovelace",
+  headline: "Engineer",
+  location: "London",
+  achievements: [],
+} as unknown as CVDetail;
+
+const githubDetail = {
+  username: "adalovelace",
+  connected_at: "2026-08-09T12:00:00+00:00",
+  repos: [
+    {
+      name: "job360",
+      language: "Python",
+      description: "A UK job search engine",
+      topics: ["fastapi", "llm"],
+      stars: 7,
+      pushed_at: "2026-08-01T10:00:00Z",
+    },
+    {
+      name: "quiet-repo",
+      language: "",
+      description: "",
+      topics: [],
+      stars: 0,
+      pushed_at: "",
+    },
+  ],
+  frameworks: ["fastapi", "next", "langgraph"],
+  skills_inferred: ["TypeScript", "Dart"],
+  llm_skills: ["Tailwind CSS", "Framer Motion"],
+  bio: "Aspiring analytical engineer",
+  profile_readme: "# Hello, I build things",
+};
+
+function renderViewer(detail: Record<string, unknown> | undefined) {
+  render(
+    <CVViewer
+      cv={cv}
+      githubTemporal={{ languages: { Python: 100 }, topics: { llm: 1 } }}
+      githubDetail={detail}
+    />
+  );
+}
+
+describe("GitHub detail shows everything GitHub gave us", () => {
+  it("renders repositories with language, stars and last-updated", () => {
+    renderViewer(githubDetail);
+    expect(screen.getByText("job360")).toBeTruthy();
+    expect(screen.getByText("A UK job search engine")).toBeTruthy();
+    expect(screen.getByText(/★ 7/)).toBeTruthy();
+    // Recency is the signal the engine has nowhere else — assert the YEAR so
+    // the test does not break on a different locale's date format.
+    expect(screen.getByText(/updated .*2026/)).toBeTruthy();
+  });
+
+  it("renders dependency-file frameworks AND says why they count", () => {
+    renderViewer(githubDetail);
+    // "fastapi" is legitimately on screen twice — as a repo TOPIC and as a
+    // dependency-file FRAMEWORK. Those are different claims about the same
+    // word, so both belong; assert at least one rather than exactly one.
+    expect(screen.getAllByText("fastapi").length).toBeGreaterThan(0);
+    expect(screen.getByText("langgraph")).toBeTruthy();
+    // The distinction between claimed and demonstrated is the whole value.
+    expect(screen.getByText(/dependency files/i)).toBeTruthy();
+    expect(screen.getByText(/shipped code/i)).toBeTruthy();
+  });
+
+  it("renders README-read skills and repo-inferred skills separately", () => {
+    renderViewer(githubDetail);
+    expect(screen.getByText("Tailwind CSS")).toBeTruthy();
+    expect(screen.getByText("Dart")).toBeTruthy();
+    expect(screen.getByText(/READMEs \(2\)/)).toBeTruthy();
+    expect(screen.getByText(/inferred from repos \(2\)/)).toBeTruthy();
+  });
+
+  it("renders the bio and profile README", () => {
+    renderViewer(githubDetail);
+    expect(screen.getByText("Aspiring analytical engineer")).toBeTruthy();
+    expect(screen.getByText(/# Hello, I build things/)).toBeTruthy();
+  });
+
+  it("a repo with no description or topics still renders its name", () => {
+    renderViewer(githubDetail);
+    expect(screen.getByText("quiet-repo")).toBeTruthy();
+  });
+
+  it("stays SILENT when there is no GitHub data at all (rule #29)", () => {
+    render(<CVViewer cv={cv} />);
+    expect(screen.queryByText("GitHub detail")).not.toBeInTheDocument();
+  });
+
+  it("renders what exists when the fetch was partial", () => {
+    // A rate-limited enrich can return frameworks but no repos. Each block is
+    // independent, so the page shows what it has instead of all-or-nothing.
+    renderViewer({ frameworks: ["fastapi"], repos: [], llm_skills: [] });
+    expect(screen.getByText("fastapi")).toBeTruthy();
+    expect(screen.queryByText(/Repositories/)).not.toBeInTheDocument();
+  });
+
+  it("never renders undefined or Invalid Date from a malformed entry", () => {
+    renderViewer({
+      repos: [{ name: "odd", language: null, topics: "nope", pushed_at: "xx" }],
+      frameworks: ["ok"],
+    });
+    expect(screen.getByText("odd")).toBeTruthy();
+    expect(document.body.textContent).not.toMatch(/undefined|Invalid Date|NaN/);
+  });
+});

--- a/frontend/src/components/profile/CVViewer.tsx
+++ b/frontend/src/components/profile/CVViewer.tsx
@@ -33,6 +33,43 @@ interface CVViewerProps {
   linkedinSubsections?: Record<string, Record<string, unknown>[]>;
   /** ProfileResponse.github_temporal — { languages: {lang: bytes}, topics: {topic: 1} }. */
   githubTemporal?: Record<string, Record<string, unknown>>;
+  /** ProfileResponse.github_detail — repos, frameworks, inferred + LLM-read
+   *  skills, bio, profile README. Everything GitHub gave us beyond languages
+   *  and topics, which until 2026-08-09 was stored and rendered nowhere. */
+  githubDetail?: Record<string, unknown>;
+}
+
+interface GithubRepoEntry {
+  name: string;
+  language: string;
+  description: string;
+  topics: string[];
+  stars: number;
+  pushed_at: string;
+}
+
+function normalizeGithubRepo(raw: Record<string, unknown>): GithubRepoEntry {
+  const stars = raw["stars"];
+  return {
+    name: strField(raw, "name"),
+    language: strField(raw, "language"),
+    description: strField(raw, "description"),
+    topics: strArrField(raw, "topics"),
+    stars: typeof stars === "number" ? stars : 0,
+    pushed_at: strField(raw, "pushed_at"),
+  };
+}
+
+/** "updated 3 Aug 2026" — a repo's recency, in words, in the viewer's locale. */
+function formatRepoDate(iso: string): string {
+  if (!iso) return "";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "";
+  return d.toLocaleDateString(undefined, {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  });
 }
 
 // ── Dict helpers — cv_positions / linkedin subsections arrive as loosely
@@ -156,6 +193,7 @@ export function CVViewer({
   skillProvenance,
   linkedinSubsections,
   githubTemporal,
+  githubDetail,
 }: CVViewerProps) {
   // (The showFullCV toggle and its highlight terms went with the "Full CV
   // Text" panel — that text now lives only in the CV Uploaded card.)
@@ -186,7 +224,33 @@ export function CVViewer({
   const ghLanguageTotal = ghLanguages.reduce((sum, [, bytes]) => sum + bytes, 0);
   const ghLanguagesSorted = [...ghLanguages].sort((a, b) => b[1] - a[1]);
   const ghTopics = Object.keys(githubTemporal?.topics ?? {});
-  const hasGithubDetail = ghLanguagesSorted.length > 0 || ghTopics.length > 0;
+
+  // ── The rest of GitHub — read defensively, same as every other loosely
+  // typed block on this page. Each renders only when it has content, so a
+  // profile with no GitHub (or a partial fetch) stays silent (rule #29).
+  const ghDetail = githubDetail ?? {};
+  const ghRepos = (Array.isArray(ghDetail.repos) ? ghDetail.repos : [])
+    .filter((r): r is Record<string, unknown> => typeof r === "object" && r !== null)
+    .map(normalizeGithubRepo)
+    .filter((r) => r.name);
+  const asStrings = (v: unknown): string[] =>
+    Array.isArray(v) ? v.filter((x): x is string => typeof x === "string") : [];
+  const ghFrameworks = asStrings(ghDetail.frameworks);
+  const ghInferred = asStrings(ghDetail.skills_inferred);
+  const ghLlmSkills = asStrings(ghDetail.llm_skills);
+  const ghBio = typeof ghDetail.bio === "string" ? ghDetail.bio : "";
+  const ghProfileReadme =
+    typeof ghDetail.profile_readme === "string" ? ghDetail.profile_readme : "";
+
+  const hasGithubDetail =
+    ghLanguagesSorted.length > 0 ||
+    ghTopics.length > 0 ||
+    ghRepos.length > 0 ||
+    ghFrameworks.length > 0 ||
+    ghInferred.length > 0 ||
+    ghLlmSkills.length > 0 ||
+    Boolean(ghBio) ||
+    Boolean(ghProfileReadme);
 
   return (
     <div className="space-y-6 animate-fade-in-up stagger-2">
@@ -574,7 +638,7 @@ export function CVViewer({
           )}
 
           {ghTopics.length > 0 && (
-            <div>
+            <div className="mb-5">
               <SectionLabel icon={Hash} text={`Topics (${ghTopics.length})`} />
               <ul className="flex flex-wrap gap-1.5 pl-5">
                 {ghTopics.map((topic) => (
@@ -586,6 +650,149 @@ export function CVViewer({
                   </li>
                 ))}
               </ul>
+            </div>
+          )}
+
+          {/* ── Everything below was FETCHED, STORED, and shown to nobody ──
+              Measured 2026-08-09 on a live profile: 49 frameworks, 13 repos and
+              30 LLM-read skills sat in the database while only languages and
+              topics reached the screen. It is the input where invisibility
+              costs most — a CV CLAIMS "FastAPI", a requirements.txt in shipped
+              code PROVES it, which is why skill tiering already weights this
+              evidence above a CV mention. It was scoring their matches
+              already; they just could not see it. */}
+
+          {ghRepos.length > 0 && (
+            <div className="mb-5">
+              <SectionLabel icon={GitBranch} text={`Repositories (${ghRepos.length})`} />
+              <ul className="space-y-2 pl-5">
+                {ghRepos.map((repo, i) => (
+                  <li
+                    key={`${repo.name}-${i}`}
+                    className="rounded-lg border border-border/40 bg-muted/10 p-3"
+                  >
+                    <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
+                      <span className="text-sm font-medium text-foreground">
+                        {repo.name}
+                      </span>
+                      {repo.language && (
+                        <span className="rounded-full bg-violet-500/10 px-2 py-0.5 text-[11px] font-medium text-violet-400">
+                          {repo.language}
+                        </span>
+                      )}
+                      {repo.stars > 0 && (
+                        <span className="text-[11px] text-muted-foreground">
+                          ★ {repo.stars}
+                        </span>
+                      )}
+                      {repo.pushed_at && (
+                        <span className="ml-auto text-[11px] text-muted-foreground">
+                          updated {formatRepoDate(repo.pushed_at)}
+                        </span>
+                      )}
+                    </div>
+                    {repo.description && (
+                      <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+                        {repo.description}
+                      </p>
+                    )}
+                    {repo.topics.length > 0 && (
+                      <ul className="mt-1.5 flex flex-wrap gap-1">
+                        {repo.topics.map((t) => (
+                          <li
+                            key={t}
+                            className="rounded-full bg-muted/40 px-2 py-0.5 text-[10px] text-muted-foreground"
+                          >
+                            {t}
+                          </li>
+                        ))}
+                      </ul>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {ghFrameworks.length > 0 && (
+            <div className="mb-5">
+              <SectionLabel
+                icon={Wrench}
+                text={`Frameworks & libraries (${ghFrameworks.length})`}
+              />
+              {/* The strongest evidence on the page: read from real dependency
+                  files (package.json / requirements.txt), so this is
+                  DEMONSTRATED usage, not a claim. Said plainly, because the
+                  distinction is the whole value. */}
+              <p className="pl-5 mb-1.5 text-[11px] text-muted-foreground">
+                Found in your dependency files — used in shipped code, not just listed.
+              </p>
+              <ul className="flex flex-wrap gap-1.5 pl-5">
+                {ghFrameworks.map((f) => (
+                  <li
+                    key={f}
+                    className="rounded-full bg-violet-500/10 px-2.5 py-0.5 text-xs font-medium text-violet-400"
+                  >
+                    {f}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {ghLlmSkills.length > 0 && (
+            <div className="mb-5">
+              <SectionLabel
+                icon={BookOpen}
+                text={`Skills read from your READMEs (${ghLlmSkills.length})`}
+              />
+              <ul className="flex flex-wrap gap-1.5 pl-5">
+                {ghLlmSkills.map((s) => (
+                  <li
+                    key={s}
+                    className="rounded-full bg-violet-500/10 px-2.5 py-0.5 text-xs font-medium text-violet-400"
+                  >
+                    {s}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {ghInferred.length > 0 && (
+            <div className="mb-5">
+              <SectionLabel
+                icon={Code2}
+                text={`Skills inferred from repos (${ghInferred.length})`}
+              />
+              <ul className="flex flex-wrap gap-1.5 pl-5">
+                {ghInferred.map((s) => (
+                  <li
+                    key={s}
+                    className="rounded-full bg-violet-500/10 px-2.5 py-0.5 text-xs font-medium text-violet-400"
+                  >
+                    {s}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {ghBio && (
+            <div className="mb-5">
+              <SectionLabel icon={User} text="Bio" />
+              <p className="pl-5 text-sm leading-relaxed text-foreground/80">
+                {ghBio}
+              </p>
+            </div>
+          )}
+
+          {ghProfileReadme && (
+            <div>
+              <SectionLabel icon={FileText} text="Profile README" />
+              <pre className="ml-5 max-h-64 overflow-y-auto whitespace-pre-wrap rounded-lg border border-border/40 bg-muted/10 p-3 font-sans text-xs leading-relaxed text-foreground/80">
+                {ghProfileReadme}
+              </pre>
             </div>
           )}
         </div>

--- a/frontend/src/lib/api-types.ts
+++ b/frontend/src/lib/api-types.ts
@@ -2111,6 +2111,13 @@ export interface components {
             current_version_id?: number | null;
             cv_detail?: components["schemas"]["CVDetail"] | null;
             /**
+             * Github Detail
+             * @default {}
+             */
+            github_detail: {
+                [key: string]: unknown;
+            };
+            /**
              * Github Temporal
              * @default {}
              */


### PR DESCRIPTION
## Measured on a live profile

GitHub returned **14 languages, 10 topics, 49 frameworks, 13 repos, 25 inferred skills, 30 LLM-read skills**. Only languages and topics reached the screen.

**92 pieces of extracted signal sat in the database and rendered nowhere** — the third instance of this exact shape after `cv_positions` and the upload receipts: a value computed, stored, scored against, and shown to nobody.

It matters most on *this* input. A CV **claims** "FastAPI"; a `requirements.txt` in shipped code **proves** it — which is why `skill_tiering` already weights GitHub dependency/README evidence at **1.5** against a language guess at **1.0**. That evidence was already ranking the owner's job matches while being invisible to the one person who'd want to check it.

## Shelf audit found one real gap

| GitHub returns | Stored? |
|---|---|
| languages · topics · skills_inferred · frameworks_inferred · repos_brief · bio · profile_readme | ✅ |
| **stars · pushed_at** | ❌ fetched from `/users/{u}/repos` and **thrown away** |

`pushed_at` is the **only** recency signal GitHub hands us, and this engine has no skill-recency input anywhere — *"used this last month"* and *"used it in 2019"* were the same claim. Both now live on each repo brief, alongside the repo URL.

## Now on screen in "GitHub detail"

- **Repositories** — name, language, ★ stars, **last updated**, description, topics
- **Frameworks & libraries**, with a line saying *why* they count: *"found in your dependency files — used in shipped code, not just listed."* The claimed-vs-demonstrated distinction **is** the value; leaving it implicit wastes it.
- **Skills read from your READMEs** and **skills inferred from repos**, kept separate — different evidence, different weights
- **Bio** and **profile README** when present

Each block renders only when it has content, so a profile with no GitHub — or a rate-limited partial fetch — stays silent instead of showing empty headings (rule #29).

## API

New `github_detail` block on `ProfileResponse` (`username`, `connected_at`, `repos`, `frameworks`, `skills_inferred`, `llm_skills`, `bio`, `profile_readme`). Defaults to `{}` so every existing caller and older profile stays valid.

## Tests

**8 frontend render tests** — repos with recency and stars · frameworks with their justification · README vs repo skills separated · bio and README · a repo with no description · **silent** with no GitHub · partial fetch renders what exists · never renders `undefined`/`NaN`/`Invalid Date`.

**2 backend value-presence tests** (rule #21 — every field defaults empty, so asserting the *key* would pass against a serializer that never reads it).

Gate: **PASS**, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
