### PR TITLE
fix(journey-audit): #198 is a false alarm — the detector named the wrong stage

### DIFF
--- a/.github/workflows/user-journey.yml
+++ b/.github/workflows/user-journey.yml
@@ -15,6 +15,13 @@ name: User journey (walk every user, find where it breaks for them)
 #   both real users have 130-152 extracted skills          -> over-extraction
 # Aggregate checks said the product was fine. It was fine on average.
 #
+# CORRECTION 2026-08-11 (issue #198): the 7edd5b59 line above was WRONG, and it
+# re-fired here every morning for nine days. That account never confirmed its
+# email, and search - the only thing that fills a feed - is gated on that. No
+# feed bug existed. The audit now says "email-not-confirmed" instead. Keep this
+# note: a detector that names the wrong stage is more expensive than one that
+# says nothing, because every reader goes hunting a bug that is not there.
+#
 # WHAT IT DOES: walks each user down the real pipeline —
 #   signup -> profile -> extraction -> search keywords -> feed -> scoring
 #          -> visible on the dashboard

--- a/backend/tests/test_user_journey_audit.py
+++ b/backend/tests/test_user_journey_audit.py
@@ -1,0 +1,152 @@
+"""Tests for scripts/user_journey_audit.py — the per-user pipeline walker.
+
+WHY THESE EXIST. Issue #198 ran for 9 straight days saying user `7edd5b59`
+was "BROKEN at feed - only 0 jobs reached this user". The feed writer was
+never at fault. That account never confirmed its email, and `POST /api/search`
+is gated on a confirmed email (`src/api/routes/search.py:177` ->
+`auth_deps.require_verified_user`, `src/api/auth_deps.py:105-128`). The feed is
+only ever written by a search or by a profile-change re-score, so an unconfirmed
+account CANNOT have feed rows. Calling that "broken at feed" points the reader
+at a bug that does not exist.
+
+No DB, no HTTP — the audit's stage logic is pure given a fake cursor.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+# The audit lives at the REPO ROOT (scripts/), not backend/scripts/, so it is
+# not importable by name from here. Load it by path — module-level imports are
+# stdlib only (psycopg is imported inside main()), so this is offline-safe.
+_AUDIT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "user_journey_audit.py"
+
+
+def _load_audit() -> Any:
+    spec = importlib.util.spec_from_file_location("_user_journey_audit", _AUDIT_PATH)
+    assert spec and spec.loader, f"cannot load {_AUDIT_PATH}"
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def audit() -> Any:
+    return _load_audit()
+
+
+class FakeCursor:
+    """Answers the audit's queries from a dict, in the order it asks them.
+
+    The audit only ever runs two shapes: a scalar `SELECT count(...)`/`max(...)`
+    and the one `SELECT cv_data, preferences` row. Dispatch on the SQL text.
+    """
+
+    def __init__(self, *, cv: dict, prefs: dict, counts: dict[str, int]) -> None:
+        self._cv = cv
+        self._prefs = prefs
+        self._counts = counts
+        self._result: tuple = ()
+
+    def execute(self, sql: str, params: tuple = ()) -> None:
+        s = " ".join(sql.split())
+        if "cv_data, preferences" in s:
+            self._result = (json.dumps(self._cv), json.dumps(self._prefs))
+        elif "FROM user_profiles" in s:
+            self._result = (self._counts.get("profile_rows", 0),)
+        elif "score >=" in s:
+            self._result = (self._counts.get("visible", 0),)
+        elif "llm_fit_score" in s:
+            self._result = (self._counts.get("llm_verdicts", 0),)
+        elif "count(DISTINCT score)" in s:
+            self._result = (self._counts.get("distinct_scores", 0),)
+        elif "max(score)" in s:
+            self._result = (self._counts.get("max_score", 0),)
+        elif "FROM user_feed" in s:
+            self._result = (self._counts.get("feed_rows", 0),)
+        else:  # pragma: no cover — a new query shape must not pass silently
+            raise AssertionError(f"unexpected query: {s}")
+
+    def fetchone(self) -> tuple:
+        return self._result
+
+
+FULL_CV = {"raw_text": "x" * 5000, "skills": ["a"] * 142, "job_titles": ["t1", "t2"]}
+FULL_PREFS = {"target_job_titles": ["t1", "t2"], "additional_skills": ["a"] * 142}
+
+
+def _cursor(feed_rows: int = 0, **counts: int) -> FakeCursor:
+    base = {"profile_rows": 1, "feed_rows": feed_rows}
+    base.update(counts)
+    return FakeCursor(cv=FULL_CV, prefs=FULL_PREFS, counts=base)
+
+
+class TestUnconfirmedEmail:
+    """The live #198 case: full profile, zero feed, email never confirmed."""
+
+    def test_unconfirmed_user_is_not_reported_broken(self, audit: Any) -> None:
+        stage, verdict, facts = audit.audit_user(
+            _cursor(feed_rows=0), "7edd5b59", "j@example.com", verified=False
+        )
+        assert verdict == "not-started", (
+            "an account that never confirmed its email cannot reach the feed by "
+            "design — calling it BROKEN sends the reader hunting a feed bug"
+        )
+        assert stage == "email-not-confirmed"
+        assert facts["email_confirmed"] is False
+
+    def test_unconfirmed_user_is_still_visible_not_swallowed(self, audit: Any) -> None:
+        """Silently dropping them would hide a real signup-funnel leak."""
+        _stage, _verdict, facts = audit.audit_user(
+            _cursor(feed_rows=0), "7edd5b59", "j@example.com", verified=False
+        )
+        # the profile facts are still gathered, so the report can say what they
+        # DID give us before they stalled at the door
+        assert facts["skills"] == 142
+        assert facts["cv_chars"] == 5000
+
+    def test_no_profile_still_reads_as_signup(self, audit: Any) -> None:
+        cur = FakeCursor(cv={}, prefs={}, counts={"profile_rows": 0})
+        stage, verdict, _f = audit.audit_user(cur, "d5a1b8c2", "d@example.com", verified=False)
+        assert (stage, verdict) == ("signup", "not-started")
+
+
+class TestConfirmedEmailStillDetectsRealBreaks:
+    """The fix must not blind the audit for people who DID confirm."""
+
+    def test_confirmed_user_with_empty_feed_is_broken(self, audit: Any) -> None:
+        stage, verdict, _f = audit.audit_user(
+            _cursor(feed_rows=0), "ad13c75d", "r@gmail.com", verified=True
+        )
+        assert (stage, verdict) == ("feed", "broken")
+
+    def test_confirmed_user_with_flat_scores_is_broken_at_scoring(self, audit: Any) -> None:
+        stage, verdict, _f = audit.audit_user(
+            _cursor(feed_rows=500, max_score=0, distinct_scores=1),
+            "ad13c75d",
+            "r@gmail.com",
+            verified=True,
+        )
+        assert (stage, verdict) == ("scoring", "broken")
+
+    def test_healthy_confirmed_user_completes(self, audit: Any) -> None:
+        stage, verdict, facts = audit.audit_user(
+            _cursor(
+                feed_rows=7300,
+                max_score=92,
+                distinct_scores=60,
+                visible=7300,
+                llm_verdicts=158,
+            ),
+            "ad13c75d",
+            "r@gmail.com",
+            verified=True,
+        )
+        assert (stage, verdict) == ("complete", "ok")
+        assert facts["visible_pct"] == 100

