### PR TITLE
fix(profile): the CV merge dropped two shelves — make it derive, not hand-list

### DIFF
--- a/backend/src/services/profile/two_pass.py
+++ b/backend/src/services/profile/two_pass.py
@@ -298,6 +298,40 @@ def reset_cv_owned_fields(cv: CVData) -> None:
     cv.llm_input_hashes.pop("cv", None)
 
 
+# Scalar CVData fields the CV pass must NOT write, each with the reason it is
+# somebody else's to own. Everything else that is a plain string is CV-owned.
+_NOT_CV_OWNED_SCALARS: dict[str, str] = {
+    "raw_text": "the source document itself — written by the upload route",
+    "cv_filename": "upload receipt, stamped by the API route",
+    "cv_uploaded_at": "upload receipt, stamped by the API route",
+    "linkedin_filename": "upload receipt, stamped by the API route",
+    "linkedin_uploaded_at": "upload receipt, stamped by the API route",
+    "github_connected_at": "connection receipt, stamped by the API route",
+}
+
+_SCALAR_ANNOTATIONS = frozenset({"str", "Optional[str]"})
+
+
+def _cv_owned_scalars() -> tuple[str, ...]:
+    """Every plain-string CVData field the CV pass is allowed to fill.
+
+    Fields belonging to the other passes are excluded by PREFIX rather than by
+    name, so a new ``linkedin_*`` or ``github_*`` scalar can never be clobbered
+    by a CV re-parse just because someone forgot to list it here.
+    """
+    import dataclasses as _dc
+
+    out: list[str] = []
+    for f in _dc.fields(CVData):
+        if f.name in _NOT_CV_OWNED_SCALARS:
+            continue
+        if f.name.startswith(("linkedin_", "github_", "about_me_")):
+            continue
+        if str(f.type) in _SCALAR_ANNOTATIONS:
+            out.append(f.name)
+    return tuple(out)
+
+
 def _merge_cv_llm_into(cv: CVData, llm_cv: CVData) -> None:
     """Merge the CV-OWNED fields of an LLM result into the live ``cv``.
 
@@ -314,25 +348,23 @@ def _merge_cv_llm_into(cv: CVData, llm_cv: CVData) -> None:
     _merge_str_list(cv.cv_industries, llm_cv.cv_industries)
     _merge_str_list(cv.cv_languages, llm_cv.cv_languages)
     # Fill empty scalars only — never overwrite a value the user already has.
-    if not cv.name and llm_cv.name:
-        cv.name = llm_cv.name
-    if not cv.headline and llm_cv.headline:
-        cv.headline = llm_cv.headline
-    if not cv.location and llm_cv.location:
-        cv.location = llm_cv.location
-    if not cv.summary and llm_cv.summary:
-        cv.summary = llm_cv.summary
-    if not cv.experience_text and llm_cv.experience_text:
-        cv.experience_text = llm_cv.experience_text
-    # ADAPTER-PARITY FIX (2026-08-07). Every OTHER CV-owned scalar in this
-    # function was merged; `career_domain` was not, so even once the prompt
-    # asks for it (cv_parser._CV_PROMPT) and the schema adapter surfaces it
-    # (schemas.cv_schema_to_cvdata), the value stopped here — one layer above
-    # the fix, same shape as the `cv_positions` miss just below. Fill-if-
-    # empty like every scalar above: a re-run that classifies differently
-    # must not clobber a domain the user's profile already carries.
-    if not cv.career_domain and llm_cv.career_domain:
-        cv.career_domain = llm_cv.career_domain
+    #
+    # DERIVED FROM THE DATACLASS, not hand-listed. This function has now lost a
+    # field three separate times, always the same way: the prompt is taught to
+    # extract something, the schema declares it, the adapter surfaces it, and
+    # then this merge — which names each scalar individually — silently drops it
+    # one layer above the fix. It happened to `career_domain` (2026-08-07), then
+    # to `cv_experience_level` and `cv_right_to_work` (2026-08-10), the latter
+    # two verified EMPTY on a live production profile after a real re-extraction
+    # while every unit test passed, because the tests set the field directly
+    # instead of letting the LLM pass produce it.
+    #
+    # A scalar added to CVData tomorrow is now carried automatically. The
+    # exclusions are the only thing that needs maintaining, and each one states
+    # WHY it is not the CV pass's to write.
+    for name in _cv_owned_scalars():
+        if not getattr(cv, name, None) and getattr(llm_cv, name, None):
+            setattr(cv, name, getattr(llm_cv, name))
     # ESCO skill-normalisation map (Step-1.5 S1.5-D). `reset_cv_owned_fields`
     # has always cleared `cv_skills_esco` on a CV swap — treating it as CV-
     # owned — but nothing here ever copied it back in, so fixing the adapter

--- a/backend/tests/test_cv_experience_level.py
+++ b/backend/tests/test_cv_experience_level.py
@@ -98,6 +98,74 @@ class TestItFillsTheScoringSeamOnlyWhenTitlesCannot:
         assert after.preferences.experience_level_inferred == ""
 
 
+class TestEveryCvScalarSurvivesTheMerge:
+    """The bug the tests above MISSED, caught by production.
+
+    ``_merge_cv_llm_into`` named every scalar individually. Adding
+    ``cv_experience_level`` and ``cv_right_to_work`` to the prompt, the schema
+    and the adapter was not enough — the merge dropped both one layer above the
+    fix, and a live re-extraction produced two empty shelves while every unit
+    test passed. The tests passed because they SET the field on the CVData
+    directly instead of letting the CV pass produce it, so the merge was never
+    exercised.
+
+    This is the third time this function has lost a field that way
+    (``career_domain`` was the first). So the assertion is structural: whatever
+    the CV pass produces on a CV-owned scalar must reach the profile — no list
+    of names to keep in step.
+    """
+
+    def _merged(self, produced: CVData) -> CVData:
+        from src.services.profile.two_pass import _merge_cv_llm_into
+
+        cv = CVData(raw_text="x")
+        _merge_cv_llm_into(cv, produced)
+        return cv
+
+    def test_every_cv_owned_scalar_the_pass_produces_is_carried(self) -> None:
+        from src.services.profile.two_pass import _cv_owned_scalars
+
+        names = _cv_owned_scalars()
+        assert names, "no CV-owned scalars detected — the derivation is broken"
+
+        produced = CVData(**{n: f"value-for-{n}" for n in names})
+        merged = self._merged(produced)
+
+        dropped = [n for n in names if not getattr(merged, n)]
+        assert not dropped, (
+            f"the CV merge dropped these scalars the pass produced: {dropped}. "
+            "They will be empty on every live profile no matter how correct the "
+            "prompt, schema and adapter are."
+        )
+
+    def test_the_two_shelves_production_caught_are_covered(self) -> None:
+        from src.services.profile.two_pass import _cv_owned_scalars
+
+        assert "cv_experience_level" in _cv_owned_scalars()
+        assert "cv_right_to_work" in _cv_owned_scalars()
+
+    def test_another_passes_scalar_is_never_clobbered_by_a_cv_reparse(self) -> None:
+        """The exclusions are load-bearing: a CV re-parse must not overwrite the
+        LinkedIn About or a GitHub bio, which the CV pass knows nothing about."""
+        from src.services.profile.two_pass import _cv_owned_scalars
+
+        for name in ("linkedin_summary", "github_bio", "github_profile_readme",
+                     "raw_text", "cv_filename"):
+            assert name not in _cv_owned_scalars(), (
+                f"{name} is not the CV pass's to write"
+            )
+
+    def test_a_populated_scalar_is_not_overwritten(self) -> None:
+        from src.services.profile.two_pass import _merge_cv_llm_into
+
+        cv = CVData(raw_text="x", cv_experience_level="senior")
+        _merge_cv_llm_into(cv, CVData(cv_experience_level="junior"))
+        assert cv.cv_experience_level == "senior", (
+            "fill-if-empty, never overwrite — a re-run that reads differently "
+            "must not clobber what the profile already carries"
+        )
+
+
 class TestTheJudgeSeesIt:
     def test_the_level_reaches_the_candidate_text(self) -> None:
         from src.services.llm_matcher import profile_to_matcher_text


### PR DESCRIPTION
Production caught this, not the tests.

PR #292 added `cv_experience_level` and `cv_right_to_work` — taught the prompt, declared them on `CVSchema`, surfaced them in the adapter, wired them to the judge, bumped `EXTRACTOR_VERSION`. All green. A real re-extraction on the live profile then produced **both shelves empty**.

`_merge_cv_llm_into` named every scalar it copied, one `if not cv.x and llm_cv.x` per field. The two new ones weren't in that list, so the LLM extracted them and the merge discarded them one layer above the fix.

**Third time this function has lost a field that way.** The comment being replaced documents `career_domain` suffering it on 2026-08-07, and the LinkedIn merger in #292 was the same shape again. Adding two more lines would have set up the fourth.

So the scalar merge now derives from the dataclass: every plain-string `CVData` field is CV-owned unless it carries a `linkedin_`/`github_`/`about_me_` prefix (another pass owns it) or appears in `_NOT_CV_OWNED_SCALARS` with a stated reason. Eight fields today; one added tomorrow is carried without touching this function.

## Why the tests missed it

They set `cv_experience_level` on the CVData **directly** and asserted downstream behaviour, so the merge was never on the path. The new tests assert structurally: whatever the CV pass produces on a CV-owned scalar must reach the profile, with no list of names to keep in step — plus that other passes' scalars are never clobbered by a CV re-parse.

## Verification

850 tests across the 38 files that touch `CVData` or any renamed/added symbol, **selected by symbol rather than by diff** — a diff-based selection is exactly what let the previous miss reach CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6DsQH5EUxJc3Vnqz9YHgQ
