### PR TITLE
feat(profile): show the LinkedIn About — the shelf was matched on but invisible

### DIFF
--- a/backend/src/api/routes/profile.py
+++ b/backend/src/api/routes/profile.py
@@ -223,6 +223,14 @@ def _build_profile_response(profile: UserProfile, user_id: str) -> ProfileRespon
         "contact": [getattr(cv, "linkedin_contact", {}) or {}]
         if getattr(cv, "linkedin_contact", None)
         else [],
+        # The About section. It reaches the judge and the vector, and would
+        # otherwise be the one thing on this profile that is extracted, stored
+        # and MATCHED ON while being invisible to the person it describes — the
+        # third way a shelf goes dark, after a broken extractor and a dropping
+        # merge. Shown as a single row so it renders like every other section.
+        "summary": [{"text": (getattr(cv, "linkedin_summary", "") or "").strip()}]
+        if (getattr(cv, "linkedin_summary", "") or "").strip()
+        else [],
     }
     github_temporal: dict[str, dict[str, Any]] = {
         "languages": dict(getattr(cv, "github_languages", {}) or {}),

--- a/backend/src/services/profile/two_pass.py
+++ b/backend/src/services/profile/two_pass.py
@@ -298,6 +298,40 @@ def reset_cv_owned_fields(cv: CVData) -> None:
     cv.llm_input_hashes.pop("cv", None)
 
 
+# Scalar CVData fields the CV pass must NOT write, each with the reason it is
+# somebody else's to own. Everything else that is a plain string is CV-owned.
+_NOT_CV_OWNED_SCALARS: dict[str, str] = {
+    "raw_text": "the source document itself — written by the upload route",
+    "cv_filename": "upload receipt, stamped by the API route",
+    "cv_uploaded_at": "upload receipt, stamped by the API route",
+    "linkedin_filename": "upload receipt, stamped by the API route",
+    "linkedin_uploaded_at": "upload receipt, stamped by the API route",
+    "github_connected_at": "connection receipt, stamped by the API route",
+}
+
+_SCALAR_ANNOTATIONS = frozenset({"str", "Optional[str]"})
+
+
+def _cv_owned_scalars() -> tuple[str, ...]:
+    """Every plain-string CVData field the CV pass is allowed to fill.
+
+    Fields belonging to the other passes are excluded by PREFIX rather than by
+    name, so a new ``linkedin_*`` or ``github_*`` scalar can never be clobbered
+    by a CV re-parse just because someone forgot to list it here.
+    """
+    import dataclasses as _dc
+
+    out: list[str] = []
+    for f in _dc.fields(CVData):
+        if f.name in _NOT_CV_OWNED_SCALARS:
+            continue
+        if f.name.startswith(("linkedin_", "github_", "about_me_")):
+            continue
+        if str(f.type) in _SCALAR_ANNOTATIONS:
+            out.append(f.name)
+    return tuple(out)
+
+
 def _merge_cv_llm_into(cv: CVData, llm_cv: CVData) -> None:
     """Merge the CV-OWNED fields of an LLM result into the live ``cv``.
 
@@ -314,25 +348,23 @@ def _merge_cv_llm_into(cv: CVData, llm_cv: CVData) -> None:
     _merge_str_list(cv.cv_industries, llm_cv.cv_industries)
     _merge_str_list(cv.cv_languages, llm_cv.cv_languages)
     # Fill empty scalars only — never overwrite a value the user already has.
-    if not cv.name and llm_cv.name:
-        cv.name = llm_cv.name
-    if not cv.headline and llm_cv.headline:
-        cv.headline = llm_cv.headline
-    if not cv.location and llm_cv.location:
-        cv.location = llm_cv.location
-    if not cv.summary and llm_cv.summary:
-        cv.summary = llm_cv.summary
-    if not cv.experience_text and llm_cv.experience_text:
-        cv.experience_text = llm_cv.experience_text
-    # ADAPTER-PARITY FIX (2026-08-07). Every OTHER CV-owned scalar in this
-    # function was merged; `career_domain` was not, so even once the prompt
-    # asks for it (cv_parser._CV_PROMPT) and the schema adapter surfaces it
-    # (schemas.cv_schema_to_cvdata), the value stopped here — one layer above
-    # the fix, same shape as the `cv_positions` miss just below. Fill-if-
-    # empty like every scalar above: a re-run that classifies differently
-    # must not clobber a domain the user's profile already carries.
-    if not cv.career_domain and llm_cv.career_domain:
-        cv.career_domain = llm_cv.career_domain
+    #
+    # DERIVED FROM THE DATACLASS, not hand-listed. This function has now lost a
+    # field three separate times, always the same way: the prompt is taught to
+    # extract something, the schema declares it, the adapter surfaces it, and
+    # then this merge — which names each scalar individually — silently drops it
+    # one layer above the fix. It happened to `career_domain` (2026-08-07), then
+    # to `cv_experience_level` and `cv_right_to_work` (2026-08-10), the latter
+    # two verified EMPTY on a live production profile after a real re-extraction
+    # while every unit test passed, because the tests set the field directly
+    # instead of letting the LLM pass produce it.
+    #
+    # A scalar added to CVData tomorrow is now carried automatically. The
+    # exclusions are the only thing that needs maintaining, and each one states
+    # WHY it is not the CV pass's to write.
+    for name in _cv_owned_scalars():
+        if not getattr(cv, name, None) and getattr(llm_cv, name, None):
+            setattr(cv, name, getattr(llm_cv, name))
     # ESCO skill-normalisation map (Step-1.5 S1.5-D). `reset_cv_owned_fields`
     # has always cleared `cv_skills_esco` on a CV swap — treating it as CV-
     # owned — but nothing here ever copied it back in, so fixing the adapter

--- a/backend/tests/test_cv_experience_level.py
+++ b/backend/tests/test_cv_experience_level.py
@@ -98,6 +98,74 @@ class TestItFillsTheScoringSeamOnlyWhenTitlesCannot:
         assert after.preferences.experience_level_inferred == ""
 
 
+class TestEveryCvScalarSurvivesTheMerge:
+    """The bug the tests above MISSED, caught by production.
+
+    ``_merge_cv_llm_into`` named every scalar individually. Adding
+    ``cv_experience_level`` and ``cv_right_to_work`` to the prompt, the schema
+    and the adapter was not enough — the merge dropped both one layer above the
+    fix, and a live re-extraction produced two empty shelves while every unit
+    test passed. The tests passed because they SET the field on the CVData
+    directly instead of letting the CV pass produce it, so the merge was never
+    exercised.
+
+    This is the third time this function has lost a field that way
+    (``career_domain`` was the first). So the assertion is structural: whatever
+    the CV pass produces on a CV-owned scalar must reach the profile — no list
+    of names to keep in step.
+    """
+
+    def _merged(self, produced: CVData) -> CVData:
+        from src.services.profile.two_pass import _merge_cv_llm_into
+
+        cv = CVData(raw_text="x")
+        _merge_cv_llm_into(cv, produced)
+        return cv
+
+    def test_every_cv_owned_scalar_the_pass_produces_is_carried(self) -> None:
+        from src.services.profile.two_pass import _cv_owned_scalars
+
+        names = _cv_owned_scalars()
+        assert names, "no CV-owned scalars detected — the derivation is broken"
+
+        produced = CVData(**{n: f"value-for-{n}" for n in names})
+        merged = self._merged(produced)
+
+        dropped = [n for n in names if not getattr(merged, n)]
+        assert not dropped, (
+            f"the CV merge dropped these scalars the pass produced: {dropped}. "
+            "They will be empty on every live profile no matter how correct the "
+            "prompt, schema and adapter are."
+        )
+
+    def test_the_two_shelves_production_caught_are_covered(self) -> None:
+        from src.services.profile.two_pass import _cv_owned_scalars
+
+        assert "cv_experience_level" in _cv_owned_scalars()
+        assert "cv_right_to_work" in _cv_owned_scalars()
+
+    def test_another_passes_scalar_is_never_clobbered_by_a_cv_reparse(self) -> None:
+        """The exclusions are load-bearing: a CV re-parse must not overwrite the
+        LinkedIn About or a GitHub bio, which the CV pass knows nothing about."""
+        from src.services.profile.two_pass import _cv_owned_scalars
+
+        for name in ("linkedin_summary", "github_bio", "github_profile_readme",
+                     "raw_text", "cv_filename"):
+            assert name not in _cv_owned_scalars(), (
+                f"{name} is not the CV pass's to write"
+            )
+
+    def test_a_populated_scalar_is_not_overwritten(self) -> None:
+        from src.services.profile.two_pass import _merge_cv_llm_into
+
+        cv = CVData(raw_text="x", cv_experience_level="senior")
+        _merge_cv_llm_into(cv, CVData(cv_experience_level="junior"))
+        assert cv.cv_experience_level == "senior", (
+            "fill-if-empty, never overwrite — a re-run that reads differently "
+            "must not clobber what the profile already carries"
+        )
+
+
 class TestTheJudgeSeesIt:
     def test_the_level_reaches_the_candidate_text(self) -> None:
         from src.services.llm_matcher import profile_to_matcher_text

--- a/frontend/src/components/profile/CVViewer.linkedin-sections.test.tsx
+++ b/frontend/src/components/profile/CVViewer.linkedin-sections.test.tsx
@@ -80,6 +80,25 @@ describe("LinkedIn detail shows every section", () => {
     expect(screen.getByText(/IELTS · 8\.0/)).toBeTruthy();
   });
 
+  it("renders the LinkedIn About section", () => {
+    // This text is the person's own first-person prose. It was discarded
+    // whenever the CV already carried a summary — so most profiles lost it —
+    // and once it finally had a shelf it went straight to the judge and the
+    // vector while remaining invisible on screen. Extracted, stored and matched
+    // on but never shown is the third way a shelf goes dark.
+    renderWith({
+      summary: [{ text: "AI/ML Engineer building production GenAI systems." }],
+    });
+    expect(
+      screen.getByText(/AI\/ML Engineer building production GenAI systems\./),
+    ).toBeTruthy();
+  });
+
+  it("stays silent when there is no About text", () => {
+    renderWith({ summary: [{ text: "" }] });
+    expect(screen.queryByText("About")).not.toBeInTheDocument();
+  });
+
   it("renders interests", () => {
     renderWith({ interests: [{ name: "DeepMind" }, { name: "Royal Society" }] });
     expect(screen.getByText("DeepMind")).toBeTruthy();

--- a/frontend/src/components/profile/CVViewer.tsx
+++ b/frontend/src/components/profile/CVViewer.tsx
@@ -248,6 +248,10 @@ export function CVViewer({
   const liRecommendations = linkedinSubsections?.recommendations ?? [];
   const liInterests = linkedinSubsections?.interests ?? [];
   const liContact = (linkedinSubsections?.contact ?? [])[0] ?? {};
+  // The LinkedIn "About" — the person's own first-person prose. It was
+  // discarded whenever the CV already had a summary, so most profiles lost it
+  // entirely; now it has a shelf, reaches the judge, and is finally shown.
+  const liSummary = strField((linkedinSubsections?.summary ?? [])[0] ?? {}, "text");
   const liContactRows: [string, string][] = (
     [
       ["Email", strField(liContact, "email")],
@@ -269,7 +273,8 @@ export function CVViewer({
     liTestScores.length > 0 ||
     liRecommendations.length > 0 ||
     liInterests.length > 0 ||
-    liContactRows.length > 0;
+    liContactRows.length > 0 ||
+    liSummary.length > 0;
 
   // ── GitHub temporal (languages by byte share + topics) ─────
   const ghLanguages = Object.entries(githubTemporal?.languages ?? {}).filter(
@@ -601,6 +606,19 @@ export function CVViewer({
                   </div>
                 ))}
               </div>
+            </div>
+          )}
+
+          {/* About — the person's own words. This was extracted, stored and
+              MATCHED ON while being invisible to the person it describes: the
+              third way a shelf goes dark, after a broken extractor and a
+              dropping merge. */}
+          {liSummary.length > 0 && (
+            <div className="mb-5">
+              <SectionLabel icon={User} text="About" />
+              <p className="whitespace-pre-line pl-5 text-xs leading-relaxed text-foreground/85">
+                {liSummary}
+              </p>
             </div>
           )}
 


### PR DESCRIPTION
`linkedin_summary` shipped in #292 with a writer, a reader, and a place in both the judge prompt and the embedding text. It had **no UI**. So the one piece of prose you wrote about yourself was extracted, stored, and **scored against** while being invisible to the person it describes.

That's the third distinct way a shelf goes dark, and the only one the previous two commits didn't cover:

| cause | fix |
|---|---|
| broken extractor | #292 — the merge dropped 8 keys |
| dropping merge | #294 — derive the scalar merge from the dataclass |
| **no front door** | **this** |

Identical in the database. Identical to the user. Different fix each time.

Now rendered as an **About** block in LinkedIn detail, only when the profile carries it (rule #29 — an export without one stays silent).

## Verified on production

The owner's real profile carries **2,038 characters** of About text that had been discarded on every extraction until #292, because the old merge only copied it into `summary` when the CV had none.

Gate: PASS — backend targeted, 252 frontend tests, api-types drift clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6DsQH5EUxJc3Vnqz9YHgQ