### PR TITLE
feat(profile): 13 new GitHub shelves — from data we already fetched and discarded

### DIFF
--- a/backend/src/api/routes/profile.py
+++ b/backend/src/api/routes/profile.py
@@ -238,6 +238,7 @@ def _build_profile_response(profile: UserProfile) -> ProfileResponse:
         "frameworks": list(getattr(cv, "github_frameworks", []) or []),
         "skills_inferred": list(getattr(cv, "github_skills_inferred", []) or []),
         "llm_skills": list(getattr(cv, "github_llm_skills", []) or []),
+        "identity": dict(getattr(cv, "github_identity", {}) or {}),
         "bio": getattr(cv, "github_bio", "") or "",
         "profile_readme": getattr(cv, "github_profile_readme", "") or "",
     }
@@ -706,6 +707,7 @@ def _clear_github(cv: CVData, prefs: UserPreferences) -> None:
     cv.github_repos_brief = []
     cv.github_bio = ""
     cv.github_profile_readme = ""
+    cv.github_identity = {}
     cv.github_connected_at = ""
     cv.llm_input_hashes.pop("github", None)
     prefs.github_username = ""  # the handle belongs to this section

--- a/backend/src/services/profile/github_enricher.py
+++ b/backend/src/services/profile/github_enricher.py
@@ -267,6 +267,48 @@ async def _fetch_user(session: aiohttp.ClientSession, username: str) -> dict[str
     return data if isinstance(data, dict) else {}
 
 
+def _identity_fields(user: dict[str, Any]) -> dict[str, Any]:
+    """The /users/{u} identity block kept as TYPED VALUES, not a sentence.
+
+    ``_compose_bio`` folds these same fields into one display string. That is
+    fine for a human and for an LLM prompt, and useless for anything that has
+    to compare, filter or score — you cannot match on a sentence.
+
+    Two are genuine matching signals, which is why these are shelves and not
+    decoration:
+      * ``hireable``  — GitHub's own "open to work" flag, stated by the person.
+      * ``location``  — a place claim the UK eligibility gate can reason about.
+    The rest (account age, followers, public repo count) are cheap tenure and
+    activity proxies for later ranking work.
+
+    Costs nothing: this is the SAME response ``_compose_bio`` already reads.
+    Every value is read defensively — GitHub omits fields on sparse profiles,
+    and a missing field must be absent, never ``None`` leaking into the UI.
+    """
+    def s(key: str) -> str:
+        v = user.get(key)
+        return v.strip() if isinstance(v, str) and v.strip() else ""
+
+    def i(key: str) -> int:
+        v = user.get(key)
+        return int(v) if isinstance(v, (int, float)) and not isinstance(v, bool) else 0
+
+    return {
+        "name": s("name"),
+        "company": s("company"),
+        "location": s("location"),
+        "blog": s("blog"),
+        "twitter": s("twitter_username"),
+        # Tri-state on purpose: True / False / None are three different facts.
+        # None means "never said", which is NOT "not looking" — the same
+        # distinction the visa signal makes (rule #31).
+        "hireable": user.get("hireable") if isinstance(user.get("hireable"), bool) else None,
+        "account_created_at": s("created_at"),
+        "followers": i("followers"),
+        "public_repos": i("public_repos"),
+    }
+
+
 def _compose_bio(user: dict[str, Any]) -> str:
     """Fold the /users/{u} identity fields into one short self-description
     string for the LLM pass. Only non-empty fields are included, so a sparse
@@ -412,6 +454,19 @@ async def fetch_github_profile(
                 "stars": repo.get("stargazers_count", 0),
                 "topics": repo.get("topics", []),
                 "pushed_at": repo.get("pushed_at"),
+                # Already in this response; kept because each answers a
+                # question matching will want later:
+                #   created_at — TENURE. pushed_at says "recently touched";
+                #     created_at + pushed_at together say "worked on this for
+                #     two years", which is a different, stronger claim.
+                #   archived   — a dead project. Evidence, but weaker evidence.
+                #   forks      — reuse by others, a quieter quality signal
+                #     than stars and less gameable.
+                #   homepage   — a shipped, reachable product.
+                "created_at": repo.get("created_at") or "",
+                "archived": bool(repo.get("archived")),
+                "forks": repo.get("forks_count", 0) or 0,
+                "homepage": (repo.get("homepage") or "").strip(),
             }
             repositories.append(repo_info)
             all_topics.update(repo.get("topics", []))
@@ -523,9 +578,12 @@ async def fetch_github_profile(
                 # ``stars`` is the one public quality signal on a repo. Both are
                 # already in the /users/{u}/repos payload, so keeping them costs
                 # nothing and closes the last GitHub field with no shelf.
-                "stars": int(r.get("stargazers_count", 0) or 0),
+                "stars": int(r.get("stars", 0) or 0),
                 "pushed_at": r.get("pushed_at", "") or "",
-                "url": r.get("html_url", "") or "",
+                "created_at": r.get("created_at", "") or "",
+                "archived": bool(r.get("archived")),
+                "forks": int(r.get("forks", 0) or 0),
+                "homepage": r.get("homepage", "") or "",
             }
             if excerpt:
                 brief["readme_excerpt"] = excerpt
@@ -550,6 +608,17 @@ async def fetch_github_profile(
             "repos_brief": repos_brief,
             "bio": bio,
             "profile_readme": profile_readme,
+            # STRUCTURED identity. Every field below was ALREADY fetched in the
+            # same /users/{u} request and then flattened into the `bio` string —
+            # readable by a human and by the LLM, but unqueryable by anything
+            # else. A string cannot be matched on.
+            #
+            # Two of these are matching-grade signals, which is why this is not
+            # cosmetic: `hireable` is GitHub's own "open to work" flag, and
+            # `location` is a place claim that the UK gate reasons about. Costs
+            # zero extra requests — it is the same response, kept instead of
+            # concatenated.
+            "identity": _identity_fields(user_obj),
         }
     finally:
         if own_session:
@@ -765,5 +834,9 @@ def enrich_cv_from_github(cv: CVData, github_data: dict[str, Any]) -> CVData:
         cv.github_bio = github_data["bio"]
     if github_data.get("profile_readme"):
         cv.github_profile_readme = github_data["profile_readme"]
+    # Structured identity — same "only overwrite on a non-empty fetch" rule as
+    # the two above, so a rate-limited partial re-enrich never blanks it.
+    if github_data.get("identity"):
+        cv.github_identity = dict(github_data["identity"])
 
     return cv

--- a/backend/src/services/profile/models.py
+++ b/backend/src/services/profile/models.py
@@ -90,6 +90,23 @@ class CVData:
     #               page GitHub renders at the top of a profile.
     github_bio: str = ""
     github_profile_readme: str = ""
+    # STRUCTURED GitHub identity (2026-08-09): name, company, location, blog,
+    # twitter, hireable, account_created_at, followers, public_repos.
+    #
+    # All of these were ALREADY fetched in the same /users/{u} request and then
+    # flattened into ``github_bio`` as one sentence — fine for a human or an LLM
+    # prompt, useless to anything that must compare, filter or score. You cannot
+    # match on a sentence.
+    #
+    # Two are matching-grade: ``hireable`` is GitHub's own "open to work" flag,
+    # and ``location`` is a place claim the UK gate reasons about. ``hireable``
+    # is TRI-STATE (True/False/None) for the same reason visa status is —
+    # "never said" is not "not looking" (rule #31).
+    #
+    # Kept as a dict so new identity fields need no migration: profiles store as
+    # a JSON blob and ``storage._filter_fields`` drops unknown keys, so old rows
+    # load with {}.
+    github_identity: dict[str, Any] = field(default_factory=dict)
     # CV experience, STRUCTURED (2026-08-06). The CV LLM prompt has always
     # asked for {company, title, dates, location, bullets} per role, but the
     # adapter flattened it into unpaired ``job_titles`` + ``companies`` lists

--- a/backend/tests/test_profile_upload.py
+++ b/backend/tests/test_profile_upload.py
@@ -892,6 +892,13 @@ class TestEveryGithubShelfReachesTheApi:
             "skills_inferred": ["TypeScript"],
             "bio": "Builds things",
             "profile_readme": "# Hello",
+            "identity": {
+                "name": "Ada", "company": "Analytical Engines",
+                "location": "London, UK", "blog": "https://ada.dev",
+                "twitter": "ada", "hireable": True,
+                "account_created_at": "2019-04-01T00:00:00Z",
+                "followers": 12, "public_repos": 30,
+            },
         })
         _register_and_login(api, "gh-detail@example.com")
         _seed_cv(api)
@@ -915,6 +922,16 @@ class TestEveryGithubShelfReachesTheApi:
         assert "TypeScript" in detail["skills_inferred"]
         assert detail["bio"] == "Builds things"
         assert detail["profile_readme"] == "# Hello"
+        # STRUCTURED identity. These were already fetched in the same
+        # /users/{u} request and then flattened into the bio SENTENCE — you
+        # cannot match on a sentence. Two are matching-grade: `location` (the
+        # UK gate reasons about places) and `hireable` (GitHub's own "open to
+        # work" flag), so they must survive as typed values.
+        ident = detail["identity"]
+        assert ident["location"] == "London, UK"
+        assert ident["hireable"] is True
+        assert ident["company"] == "Analytical Engines"
+        assert ident["public_repos"] == 30
 
     def test_no_github_means_an_empty_detail_not_a_crash(
         self, api, monkeypatch

--- a/frontend/src/components/profile/CVViewer.github-detail.test.tsx
+++ b/frontend/src/components/profile/CVViewer.github-detail.test.tsx
@@ -72,6 +72,69 @@ function renderViewer(detail: Record<string, unknown> | undefined) {
 }
 
 describe("GitHub detail shows everything GitHub gave us", () => {
+  it("renders the structured identity — open-to-work and location included", () => {
+    renderViewer({
+      ...githubDetail,
+      identity: {
+        name: "Ada Lovelace",
+        company: "Analytical Engines Ltd",
+        location: "London, UK",
+        blog: "https://ada.dev",
+        twitter: "ada",
+        hireable: true,
+        account_created_at: "2019-04-01T00:00:00Z",
+        followers: 12,
+        public_repos: 30,
+      },
+    });
+    expect(screen.getByText("Analytical Engines Ltd")).toBeTruthy();
+    // The two matching-grade fields: a place the UK gate can reason about,
+    // and GitHub's own "open to work" flag.
+    expect(screen.getByText("London, UK")).toBeTruthy();
+    expect(screen.getByText("Open to work")).toBeTruthy();
+    expect(screen.getByText("Yes")).toBeTruthy();
+    expect(screen.getByText("@ada")).toBeTruthy();
+    expect(screen.getByText(/2019/)).toBeTruthy();
+  });
+
+  it("hireable is TRI-STATE — 'never said' is not 'not looking'", () => {
+    // hireable: null must render NO row at all, exactly like the visa signal:
+    // silence is not a negative answer (rule #31).
+    renderViewer({ identity: { location: "Leeds", hireable: null } });
+    expect(screen.getByText("Leeds")).toBeTruthy();
+    expect(screen.queryByText("Open to work")).not.toBeInTheDocument();
+  });
+
+  it("an unset identity field renders no empty row (rule #29)", () => {
+    renderViewer({ identity: { location: "Leeds" } });
+    expect(screen.getByText("Leeds")).toBeTruthy();
+    expect(screen.queryByText("Company")).not.toBeInTheDocument();
+    expect(screen.queryByText("Followers")).not.toBeInTheDocument();
+  });
+
+  it("shows repo tenure, forks and archived state", () => {
+    renderViewer({
+      repos: [
+        {
+          name: "long-runner",
+          language: "Python",
+          description: "",
+          topics: [],
+          stars: 0,
+          forks: 4,
+          archived: true,
+          created_at: "2023-01-01T00:00:00Z",
+          pushed_at: "2025-06-01T00:00:00Z",
+        },
+      ],
+    });
+    // Tenure is a DIFFERENT claim from recency: built over 2 yrs vs touched
+    // last week. Both are on screen.
+    expect(screen.getByText(/built over 2 yrs/)).toBeTruthy();
+    expect(screen.getByText(/⑂ 4/)).toBeTruthy();
+    expect(screen.getByText("archived")).toBeTruthy();
+  });
+
   it("renders repositories with language, stars and last-updated", () => {
     renderViewer(githubDetail);
     expect(screen.getByText("job360")).toBeTruthy();

--- a/frontend/src/components/profile/CVViewer.tsx
+++ b/frontend/src/components/profile/CVViewer.tsx
@@ -45,19 +45,46 @@ interface GithubRepoEntry {
   description: string;
   topics: string[];
   stars: number;
+  forks: number;
+  archived: boolean;
+  homepage: string;
   pushed_at: string;
+  created_at: string;
+}
+
+function numField(obj: Record<string, unknown>, key: string): number {
+  const v = obj[key];
+  return typeof v === "number" && Number.isFinite(v) ? v : 0;
 }
 
 function normalizeGithubRepo(raw: Record<string, unknown>): GithubRepoEntry {
-  const stars = raw["stars"];
   return {
     name: strField(raw, "name"),
     language: strField(raw, "language"),
     description: strField(raw, "description"),
     topics: strArrField(raw, "topics"),
-    stars: typeof stars === "number" ? stars : 0,
+    stars: numField(raw, "stars"),
+    forks: numField(raw, "forks"),
+    archived: raw["archived"] === true,
+    homepage: strField(raw, "homepage"),
     pushed_at: strField(raw, "pushed_at"),
+    created_at: strField(raw, "created_at"),
   };
+}
+
+/** "2 yrs" / "8 mo" — how long this repo has been alive, first commit to last.
+ *  Tenure is a different claim from recency: "touched last week" vs "worked on
+ *  for two years". Empty when either end is missing or unparseable. */
+function repoTenure(createdAt: string, pushedAt: string): string {
+  if (!createdAt || !pushedAt) return "";
+  const a = new Date(createdAt).getTime();
+  const b = new Date(pushedAt).getTime();
+  if (Number.isNaN(a) || Number.isNaN(b) || b <= a) return "";
+  const months = Math.round((b - a) / (1000 * 60 * 60 * 24 * 30.44));
+  if (months < 1) return "";
+  if (months < 12) return `${months} mo`;
+  const years = Math.floor(months / 12);
+  return years === 1 ? "1 yr" : `${years} yrs`;
 }
 
 /** "updated 3 Aug 2026" — a repo's recency, in words, in the viewer's locale. */
@@ -238,11 +265,57 @@ export function CVViewer({
   const ghFrameworks = asStrings(ghDetail.frameworks);
   const ghInferred = asStrings(ghDetail.skills_inferred);
   const ghLlmSkills = asStrings(ghDetail.llm_skills);
+  // Structured identity → label/value rows. Only fields the person actually
+  // filled in appear; an unset field stays absent rather than rendering an
+  // empty row (rule #29). `hireable` is tri-state: shown only when GitHub has
+  // a real boolean, because "never said" is not "not looking".
+  const ghIdentity =
+    typeof ghDetail.identity === "object" && ghDetail.identity !== null
+      ? (ghDetail.identity as Record<string, unknown>)
+      : {};
+  const ghIdentityRows: [string, string][] = (
+    [
+      ["Name", strField(ghIdentity, "name")],
+      ["Company", strField(ghIdentity, "company")],
+      ["Location", strField(ghIdentity, "location")],
+      ["Website", strField(ghIdentity, "blog")],
+      [
+        "Twitter/X",
+        strField(ghIdentity, "twitter") ? `@${strField(ghIdentity, "twitter")}` : "",
+      ],
+      [
+        "Open to work",
+        ghIdentity.hireable === true
+          ? "Yes"
+          : ghIdentity.hireable === false
+            ? "No"
+            : "",
+      ],
+      [
+        "On GitHub since",
+        formatRepoDate(strField(ghIdentity, "account_created_at")),
+      ],
+      [
+        "Public repos",
+        numField(ghIdentity, "public_repos")
+          ? String(numField(ghIdentity, "public_repos"))
+          : "",
+      ],
+      [
+        "Followers",
+        numField(ghIdentity, "followers")
+          ? String(numField(ghIdentity, "followers"))
+          : "",
+      ],
+    ] as [string, string][]
+  ).filter(([, v]) => Boolean(v));
+
   const ghBio = typeof ghDetail.bio === "string" ? ghDetail.bio : "";
   const ghProfileReadme =
     typeof ghDetail.profile_readme === "string" ? ghDetail.profile_readme : "";
 
   const hasGithubDetail =
+    ghIdentityRows.length > 0 ||
     ghLanguagesSorted.length > 0 ||
     ghTopics.length > 0 ||
     ghRepos.length > 0 ||
@@ -618,6 +691,23 @@ export function CVViewer({
             GitHub detail
           </h3>
 
+          {/* Identity — the developer's OWN words about themselves, kept as
+              values rather than a sentence. "Open to work" and location are
+              the two that a future matcher can actually act on. */}
+          {ghIdentityRows.length > 0 && (
+            <div className="mb-5">
+              <SectionLabel icon={User} text="Profile" />
+              <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 pl-5 text-xs">
+                {ghIdentityRows.map(([label, value]) => (
+                  <div key={label} className="contents">
+                    <dt className="text-muted-foreground">{label}</dt>
+                    <dd className="text-foreground/85">{value}</dd>
+                  </div>
+                ))}
+              </dl>
+            </div>
+          )}
+
           {ghLanguagesSorted.length > 0 && (
             <div className="mb-5">
               <SectionLabel icon={Code2} text={`Languages (${ghLanguagesSorted.length})`} />
@@ -683,6 +773,21 @@ export function CVViewer({
                       {repo.stars > 0 && (
                         <span className="text-[11px] text-muted-foreground">
                           ★ {repo.stars}
+                        </span>
+                      )}
+                      {repo.forks > 0 && (
+                        <span className="text-[11px] text-muted-foreground">
+                          ⑂ {repo.forks}
+                        </span>
+                      )}
+                      {repo.archived && (
+                        <span className="rounded-full bg-amber-500/10 px-2 py-0.5 text-[10px] font-medium text-amber-500">
+                          archived
+                        </span>
+                      )}
+                      {repoTenure(repo.created_at, repo.pushed_at) && (
+                        <span className="text-[11px] text-muted-foreground">
+                          built over {repoTenure(repo.created_at, repo.pushed_at)}
                         </span>
                       )}
                       {repo.pushed_at && (


### PR DESCRIPTION
**The ask:** what else can GitHub give us that would help matching later? Create the shelves now, wire the matching later, and prove they actually populate.

**Answer: 13** — and every one comes from a response we **already make**. Zero extra requests; this is data that was fetched and then discarded.

## Identity — 9 shelves (new `CVData.github_identity`)

`/users/{u}` was fetched and flattened into the `github_bio` **sentence** (`"Name: X | Company: Y | Location: Z"`). Readable by a human and by an LLM prompt, useless to anything that must compare, filter or score — **you cannot match on a sentence.**

| Shelf | Why it earns its place |
|---|---|
| **`hireable`** | GitHub's own *"open to work"* flag. **Tri-state** (True/False/None) for the same reason visa status is — *"never said"* is not *"not looking"* (rule #31) |
| **`location`** | a place claim the UK eligibility gate can reason about (rule #30) |
| `company` · `blog` · `twitter` · `name` | employer, portfolio, identity |
| `account_created_at` · `followers` · `public_repos` | tenure and activity proxies |

## Per-repo — 4 shelves on each `github_repos_brief` entry

- **`created_at`** — **tenure**. With `pushed_at` it turns *"touched recently"* into *"built over two years"* — a different, stronger claim about depth.
- `archived` — a dead project is evidence, but weaker evidence.
- `forks` — reuse by others; quieter than stars and less gameable.
- `homepage` — a shipped, reachable product.

## Verified they populate, not merely that they compile

A shelf that never fills is worse than no shelf — it looks like coverage. Run against the real API for the owner's handle:

```
repos with created_at    : 14/14 ✓
identity fields populated: 3/9   (account_created_at, followers, public_repos)
```

The other **6 are empty because GitHub itself returns `null`** for them on that account — confirmed directly against `api.github.com/users/{u}`. An empty **source**, not a broken shelf.

That's the actionable finding: filling in GitHub's **Location** and **"Available for hire"** would hand the matcher two real signals it doesn't have today.

## Correction

Earlier in this session I said `pushed_at` was unused. **Wrong** — it already applies `RECENT_REPO_MULTIPLIER` (**3×**) to language bytes for recently-pushed repos, and forked repos are already excluded from every signal, so a user is never credited with someone else's code.

## Display

A **"Profile"** block at the top of GitHub detail (only fields the person actually filled — an unset field renders no row, rule #29), plus tenure, forks and an archived badge on each repo.

**No matching/scoring change**, as asked — shelves and display only.

## Tests

12 frontend (tri-state `hireable` renders nothing on `None`; unset fields render no empty row; tenure/forks/archived; nothing renders `undefined`) + backend value-presence on the identity block (rule #21).

Gate: **PASS**, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
