### PR TITLE
fix(prefilter): "United Kingdom" as a location preference deleted the feed

### DIFF
--- a/backend/src/services/prefilter.py
+++ b/backend/src/services/prefilter.py
@@ -22,6 +22,12 @@ from typing import Iterable
 
 from src.models import Job
 
+# One definition of "this string names the UK", shared with the ingestion gate
+# (rule #30). A second copy here would drift, and the two would disagree about
+# what counts as a country — which is exactly the class of bug this module has
+# just been fixed for.
+from src.services.uk_gate import _UK_SELF
+
 # Experience level ladder — lower index = more junior.
 _LEVEL_ORDER = {
     "intern": 0,
@@ -76,6 +82,16 @@ def location_ok(profile: FilterProfile, job: Job) -> bool:
         return True
 
     for pref in _lower(profile.preferred_locations):
+        # A COUNTRY-level preference is not a constraint here. The catalogue is
+        # UK-only by construction (rule #30 — `uk_gate.check_uk` refuses the
+        # rest at ingestion), so "United Kingdom" says nothing this gate can
+        # act on. Matching it literally is worse than useless: the test is a
+        # substring one, and "united kingdom" appears in neither direction of
+        # "London" — so the single most natural thing a UK user can type would
+        # have deleted almost the entire feed. Reuses the gate's own set so
+        # there is one definition of "names the UK", not two.
+        if pref in _UK_SELF:
+            return True
         if pref in loc or loc in pref:
             return True
     # If user has no preferred location list but a non-remote arrangement

--- a/backend/tests/test_prefilter_wiring.py
+++ b/backend/tests/test_prefilter_wiring.py
@@ -98,6 +98,57 @@ class TestAnUnstatedPreferenceNeverDeletesAJob:
         assert passes_prefilter(fp, _job(title="Principal ML Engineer")) is False
 
 
+class TestACountryLevelPreferenceIsNotAConstraint:
+    """The hazard created by wiring this gate at all.
+
+    ``location_ok`` compares by SUBSTRING. Before the prefilter was fed, that
+    never ran on real data. Once it did, the single most natural thing a UK user
+    can type — "United Kingdom" — matched neither direction of "London", so the
+    gate would have deleted almost the entire feed the moment anyone set it.
+
+    The catalogue is UK-only by construction (rule #30 refuses the rest at
+    ingestion), so a country-level preference carries no information this gate
+    can act on. It passes.
+    """
+
+    def _fp(self, monkeypatch, locations):
+        profile = UserProfile(
+            cv_data=CVData(raw_text="x", skills=["python"]),
+            preferences=UserPreferences(preferred_locations=locations),
+        )
+        monkeypatch.setattr(
+            "src.workers.tasks._user_profile_for", lambda _uid: profile
+        )
+        return _filter_profile_for("u1")
+
+    def test_united_kingdom_does_not_delete_a_london_job(self, monkeypatch) -> None:
+        fp = self._fp(monkeypatch, ["United Kingdom"])
+        assert passes_prefilter(fp, _job()) is True, (
+            "a country-level location preference deleted a UK job — the whole "
+            "catalogue is UK-only, so this preference constrains nothing"
+        )
+
+    def test_every_way_of_naming_the_uk_behaves_the_same(self, monkeypatch) -> None:
+        for name in ("UK", "uk", "United Kingdom", "Great Britain", "England",
+                     "Scotland", "Wales", "Northern Ireland"):
+            fp = self._fp(monkeypatch, [name])
+            assert passes_prefilter(fp, _job()) is True, f"{name!r} filtered a UK job"
+
+    def test_a_real_city_preference_still_filters(self, monkeypatch) -> None:
+        """The fix must not turn the gate back into a no-op: a CITY the user
+        named is a genuine constraint and must still apply."""
+        fp = self._fp(monkeypatch, ["Manchester"])
+        assert passes_prefilter(fp, _job()) is False  # the job is in London
+
+    def test_a_country_preference_alongside_a_city_still_passes_both(
+        self, monkeypatch
+    ) -> None:
+        fp = self._fp(monkeypatch, ["United Kingdom", "Manchester"])
+        # London matches the country entry, so it survives — the user asking for
+        # "UK or Manchester" wants UK-wide results.
+        assert passes_prefilter(fp, _job()) is True
+
+
 class TestSkillsStayOutUntilMeasured:
     """Extracted skills are NOT a stated preference, and the one measurement we
     have says wiring them here deletes 71% of the catalogue. If a future change


### PR DESCRIPTION
A hazard created by feeding the prefilter at all — found before any user hit it.

`location_ok` compares by **substring**. That never ran on real data while the gate was handed an empty `FilterProfile`, so nothing exercised it. Now that the gate receives the stored profile:

```
preference: "United Kingdom"     job.location: "London"
  "united kingdom" in "london"  ->  False
  "london" in "united kingdom"  ->  False
  -> falls through to `return not profile.preferred_locations`  ->  DROPPED
```

Setting one sensible preference would have deleted almost the entire feed, silently, before anything scored it.

A country-level preference carries **no information this gate can act on**: the catalogue is UK-only by construction (rule #30 — `uk_gate.check_uk` refuses the rest at ingestion). So it passes.

Reuses `uk_gate._UK_SELF` rather than re-listing the country names. A second copy would drift from the first, and disagreeing definitions of the same concept is exactly the bug class this batch has spent the day removing.

A **city** preference still filters — the tests pin both halves, so the fix cannot quietly turn the gate back into the no-op it was.

Gate: PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6DsQH5EUxJc3Vnqz9YHgQ