### PR TITLE
fix(rescore): #271's stated cause is stale — here is the real one, plus the silence that hid it

### DIFF
--- a/backend/src/api/routes/profile.py
+++ b/backend/src/api/routes/profile.py
@@ -62,6 +62,41 @@ logger = logging.getLogger("job360.api.profile")
 _rescore_bg_tasks: set[Any] = set()
 
 
+def _rescore_finished(task: Any) -> None:
+    """Discard the task reference AND say something when it failed.
+
+    The previous callback was ``_rescore_bg_tasks.discard`` — it dropped the
+    reference and never touched ``task.exception()``. asyncio only reports an
+    unretrieved exception when the task object is garbage-collected, and by then
+    the message is detached from the user it belonged to. The surrounding
+    ``except`` covers SCHEDULING, not execution, so a re-score that started and
+    then died left the feed permanently stale with nothing in the logs.
+
+    Measured in production 2026-08-11: 9,708 user_feed rows carry a
+    profile_version older than their user's current one, and all 9,708 point at
+    jobs still in the catalog (0 orphans) — so every one of them was reachable
+    and simply never got re-scored. One user sits at profile_version 10 while
+    their current version is 15: five profile changes, no completed re-score,
+    no error anywhere.
+
+    This does not FIX that (see the note in _maybe_trigger_rescore); it makes the
+    failure visible, which is the difference between a bug you can find and one
+    you cannot.
+    """
+    _rescore_bg_tasks.discard(task)
+    if task.cancelled():
+        logger.warning("rescore: background re-score was CANCELLED — feed left stale")
+        return
+    exc = task.exception()
+    if exc is not None:
+        logger.error(
+            "rescore: background re-score FAILED, feed left on a stale "
+            "profile_version: %r",
+            exc,
+            exc_info=exc,
+        )
+
+
 async def _maybe_trigger_rescore(user_id: str) -> None:
     """Fire-and-forget: schedule a background re-score if the profile content changed.
 
@@ -72,6 +107,15 @@ async def _maybe_trigger_rescore(user_id: str) -> None:
     to ``_rescore_bg_tasks`` to prevent GC loss.
     Never lets scheduling errors propagate — the profile save must never 500.
     Lazy imports keep the hot GET/POST paths import-cycle-free (rule #16).
+
+    KNOWN LIMITATION — this is fire-and-forget IN THE WEB PROCESS, and that is
+    why issue #271 exists. There is no queue entry, no retry and no ledger:
+    ``grep -c rescore src/workers/tasks.py`` is 0, so nothing outside this
+    process ever knows a re-score was owed. Any restart kills an in-flight run,
+    and `main` auto-deploys on every merge, so deploys alone can drop them.
+    The durable fix is an ARQ job (the worker and Redis already exist) with a
+    retry and a completion record — a change to how production schedules work,
+    so it is deliberately NOT bundled with the logging fix below.
     """
     try:
         from src.services.profile.storage import (  # noqa: PLC0415
@@ -91,7 +135,7 @@ async def _maybe_trigger_rescore(user_id: str) -> None:
 
         task = asyncio.create_task(rescore_user_feed(user_id))
         _rescore_bg_tasks.add(task)
-        task.add_done_callback(_rescore_bg_tasks.discard)
+        task.add_done_callback(_rescore_finished)
         logger.info("rescore: background re-score scheduled for user %s", user_id)
     except Exception as exc:  # noqa: BLE001
         logger.warning(

--- a/backend/tests/test_rescore_failures_are_loud.py
+++ b/backend/tests/test_rescore_failures_are_loud.py
@@ -1,0 +1,98 @@
+"""A background re-score that dies must say so — issue #271.
+
+``_maybe_trigger_rescore`` fires ``rescore_user_feed`` with
+``asyncio.create_task``. The old done-callback was ``_rescore_bg_tasks.discard``:
+it dropped the reference and never read ``task.exception()``. asyncio only
+surfaces an unretrieved exception when the task object is garbage-collected, and
+by then the message has no user attached to it. The ``except`` around the call
+covers SCHEDULING, not execution.
+
+So a re-score that started and then failed left the user's feed permanently on a
+stale ``profile_version``, with nothing in the logs to say it had happened.
+Measured in production 2026-08-11: 9,708 such rows, all pointing at jobs still in
+the catalog (0 orphans), one user stuck at version 10 with 15 current.
+
+These tests pin the visibility, not the scheduling — the durable fix is to move
+the work onto the ARQ queue, which is a separate change.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import pytest
+
+from src.api.routes.profile import _rescore_bg_tasks, _rescore_finished
+
+
+@pytest.mark.asyncio
+async def test_a_failed_rescore_is_logged_at_error(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    async def boom() -> None:
+        raise RuntimeError("scorer exploded")
+
+    task = asyncio.ensure_future(boom())
+    _rescore_bg_tasks.add(task)
+    with pytest.raises(RuntimeError):
+        await task
+
+    with caplog.at_level(logging.ERROR, logger="src.api.routes.profile"):
+        _rescore_finished(task)
+
+    assert any(
+        r.levelno == logging.ERROR and "stale" in r.getMessage()
+        for r in caplog.records
+    ), (
+        "A failed background re-score produced no ERROR log. That is the exact "
+        "silence behind issue #271: the feed is left on an old profile_version "
+        f"and nobody finds out. Records: {[r.getMessage() for r in caplog.records]}"
+    )
+    assert task not in _rescore_bg_tasks, "the task reference must still be released"
+
+
+@pytest.mark.asyncio
+async def test_a_cancelled_rescore_is_logged(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A deploy mid-run cancels the task. `main` auto-deploys on every merge."""
+
+    async def slow() -> None:
+        await asyncio.sleep(30)
+
+    task = asyncio.ensure_future(slow())
+    _rescore_bg_tasks.add(task)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    with caplog.at_level(logging.WARNING, logger="src.api.routes.profile"):
+        _rescore_finished(task)
+
+    assert any("CANCELLED" in r.getMessage() for r in caplog.records), (
+        "A cancelled re-score logged nothing. Restarts are the common case here — "
+        "every merge to main redeploys and kills anything in flight."
+    )
+    assert task not in _rescore_bg_tasks
+
+
+@pytest.mark.asyncio
+async def test_a_successful_rescore_stays_quiet(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The guard must not cry wolf: a clean run logs no error or warning."""
+
+    async def fine() -> None:
+        return None
+
+    task = asyncio.ensure_future(fine())
+    _rescore_bg_tasks.add(task)
+    await task
+
+    with caplog.at_level(logging.WARNING, logger="src.api.routes.profile"):
+        _rescore_finished(task)
+
+    noisy = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+    assert not noisy, f"A successful re-score should be silent, but logged: {noisy}"
+    assert task not in _rescore_bg_tasks


### PR DESCRIPTION
Issue #271 is real. Its **stated cause is stale**: it blames a 5,000-row cap in `get_catalog_jobs_for_rescore`. That was already raised to 50,000, and the live catalog is 8,912 rows — well under it.

## Measured against production (read-only, 2026-08-11)

```
catalog jobs .............................. 8,912   (limit is 50,000)
feed rows on a stale profile_version ...... 9,708
  ...of those, rows whose job is GONE ..... 0       <-- ALL were reachable
user 88e7d907 ............................. 3,208 rows at version 10
                                            current version 15
```

**Zero orphans is the load-bearing number.** Every stale row points at a job still in the catalog, so a re-score *could* have fixed all of them. They were reachable and simply never re-scored — and one user went through **five** profile versions without a single completed run, with no error anywhere.

## Why it is silent

```
profile.py   task = asyncio.create_task(rescore_user_feed(user_id))
             task.add_done_callback(_rescore_bg_tasks.discard)
                                    ^^^^^^^^^^^^^^^^^^^^^^^^
                                    releases the ref, never reads task.exception()

the surrounding except covers SCHEDULING, not execution
grep -c rescore src/workers/tasks.py  ->  0    no queue, no retry, no ledger
```

asyncio only surfaces an unretrieved exception at GC time, by which point the message has no user attached. And `main` auto-deploys on every merge — so a deploy alone kills anything in flight. I merged seven times today.

## What this PR does — and does not

It does **not** fix the staleness. It makes the failure visible:

| outcome | before | after |
|---|---|---|
| re-score raises | nothing | **ERROR** + traceback, naming the consequence |
| re-score cancelled (deploy) | nothing | **WARNING** |
| re-score succeeds | nothing | still nothing — the guard must not cry wolf |

3 tests pin all three, including the negative case.

## The durable fix — your call

Move the work onto the **ARQ queue** (worker and Redis already exist) with a retry and a completion record. That changes how production schedules work, so I did not bundle it into a logging fix at the end of a long session. Recorded as a KNOWN LIMITATION in the trigger's own docstring, where the next reader will actually be.

The 9,708 existing stale rows also need a backfill decision — and note this repo's own lesson: *a correctness fix with an operational cost is still a regression.* A naive backfill froze the event loop once already.

Gate: PASS. New tests 3 passed; profile route suite 70 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G7mLsrkujpTyUhwMTn7itb