### PR TITLE
fix(build): the image threw away the reference data the repo commits on purpose

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,6 +1,31 @@
 # Runtime data — never bake into the image; mount as a volume.
 data/
 
+# ...EXCEPT the data that is not runtime state but SHIPPED REFERENCE DATA.
+#
+# `.gitignore` deliberately un-ignores these same two directories, which is the
+# whole reason they are committed. This file did not mirror that, and the
+# Dockerfile is `COPY . .`, so the build threw away exactly the files someone had
+# gone to the trouble of exempting — and nothing rebuilds them at deploy time.
+# Railway volumes start empty, so no mount could supply them either.
+#
+# What that cost, silently and with no error:
+#   uk_gazetteer/  — the ~52k UK place names rule #30 is built on. Without it
+#                    `uk_gate._read()` returns an empty frozenset (it degrades
+#                    rather than raising), so no job can match a UK place and the
+#                    gate falls through to source-trust and ad-text evidence.
+#   job_signals/   — the seniority / workplace / location term tables behind
+#                    `signal_backed_lookup`, which fills 'unknown' enrichment at
+#                    read time, and `detect_seniority`. `_load_terms` returns {}
+#                    on a missing file, so those detectors quietly answer nothing.
+#
+# Both failure modes are invisible: empty data, no exception, no log line.
+# `tests/test_shipped_data.py` now pins the two ignore files together.
+!data/uk_gazetteer/
+!data/uk_gazetteer/**
+!data/job_signals/
+!data/job_signals/**
+
 # Python caches
 __pycache__/
 *.pyc

--- a/backend/tests/test_shipped_data.py
+++ b/backend/tests/test_shipped_data.py
@@ -1,0 +1,99 @@
+"""Data the repo deliberately COMMITS must survive the Docker build.
+
+Two ignore files describe the same intent from opposite directions, and nothing
+made them agree. `.gitignore` ignores `data/` and then un-ignores
+`backend/data/uk_gazetteer/**` and `backend/data/job_signals/**` — the exemptions
+are the reason those files are in the repository at all. `.dockerignore` ignored
+`data/` with no exemptions, and the Dockerfile is `COPY . .`, so the image was
+built without precisely the files someone had gone out of their way to commit.
+
+Nothing failed. Both loaders degrade silently by design:
+
+    uk_gate._read()          -> frozenset()  when the file is absent
+    job_signals._load_terms() -> {}           when the file is absent
+
+So the UK gate (rule #30's entire basis) and the seniority / workplace
+detectors would answer "nothing" in production, with no exception and no log
+line, while passing every test on a developer machine where the files exist.
+
+This is the same shape as every other bug in this batch: two hand-maintained
+copies of one intent, drifting apart with nobody watching. The test is therefore
+DERIVED from `.gitignore` rather than hard-coding a list of directories — a
+third exemption added tomorrow is covered automatically.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_BACKEND = Path(__file__).resolve().parent.parent
+_REPO = _BACKEND.parent
+
+
+def _negations(path: Path) -> set[str]:
+    """Un-ignore patterns (`!...`) under a data/ directory, normalised.
+
+    Both files are read into the same namespace: `.gitignore` sits at the repo
+    root and writes `backend/data/...`, `.dockerignore` sits in `backend/` and
+    writes `data/...`. Stripping the `backend/` prefix makes them comparable.
+    """
+    if not path.exists():
+        return set()
+    out: set[str] = set()
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line.startswith("!"):
+            continue
+        pattern = line[1:].strip().lstrip("/")
+        pattern = re.sub(r"^backend/", "", pattern)
+        if pattern.startswith("data/"):
+            out.add(pattern.rstrip("/").removesuffix("/**"))
+    return out
+
+
+class TestTheImageShipsWhatTheRepoCommits:
+    def test_dockerignore_exempts_everything_gitignore_exempts(self) -> None:
+        wanted = _negations(_REPO / ".gitignore")
+        assert wanted, (
+            "no data/ exemptions found in .gitignore — if the committed "
+            "reference data moved, this test needs to move with it"
+        )
+        have = _negations(_BACKEND / ".dockerignore")
+        missing = sorted(wanted - have)
+        assert not missing, (
+            "These directories are deliberately committed to the repo but "
+            f"excluded from the Docker image: {missing}. The loaders degrade "
+            "silently on a missing file, so production answers 'nothing' with "
+            "no error while every local test passes."
+        )
+
+    @pytest.mark.parametrize("rel", ["data/uk_gazetteer", "data/job_signals"])
+    def test_the_committed_data_actually_exists(self, rel: str) -> None:
+        """The exemption is worthless if the directory is empty — that would
+        look identical to the bug it prevents."""
+        d = _BACKEND / rel
+        assert d.is_dir(), f"{rel} is exempted from both ignore files but absent"
+        files = [p for p in d.iterdir() if p.is_file() and p.suffix in (".txt", "")]
+        assert files, f"{rel} exists but ships no data files"
+
+
+class TestTheLoadersStillDegradeQuietly:
+    """Pins WHY this needed a test rather than being caught at runtime: neither
+    loader raises. If someone later makes them raise, that is an improvement —
+    but it should be a deliberate change, seen here first."""
+
+    def test_uk_gate_returns_empty_rather_than_raising(self) -> None:
+        from src.services import uk_gate
+
+        # A missing data directory yields empty sets, not an error — which is
+        # exactly why an image built without them looked healthy.
+        places, foreign, ambiguous = uk_gate._gazetteer()
+        for s in (places, foreign, ambiguous):
+            assert isinstance(s, frozenset)
+
+    def test_job_signals_returns_empty_dict_for_a_missing_file(self) -> None:
+        from src.services.job_signals import _load_terms
+
+        assert _load_terms("definitely-not-a-real-file.txt") == {}


### PR DESCRIPTION
`.gitignore` ignores `data/` and then **un-ignores** two directories:

```
!backend/data/uk_gazetteer/**
!backend/data/job_signals/**
```

Those exemptions are the only reason those files are in the repository. `.dockerignore` did not mirror them, and the Dockerfile is `COPY . .` — so the build excluded exactly the data someone had gone out of their way to commit. Nothing rebuilds it at deploy, and a Railway volume starts empty, so nothing could supply it at runtime either.

## What it cost, silently

| | |
|---|---|
| `uk_gazetteer/` | The ~52k UK place names **rule #30 is built on**. `uk_gate._read()` returns an empty frozenset on a missing file — by design, so a forgotten data file degrades rather than crashes — so **no job can match a UK place**. `check_uk` falls through to source-trust and ad-text evidence, and a bare "Manchester" from a global source lands on `unverified_location_on_global_source`. |
| `job_signals/` | The seniority / workplace / location term tables behind `signal_backed_lookup` (which fills 'unknown' enrichment at read time, feeding the **dimension scores**) and `detect_seniority`. `_load_terms` returns `{}` on a missing file, so both answer nothing. |

**Neither failure raises. Neither logs.** On a developer machine the files exist and every test passes — which is why this survived. The only place it was wrong was the one place nobody could see.

## The test is derived, not hard-coded

`test_shipped_data.py` reads the exemptions out of `.gitignore` and asserts `.dockerignore` carries the same ones, so a third directory added tomorrow is covered without touching the test.

Two hand-kept copies of one intent, drifting with nobody watching, is the same shape as every other bug in this batch. The fix is to stop keeping two copies by hand.

Gate: PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6DsQH5EUxJc3Vnqz9YHgQ