--- a/scripts/user_journey_audit.py
+++ b/scripts/user_journey_audit.py
@@ -12,6 +12,16 @@ person. Found live 2026-08-03 by the first run of this script:
 Neither throws an error. Neither fails a test. Both are somebody's product
 being quietly useless.
 
+CORRECTION (2026-08-11, issue #198). The 7edd5b59 finding above was a
+MISDIAGNOSIS, and it re-fired every morning for nine days. That account never
+confirmed its email; `POST /api/search` is gated on that, and `user_feed` is
+only ever written by a search or a profile-change re-score — so it could not
+have feed rows, and nothing was broken. Traced in prod: zero `run_log` rows for
+it, and its single profile write (11:53) predates the first job in the catalog
+(18:46) by seven hours. STAGE 1b below is the fix. The lesson is not "be less
+sensitive": it is that a detector naming the WRONG stage costs more than one
+that stays quiet, because everyone who reads it hunts a bug that isn't there.
+
 THE IDEA: the pipeline is a chain of stages. For each user, walk the chain and
 report the FIRST stage that broke. That turns "the product feels off" into
 "extraction works for this user, search config is empty, so the feed is empty" —
@@ -49,12 +59,14 @@ def mask(email: str | None) -> str:
     return f"{email[0]}***@{email.split('@')[-1]}"
 
 
-def audit_user(cur, uid, email) -> tuple[str, str, dict]:
+def audit_user(cur, uid, email, verified=True) -> tuple[str, str, dict]:
     """Return (stage_reached, verdict, facts) for one user.
 
     verdict is 'ok', 'broken', or 'not-started'.
+
+    ``verified`` is ``users.email_verified_at IS NOT NULL``. See STAGE 1b.
     """
-    f: dict = {}
+    f: dict = {"email_confirmed": bool(verified)}
 
     def one(q, default=0):
         cur.execute(q, (uid,))
@@ -79,6 +91,28 @@ def audit_user(cur, uid, email) -> tuple[str, str, dict]:
     f["extra_skills"] = len(pref.get("additional_skills") or [])
     f["has_linkedin"] = bool(cv.get("linkedin_raw_text"))
     f["has_github"] = bool(cv.get("github_repos_brief"))
+
+    # STAGE 1b — the product's own front door.
+    #
+    # `POST /api/search` is gated on a confirmed email (api/routes/search.py:177
+    # -> auth_deps.require_verified_user), and `user_feed` is ONLY ever written
+    # by a search or by a profile-change re-score. So an account that never
+    # confirmed its email cannot have feed rows — not because anything broke,
+    # but because it never got through the door.
+    #
+    # This cost 9 days. Issue #198 reported user 7edd5b59 "BROKEN at feed -
+    # only 0 jobs reached this user" every morning from 2026-08-03. Verified
+    # against prod 2026-08-11: that account confirmed no email, ran no search
+    # (`run_log` has zero rows for it), and its single profile write at
+    # 11:53:40 predates the FIRST job in the catalog (18:46) by seven hours.
+    # There was no feed bug. A detector that names the wrong stage sends every
+    # reader after a bug that does not exist, which is worse than silence.
+    #
+    # Not swallowed: these users are reported in their own section, because a
+    # signup funnel leaking at email confirmation is worth knowing about. It is
+    # just not an alarm — nothing is broken to fix.
+    if not verified:
+        return "email-not-confirmed", "not-started", f
 
     # STAGE 2 — extraction. Input went in; did anything come out?
     if f["cv_chars"] and f["skills"] < MIN_SKILLS:
@@ -137,9 +171,15 @@ def main() -> int:
 
     try:
         with psycopg.connect(dsn, connect_timeout=25) as conn, conn.cursor() as cur:
-            cur.execute("SELECT id, email FROM users ORDER BY created_at")
+            cur.execute(
+                "SELECT id, email, email_verified_at IS NOT NULL "
+                "FROM users ORDER BY created_at"
+            )
             users = cur.fetchall()
-            results = [(uid, email, *audit_user(cur, uid, email)) for uid, email in users]
+            results = [
+                (uid, email, *audit_user(cur, uid, email, verified=bool(ok)))
+                for uid, email, ok in users
+            ]
     except Exception as exc:  # noqa: BLE001
         print(f"::error::user journey audit could not run: {exc}")
         return 2
@@ -172,7 +212,12 @@ def main() -> int:
     for uid, email, stage, verdict, f in results:
         tag = {"ok": "OK", "broken": "**BROKEN**", "not-started": "-"}[verdict]
         if verdict == "not-started":
-            ev = "never uploaded a CV or set preferences"
+            ev = (
+                "signed up and gave us input, but never confirmed their email - "
+                "search is gated on it, so no job can reach them"
+                if stage == "email-not-confirmed"
+                else "never uploaded a CV or set preferences"
+            )
         elif verdict == "broken":
             ev = {
                 "extraction": f"CV has {f.get('cv_chars',0)} chars but only "
@@ -192,6 +237,20 @@ def main() -> int:
                   f"{f.get('llm_verdicts',0)} AI verdicts")
         print(f"| `{str(uid)[:8]}` {mask(email)} | {tag} | {stage} | {ev} |")
     print()
+
+    # Stalled at the front door. Not an alarm — nothing is broken, so there is
+    # nothing to repair. But a signup funnel that leaks here is still a real
+    # product fact, and burying it would just swap one blind spot for another.
+    stalled = [r for r in results if r[2] == "email-not-confirmed"]
+    if stalled:
+        print("## Signed up, gave us input, never confirmed their email\n")
+        print("Not a failure of ours: `POST /api/search` requires a confirmed "
+              "email, and the feed is only written by a search or a profile "
+              "re-score. These people cannot have a feed by design.\n")
+        for uid, _email, _stage, _verdict, f in stalled:
+            print(f"- `{str(uid)[:8]}` - {f.get('skills', 0)} skills, "
+                  f"{f.get('cv_chars', 0)} CV chars extracted, then stopped")
+        print()
 
     # Quality warnings: healthy users can still have a degraded experience.
     warnings = []


### PR DESCRIPTION
Issue #198, "the pipeline is broken for at least one user". **The pipeline is not broken. The detector was wrong.**

User `7edd5b59` never confirmed its email (`users.email_verified_at IS NULL`). `POST /api/search` is gated on a confirmed email (`search.py:177` -> `require_verified_user`), and `user_feed` is only ever written by a search (`main.py:1175`) or a profile-change re-score. So that account **structurally cannot have feed rows.**

Three more facts, all read from live prod:
```
run_log rows ......... 0          never ran a search
sessions ............. 2, created in the same second on 2026-07-02, expired 08-01
profile write ........ 2026-07-02 11:53:40
first job in catalog . 2026-07-02 18:46:00   <- 7 hours LATER
```
Even the one re-score that could have fired had an empty catalog to match against.

`scripts/user_journey_audit.py` read `users` without `email_verified_at`, so unconfirmed accounts fell through to the feed check and got labelled **"broken"**. It has been crying wolf since 2026-08-03.

**Fixed test-first** — `main()` now selects `email_verified_at`, `audit_user()` takes `verified`, and a new STAGE 1b reports unconfirmed accounts as unconfirmed rather than broken. 6 new tests: an unconfirmed user is not "broken" but IS still reported; no-profile still reads "signup"; confirmed users still go red at feed/scoring and complete when healthy.

No runtime backend/frontend code touched — only the audit script, its workflow, and the new test.

**Close #198** with: user `7edd5b59` is an unverified launch-day `@example.com` account that never confirmed its email and never ran a search.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G7mLsrkujpTyUhwMTn7itb