### PR TITLE
fix(backup): the nightly dump has been thrown away for 4 nights — verify container lacks pgvector

### DIFF
--- a/.github/workflows/db-backup.yml
+++ b/.github/workflows/db-backup.yml
@@ -26,8 +26,23 @@ jobs:
     timeout-minutes: 20
     services:
       # Throwaway Postgres used ONLY to restore-verify tonight's dump.
+      #
+      # MUST carry pgvector, not stock postgres. Prod enabled the `vector`
+      # extension on 2026-08-07 (migration 0027, PR #244 — prod runs pgvector
+      # 0.8.3 on server 18.4, verified live 2026-08-11), so pg_dump now emits
+      # `CREATE EXTENSION IF NOT EXISTS vector` near the top of every dump.
+      # Against stock `postgres:18` that line dies with
+      #   psql:dump.sql:26: ERROR: extension "vector" is not available
+      # and `-v ON_ERROR_STOP=1` aborts the restore. That failure SKIPS the
+      # encrypt + upload steps, so four consecutive nights (2026-08-08 ->
+      # 2026-08-11, runs 31237821860/31293351679/31354509976/31456829224)
+      # pushed NOTHING to R2 while the dump itself was healthy (~23 MB).
+      # The dump was never the problem — the verifier was.
+      #
+      # PR #244 moved ci.yml + ci-offline.yml to the pgvector image but missed
+      # this workflow. Keep the major version matched to Railway's Postgres 18.
       verify_db:
-        image: postgres:18
+        image: pgvector/pgvector:pg18
         env:
           POSTGRES_USER: verify
           POSTGRES_PASSWORD: verify


### PR DESCRIPTION
**Your production database has not been backed up since 2026-08-07.** Four consecutive nights failed. The last usable backup is 4 days stale — and it predates migration 0027, so it contains no embeddings.

## The dump was never broken

That is the part worth reading. Every failed run dumped prod **successfully** (19–23 MB, size guard passed). The step that dies is VERIFY:

```
Dump prod database ....................... success   (23,802,066 bytes)
VERIFY — restore into a throwaway DB ..... FAILURE
    psql:dump.sql:26: ERROR: extension "vector" is not available
Encrypt .................................. skipped
Upload to Cloudflare R2 .................. skipped   <-- a healthy backup, discarded
Prune R2 ................................. skipped
```

Migration 0027 (PR #244, merged 2026-08-07) enabled pgvector in prod, so `pg_dump` now emits `CREATE EXTENSION IF NOT EXISTS vector` at line 26 of every dump. The verify service ran stock `postgres:18`, which has no pgvector, and `-v ON_ERROR_STOP=1` aborts the whole restore on that one line.

**#244 updated `ci.yml` and `ci-offline.yml` to `pgvector/pgvector` and missed `db-backup.yml`.** One-line fix: `postgres:18` -> `pgvector/pgvector:pg18`.

## Why pg18 and not pg16

Read from live prod (read-only):
```
EXTENSIONS: [(plpgsql, 1.0), (vector, 0.8.3)]      <- vector is the ONLY non-default one
SERVER:     18.4 (Debian 18.4-1.pgdg13+1)          <- so pg18 is the matching tag
USERS: 11   MIGRATIONS: 31                         <- the workflow assertions were always fine
```

So this is not case (a) a missing secret — the dump step, the only consumer of `PROD_DATABASE_URL`, succeeds every run — and not case (c) a wrong assertion. It is a broken image.

## What you need to do

1. **Merge this** (merging = a production release).
2. **Run `db-backup.yml` from the Actions tab immediately** — do not wait for 02:17 UTC. That closes the 4-day gap, and on green the notify job auto-closes #259. Watch that the restore clears line 26 and reaches Upload — that is the real proof, which could not be produced locally (Docker was down).

## Unrelated, found on the way

`journey.yml` is **also red, 5 nights running**, for a completely different reason: `##[error]JOURNEY_API is not set`. That one IS a missing secret and needs your hand. Not covered by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G7mLsrkujpTyUhwMTn7itb