### PR TITLE
feat(profile): cv_projects — the CV section used as a boundary, then discarded

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,6 +1,31 @@
 # Runtime data — never bake into the image; mount as a volume.
 data/
 
+# ...EXCEPT the data that is not runtime state but SHIPPED REFERENCE DATA.
+#
+# `.gitignore` deliberately un-ignores these same two directories, which is the
+# whole reason they are committed. This file did not mirror that, and the
+# Dockerfile is `COPY . .`, so the build threw away exactly the files someone had
+# gone to the trouble of exempting — and nothing rebuilds them at deploy time.
+# Railway volumes start empty, so no mount could supply them either.
+#
+# What that cost, silently and with no error:
+#   uk_gazetteer/  — the ~52k UK place names rule #30 is built on. Without it
+#                    `uk_gate._read()` returns an empty frozenset (it degrades
+#                    rather than raising), so no job can match a UK place and the
+#                    gate falls through to source-trust and ad-text evidence.
+#   job_signals/   — the seniority / workplace / location term tables behind
+#                    `signal_backed_lookup`, which fills 'unknown' enrichment at
+#                    read time, and `detect_seniority`. `_load_terms` returns {}
+#                    on a missing file, so those detectors quietly answer nothing.
+#
+# Both failure modes are invisible: empty data, no exception, no log line.
+# `tests/test_shipped_data.py` now pins the two ignore files together.
+!data/uk_gazetteer/
+!data/uk_gazetteer/**
+!data/job_signals/
+!data/job_signals/**
+
 # Python caches
 __pycache__/
 *.pyc

--- a/backend/src/api/models.py
+++ b/backend/src/api/models.py
@@ -213,6 +213,10 @@ class CVDetail(BaseModel):
     # never SEE their parsed experience — only a "Roles: N" count. Part of
     # the "stored but not shown" gap closed 2026-08-08.
     cv_positions: list[dict[str, Any]] = []
+    # Projects stated on the CV. A Projects heading was already used as a
+    # section boundary and then discarded — for a junior or career-changing
+    # candidate it is often the strongest evidence on the document.
+    cv_projects: list[dict[str, Any]] = []
     # Aggregated highlights for the CV viewer — merges skills + titles +
     # companies + achievements + name/headline/location for in-text highlighting
     highlights: list[str] = []

--- a/backend/src/api/routes/profile.py
+++ b/backend/src/api/routes/profile.py
@@ -141,6 +141,7 @@ def _build_profile_response(profile: UserProfile, user_id: str) -> ProfileRespon
         location=getattr(cv, "location", ""),
         achievements=getattr(cv, "achievements", []),
         cv_positions=getattr(cv, "cv_positions", []) or [],
+        cv_projects=getattr(cv, "cv_projects", []) or [],
         highlights=cv.highlights if hasattr(cv, "highlights") else cv.skills,
     )
 

--- a/backend/src/services/embeddings.py
+++ b/backend/src/services/embeddings.py
@@ -198,7 +198,9 @@ def profile_to_embedding_text(profile: Any) -> str:
                 blob = " ".join(b for b in bits if b)
                 if blob:
                     parts.append(blob)
-        for proj in getattr(cv, "linkedin_projects", []) or []:
+        for proj in list(getattr(cv, "cv_projects", []) or []) + list(
+            getattr(cv, "linkedin_projects", []) or []
+        ):
             if isinstance(proj, dict):
                 blob = f"{proj.get('title') or ''} {proj.get('description') or ''}".strip()
                 if blob:

--- a/backend/src/services/llm_matcher.py
+++ b/backend/src/services/llm_matcher.py
@@ -222,6 +222,8 @@ def profile_to_matcher_text(profile: Any) -> str:
         # NOWHERE else. Rendered as labelled rows because a judge reads
         # structure; each stays silent when the person has none (rule #29).
         for label, field, keys in (
+            ("Projects (from the CV)", "cv_projects",
+             ("name", "description", "technologies")),
             ("Recommendations (written by others)", "linkedin_recommendations",
              ("author", "relationship", "text")),
             ("Publications", "linkedin_publications", ("title", "publisher", "date")),

--- a/backend/src/services/profile/cv_parser.py
+++ b/backend/src/services/profile/cv_parser.py
@@ -54,6 +54,14 @@ Return a JSON object with exactly these fields:
       "details": ["Coursework, dissertation, projects — each as separate string"]
     }}
   ],
+  "projects": [
+    {{
+      "name": "Project name",
+      "description": "What it does and what they built, in their words",
+      "technologies": ["Each tool/framework named for THIS project"],
+      "dates": "Date range if written"
+    }}
+  ],
   "certifications": [
     "Each certification with issuer and date, as a single string"
   ],

--- a/backend/src/services/profile/models.py
+++ b/backend/src/services/profile/models.py
@@ -257,6 +257,18 @@ class CVData:
     # would make the extractor guess. Never inferred from nationality or
     # place of study — that would be discrimination dressed up as a feature.
     cv_right_to_work: str = ""
+    # Projects stated on the CV: {name, description, technologies, dates}.
+    #
+    # A Projects heading was already recognised — as a section BOUNDARY, to
+    # stop a skills block (cv_parser lines 268/322/373) — and then thrown
+    # away. Exactly the 'split it out, then drop it' shape as the seven
+    # LinkedIn sections, one input over.
+    #
+    # For a junior or career-changing candidate this is often the strongest
+    # evidence they have: the CV lists two short roles but five real builds.
+    # GitHub already contributes ``github_repos_brief`` for people who push
+    # code publicly; this is the same signal for the people who do not.
+    cv_projects: list[dict[str, Any]] = field(default_factory=list)
     # Step-1.5 S1.5-D — ESCO normalisation map populated by
     # ``cv_parser._llm_result_to_cvdata`` when ``SEMANTIC_ENABLED=true`` and
     # the ESCO index is on disk. Maps the *canonical* skill label (which

--- a/backend/src/services/profile/schemas.py
+++ b/backend/src/services/profile/schemas.py
@@ -144,6 +144,12 @@ class CVSchema(BaseModel):
     achievements: list[str] = Field(default_factory=list)
     industries: list[str] = Field(default_factory=list)
     languages: list[str] = Field(default_factory=list)
+    # A CV Projects section was recognised as a section BOUNDARY (it stops a
+    # skills block) and then discarded — the same 'split it out, then drop
+    # it' shape as the seven LinkedIn sections. For a junior or
+    # career-changing candidate, projects are often the strongest evidence
+    # they have.
+    projects: list[dict[str, Any]] = Field(default_factory=list)
 
     experience_level: Optional[str] = ""
     # TRI-STATE by design (rule #31): "" means the CV never said, which is
@@ -289,5 +295,6 @@ def cv_schema_to_cvdata(schema: CVSchema, raw_text: str) -> CVData:
         # dropped right here.
         cv_experience_level=(schema.experience_level or "").strip(),
         cv_right_to_work=(schema.right_to_work or "").strip(),
+        cv_projects=[p for p in (schema.projects or []) if isinstance(p, dict)],
         cv_skills_esco=cv_skills_esco,
     )

--- a/backend/src/services/profile/two_pass.py
+++ b/backend/src/services/profile/two_pass.py
@@ -61,7 +61,7 @@ async def _none() -> None:
     return None
 
 
-EXTRACTOR_VERSION = "5"
+EXTRACTOR_VERSION = "6"
 """Bump this whenever an LLM extraction PROMPT changes in a way that should
 re-read inputs the system has already seen.
 
@@ -93,7 +93,8 @@ Version log — 1: input-only hash (pre-2026-08-08). 2: prose-mining CV prompt.
 3: the seven LinkedIn section prompts (honors, publications, patents,
 organizations, test_scores, recommendations, interests) + the contact block.
 4: the CV ``right_to_work`` prompt field. 5: the LinkedIn ``headline``
-prompt — empty on every two-column export before it.
+prompt — empty on every two-column export before it. 6: the CV
+``projects`` prompt field.
 """
 
 
@@ -348,6 +349,10 @@ def _merge_cv_llm_into(cv: CVData, llm_cv: CVData) -> None:
     _merge_str_list(cv.achievements, llm_cv.achievements)
     _merge_str_list(cv.cv_industries, llm_cv.cv_industries)
     _merge_str_list(cv.cv_languages, llm_cv.cv_languages)
+    # Structured rows, replaced wholesale like cv_positions: a re-parse of a
+    # NEW CV must reflect that CV, not accumulate projects from an old one.
+    if llm_cv.cv_projects:
+        cv.cv_projects = list(llm_cv.cv_projects)
     # Fill empty scalars only — never overwrite a value the user already has.
     #
     # DERIVED FROM THE DATACLASS, not hand-listed. This function has now lost a

--- a/backend/tests/test_derived_shelves.py
+++ b/backend/tests/test_derived_shelves.py
@@ -1,0 +1,91 @@
+"""Two shelves are DERIVED VIEWS of other shelves. Pin them so they stay that way.
+
+The shelf audit found four duplicate pairs. Two were genuine defects and were
+fixed by deleting a copy (``skill_entry`` duplicated ``skill_tiering``;
+``industries`` was declared on both dataclasses). These two are different: they
+are stored derivations with real consumers, and they cause no wrong behaviour.
+
+    github_skills_inferred  == github_languages (by bytes) + github_topics
+    preferred_workplace     == work_arrangement, lower-cased
+
+Deleting either is the wrong trade. ``github_skills_inferred`` has genuine
+ASSIGNMENT writers (``github_enricher`` and the clear route), so making it a
+read-only property would break them — and ``two_pass`` mutates it in place, which
+a property would silently swallow. ``preferred_workplace`` is what the scoring
+dimension reads, with no frontend control of its own.
+
+So the risk worth guarding is not the duplication. It is DIVERGENCE: a derived
+field that quietly stops matching its source becomes a third, wrong truth that
+nothing can detect — the exact failure mode behind every other bug in this batch.
+These tests make divergence loud.
+"""
+from __future__ import annotations
+
+import pytest
+
+from src.services.profile.github_enricher import _infer_skills
+
+
+class TestGithubSkillsInferredIsPurelyDerived:
+    """It must hold NOTHING that ``github_languages`` + ``github_topics`` do not
+    already hold. The moment it does, it is a third source of truth and the
+    profile can disagree with itself."""
+
+    def test_it_is_exactly_languages_then_topics(self) -> None:
+        langs = {"Python": 900, "Rust": 100, "Shell": 5}
+        topics = {"machine-learning", "rag"}
+        got = _infer_skills(langs, topics)
+        assert got == ["Python", "Rust", "Shell", "machine learning", "rag"], (
+            "the derivation changed shape — anything it now adds is data that "
+            "exists in no other shelf, which makes this an independent fact "
+            "rather than a view"
+        )
+
+    def test_languages_are_ordered_by_bytes(self) -> None:
+        assert _infer_skills({"A": 1, "B": 50, "C": 10}, set())[0] == "B"
+
+    def test_it_invents_nothing_when_both_sources_are_empty(self) -> None:
+        assert _infer_skills({}, set()) == []
+
+    def test_every_entry_traces_back_to_a_source(self) -> None:
+        """The general form of the rule, not a fixed expected list: a future
+        change may reorder or reformat, but must never introduce a term that
+        neither source contains."""
+        langs = {"Python": 10, "Go": 5}
+        topics = {"data-engineering"}
+        derived = {s.lower() for s in _infer_skills(langs, topics)}
+        allowed = {k.lower() for k in langs} | {t.replace("-", " ") for t in topics}
+        assert derived <= allowed, f"invented: {sorted(derived - allowed)}"
+
+
+class TestPreferredWorkplaceMirrorsWorkArrangement:
+    """``preferred_workplace`` is the enum form of ``work_arrangement``, bridged
+    in the profile route because the scoring dimension reads the former while the
+    form writes the latter. Rule #29 makes the empty case the important one: an
+    unstated arrangement must NOT become a stated workplace preference."""
+
+    def _bridge(self, arrangement: str):
+        from src.services.profile.models import CVData, UserPreferences
+        from src.services.profile.preferences import sanitize_preferences
+
+        prefs = UserPreferences(work_arrangement=arrangement)
+        return sanitize_preferences(prefs, CVData())
+
+    @pytest.mark.parametrize("value", ["remote", "hybrid", "onsite"])
+    def test_a_stated_arrangement_agrees_with_the_workplace(self, value: str) -> None:
+        out = self._bridge(value)
+        if out.preferred_workplace is not None:
+            assert out.preferred_workplace == out.work_arrangement.lower(), (
+                "the two have diverged — the scorer and the prefilter would now "
+                "act on different answers to the same question"
+            )
+
+    def test_an_unstated_arrangement_never_becomes_a_preference(self) -> None:
+        """Rule #29 at its sharpest: silence must stay silence. A default written
+        here is indistinguishable from a choice the user made."""
+        out = self._bridge("")
+        assert not out.work_arrangement
+        assert out.preferred_workplace in (None, ""), (
+            "an empty work_arrangement produced a workplace preference — that is "
+            "a fake constraint the user never stated"
+        )

--- a/backend/tests/test_shelf_registry.py
+++ b/backend/tests/test_shelf_registry.py
@@ -170,7 +170,7 @@ class TestMatchingCoverageDoesNotRegress:
     # nine matching modules); raised to 46 by the shelf-completeness batch, which
     # wired the LinkedIn evidence sections, cv_industries, cv_languages,
     # career_domain and linkedin_summary into the judge and the vector.
-    BASELINE = 49
+    BASELINE = 50
 
     def test_matching_shelf_count_never_falls(self) -> None:
         current = sum(1 for n in shelf_names() if is_matching_shelf(n))

--- a/backend/tests/test_shipped_data.py
+++ b/backend/tests/test_shipped_data.py
@@ -1,0 +1,99 @@
+"""Data the repo deliberately COMMITS must survive the Docker build.
+
+Two ignore files describe the same intent from opposite directions, and nothing
+made them agree. `.gitignore` ignores `data/` and then un-ignores
+`backend/data/uk_gazetteer/**` and `backend/data/job_signals/**` — the exemptions
+are the reason those files are in the repository at all. `.dockerignore` ignored
+`data/` with no exemptions, and the Dockerfile is `COPY . .`, so the image was
+built without precisely the files someone had gone out of their way to commit.
+
+Nothing failed. Both loaders degrade silently by design:
+
+    uk_gate._read()          -> frozenset()  when the file is absent
+    job_signals._load_terms() -> {}           when the file is absent
+
+So the UK gate (rule #30's entire basis) and the seniority / workplace
+detectors would answer "nothing" in production, with no exception and no log
+line, while passing every test on a developer machine where the files exist.
+
+This is the same shape as every other bug in this batch: two hand-maintained
+copies of one intent, drifting apart with nobody watching. The test is therefore
+DERIVED from `.gitignore` rather than hard-coding a list of directories — a
+third exemption added tomorrow is covered automatically.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_BACKEND = Path(__file__).resolve().parent.parent
+_REPO = _BACKEND.parent
+
+
+def _negations(path: Path) -> set[str]:
+    """Un-ignore patterns (`!...`) under a data/ directory, normalised.
+
+    Both files are read into the same namespace: `.gitignore` sits at the repo
+    root and writes `backend/data/...`, `.dockerignore` sits in `backend/` and
+    writes `data/...`. Stripping the `backend/` prefix makes them comparable.
+    """
+    if not path.exists():
+        return set()
+    out: set[str] = set()
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line.startswith("!"):
+            continue
+        pattern = line[1:].strip().lstrip("/")
+        pattern = re.sub(r"^backend/", "", pattern)
+        if pattern.startswith("data/"):
+            out.add(pattern.rstrip("/").removesuffix("/**"))
+    return out
+
+
+class TestTheImageShipsWhatTheRepoCommits:
+    def test_dockerignore_exempts_everything_gitignore_exempts(self) -> None:
+        wanted = _negations(_REPO / ".gitignore")
+        assert wanted, (
+            "no data/ exemptions found in .gitignore — if the committed "
+            "reference data moved, this test needs to move with it"
+        )
+        have = _negations(_BACKEND / ".dockerignore")
+        missing = sorted(wanted - have)
+        assert not missing, (
+            "These directories are deliberately committed to the repo but "
+            f"excluded from the Docker image: {missing}. The loaders degrade "
+            "silently on a missing file, so production answers 'nothing' with "
+            "no error while every local test passes."
+        )
+
+    @pytest.mark.parametrize("rel", ["data/uk_gazetteer", "data/job_signals"])
+    def test_the_committed_data_actually_exists(self, rel: str) -> None:
+        """The exemption is worthless if the directory is empty — that would
+        look identical to the bug it prevents."""
+        d = _BACKEND / rel
+        assert d.is_dir(), f"{rel} is exempted from both ignore files but absent"
+        files = [p for p in d.iterdir() if p.is_file() and p.suffix in (".txt", "")]
+        assert files, f"{rel} exists but ships no data files"
+
+
+class TestTheLoadersStillDegradeQuietly:
+    """Pins WHY this needed a test rather than being caught at runtime: neither
+    loader raises. If someone later makes them raise, that is an improvement —
+    but it should be a deliberate change, seen here first."""
+
+    def test_uk_gate_returns_empty_rather_than_raising(self) -> None:
+        from src.services import uk_gate
+
+        # A missing data directory yields empty sets, not an error — which is
+        # exactly why an image built without them looked healthy.
+        places, foreign, ambiguous = uk_gate._gazetteer()
+        for s in (places, foreign, ambiguous):
+            assert isinstance(s, frozenset)
+
+    def test_job_signals_returns_empty_dict_for_a_missing_file(self) -> None:
+        from src.services.job_signals import _load_terms
+
+        assert _load_terms("definitely-not-a-real-file.txt") == {}

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -210,6 +210,15 @@
             "title": "Cv Positions",
             "type": "array"
           },
+          "cv_projects": {
+            "default": [],
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "title": "Cv Projects",
+            "type": "array"
+          },
           "education": {
             "default": [],
             "items": {

--- a/frontend/src/components/profile/CVViewer.tsx
+++ b/frontend/src/components/profile/CVViewer.tsx
@@ -225,6 +225,17 @@ export function CVViewer({
   // (The showFullCV toggle and its highlight terms went with the "Full CV
   // Text" panel — that text now lives only in the CV Uploaded card.)
 
+  // Projects the CV states. Defensive field reads for the same reason as
+  // cv_positions: these rows are LLM output with no strict wire schema.
+  const cvProjects = ((cv.cv_projects ?? []) as Record<string, unknown>[])
+    .map((raw) => ({
+      name: strField(raw, "name"),
+      description: strField(raw, "description"),
+      technologies: strArrField(raw, "technologies"),
+      dates: strField(raw, "dates"),
+    }))
+    .filter((p) => p.name || p.description);
+
   const positions = (cv.cv_positions ?? [])
     .map((raw) => normalizePosition(raw as Record<string, unknown>))
     .filter((p) => p.company || p.title);
@@ -539,6 +550,42 @@ export function CVViewer({
                 </li>
               ))}
             </ul>
+          </div>
+        )}
+
+        {/* Projects stated on the CV. A "Projects" heading was already
+            recognised — as a boundary that stops a skills block — and then
+            discarded. For a junior or career-changing candidate these are
+            often the strongest evidence on the document. */}
+        {cvProjects.length > 0 && (
+          <div className="mb-5">
+            <SectionLabel icon={FolderKanban} text={`Projects (${cvProjects.length})`} />
+            <div className="space-y-3 pl-5">
+              {cvProjects.map((proj, i) => (
+                <div key={i}>
+                  <div className="flex flex-wrap items-baseline gap-x-2">
+                    <span className="text-sm font-medium text-foreground">{proj.name}</span>
+                    {proj.dates && (
+                      <span className="text-xs text-muted-foreground">{proj.dates}</span>
+                    )}
+                  </div>
+                  {proj.description && (
+                    <p className="text-xs leading-relaxed text-foreground/80">
+                      {proj.description}
+                    </p>
+                  )}
+                  {proj.technologies.length > 0 && (
+                    <div className="mt-1 flex flex-wrap gap-1">
+                      {proj.technologies.map((t, j) => (
+                        <Badge key={j} variant="secondary" className="text-[10px]">
+                          {t}
+                        </Badge>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
           </div>
         )}
 

--- a/frontend/src/lib/api-types.ts
+++ b/frontend/src/lib/api-types.ts
@@ -1564,6 +1564,13 @@ export interface components {
                 [key: string]: unknown;
             }[];
             /**
+             * Cv Projects
+             * @default []
+             */
+            cv_projects: {
+                [key: string]: unknown;
+            }[];
+            /**
              * Education
              * @default []
              */


### PR DESCRIPTION
A "Projects" heading was **already recognised** by the CV parser — three times, at `cv_parser` lines 268/322/373 — but only as a section **boundary**, something that stops a skills block. The content under it was never extracted.

Same "split it out so it delimits its neighbours, then drop it" shape as the seven LinkedIn sections, one input over.

For a junior or career-changing candidate this is often the strongest evidence on the document: two short roles listed above, five real builds below. GitHub already contributes `github_repos_brief` for people who push code publicly — this is the same signal for the people who don't.

Wired end to end in **one** commit, because a shelf that lands in only some of these places is the exact failure this batch has spent the day unpicking:

```
prompt → CVSchema → adapter → two_pass merge → judge → embedding → API → UI
```

`EXTRACTOR_VERSION` 5 → 6. Matching shelves 49 → 50, ratchet raised.

## Also: the last two duplicate shelves, governed rather than deleted

```
github_skills_inferred == github_languages (by bytes) + github_topics
preferred_workplace    == work_arrangement, lower-cased
```

Deleting either is the wrong trade. `github_skills_inferred` has real **assignment** writers (`github_enricher`, the clear route) and `two_pass` mutates it in place — a read-only property would break the first and silently swallow the second. `preferred_workplace` is what the scoring dimension reads and has no frontend control of its own.

The risk worth guarding was never the duplication; it's **divergence**. A derived field that quietly stops matching its source becomes a third, wrong truth that nothing can detect — the shape of every bug in this batch. So `test_derived_shelves.py` pins each derivation, including the rule-#29 case that an unstated `work_arrangement` must never become a stated workplace preference.

Gate: PASS — 279 backend targeted, 253 frontend, api-types drift clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6DsQH5EUxJc3Vnqz9YHgQ
