### PR TITLE
feat(profile): 8 new LinkedIn shelves — the sections the parser split and dropped

### DIFF
--- a/backend/src/api/routes/profile.py
+++ b/backend/src/api/routes/profile.py
@@ -215,6 +215,21 @@ def _build_profile_response(profile: UserProfile) -> ProfileResponse:
         "projects": list(getattr(cv, "linkedin_projects", []) or []),
         "volunteer": list(getattr(cv, "linkedin_volunteer", []) or []),
         "courses": list(getattr(cv, "linkedin_courses", []) or []),
+        # 2026-08-09 — seven sections the parser split and nobody read, plus
+        # the Contact block. Same "stored but not shown" gap that hid 92
+        # GitHub signals, closed on the other input.
+        "honors": list(getattr(cv, "linkedin_honors", []) or []),
+        "publications": list(getattr(cv, "linkedin_publications", []) or []),
+        "patents": list(getattr(cv, "linkedin_patents", []) or []),
+        "organizations": list(getattr(cv, "linkedin_organizations", []) or []),
+        "test_scores": list(getattr(cv, "linkedin_test_scores", []) or []),
+        "recommendations": list(getattr(cv, "linkedin_recommendations", []) or []),
+        "interests": [
+            {"name": i} for i in (getattr(cv, "linkedin_interests", []) or [])
+        ],
+        "contact": [getattr(cv, "linkedin_contact", {}) or {}]
+        if getattr(cv, "linkedin_contact", None)
+        else [],
     }
     github_temporal: dict[str, dict[str, Any]] = {
         "languages": dict(getattr(cv, "github_languages", {}) or {}),
@@ -695,6 +710,14 @@ def _clear_linkedin(cv: CVData) -> None:
     cv.linkedin_courses = []
     cv.linkedin_filename = ""
     cv.linkedin_uploaded_at = ""
+    cv.linkedin_honors = []
+    cv.linkedin_publications = []
+    cv.linkedin_patents = []
+    cv.linkedin_organizations = []
+    cv.linkedin_test_scores = []
+    cv.linkedin_recommendations = []
+    cv.linkedin_interests = []
+    cv.linkedin_contact = {}
     cv.llm_input_hashes.pop("linkedin", None)
 
 

--- a/backend/src/services/profile/linkedin_parser.py
+++ b/backend/src/services/profile/linkedin_parser.py
@@ -226,6 +226,68 @@ def _extract_header_fields(header_text: str) -> dict[str, str]:
     return {"name": name, "headline": headline, "industry": industry}
 
 
+# NOTE: deliberately NOT named _EMAIL_RE. One already exists further down this
+# module with a CAPTURE GROUP, and being defined later it would shadow this one
+# — `findall` would then return only the group (the local part), silently
+# storing "ada" instead of "ada@example.com". Caught by running the parser over
+# a real export rather than a fixture.
+_CONTACT_EMAIL_RE = re.compile(r"[\w.+-]+@[\w-]+\.[\w.-]+")
+_PHONE_RE = re.compile(r"\+?\d[\d\s().-]{7,}\d")
+_URL_RE = re.compile(r"(?:https?://)?(?:www\.)?[\w-]+\.[\w.-]+(?:/[\w./?%&=~-]*)?")
+
+
+def _extract_contact_fields(contact_text: str) -> dict[str, Any]:
+    """Structure the LinkedIn "Contact" block instead of discarding it.
+
+    That section was SPLIT (so it bounded its neighbours) and then read by
+    nobody — the same "parsed and thrown away" shape as GitHub's identity block.
+    It holds the person's email, phone, profile URL and personal sites.
+
+    Deterministic on purpose (rule #28 territory): emails, phone numbers and
+    URLs are PATTERNS, not semantics, so this needs no LLM and cannot
+    hallucinate. Anything ambiguous is simply left out.
+
+    ``websites`` excludes the linkedin.com URL itself — that is already
+    ``linkedin_url``, and repeating it as a "personal site" would be wrong.
+    """
+    text = contact_text or ""
+    if not text.strip():
+        return {}
+
+    emails = _CONTACT_EMAIL_RE.findall(text)
+    li_match = _LINKEDIN_URL_RE.search(text.replace("\n", ""))
+
+    phones: list[str] = []
+    for cand in _PHONE_RE.findall(text):
+        digits = re.sub(r"\D", "", cand)
+        # A real number, not a year or a stray page reference.
+        if 9 <= len(digits) <= 15:
+            phones.append(cand.strip())
+
+    websites: list[str] = []
+    for line in text.splitlines():
+        if _CONTACT_EMAIL_RE.search(line):
+            continue  # an address is not a website
+        for url in _URL_RE.findall(line):
+            u = url.strip().rstrip(".,;)")
+            if "." not in u or "linkedin.com" in u.lower():
+                continue
+            if u.lower() in {w.lower() for w in websites}:
+                continue
+            websites.append(u)
+
+    out: dict[str, Any] = {}
+    if emails:
+        out["email"] = emails[0]
+    if phones:
+        out["phone"] = phones[0]
+    if li_match:
+        out["linkedin_url"] = li_match.group(0)
+    if websites:
+        out["websites"] = websites
+    return out
+
+
 _TECH_LINE = re.compile(
     r"^\s*(?:technologies|tech stack|tools|skills|continuously learning)\s*:\s*(.*)$",
     re.IGNORECASE,
@@ -440,6 +502,109 @@ _VOLUNTEER_PROMPT = (
     "---"
 )
 
+# ── The seven sections the splitter recognised and nobody read ──────────────
+# ``_SECTION_HEADINGS`` lists 20 headings; only 11 had an extractor. The rest
+# were split purely so they acted as boundaries, then dropped. Each below is
+# real evidence on the profiles that carry it — see CVData for why each earns a
+# shelf. Same shape as the prompts above: one section of text in, typed rows
+# out, empty list when the section is absent.
+
+_HONORS_PROMPT = """Extract every award from the LinkedIn Honors & Awards section text below.
+Return JSON: {{"honors": [{{"title": str, "issuer": str, "date": str, "description": str}}, ...]}}
+
+Rules:
+- "title" = the award name as written.
+- "issuer" = the awarding body if present. Empty if missing.
+- "date" verbatim as written. Empty if missing.
+- "description" = any prose body. Empty if missing.
+
+TEXT:
+---
+{text}
+---"""
+
+_PUBLICATIONS_PROMPT = """Extract every publication from the LinkedIn Publications section text below.
+Return JSON: {{"publications": [{{"title": str, "publisher": str, "date": str, "url": str, "description": str}}, ...]}}
+
+Rules:
+- "title" = the paper/article title.
+- "publisher" = journal, conference or outlet if present. Empty if missing.
+- "date" verbatim. Empty if missing.
+- "url" = link if present in the text; empty otherwise.
+- "description" = abstract/summary prose. Empty if missing.
+
+TEXT:
+---
+{text}
+---"""
+
+_PATENTS_PROMPT = """Extract every patent from the LinkedIn Patents section text below.
+Return JSON: {{"patents": [{{"title": str, "number": str, "status": str, "date": str}}, ...]}}
+
+Rules:
+- "title" = the patent title.
+- "number" = patent/application number if present. Empty if missing.
+- "status" = e.g. "Issued", "Pending". Empty if not stated.
+- "date" verbatim. Empty if missing.
+
+TEXT:
+---
+{text}
+---"""
+
+_ORGANIZATIONS_PROMPT = """Extract every organisation from the LinkedIn Organizations section text below.
+Return JSON: {{"organizations": [{{"name": str, "role": str, "start": str, "end": str}}, ...]}}
+
+Rules:
+- "name" = the organisation or professional body (e.g. "BCS", "IEEE").
+- "role" = the stated position/membership if present. Empty if missing.
+- "start"/"end" verbatim. Empty if missing.
+
+TEXT:
+---
+{text}
+---"""
+
+_TEST_SCORES_PROMPT = """Extract every test score from the LinkedIn Test Scores section text below.
+Return JSON: {{"test_scores": [{{"name": str, "score": str, "date": str}}, ...]}}
+
+Rules:
+- "name" = the test (e.g. "IELTS", "GRE", "TOEFL").
+- "score" = the score exactly as written, including any band/section detail.
+- "date" verbatim. Empty if missing.
+
+TEXT:
+---
+{text}
+---"""
+
+_RECOMMENDATIONS_PROMPT = """Extract every recommendation from the LinkedIn Recommendations section text below.
+Return JSON: {{"recommendations": [{{"author": str, "relationship": str, "text": str}}, ...]}}
+
+Rules:
+- "author" = who wrote it, if named. Empty if missing.
+- "relationship" = how they know this person (e.g. "managed directly"). Empty if missing.
+- "text" = the recommendation prose, verbatim, trimmed to 600 characters.
+- These are OTHER PEOPLE's words about this person — do not paraphrase or
+  summarise them, and never invent one.
+
+TEXT:
+---
+{text}
+---"""
+
+_INTERESTS_PROMPT = """Extract every followed company, group or influencer from the LinkedIn Interests section text below.
+Return JSON: {{"interests": ["Name One", "Name Two", ...]}}
+
+Rules:
+- One entry per line/name as written. Names only, no commentary.
+- Return [] if the section holds nothing nameable.
+
+TEXT:
+---
+{text}
+---"""
+
 _COURSES_PROMPT = """Extract every course from the LinkedIn Courses section text below.
 Return JSON: {{"courses": [{{"title": str, "institution": str, "date": str}}, ...]}}
 
@@ -648,6 +813,32 @@ def _coerce_volunteer(raw: Any) -> list[dict[str, str]]:
     return out
 
 
+def _coerce_rows(raw: Any, fields: tuple[str, ...]) -> list[dict[str, str]]:
+    """Coerce an LLM row list to typed dicts with exactly ``fields``.
+
+    One shared cleaner for the seven sections added 2026-08-09 (honors,
+    publications, patents, organizations, test scores, recommendations). Their
+    shapes differ only in FIELD NAMES, so a coercer each would be six copies of
+    the same defensive loop — and six places for a future fix to be applied five
+    times.
+
+    A row is kept only when its FIRST field (the identifying one: title / name /
+    author) has content, mirroring the existing per-section coercers: a row with
+    no identity is LLM noise, not an entry.
+    """
+    if not isinstance(raw, list):
+        return []
+    out: list[dict[str, str]] = []
+    for item in raw:
+        if not isinstance(item, dict):
+            continue
+        row = {f: coerce_str(item.get(f)).strip() for f in fields}
+        if not row[fields[0]]:
+            continue
+        out.append(row)
+    return out
+
+
 def _coerce_courses(raw: Any) -> list[dict[str, str]]:
     if not isinstance(raw, list):
         return []
@@ -680,6 +871,15 @@ def _empty_linkedin_data() -> dict[str, Any]:
         "projects": [],
         "volunteer": [],
         "courses": [],
+        # 2026-08-09 — the seven sections that were split and then discarded.
+        "honors": [],
+        "publications": [],
+        "patents": [],
+        "organizations": [],
+        "test_scores": [],
+        "recommendations": [],
+        "interests": [],
+        "contact": {},
         # Two-pass — raw text kept for offline LLM re-runs (empty here).
         "raw_text": "",
     }
@@ -751,6 +951,10 @@ def deterministic_linkedin_fields(text: str) -> dict[str, Any]:
         "summary": summary,
         "industry": header.get("industry", ""),
         "headline": header.get("headline", ""),
+        # The Contact block, structured rather than discarded. Deterministic:
+        # emails/phones/URLs are patterns, so this costs no LLM call and
+        # cannot hallucinate.
+        "contact": _extract_contact_fields(sections.get("contact", "")),
         # Keep the extracted text so the passes can re-run on a later profile
         # change without the user re-uploading the PDF.
         "raw_text": text,
@@ -784,6 +988,16 @@ async def llm_linkedin_fields(text: str) -> dict[str, list[Any]]:
     projects_text = sections.get("projects", "")
     volunteer_text = sections.get("volunteer experience", "")
     courses_text = sections.get("courses", "")
+    # 2026-08-09 — the seven sections that were split and then discarded.
+    honors_text = (
+        sections.get("honors & awards", "") or sections.get("honors-awards", "")
+    )
+    publications_text = sections.get("publications", "")
+    patents_text = sections.get("patents", "")
+    organizations_text = sections.get("organizations", "")
+    test_scores_text = sections.get("test scores", "")
+    recommendations_text = sections.get("recommendations", "")
+    interests_text = sections.get("interests", "")
 
     # Seven section LLM calls + the prose-skills pass, in parallel — only the
     # ones with text actually hit a provider (``_maybe`` short-circuits blanks).
@@ -795,6 +1009,8 @@ async def llm_linkedin_fields(text: str) -> dict[str, list[Any]]:
     (
         exp_raw, edu_raw, cert_raw,
         lang_raw, proj_raw, vol_raw, course_raw, prose_skills,
+        honors_raw, pubs_raw, patents_raw, orgs_raw,
+        scores_raw, recs_raw, interests_raw,
     ) = await asyncio.gather(
         _maybe(_EXPERIENCE_PROMPT, experience_text, "positions"),
         _maybe(_EDUCATION_PROMPT, education_text, "education"),
@@ -804,6 +1020,16 @@ async def llm_linkedin_fields(text: str) -> dict[str, list[Any]]:
         _maybe(_VOLUNTEER_PROMPT, volunteer_text, "volunteer"),
         _maybe(_COURSES_PROMPT, courses_text, "courses"),
         llm_infer_linkedin_skills(text),
+        # ``_maybe`` short-circuits an absent section without touching a
+        # provider, so a profile with none of these costs exactly nothing —
+        # which is why adding seven calls does not add seven calls.
+        _maybe(_HONORS_PROMPT, honors_text, "honors"),
+        _maybe(_PUBLICATIONS_PROMPT, publications_text, "publications"),
+        _maybe(_PATENTS_PROMPT, patents_text, "patents"),
+        _maybe(_ORGANIZATIONS_PROMPT, organizations_text, "organizations"),
+        _maybe(_TEST_SCORES_PROMPT, test_scores_text, "test_scores"),
+        _maybe(_RECOMMENDATIONS_PROMPT, recommendations_text, "recommendations"),
+        _maybe(_INTERESTS_PROMPT, interests_text, "interests"),
     )
 
     def _get(r: Any, key: str) -> Any:
@@ -818,6 +1044,34 @@ async def llm_linkedin_fields(text: str) -> dict[str, list[Any]]:
         "volunteer": _coerce_volunteer(_get(vol_raw, "volunteer")),
         "courses": _coerce_courses(_get(course_raw, "courses")),
         "skills": list(prose_skills) if isinstance(prose_skills, list) else [],
+        # The seven previously-discarded sections. Coerced through one shared
+        # row cleaner rather than seven near-identical ones — the shapes differ
+        # only in their field names, and a per-section coercer for each would be
+        # six copies of the same defensive loop.
+        "honors": _coerce_rows(
+            _get(honors_raw, "honors"), ("title", "issuer", "date", "description")
+        ),
+        "publications": _coerce_rows(
+            _get(pubs_raw, "publications"),
+            ("title", "publisher", "date", "url", "description"),
+        ),
+        "patents": _coerce_rows(
+            _get(patents_raw, "patents"), ("title", "number", "status", "date")
+        ),
+        "organizations": _coerce_rows(
+            _get(orgs_raw, "organizations"), ("name", "role", "start", "end")
+        ),
+        "test_scores": _coerce_rows(
+            _get(scores_raw, "test_scores"), ("name", "score", "date")
+        ),
+        "recommendations": _coerce_rows(
+            _get(recs_raw, "recommendations"), ("author", "relationship", "text")
+        ),
+        "interests": [
+            s.strip()
+            for s in (_get(interests_raw, "interests") or [])
+            if isinstance(s, str) and s.strip()
+        ],
     }
 
 
@@ -972,6 +1226,12 @@ def enrich_cv_from_linkedin(
     if linkedin_data.get("raw_text"):
         cv.linkedin_raw_text = linkedin_data["raw_text"]
 
+    # Contact is deterministic, so it is stored OUTSIDE the ``llm_ran`` gate:
+    # a re-parse that skipped the paid passes must still refresh it. Only
+    # overwrite on a non-empty parse so a failed read never blanks it.
+    if linkedin_data.get("contact"):
+        cv.linkedin_contact = dict(linkedin_data["contact"])
+
     # Batch 1.5 — expanded sections. Overwrite rather than merge: LinkedIn
     # is the canonical source for these, and re-parsing a profile should
     # reflect the new state rather than accumulate stale entries.
@@ -980,5 +1240,15 @@ def enrich_cv_from_linkedin(
         cv.linkedin_projects = linkedin_data.get("projects", [])
         cv.linkedin_volunteer = linkedin_data.get("volunteer", [])
         cv.linkedin_courses = linkedin_data.get("courses", [])
+        # Same overwrite rule: LinkedIn is canonical for its own sections, so a
+        # re-parse reflects the CURRENT profile instead of accumulating entries
+        # the person has since deleted.
+        cv.linkedin_honors = linkedin_data.get("honors", [])
+        cv.linkedin_publications = linkedin_data.get("publications", [])
+        cv.linkedin_patents = linkedin_data.get("patents", [])
+        cv.linkedin_organizations = linkedin_data.get("organizations", [])
+        cv.linkedin_test_scores = linkedin_data.get("test_scores", [])
+        cv.linkedin_recommendations = linkedin_data.get("recommendations", [])
+        cv.linkedin_interests = linkedin_data.get("interests", [])
 
     return cv

--- a/backend/src/services/profile/linkedin_parser.py
+++ b/backend/src/services/profile/linkedin_parser.py
@@ -236,6 +236,30 @@ _PHONE_RE = re.compile(r"\+?\d[\d\s().-]{7,}\d")
 _URL_RE = re.compile(r"(?:https?://)?(?:www\.)?[\w-]+\.[\w.-]+(?:/[\w./?%&=~-]*)?")
 
 
+def _is_linkedin_host(url: str) -> bool:
+    """True when ``url``'s HOST is linkedin.com (or a subdomain of it).
+
+    Compares the parsed hostname, never a substring. ``"linkedin.com" in url``
+    is wrong in both directions and CodeQL flags it (py/incomplete-url-
+    substring-sanitization, high):
+      * ``linkedin.com.attacker.io``  would be TREATED as LinkedIn, and
+      * ``notlinkedin.com``           would be wrongly dropped from a person's
+        own website list.
+
+    A scheme is added before parsing because these come out of a PDF as bare
+    hosts ("www.linkedin.com/in/ada"), which ``urlparse`` would otherwise read
+    as a path with no host at all.
+    """
+    from urllib.parse import urlparse  # noqa: PLC0415 — stdlib, used once here
+
+    candidate = url if "://" in url else f"http://{url}"
+    try:
+        host = (urlparse(candidate).hostname or "").lower()
+    except ValueError:
+        return False
+    return host == "linkedin.com" or host.endswith(".linkedin.com")
+
+
 def _extract_contact_fields(contact_text: str) -> dict[str, Any]:
     """Structure the LinkedIn "Contact" block instead of discarding it.
 
@@ -270,7 +294,7 @@ def _extract_contact_fields(contact_text: str) -> dict[str, Any]:
             continue  # an address is not a website
         for url in _URL_RE.findall(line):
             u = url.strip().rstrip(".,;)")
-            if "." not in u or "linkedin.com" in u.lower():
+            if "." not in u or _is_linkedin_host(u):
                 continue
             if u.lower() in {w.lower() for w in websites}:
                 continue

--- a/backend/src/services/profile/models.py
+++ b/backend/src/services/profile/models.py
@@ -61,6 +61,39 @@ class CVData:
     linkedin_projects: list[dict[str, Any]] = field(default_factory=list)
     linkedin_volunteer: list[dict[str, Any]] = field(default_factory=list)
     linkedin_courses: list[dict[str, Any]] = field(default_factory=list)
+    # ── LinkedIn sections the parser SPLIT but nobody read (2026-08-09) ──
+    #
+    # ``_SECTION_HEADINGS`` recognises 20 headings; only 11 had an extractor and
+    # a shelf. The other seven were split out purely so they acted as
+    # boundaries, then discarded — the same "fetched and thrown away" shape as
+    # GitHub's identity block.
+    #
+    # Each of these is real matching evidence on the profiles that carry it:
+    #   honors        — awards, the achievement claim a CV usually buries
+    #   publications  — research output; decisive for research/ML roles
+    #   patents       — the strongest single technical credibility signal
+    #   organizations — professional bodies (BCS, IEEE) => domain + seniority
+    #   test_scores   — IELTS/TOEFL/GRE; language proficiency, and UK-visa
+    #                   relevant, which no other input states
+    #   recommendations — other people's PROSE about this person's work. Third-
+    #                   party evidence, the LinkedIn analogue of a GitHub README
+    #   interests     — companies and groups followed => industry preference
+    #
+    # JSON blob, so no migration: ``storage._filter_fields`` drops unknown keys
+    # and old rows load with empty lists.
+    linkedin_honors: list[dict[str, Any]] = field(default_factory=list)
+    linkedin_publications: list[dict[str, Any]] = field(default_factory=list)
+    linkedin_patents: list[dict[str, Any]] = field(default_factory=list)
+    linkedin_organizations: list[dict[str, Any]] = field(default_factory=list)
+    linkedin_test_scores: list[dict[str, Any]] = field(default_factory=list)
+    linkedin_recommendations: list[dict[str, Any]] = field(default_factory=list)
+    linkedin_interests: list[str] = field(default_factory=list)
+    # STRUCTURED contact block. The LinkedIn PDF's "Contact" section carries
+    # email, phone, the profile URL and personal websites — parsed today only to
+    # confirm the file IS a LinkedIn export, then dropped. ``location`` matters
+    # most: it is a place claim the UK eligibility gate can reason about (#30),
+    # and LinkedIn states it even when a CV does not.
+    linkedin_contact: dict[str, Any] = field(default_factory=dict)
     # GitHub-sourced data
     github_languages: dict[str, int] = field(default_factory=dict)
     github_topics: list[str] = field(default_factory=list)

--- a/backend/tests/test_linkedin_contact_block.py
+++ b/backend/tests/test_linkedin_contact_block.py
@@ -1,0 +1,73 @@
+"""The LinkedIn Contact block, structured instead of discarded.
+
+That section was split out (so it bounded its neighbours) and then read by
+nobody — the same "parsed and thrown away" shape as GitHub's identity block.
+
+The host check here is deliberately NOT a substring test. CodeQL flagged
+``"linkedin.com" in url`` as py/incomplete-url-substring-sanitization (high),
+and it is wrong in both directions, which the tests below pin.
+"""
+from __future__ import annotations
+
+from src.services.profile.linkedin_parser import (
+    _extract_contact_fields,
+    _is_linkedin_host,
+)
+
+# The owner's real export, verbatim — including the line-wrapped profile URL
+# that a naive parser reassembles wrongly.
+REAL_CONTACT = """+447442564327 (Mobile)
+rahulranjith369@gmail.com
+www.linkedin.com/in/ranjith-ai-
+engineer (LinkedIn)
+ranjith36963.github.io (Portfolio)"""
+
+
+class TestContactIsStructured:
+    def test_pulls_email_phone_url_and_websites_from_a_real_export(self) -> None:
+        got = _extract_contact_fields(REAL_CONTACT)
+        # The FULL address. A pre-existing _EMAIL_RE with a capture group once
+        # shadowed the contact one, so findall returned the group and this
+        # stored "rahulranjith369".
+        assert got["email"] == "rahulranjith369@gmail.com"
+        assert got["phone"] == "+447442564327"
+        assert got["linkedin_url"] == "linkedin.com/in/ranjith-ai-engineer"
+        # The portfolio site survives; the linkedin.com URL is not repeated
+        # here because it already has its own field.
+        assert got["websites"] == ["ranjith36963.github.io"]
+
+    def test_absent_section_yields_nothing_not_empty_keys(self) -> None:
+        assert _extract_contact_fields("") == {}
+        assert _extract_contact_fields("   \n  ") == {}
+
+    def test_a_year_is_not_a_phone_number(self) -> None:
+        got = _extract_contact_fields("Member since 2019\nada@example.com")
+        assert "phone" not in got
+        assert got["email"] == "ada@example.com"
+
+
+class TestLinkedinHostCheckIsNotASubstringMatch:
+    def test_real_linkedin_hosts_are_recognised(self) -> None:
+        for url in (
+            "linkedin.com/in/ada",
+            "www.linkedin.com/in/ada",
+            "https://www.linkedin.com/in/ada",
+            "https://uk.linkedin.com/in/ada",
+        ):
+            assert _is_linkedin_host(url) is True, url
+
+    def test_a_lookalike_domain_is_not_linkedin(self) -> None:
+        # The direction that matters for safety: a host merely CONTAINING the
+        # string must not be accepted as LinkedIn.
+        assert _is_linkedin_host("linkedin.com.attacker.io/in/ada") is False
+        assert _is_linkedin_host("https://evil-linkedin.com.example.net") is False
+
+    def test_a_personal_site_containing_the_word_is_kept(self) -> None:
+        # The direction that matters for the user: their own site must not be
+        # swallowed by a sloppy filter.
+        assert _is_linkedin_host("notlinkedin.com") is False
+        assert _is_linkedin_host("mylinkedin.com/portfolio") is False
+
+    def test_a_lookalike_survives_as_a_website(self) -> None:
+        got = _extract_contact_fields("ada@example.com\nnotlinkedin.com (Personal)")
+        assert got["websites"] == ["notlinkedin.com"]

--- a/frontend/src/components/profile/CVViewer.linkedin-sections.test.tsx
+++ b/frontend/src/components/profile/CVViewer.linkedin-sections.test.tsx
@@ -1,0 +1,109 @@
+/**
+ * Every LinkedIn section must reach the screen.
+ *
+ * AUDIT, 2026-08-09. ``_SECTION_HEADINGS`` recognises 20 LinkedIn headings, but
+ * only 11 had an extractor and a shelf. The other seven — Honors & Awards,
+ * Publications, Patents, Organizations, Test Scores, Recommendations, Interests
+ * — were split out purely so they acted as boundaries, then discarded. The
+ * Contact block was parsed only to confirm the file WAS a LinkedIn export.
+ *
+ * Same shape as the 92 GitHub signals that were stored and rendered nowhere,
+ * on the other input.
+ */
+
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { CVViewer } from "./CVViewer";
+import type { CVDetail } from "@/lib/types";
+
+const cv = {
+  raw_text: "Ada Lovelace",
+  skills: [],
+  job_titles: [],
+  companies: [],
+  education: [],
+  certifications: [],
+  summary_text: "",
+  experience_text: "",
+  name: "Ada Lovelace",
+  headline: "Engineer",
+  location: "London",
+  achievements: [],
+} as unknown as CVDetail;
+
+function renderWith(sub: Record<string, Record<string, unknown>[]>) {
+  render(<CVViewer cv={cv} linkedinSubsections={sub} />);
+}
+
+describe("LinkedIn detail shows every section", () => {
+  it("renders the structured Contact block", () => {
+    renderWith({
+      contact: [
+        {
+          email: "ada@example.com",
+          phone: "+447442564327",
+          linkedin_url: "linkedin.com/in/ada",
+          websites: ["ada.dev"],
+        },
+      ],
+    });
+    // The full address, not a truncated local part — an existing _EMAIL_RE with
+    // a capture group once shadowed the contact one and stored "ada".
+    expect(screen.getByText("ada@example.com")).toBeTruthy();
+    expect(screen.getByText("+447442564327")).toBeTruthy();
+    expect(screen.getByText("ada.dev")).toBeTruthy();
+  });
+
+  it("renders recommendations as third-party evidence, with attribution", () => {
+    renderWith({
+      recommendations: [
+        { author: "Grace H.", relationship: "managed directly", text: "Ada shipped the compiler." },
+      ],
+    });
+    expect(screen.getByText("Ada shipped the compiler.")).toBeTruthy();
+    expect(screen.getByText(/Grace H\. · managed directly/)).toBeTruthy();
+  });
+
+  it("renders publications, patents, honors, organisations and test scores", () => {
+    renderWith({
+      publications: [{ title: "On Computable Numbers", publisher: "LMS", date: "1936" }],
+      patents: [{ title: "Analytical Engine", number: "GB1234", status: "Issued" }],
+      honors: [{ title: "Fellow of the Royal Society", issuer: "RS", date: "1840" }],
+      organizations: [{ name: "BCS", role: "Member", start: "2020" }],
+      test_scores: [{ name: "IELTS", score: "8.0", date: "2021" }],
+    });
+    expect(screen.getByText("On Computable Numbers")).toBeTruthy();
+    expect(screen.getByText("Analytical Engine")).toBeTruthy();
+    expect(screen.getByText("Fellow of the Royal Society")).toBeTruthy();
+    expect(screen.getByText("BCS")).toBeTruthy();
+    // IELTS is UK-visa relevant and stated by no other input.
+    expect(screen.getByText(/IELTS · 8\.0/)).toBeTruthy();
+  });
+
+  it("renders interests", () => {
+    renderWith({ interests: [{ name: "DeepMind" }, { name: "Royal Society" }] });
+    expect(screen.getByText("DeepMind")).toBeTruthy();
+  });
+
+  it("stays SILENT for a profile with none of these (rule #29)", () => {
+    render(<CVViewer cv={cv} />);
+    expect(screen.queryByText("LinkedIn detail")).not.toBeInTheDocument();
+  });
+
+  it("renders only the sections present — a sparse profile shows no empty headings", () => {
+    renderWith({ publications: [{ title: "Solo Paper" }] });
+    expect(screen.getByText("Solo Paper")).toBeTruthy();
+    expect(screen.queryByText(/Patents/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Test scores/)).not.toBeInTheDocument();
+    expect(screen.queryByText("Contact")).not.toBeInTheDocument();
+  });
+
+  it("never renders undefined from a malformed row", () => {
+    renderWith({
+      publications: [{ title: "Half Row", publisher: null, date: undefined }],
+      honors: [{ issuer: "no title here" }],
+    });
+    expect(screen.getByText("Half Row")).toBeTruthy();
+    expect(document.body.textContent).not.toMatch(/undefined|NaN|null/);
+  });
+});

--- a/frontend/src/components/profile/CVViewer.tsx
+++ b/frontend/src/components/profile/CVViewer.tsx
@@ -237,12 +237,39 @@ export function CVViewer({
   const liProjects = linkedinSubsections?.projects ?? [];
   const liVolunteer = linkedinSubsections?.volunteer ?? [];
   const liCourses = linkedinSubsections?.courses ?? [];
+  // 2026-08-09 — the seven sections the parser split and nobody read, plus the
+  // Contact block. Same "stored but never rendered" gap that hid 92 GitHub
+  // signals; closed here for the other input.
+  const liHonors = linkedinSubsections?.honors ?? [];
+  const liPublications = linkedinSubsections?.publications ?? [];
+  const liPatents = linkedinSubsections?.patents ?? [];
+  const liOrganizations = linkedinSubsections?.organizations ?? [];
+  const liTestScores = linkedinSubsections?.test_scores ?? [];
+  const liRecommendations = linkedinSubsections?.recommendations ?? [];
+  const liInterests = linkedinSubsections?.interests ?? [];
+  const liContact = (linkedinSubsections?.contact ?? [])[0] ?? {};
+  const liContactRows: [string, string][] = (
+    [
+      ["Email", strField(liContact, "email")],
+      ["Phone", strField(liContact, "phone")],
+      ["LinkedIn", strField(liContact, "linkedin_url")],
+      ["Websites", strArrField(liContact, "websites").join(", ")],
+    ] as [string, string][]
+  ).filter(([, v]) => Boolean(v));
   const hasLinkedinDetail =
     liPositions.length > 0 ||
     liLanguages.length > 0 ||
     liProjects.length > 0 ||
     liVolunteer.length > 0 ||
-    liCourses.length > 0;
+    liCourses.length > 0 ||
+    liHonors.length > 0 ||
+    liPublications.length > 0 ||
+    liPatents.length > 0 ||
+    liOrganizations.length > 0 ||
+    liTestScores.length > 0 ||
+    liRecommendations.length > 0 ||
+    liInterests.length > 0 ||
+    liContactRows.length > 0;
 
   // ── GitHub temporal (languages by byte share + topics) ─────
   const ghLanguages = Object.entries(githubTemporal?.languages ?? {}).filter(
@@ -574,6 +601,208 @@ export function CVViewer({
                   </div>
                 ))}
               </div>
+            </div>
+          )}
+
+          {/* Contact — parsed today only to confirm the file WAS a LinkedIn
+              export, then discarded. Structured now; `websites` excludes the
+              linkedin.com URL itself, which is already its own row. */}
+          {liContactRows.length > 0 && (
+            <div className="mb-5">
+              <SectionLabel icon={User} text="Contact" />
+              <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 pl-5 text-xs">
+                {liContactRows.map(([label, value]) => (
+                  <div key={label} className="contents">
+                    <dt className="text-muted-foreground">{label}</dt>
+                    <dd className="break-all text-foreground/85">{value}</dd>
+                  </div>
+                ))}
+              </dl>
+            </div>
+          )}
+
+          {/* ── The seven sections that were split and then dropped ──
+              Each renders only when the profile carries it, so a LinkedIn
+              export without them stays silent (rule #29). */}
+
+          {liRecommendations.length > 0 && (
+            <div className="mb-5">
+              <SectionLabel
+                icon={HeartHandshake}
+                text={`Recommendations (${liRecommendations.length})`}
+              />
+              {/* Third-party evidence — other people's words about this
+                  person's work, the LinkedIn analogue of a GitHub README. */}
+              <ul className="space-y-2 pl-5">
+                {liRecommendations.map((item, i) => {
+                  const text = strField(item, "text");
+                  if (!text) return null;
+                  const author = strField(item, "author");
+                  const rel = strField(item, "relationship");
+                  return (
+                    <li
+                      key={i}
+                      className="rounded-lg border border-border/40 bg-muted/10 p-3"
+                    >
+                      <p className="text-xs leading-relaxed text-foreground/85">
+                        {text}
+                      </p>
+                      {(author || rel) && (
+                        <p className="mt-1 text-[11px] text-muted-foreground">
+                          {[author, rel].filter(Boolean).join(" · ")}
+                        </p>
+                      )}
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+          )}
+
+          {liPublications.length > 0 && (
+            <div className="mb-5">
+              <SectionLabel
+                icon={BookOpen}
+                text={`Publications (${liPublications.length})`}
+              />
+              <ul className="space-y-1 pl-5 text-sm text-foreground/80">
+                {liPublications.map((item, i) => {
+                  const title = strField(item, "title");
+                  if (!title) return null;
+                  const meta = [
+                    strField(item, "publisher"),
+                    strField(item, "date"),
+                  ].filter(Boolean).join(" · ");
+                  return (
+                    <li key={i} className="leading-relaxed">
+                      <span className="font-medium">{title}</span>
+                      {meta && (
+                        <span className="text-xs text-muted-foreground"> — {meta}</span>
+                      )}
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+          )}
+
+          {liPatents.length > 0 && (
+            <div className="mb-5">
+              <SectionLabel icon={Award} text={`Patents (${liPatents.length})`} />
+              <ul className="space-y-1 pl-5 text-sm text-foreground/80">
+                {liPatents.map((item, i) => {
+                  const title = strField(item, "title");
+                  if (!title) return null;
+                  const meta = [
+                    strField(item, "number"),
+                    strField(item, "status"),
+                    strField(item, "date"),
+                  ].filter(Boolean).join(" · ");
+                  return (
+                    <li key={i} className="leading-relaxed">
+                      <span className="font-medium">{title}</span>
+                      {meta && (
+                        <span className="text-xs text-muted-foreground"> — {meta}</span>
+                      )}
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+          )}
+
+          {liHonors.length > 0 && (
+            <div className="mb-5">
+              <SectionLabel icon={Trophy} text={`Honors & awards (${liHonors.length})`} />
+              <ul className="space-y-1 pl-5 text-sm text-foreground/80">
+                {liHonors.map((item, i) => {
+                  const title = strField(item, "title");
+                  if (!title) return null;
+                  const meta = [
+                    strField(item, "issuer"),
+                    strField(item, "date"),
+                  ].filter(Boolean).join(" · ");
+                  return (
+                    <li key={i} className="leading-relaxed">
+                      <span className="font-medium">{title}</span>
+                      {meta && (
+                        <span className="text-xs text-muted-foreground"> — {meta}</span>
+                      )}
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+          )}
+
+          {liOrganizations.length > 0 && (
+            <div className="mb-5">
+              <SectionLabel
+                icon={Building}
+                text={`Organisations (${liOrganizations.length})`}
+              />
+              <ul className="space-y-1 pl-5 text-sm text-foreground/80">
+                {liOrganizations.map((item, i) => {
+                  const name = strField(item, "name");
+                  if (!name) return null;
+                  const meta = [
+                    strField(item, "role"),
+                    [strField(item, "start"), strField(item, "end")]
+                      .filter(Boolean)
+                      .join(" – "),
+                  ].filter(Boolean).join(" · ");
+                  return (
+                    <li key={i} className="leading-relaxed">
+                      <span className="font-medium">{name}</span>
+                      {meta && (
+                        <span className="text-xs text-muted-foreground"> — {meta}</span>
+                      )}
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+          )}
+
+          {liTestScores.length > 0 && (
+            <div className="mb-5">
+              <SectionLabel icon={Award} text={`Test scores (${liTestScores.length})`} />
+              <ul className="flex flex-wrap gap-1.5 pl-5">
+                {liTestScores.map((item, i) => {
+                  const name = strField(item, "name");
+                  if (!name) return null;
+                  const score = strField(item, "score");
+                  return (
+                    <li
+                      key={i}
+                      className="rounded-full bg-sky-500/10 px-2.5 py-0.5 text-xs font-medium text-sky-400"
+                    >
+                      {name}
+                      {score ? ` · ${score}` : ""}
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+          )}
+
+          {liInterests.length > 0 && (
+            <div className="mb-5">
+              <SectionLabel icon={Hash} text={`Interests (${liInterests.length})`} />
+              <ul className="flex flex-wrap gap-1.5 pl-5">
+                {liInterests.map((item, i) => {
+                  const name = strField(item, "name");
+                  if (!name) return null;
+                  return (
+                    <li
+                      key={i}
+                      className="rounded-full bg-muted/40 px-2.5 py-0.5 text-xs text-muted-foreground"
+                    >
+                      {name}
+                    </li>
+                  );
+                })}
+              </ul>
             </div>
           )}
 


### PR DESCRIPTION
Same audit as GitHub, run on the other input.

`_SECTION_HEADINGS` recognises **20** LinkedIn headings. Only **11** had an extractor and a shelf. The other seven were split out purely so they acted as *boundaries* for their neighbours, then discarded — and the **Contact** block was parsed only to confirm the file *was* a LinkedIn export before being thrown away.

The same "fetched, stored nowhere" shape that hid 92 GitHub signals.

## New shelves — and why each is evidence, not decoration

| Shelf | Why it matters for matching |
|---|---|
| **`linkedin_recommendations`** | **other people's prose** about this person's work — third-party evidence, the LinkedIn analogue of a GitHub README, and the only place on any input where someone *else* describes them |
| **`linkedin_publications`** | research output; decisive for ML/research roles |
| **`linkedin_patents`** | the strongest single technical credibility signal |
| **`linkedin_test_scores`** | IELTS/TOEFL/GRE — language proficiency, **UK-visa relevant** (#30/#31), stated by **no other input** we collect |
| **`linkedin_organizations`** | professional bodies (BCS, IEEE) → domain + seniority |
| **`linkedin_honors`** | awards, the achievement claim a CV usually buries |
| **`linkedin_interests`** | companies/groups followed → industry preference |
| **`linkedin_contact`** | email · phone · profile URL · **personal websites** |

Contact is parsed **deterministically** — emails, phones and URLs are patterns, not semantics, so it needs no LLM call and cannot hallucinate. It's stored *outside* the `llm_ran` gate, so a re-parse that skips the paid passes still refreshes it.

**Cost: nothing** for profiles without these sections. `_maybe` short-circuits an absent section without touching a provider, so adding seven prompts does not add seven calls.

## A real bug, caught by testing against a real export

The contact parser first returned `email="rahulranjith369"` — the **local part only**.

A `_EMAIL_RE` already existed further down the module **with a capture group**, and being defined later it shadowed the new one, so `findall` returned the group instead of the match. Renamed to `_CONTACT_EMAIL_RE`, with a note — the next person will reach for the same name.

A fixture-based test would likely have missed this.

## Two corrections to claims I made while auditing

1. I reported the owner's PDF had a **Projects** section that wasn't extracting. **Wrong** — my audit substring-matched `"projects"`, which appears only inside a summary bullet. `linkedin_projects: 0` was correct all along.
2. His export carries **6 sections** (contact, top skills, certifications, summary, experience, education) — every one correctly shelved. The seven new shelves fill for **other people's** profiles, which is the stated use case.

## Display

All of it renders in **"LinkedIn detail"**, each block only when the profile carries it, so a sparse export shows no empty headings (rule #29).

## Tests

7 frontend render tests — contact with the **full** email · recommendations with attribution · publications/patents/honors/organisations/test scores · interests · silent with nothing · sparse profile shows no empty headings · never renders `undefined`.

80 existing backend LinkedIn tests still pass. Gate: **PASS**, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
