### PR TITLE
fix(ci): 9 authed corners of the live site were reported OK while the browser sat on /login

### DIFF
--- a/.github/workflows/accuracy-audit.yml
+++ b/.github/workflows/accuracy-audit.yml
@@ -46,6 +46,9 @@ jobs:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           CEREBRAS_API_KEY: ${{ secrets.CEREBRAS_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          # GROQ is the 4th provider the judge chain will try (llm_provider.py) and
+          # was the only one this job never passed through. One more free fallback.
+          GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
           SESSION_SECRET: audit-only-not-used-0000000000000000
           CHANNEL_ENCRYPTION_KEY: sk9vWl9wZmMtc2VjcmV0LWtleS0zMzMzMzMzMzM=
         run: |
@@ -53,32 +56,77 @@ jobs:
           python scripts/eval_ranking.py 2>&1 | tee audit.out
           echo "rc=$?" >> "$GITHUB_OUTPUT"
         continue-on-error: true
-      - name: Notify on regression (or auto-close when healthy)
+      # TWO DIFFERENT ALARMS, because they have two different fixes.
+      #
+      #   "REGRESSED"        -> we measured the ranking and the number is bad. Engineering work.
+      #   "CANNOT RUN"       -> we measured NOTHING. Config work (usually a missing secret).
+      #
+      # They shared one title until 2026-08-11, so runs 31107748440 and 31368793516 —
+      # where all 160 judge calls died on "No LLM API key configured", because an
+      # unset Actions secret renders as an EMPTY string — were filed as an accuracy
+      # regression (issue #238). A config error wearing a quality-regression costume
+      # is how a week of eval data gets misread.
+      - name: Notify (config failure and accuracy regression are DIFFERENT alarms)
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          title="Accuracy audit REGRESSED (weekly ranking eval)"
-          num=$(gh issue list --state open --json number,title \
-                  --jq ".[] | select(.title==\"$title\") | .number" | head -1)
-          if [ "${{ steps.audit.outcome }}" = "failure" ] || \
-             grep -q "REGRESSED" backend/audit.out; then
+          set -uo pipefail
+          REG_TITLE="Accuracy audit REGRESSED (weekly ranking eval)"
+          BROKEN_TITLE="Accuracy audit CANNOT RUN (instrument broken, not a regression)"
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+          find_issue() {
+            gh issue list --state open --json number,title \
+              --jq ".[] | select(.title==\"$1\") | .number" | head -1
+          }
+          raise() { # $1 = title, $2 = body file
+            n=$(find_issue "$1")
+            if [ -z "$n" ]; then
+              new=$(gh issue create --title "$1" --body-file "$2" --label harness)
+              n="${new##*/}"
+              gh workflow run triage.yml -f issue="$n" \
+                || echo "::warning::issue #$n raised but triage could not be woken"
+            else
+              gh issue comment "$n" --body-file "$2"
+            fi
+          }
+          close_if_open() { # $1 = title, $2 = closing comment
+            n=$(find_issue "$1")
+            if [ -n "$n" ]; then gh issue close "$n" --comment "$2"; fi
+          }
+
+          if grep -q "INSTRUMENT BROKEN" backend/audit.out; then
+            { echo "**The weekly ranking audit measured NOTHING — the instrument is broken.**"
+              echo
+              echo "This is a CONFIG failure. Do **not** read it as a ranking regression:"
+              echo "no accuracy number was produced at all."
+              echo
+              echo '```'
+              { grep -E "INSTRUMENT BROKEN|ERROR:" backend/audit.out || tail -20 backend/audit.out; } | head -8 || true
+              echo '```'
+              echo
+              echo "Usual cause: an unset repo Actions secret renders as an EMPTY string, so"
+              echo "the judge gets no key. Set ONE of \`OPENAI_API_KEY\` (recommended),"
+              echo "\`GEMINI_API_KEY\`, \`GROQ_API_KEY\`, \`CEREBRAS_API_KEY\` and re-run"
+              echo "(\`gh workflow run accuracy-audit.yml\`) — no code change is needed."
+              echo
+              echo "- Run: $RUN_URL"
+              echo "- Instrument: backend/scripts/eval_ranking.py (exit 3 = broken, exit 2 = regressed)"
+            } > body.md
+            raise "$BROKEN_TITLE" body.md
+          elif [ "${{ steps.audit.outcome }}" = "failure" ] || \
+               grep -q "REGRESSED" backend/audit.out; then
             { echo "The weekly ground-truth ranking audit fell below its alarm floors."
               echo
               echo '```'
               grep -A 12 "ACCURACY SCOREBOARD" backend/audit.out || tail -20 backend/audit.out
               echo '```'
               echo
-              echo "- Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+              echo "- Run: $RUN_URL"
               echo "- Instrument: backend/scripts/eval_ranking.py (floors: EVAL_MIN_STRONG_100, EVAL_MAX_GEMS)"
             } > body.md
-            if [ -z "$num" ]; then
-              new=$(gh issue create --title "$title" --body-file body.md --label harness)
-              n="${new##*/}"
-              gh workflow run triage.yml -f issue="$n" \
-                || echo "::warning::issue #$n raised but triage could not be woken"
-            else
-              gh issue comment "$num" --body-file body.md
-            fi
-          elif [ -n "$num" ]; then
-            gh issue close "$num" --comment "Accuracy back within benchmark as of run ${{ github.run_id }}. (auto-close)"
+            raise "$REG_TITLE" body.md
+          else
+            close_if_open "$REG_TITLE" "Accuracy back within benchmark as of run $RUN_URL. (auto-close)"
+            close_if_open "$BROKEN_TITLE" "The instrument ran and produced judgments again as of run $RUN_URL. (auto-close)"
           fi

--- a/backend/scripts/eval_ranking.py
+++ b/backend/scripts/eval_ranking.py
@@ -42,9 +42,45 @@ STRONG = 65
 GOOD = 50
 GEM = 70
 
+# A BROKEN INSTRUMENT IS NOT A BAD MEASUREMENT.
+#
+# 2026-08-06 (run 31107748440) and again 2026-08-10 (run 31368793516): all 160
+# judge calls failed instantly with "No LLM API key configured" — GitHub renders
+# an unset secret as an EMPTY string, so the workflow handed the judge nothing
+# and every call raised. The script said only "audit produced no judgments" and
+# the notifier filed it under "Accuracy audit REGRESSED". That headline is a lie
+# with a real cost: a missing key wearing the costume of a quality regression is
+# how a week of eval data gets misread and a real regression gets ignored.
+#
+# So config failure gets its OWN marker, its OWN exit code (3), and its own
+# alarm in accuracy-audit.yml. Exit 2 stays reserved for "we measured, and the
+# number is bad".
+LLM_KEY_VARS = ("OPENAI_API_KEY", "GEMINI_API_KEY", "GROQ_API_KEY", "CEREBRAS_API_KEY")
+INSTRUMENT_BROKEN = "INSTRUMENT BROKEN"
+RC_BROKEN = 3
+RC_REGRESSED = 2
+
+
+def _missing_llm_key() -> bool:
+    """True when NOT ONE provider key is set — the judge cannot make a single call."""
+    return not any(os.environ.get(v) for v in LLM_KEY_VARS)
+
 
 async def main(user_id: str | None, top_n: int, buried_n: int) -> int:
     import psycopg
+
+    # Preflight: fail LOUDLY and CHEAPLY. Without this the script opens a prod DB
+    # connection, samples 160 rows and burns a minute to discover the same thing.
+    if _missing_llm_key():
+        print(
+            f"{INSTRUMENT_BROKEN}: no LLM API key in the environment — "
+            f"{', '.join(LLM_KEY_VARS)} are ALL empty, so the judge cannot make a "
+            "single call. This is a CONFIG failure, NOT an accuracy regression: "
+            "nothing was measured. In GitHub Actions an unset secret renders as an "
+            "empty string, so set one of these as a repo Actions secret and re-run.",
+            flush=True,
+        )
+        return RC_BROKEN
 
     from src.models import Job
     from src.services.llm_matcher import match_job, profile_to_matcher_text
@@ -114,7 +150,9 @@ async def main(user_id: str | None, top_n: int, buried_n: int) -> int:
                 return {"bucket": bucket, "id": r[0], "title": r[1],
                         "kw": r[7], "fit": v.fit_score}
             except Exception as e:  # noqa: BLE001 — one failure must not kill the audit
-                return {"bucket": bucket, "id": r[0], "title": r[1], "error": str(e)[:80]}
+                # 300, not 80: the 2026-08-10 run truncated the one line that mattered
+                # mid-word ("...or a free tier GEMI"), so the alarm could not name the key.
+                return {"bucket": bucket, "id": r[0], "title": r[1], "error": str(e)[:300]}
 
     for i in range(0, len(work), 30):
         chunk = work[i:i + 30]
@@ -123,6 +161,7 @@ async def main(user_id: str | None, top_n: int, buried_n: int) -> int:
 
     ok = [r for r in results if "fit" in r]
     errs = [r for r in results if "error" in r]
+    distinct: list[str] = []
     if errs:
         # Drill finding (2026-08-06, run 31107748440): 160/160 judge calls
         # failed INSTANTLY and the script said only "no judgments" — the
@@ -135,8 +174,18 @@ async def main(user_id: str | None, top_n: int, buried_n: int) -> int:
     top_ok = [r for r in ok if r["bucket"] == "top"]
     buried_ok = [r for r in ok if r["bucket"] == "buried"]
     if not top_ok:
+        # EVERY call failed → the judge never worked. Name that as an instrument
+        # fault so the notifier does not dress a config error up as a regression.
+        # (A key set but rate-limited/revoked lands here too — also config, not ranking.)
+        if errs and len(errs) == len(results):
+            cause = distinct[0] if distinct else "unknown"
+            print(
+                f"{INSTRUMENT_BROKEN}: all {len(errs)} judge calls failed — first cause: "
+                f"{cause} | NOTHING WAS MEASURED, so this is NOT a ranking regression."
+            )
+            return RC_BROKEN
         print("audit produced no judgments — treating as failure")
-        return 2
+        return RC_REGRESSED
 
     strong100 = round(100 * sum(1 for r in top_ok if r["fit"] >= STRONG) / len(top_ok))
     good100 = round(100 * sum(1 for r in top_ok if r["fit"] >= GOOD) / len(top_ok))
@@ -155,7 +204,7 @@ async def main(user_id: str | None, top_n: int, buried_n: int) -> int:
 
     failed = strong100 < MIN_STRONG_100 or len(gems) > MAX_GEMS
     print(f"\nverdict: {'REGRESSED — investigate' if failed else 'within benchmark'}")
-    return 2 if failed else 0
+    return RC_REGRESSED if failed else 0
 
 
 if __name__ == "__main__":

--- a/frontend/tests/synthetic/live-smoke.mjs
+++ b/frontend/tests/synthetic/live-smoke.mjs
@@ -110,6 +110,30 @@ async function gotoOK(p) {
   if (!r || r.status() >= 400) throw new Error(`GET ${p} → HTTP ${r ? r.status() : "no response"}`);
   await page.waitForTimeout(1200);
 }
+
+// AN HTTP 200 IS NOT PROOF YOU ARE LOGGED IN.
+//
+// 2026-08-09 → 2026-08-11: the synthetic session cookie went stale. `middleware.ts`
+// did exactly the right thing — it 307'd every protected path to
+// `/login?next=…` — and because a redirect lands on a page that returns 200,
+// `gotoOK` was happy. NINE authed corners reported OK for three days while the
+// robot was staring at the sign-in card (proof: run 31492026104, the
+// FAIL-profile screenshot is the login page, and report.json logs a 401).
+// Only the ONE corner that asserted something specific went red, and it went red
+// for an unrelated reason — so the alarm named the wrong thing.
+//
+// Rule: an authed corner must prove it is still authed. Landing on /login is a
+// FAILURE, never a pass.
+async function gotoAuthed(p) {
+  await gotoOK(p);
+  const landed = new URL(page.url()).pathname;
+  if (landed.startsWith("/login") || landed.startsWith("/register")) {
+    throw new Error(
+      `bounced to ${landed} — the walk is NOT authenticated, so nothing past this ` +
+      `point tests the logged-in app. Refresh the SMOKE_SESSION secret.`,
+    );
+  }
+}
 const seeText = (re, timeout = 15000) => page.getByText(re).first().waitFor({ state: "visible", timeout });
 
 console.log(`\n=== LIVE SMOKE vs ${FE} ${SESSION ? "(authed)" : "(public only — no SMOKE_SESSION)"} ===`);
@@ -159,10 +183,10 @@ async function scanPoison(where) {
 }
 
 const AUTHED = [
-  ["dashboard loads", async () => { await gotoOK("/dashboard"); await page.waitForTimeout(2500); }],
+  ["dashboard loads", async () => { await gotoAuthed("/dashboard"); await page.waitForTimeout(2500); }],
 
   ["dashboard renders no impossible text", async () => {
-    await gotoOK("/dashboard");
+    await gotoAuthed("/dashboard");
     await page.waitForTimeout(2500);
     await scanPoison("dashboard");
   }],
@@ -177,7 +201,7 @@ const AUTHED = [
     // limit=100. So the screen contradicted itself while every backend check
     // passed. No SQL invariant can ever catch this shape; only reading the
     // rendered page can.
-    await gotoOK("/dashboard");
+    await gotoAuthed("/dashboard");
     await page.waitForTimeout(2500);
     const text = await page.evaluate(() => document.body.innerText || "");
 
@@ -201,11 +225,18 @@ const AUTHED = [
   }],
 
   [ALLOW_WRITES ? "profile + CV upload → extraction" : "profile page renders (read-only)", async () => {
-    await gotoOK("/profile");
+    await gotoAuthed("/profile");
     if (!ALLOW_WRITES) {
       // READ-ONLY: just prove the profile page renders. No upload → no profile overwrite,
       // no LLM call. Safe to point at a real user's account.
-      await page.locator("input, button").first().waitFor({ state: "visible", timeout: 15000 });
+      //
+      // `:visible` is load-bearing. `locator("input, button").first()` picks the first
+      // match in DOM ORDER, and the first button in the header is the mobile-nav
+      // sheet-trigger — permanently hidden at this 1440px viewport. The locator then
+      // waits 15s for an element that can never be visible, so the corner failed even
+      // on a perfectly healthy page. Filtering in the selector makes `.first()` mean
+      // "the first control a human can actually see".
+      await page.locator("input:visible, button:visible").first().waitFor({ state: "visible", timeout: 15000 });
       return;
     }
     // MUTATING (opt-in, synthetic accounts only): upload a sample CV and wait for extraction.
@@ -216,15 +247,47 @@ const AUTHED = [
     // extraction is a real LLM call on prod — wait, then assert a skill from the sample CV shows up
     await page.getByText(/python|airflow|data engineer/i).first().waitFor({ timeout: 90000 });
   }],
-  ["jobs / search", async () => { await gotoOK("/jobs"); await page.waitForTimeout(2500); }],
-  ["pipeline (kanban)", async () => { await gotoOK("/pipeline"); await page.waitForTimeout(1500); }],
-  ["channels", async () => { await gotoOK("/channels"); await page.waitForTimeout(1500); }],
-  ["settings", async () => { await gotoOK("/settings"); await page.waitForTimeout(1500); }],
-  ["notifications", async () => { await gotoOK("/notifications"); await page.waitForTimeout(1500); }],
+  ["jobs / search", async () => { await gotoAuthed("/jobs"); await page.waitForTimeout(2500); }],
+  ["pipeline (kanban)", async () => { await gotoAuthed("/pipeline"); await page.waitForTimeout(1500); }],
+  ["channels", async () => { await gotoAuthed("/channels"); await page.waitForTimeout(1500); }],
+  ["settings", async () => { await gotoAuthed("/settings"); await page.waitForTimeout(1500); }],
+  ["notifications", async () => { await gotoAuthed("/notifications"); await page.waitForTimeout(1500); }],
 ];
 
+// ── The session gate ────────────────────────────────────────────────────────
+// Ask the backend whether SMOKE_SESSION is still a real session BEFORE walking
+// nine authed corners with it. A dead cookie is a CONFIG problem with a one-line
+// fix (refresh the secret); letting it leak into the corners turns it into nine
+// misleading results and buries the actual cause. One honest red beats a puzzle.
+async function sessionIsLive() {
+  try {
+    const r = await fetch(`${BE}/api/auth/me`, {
+      headers: { Cookie: `job360_session=${SESSION}` },
+    });
+    return { ok: r.ok, status: r.status };
+  } catch (e) {
+    return { ok: false, status: `unreachable (${String(e && e.message ? e.message : e).slice(0, 80)})` };
+  }
+}
+
 if (SESSION) {
-  for (const [name, fn] of AUTHED) await corner(name, fn);
+  const gate = await sessionIsLive();
+  if (gate.ok) {
+    for (const [name, fn] of AUTHED) await corner(name, fn);
+  } else {
+    const reason =
+      `SMOKE_SESSION is not a valid session — GET ${BE}/api/auth/me returned ${gate.status}. ` +
+      `The cookie is set but dead (expired or revoked), so every protected page would ` +
+      `redirect to /login and each corner would "pass" against the sign-in card. ` +
+      `FIX: log in as the synthetic account, copy its fresh job360_session cookie, and ` +
+      `update the SMOKE_SESSION repo secret. This is NOT a production outage.`;
+    results.push({ corner: "synthetic session is valid (SMOKE_SESSION)", ok: false, reason });
+    console.log(`  FAIL  synthetic session is valid (SMOKE_SESSION) — ${reason}`);
+    for (const [name] of AUTHED) {
+      results.push({ corner: name, ok: null, reason: "BLOCKED — SMOKE_SESSION is dead; not walked (a pass here would be a lie)" });
+      console.log(`  SKIP  ${name} — blocked by a dead SMOKE_SESSION`);
+    }
+  }
 } else {
   for (const [name] of AUTHED) {
     results.push({ corner: name, ok: null, reason: "SKIPPED — set SMOKE_SESSION (a verified synthetic account cookie) to walk authed corners" });


### PR DESCRIPTION
Issues #287 and #238. Both are alarms that lied.

## #287 — the smoke test was measuring the login page

The `SMOKE_SESSION` cookie is dead. `middleware.ts:70-77` verifies it against `/api/auth/me`, gets 401, and 307s every protected path to `/login?next=...`.

```
gotoOK() checks ONLY the status code
   redirect -> /login -> HTTP 200 -> "OK"

   9 authed corners reported OK for 3 days, looking at a sign-in card
```

The single RED corner ("profile page renders") was red for an **unrelated** reason: `page.locator("input, button").first()` picks the first match in DOM order — the Navbar mobile sheet-trigger (`Navbar.tsx:103-104`, `className="md:hidden"`), permanently hidden at 1440px. It waited 15 s for an element that can never be visible.

Net effect: the alarm said *"the profile page is broken"* when the truth was *"the test's cookie expired"* — and the 9 corners that were genuinely untested stayed green.

**Fixed:** a session gate that verifies `SMOKE_SESSION` against `/api/auth/me` BEFORE the authed walk. A dead cookie now produces ONE named failure that says exactly how to fix it, and the 9 authed corners are recorded **BLOCKED (ok:null)** — never OK. New `gotoAuthed()` treats landing on `/login` or `/register` as a failure, not a pass.

## #238 — a missing key wearing a quality regression's clothes

`audit produced no judgments — treating as failure` is the signature of an LLM call returning nothing. The judge raises `RuntimeError("No LLM API key configured...")` at `llm_provider.py:262-266`, which fires only when OPENAI / GEMINI / GROQ / CEREBRAS are ALL empty — and an unset GitHub Actions secret renders as empty.

So a **missing secret** was reported as an **accuracy regression** for a week. Fixed the half that is code: the job now fails loudly with "missing API key" instead of the silent "no judgments".

## What you need to do — two secrets, neither is code

1. **`SMOKE_SESSION`** — log in to job360.uk as the synthetic/throwaway account, copy its fresh `job360_session` cookie, `gh secret set SMOKE_SESSION`. Until then synthetic-live stays red *correctly, and now with an honest reason*. **Do not point it at a real user's account.**
2. **A judge key** — `gh secret set OPENAI_API_KEY` (recommended) or GEMINI/GROQ/CEREBRAS.

Production was not touched: read-only curl, `gh`, and artifact downloads only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G7mLsrkujpTyUhwMTn7itb