### PR TITLE
fix(pillar1): eight defects a 12-agent audit found, six of them mine from today

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,6 +1,31 @@
 # Runtime data — never bake into the image; mount as a volume.
 data/
 
+# ...EXCEPT the data that is not runtime state but SHIPPED REFERENCE DATA.
+#
+# `.gitignore` deliberately un-ignores these same two directories, which is the
+# whole reason they are committed. This file did not mirror that, and the
+# Dockerfile is `COPY . .`, so the build threw away exactly the files someone had
+# gone to the trouble of exempting — and nothing rebuilds them at deploy time.
+# Railway volumes start empty, so no mount could supply them either.
+#
+# What that cost, silently and with no error:
+#   uk_gazetteer/  — the ~52k UK place names rule #30 is built on. Without it
+#                    `uk_gate._read()` returns an empty frozenset (it degrades
+#                    rather than raising), so no job can match a UK place and the
+#                    gate falls through to source-trust and ad-text evidence.
+#   job_signals/   — the seniority / workplace / location term tables behind
+#                    `signal_backed_lookup`, which fills 'unknown' enrichment at
+#                    read time, and `detect_seniority`. `_load_terms` returns {}
+#                    on a missing file, so those detectors quietly answer nothing.
+#
+# Both failure modes are invisible: empty data, no exception, no log line.
+# `tests/test_shipped_data.py` now pins the two ignore files together.
+!data/uk_gazetteer/
+!data/uk_gazetteer/**
+!data/job_signals/
+!data/job_signals/**
+
 # Python caches
 __pycache__/
 *.pyc

--- a/backend/src/api/models.py
+++ b/backend/src/api/models.py
@@ -217,6 +217,12 @@ class CVDetail(BaseModel):
     # section boundary and then discarded — for a junior or career-changing
     # candidate it is often the strongest evidence on the document.
     cv_projects: list[dict[str, Any]] = []
+    # Both are MATCHING shelves (the judge reads them) and both were
+    # invisible to the person they describe until 2026-08-12 - the same
+    # "scored on but never shown" gap that hid linkedin_summary, repeated
+    # one commit later on the shelves that replaced it.
+    cv_experience_level: str = ""
+    cv_right_to_work: str = ""
     # Aggregated highlights for the CV viewer — merges skills + titles +
     # companies + achievements + name/headline/location for in-text highlighting
     highlights: list[str] = []

--- a/backend/src/api/models.py
+++ b/backend/src/api/models.py
@@ -213,6 +213,10 @@ class CVDetail(BaseModel):
     # never SEE their parsed experience — only a "Roles: N" count. Part of
     # the "stored but not shown" gap closed 2026-08-08.
     cv_positions: list[dict[str, Any]] = []
+    # Projects stated on the CV. A Projects heading was already used as a
+    # section boundary and then discarded — for a junior or career-changing
+    # candidate it is often the strongest evidence on the document.
+    cv_projects: list[dict[str, Any]] = []
     # Aggregated highlights for the CV viewer — merges skills + titles +
     # companies + achievements + name/headline/location for in-text highlighting
     highlights: list[str] = []

--- a/backend/src/api/routes/profile.py
+++ b/backend/src/api/routes/profile.py
@@ -142,6 +142,8 @@ def _build_profile_response(profile: UserProfile, user_id: str) -> ProfileRespon
         achievements=getattr(cv, "achievements", []),
         cv_positions=getattr(cv, "cv_positions", []) or [],
         cv_projects=getattr(cv, "cv_projects", []) or [],
+        cv_experience_level=getattr(cv, "cv_experience_level", "") or "",
+        cv_right_to_work=getattr(cv, "cv_right_to_work", "") or "",
         highlights=cv.highlights if hasattr(cv, "highlights") else cv.skills,
     )
 

--- a/backend/src/api/routes/profile.py
+++ b/backend/src/api/routes/profile.py
@@ -141,6 +141,7 @@ def _build_profile_response(profile: UserProfile, user_id: str) -> ProfileRespon
         location=getattr(cv, "location", ""),
         achievements=getattr(cv, "achievements", []),
         cv_positions=getattr(cv, "cv_positions", []) or [],
+        cv_projects=getattr(cv, "cv_projects", []) or [],
         highlights=cv.highlights if hasattr(cv, "highlights") else cv.skills,
     )
 

--- a/backend/src/services/embeddings.py
+++ b/backend/src/services/embeddings.py
@@ -198,9 +198,35 @@ def profile_to_embedding_text(profile: Any) -> str:
                 blob = " ".join(b for b in bits if b)
                 if blob:
                     parts.append(blob)
-        for proj in list(getattr(cv, "cv_projects", []) or []) + list(
-            getattr(cv, "linkedin_projects", []) or []
-        ):
+        # TWO DIFFERENTLY-SHAPED LISTS, SO TWO KEY SETS. The CV pass writes
+        # {name, description, technologies}; the LinkedIn pass writes
+        # {title, description}. Reading one shared key set across both meant a
+        # CV project contributed only its description — its NAME and its whole
+        # technology list, the most matchable part of a project, reached the
+        # vector as nothing at all. Concatenating the two lists and reading
+        # "title" is exactly the shape of bug this batch keeps finding: one
+        # hand-written assumption covering two things that are not the same.
+        for proj in getattr(cv, "cv_projects", []) or []:
+            if not isinstance(proj, dict):
+                continue
+            techs = proj.get("technologies")
+            tech_txt = (
+                " ".join(str(t) for t in techs if isinstance(t, str))
+                if isinstance(techs, list)
+                else ""
+            )
+            blob = " ".join(
+                b
+                for b in (
+                    str(proj.get("name") or "").strip(),
+                    str(proj.get("description") or "").strip(),
+                    tech_txt.strip(),
+                )
+                if b
+            ).strip()
+            if blob:
+                parts.append(blob)
+        for proj in getattr(cv, "linkedin_projects", []) or []:
             if isinstance(proj, dict):
                 blob = f"{proj.get('title') or ''} {proj.get('description') or ''}".strip()
                 if blob:

--- a/backend/src/services/embeddings.py
+++ b/backend/src/services/embeddings.py
@@ -198,7 +198,9 @@ def profile_to_embedding_text(profile: Any) -> str:
                 blob = " ".join(b for b in bits if b)
                 if blob:
                     parts.append(blob)
-        for proj in getattr(cv, "linkedin_projects", []) or []:
+        for proj in list(getattr(cv, "cv_projects", []) or []) + list(
+            getattr(cv, "linkedin_projects", []) or []
+        ):
             if isinstance(proj, dict):
                 blob = f"{proj.get('title') or ''} {proj.get('description') or ''}".strip()
                 if blob:

--- a/backend/src/services/llm_matcher.py
+++ b/backend/src/services/llm_matcher.py
@@ -222,6 +222,8 @@ def profile_to_matcher_text(profile: Any) -> str:
         # NOWHERE else. Rendered as labelled rows because a judge reads
         # structure; each stays silent when the person has none (rule #29).
         for label, field, keys in (
+            ("Projects (from the CV)", "cv_projects",
+             ("name", "description", "technologies")),
             ("Recommendations (written by others)", "linkedin_recommendations",
              ("author", "relationship", "text")),
             ("Publications", "linkedin_publications", ("title", "publisher", "date")),

--- a/backend/src/services/prefilter.py
+++ b/backend/src/services/prefilter.py
@@ -94,9 +94,53 @@ def location_ok(profile: FilterProfile, job: Job) -> bool:
             return True
         if pref in loc or loc in pref:
             return True
+
+    # A preference this gate cannot RESOLVE must not be allowed to delete jobs.
+    #
+    # PR #297 fixed the country case, and stopped one level too high. Measured
+    # against the real predicate afterwards:
+    #     "United Kingdom" -> keeps everything   (the #297 fix)
+    #     "Greater London" -> keeps London       (only because one is a
+    #                                             substring of the other)
+    #     "West Midlands"  -> keeps NOTHING      (Birmingham is IN it)
+    #     "Yorkshire"      -> keeps NOTHING      (Leeds is IN it)
+    #     "South East"     -> keeps NOTHING
+    # A county or region is the second most natural thing a UK user types, and
+    # it emptied the entire feed.
+    #
+    # The gazetteer answers this from DATA, not a typed list of regions (rule
+    # #30): it holds ~52k UK SETTLEMENTS and no administrative divisions, so
+    # "is this preference a place I can compare against a job location?" is
+    # simply "is it in the gazetteer?". A settlement ("London", "Birmingham")
+    # filters normally. Anything else — a region, a county, a typo — is a
+    # preference this stage cannot evaluate, so it passes and lets the scorer's
+    # location band do the fine-grained work. That matches this module's stated
+    # philosophy: false positives are cheap here, false negatives are not.
+    if _no_resolvable_place(profile.preferred_locations):
+        return True
+
     # If user has no preferred location list but a non-remote arrangement
     # preference, let it through (arrangement will be checked by the scorer).
     return not profile.preferred_locations
+
+
+def _no_resolvable_place(preferences: list[str]) -> bool:
+    """True when NONE of the stated preferences names a UK place we know.
+
+    Degrades safely: if the gazetteer is unavailable the answer is "cannot
+    resolve", which passes the job rather than deleting it. A missing data file
+    must never silently empty a feed — that failure has already happened once
+    (the image shipped without the gazetteer for weeks).
+    """
+    try:
+        from src.services.uk_gate import _gazetteer, _norm
+
+        places, _foreign, _ambiguous = _gazetteer()
+    except Exception:  # noqa: BLE001 — never let the gate crash a run
+        return True
+    if not places:
+        return True
+    return not any(_norm(p) in places for p in preferences if p and p.strip())
 
 
 def experience_ok(profile: FilterProfile, job: Job) -> bool:

--- a/backend/src/services/profile/cv_parser.py
+++ b/backend/src/services/profile/cv_parser.py
@@ -54,6 +54,14 @@ Return a JSON object with exactly these fields:
       "details": ["Coursework, dissertation, projects — each as separate string"]
     }}
   ],
+  "projects": [
+    {{
+      "name": "Project name",
+      "description": "What it does and what they built, in their words",
+      "technologies": ["Each tool/framework named for THIS project"],
+      "dates": "Date range if written"
+    }}
+  ],
   "certifications": [
     "Each certification with issuer and date, as a single string"
   ],

--- a/backend/src/services/profile/linkedin_parser.py
+++ b/backend/src/services/profile/linkedin_parser.py
@@ -1308,7 +1308,22 @@ def enrich_cv_from_linkedin(
     # the cache-hit path being able to erase anything.
     if llm_ran:
         cv.linkedin_positions = linkedin_data.get("positions", [])
-    cv.linkedin_skills = new_linkedin_skills
+        # linkedin_skills belongs INSIDE this gate too, and sat one line outside
+        # it until 2026-08-12.
+        #
+        # The 2026-08-08 fix above covered the five sections it was written for
+        # and stopped there. Skills have the same shape and the same failure:
+        # they come from BOTH passes (the deterministic "Top Skills" sidebar and
+        # the LLM prose reader), so on a cache-hit run merge_linkedin_fields gets
+        # an empty LLM half and this assignment replaced the full list with the
+        # sidebar-only remnant. On a real profile that is 13 skills collapsing to
+        # 3, silently, on any unrelated profile edit — and unrecoverable by
+        # re-uploading the same PDF, because its text is unchanged so the pass is
+        # skipped again.
+        #
+        # A genuine re-parse still REPLACES, so a skill removed on LinkedIn is
+        # removed here. Only the cache-hit path is now unable to erase.
+        cv.linkedin_skills = new_linkedin_skills
     cv.linkedin_industry = linkedin_data.get("industry", "") or cv.linkedin_industry
     # Two-pass — keep the raw text (if the parser supplied it) so the LLM
     # pass can re-run offline. Only overwrite when a non-empty value arrives,

--- a/backend/src/services/profile/llm_curate.py
+++ b/backend/src/services/profile/llm_curate.py
@@ -17,9 +17,19 @@ raise) so a provider outage can't break extraction.
 from __future__ import annotations
 
 import logging
+import re
 from typing import Any
 
 logger = logging.getLogger("job360.profile.llm_curate")
+
+# Structural filler only — words that carry no identity for a degree, role or
+# certification. NOT a vocabulary of degrees or skills (rule #28): removing
+# "of"/"the" cannot decide what an entry MEANS, it only stops two unrelated
+# entries scoring as similar because they both contain "the".
+_MERGE_STOPWORDS = frozenset({
+    "and", "the", "for", "with", "from", "our", "your", "their",
+    "certification", "certificate", "certified", "course", "degree",
+})
 
 _MERGE_SYSTEM = (
     "You clean up lists extracted from CVs/LinkedIn. You MERGE entries that are "
@@ -94,7 +104,52 @@ async def llm_merge_duplicates(items: list[str], kind: str) -> list[str]:
     # returned nothing usable, or MORE than we sent, keep the original.
     if not merged or len(merged) > len(cleaned):
         return cleaned
+    # AND it must not silently DELETE. Until 2026-08-12 the two checks above
+    # were the only ones, so any shorter list was accepted — a rate-limited or
+    # lazy model answering with one item collapsed seven certifications to one,
+    # and the caller wrote that to the profile with no comparison against what
+    # was stored. This function runs on ``education``, ``job_titles`` and
+    # ``certifications``: three shelves the matching engines read.
+    #
+    # A merge is legitimate only when every input it removed is still
+    # REPRESENTED by something it kept. So require coverage: each input must
+    # share its normalised token set with some output entry. A genuine
+    # "Master's degree, AI and Robotics - Herts" + "Master of Science - AI and
+    # Robotics, Herts" collapse passes trivially; dropping a BEng that nothing
+    # else mentions does not.
+    if not _merge_covers_input(cleaned, merged):
+        logger.warning(
+            "llm_merge_duplicates(%s): result dropped un-represented entries "
+            "(%d -> %d), keeping original",
+            kind, len(cleaned), len(merged),
+        )
+        return cleaned
     return merged
+
+
+def _merge_tokens(value: str) -> set[str]:
+    """Normalised word set — lower-cased, punctuation stripped, stopwords out."""
+    words = re.findall(r"[a-z0-9]+", (value or "").lower())
+    return {w for w in words if len(w) > 2 and w not in _MERGE_STOPWORDS}
+
+
+def _merge_covers_input(before: list[str], after: list[str]) -> bool:
+    """True when every ``before`` entry is represented by some ``after`` entry.
+
+    "Represented" = at least half of the input entry's meaningful words appear
+    in one output entry. That is deliberately generous: the merge is SUPPOSED
+    to rewrite wording, so an exact-substring test would reject correct merges.
+    What it will not accept is an entry vanishing with nothing resembling it
+    left behind — which is the difference between de-duplication and deletion.
+    """
+    after_tokens = [_merge_tokens(a) for a in after]
+    for item in before:
+        want = _merge_tokens(item)
+        if not want:
+            continue
+        if not any(len(want & got) * 2 >= len(want) for got in after_tokens):
+            return False
+    return True
 
 
 async def llm_suggest_adjacent_skills(skills: list[str], n: int = 12) -> list[str]:

--- a/backend/src/services/profile/models.py
+++ b/backend/src/services/profile/models.py
@@ -257,6 +257,18 @@ class CVData:
     # would make the extractor guess. Never inferred from nationality or
     # place of study — that would be discrimination dressed up as a feature.
     cv_right_to_work: str = ""
+    # Projects stated on the CV: {name, description, technologies, dates}.
+    #
+    # A Projects heading was already recognised — as a section BOUNDARY, to
+    # stop a skills block (cv_parser lines 268/322/373) — and then thrown
+    # away. Exactly the 'split it out, then drop it' shape as the seven
+    # LinkedIn sections, one input over.
+    #
+    # For a junior or career-changing candidate this is often the strongest
+    # evidence they have: the CV lists two short roles but five real builds.
+    # GitHub already contributes ``github_repos_brief`` for people who push
+    # code publicly; this is the same signal for the people who do not.
+    cv_projects: list[dict[str, Any]] = field(default_factory=list)
     # Step-1.5 S1.5-D — ESCO normalisation map populated by
     # ``cv_parser._llm_result_to_cvdata`` when ``SEMANTIC_ENABLED=true`` and
     # the ESCO index is on disk. Maps the *canonical* skill label (which

--- a/backend/src/services/profile/schemas.py
+++ b/backend/src/services/profile/schemas.py
@@ -144,6 +144,12 @@ class CVSchema(BaseModel):
     achievements: list[str] = Field(default_factory=list)
     industries: list[str] = Field(default_factory=list)
     languages: list[str] = Field(default_factory=list)
+    # A CV Projects section was recognised as a section BOUNDARY (it stops a
+    # skills block) and then discarded — the same 'split it out, then drop
+    # it' shape as the seven LinkedIn sections. For a junior or
+    # career-changing candidate, projects are often the strongest evidence
+    # they have.
+    projects: list[dict[str, Any]] = Field(default_factory=list)
 
     experience_level: Optional[str] = ""
     # TRI-STATE by design (rule #31): "" means the CV never said, which is
@@ -289,5 +295,6 @@ def cv_schema_to_cvdata(schema: CVSchema, raw_text: str) -> CVData:
         # dropped right here.
         cv_experience_level=(schema.experience_level or "").strip(),
         cv_right_to_work=(schema.right_to_work or "").strip(),
+        cv_projects=[p for p in (schema.projects or []) if isinstance(p, dict)],
         cv_skills_esco=cv_skills_esco,
     )

--- a/backend/src/services/profile/shelf_audit.py
+++ b/backend/src/services/profile/shelf_audit.py
@@ -73,8 +73,20 @@ _ROLES: dict[str, str] = {
     "llm_matcher": "judge",
     "prefilter": "prefilter",
     "embeddings": "semantic",
+    # retrieval.py is mapped to the same role deliberately: it reads ZERO
+    # profile shelves today (verified: no cv./prefs./getattr access at all), so
+    # it contributes nothing on its own. The "semantic" role is earned entirely
+    # by embeddings.py. Keeping the mapping costs nothing and means a future
+    # profile read in retrieval.py is counted automatically.
     "retrieval": "semantic",
-    "feed": "feed",
+    # "feed" was here as its own MATCHING role. services/feed.py also reads zero
+    # profile shelves, so unlike "semantic" nothing else earned it — it was a
+    # declared matching role with no reader, quietly inflating the headline
+    # "N shelves feed matching" number with a module that contributes none.
+    # Removed until feed.py actually reads a shelf. This is exactly what the
+    # de-tautologised test_every_matching_role_is_actually_used caught on its
+    # first real run.
+    "feed": "persistence",
     # Not matching — kept so the manifest can show WHERE a shelf does surface.
     "profile": "api",
     "jobs": "api",
@@ -82,8 +94,17 @@ _ROLES: dict[str, str] = {
     "snapshot": "api",
 }
 
+# Roles whose consumer can change what a user actually sees. Every one of these
+# must be READ BY AT LEAST ONE SHELF — a declared role with no reader inflates
+# the count with a module that contributes nothing, which is why
+# test_every_matching_role_is_actually_used exists.
+#
+# NOT equal reach, and the difference matters when quoting the number:
+#   scorer / search-keywords / tiering / prefilter -> rank EVERY job
+#   judge                                          -> the top slice only
+#   semantic                                       -> only when the vector runs
 MATCHING_ROLES = frozenset(
-    {"search-keywords", "tiering", "scorer", "judge", "prefilter", "semantic", "feed"}
+    {"search-keywords", "tiering", "scorer", "judge", "prefilter", "semantic"}
 )
 
 # Modules that WRITE shelves. Extraction lives under services/profile/, but the
@@ -447,3 +468,38 @@ def is_matching_shelf(shelf: str) -> bool:
 
 def matching_shelves() -> tuple[str, ...]:
     return tuple(n for n in shelf_names() if is_matching_shelf(n))
+
+
+# Roles whose consumer ranks EVERY job in the feed, as opposed to a slice of it.
+EVERY_JOB_ROLES = frozenset({"scorer", "search-keywords", "tiering", "prefilter"})
+
+
+def matching_tiers() -> dict[str, tuple[str, ...]]:
+    """The matching count broken down by REACH, because one number misleads.
+
+    "50 shelves feed matching" is true as wiring and misleading as impact: it
+    counts a shelf read only by the LLM judge the same as one the keyword scorer
+    reads. They are not comparable —
+
+        every_job  the keyword engine ranks all ~7,000 rows in a feed
+        judge      the LLM judge sees a capped window (tens, not thousands)
+        semantic   the vector, and only when the index actually covers the job
+
+    This exists so the honest figure is COMPUTED rather than asserted in prose.
+    A headline number that cannot be recomputed from the code is exactly the
+    kind of claim this whole batch has been correcting.
+    """
+    every, judge, semantic = [], [], []
+    for name in matching_shelves():
+        roles = readers(name)
+        if roles & EVERY_JOB_ROLES:
+            every.append(name)
+        elif "judge" in roles:
+            judge.append(name)
+        else:
+            semantic.append(name)
+    return {
+        "every_job": tuple(every),
+        "judge_only": tuple(judge),
+        "semantic_only": tuple(semantic),
+    }

--- a/backend/src/services/profile/two_pass.py
+++ b/backend/src/services/profile/two_pass.py
@@ -61,7 +61,7 @@ async def _none() -> None:
     return None
 
 
-EXTRACTOR_VERSION = "5"
+EXTRACTOR_VERSION = "6"
 """Bump this whenever an LLM extraction PROMPT changes in a way that should
 re-read inputs the system has already seen.
 
@@ -93,7 +93,8 @@ Version log — 1: input-only hash (pre-2026-08-08). 2: prose-mining CV prompt.
 3: the seven LinkedIn section prompts (honors, publications, patents,
 organizations, test_scores, recommendations, interests) + the contact block.
 4: the CV ``right_to_work`` prompt field. 5: the LinkedIn ``headline``
-prompt — empty on every two-column export before it.
+prompt — empty on every two-column export before it. 6: the CV
+``projects`` prompt field.
 """
 
 
@@ -348,6 +349,10 @@ def _merge_cv_llm_into(cv: CVData, llm_cv: CVData) -> None:
     _merge_str_list(cv.achievements, llm_cv.achievements)
     _merge_str_list(cv.cv_industries, llm_cv.cv_industries)
     _merge_str_list(cv.cv_languages, llm_cv.cv_languages)
+    # Structured rows, replaced wholesale like cv_positions: a re-parse of a
+    # NEW CV must reflect that CV, not accumulate projects from an old one.
+    if llm_cv.cv_projects:
+        cv.cv_projects = list(llm_cv.cv_projects)
     # Fill empty scalars only — never overwrite a value the user already has.
     #
     # DERIVED FROM THE DATACLASS, not hand-listed. This function has now lost a

--- a/backend/src/services/profile/two_pass.py
+++ b/backend/src/services/profile/two_pass.py
@@ -285,6 +285,22 @@ def reset_cv_owned_fields(cv: CVData) -> None:
     # documented "not classified" sentinel on CVData.
     cv.career_domain = None
 
+    # EVERY REMAINING CV-OWNED SCALAR, DERIVED — not hand-listed.
+    #
+    # This function's own docstring says its field list "must stay in lockstep
+    # with _merge_cv_llm_into". It did not. Three shelves added on 2026-08-10
+    # (cv_experience_level, cv_right_to_work, cv_projects) were merged in but
+    # never cleared here, so uploading a DIFFERENT person's CV left the previous
+    # person's stated seniority and work-authorisation on the profile — the
+    # exact failure this function exists to prevent, and worse than the missing
+    # data because it is confidently wrong.
+    #
+    # Both halves now read the same source, so the two cannot drift again.
+    for name in _cv_owned_scalars():
+        if getattr(cv, name, None):
+            setattr(cv, name, "")
+    cv.cv_projects.clear()
+
     # Regenerated wholesale from the merged skill set on every two-pass run, but
     # cleared so a failed re-extract cannot leave suggestions computed from a
     # different person's skills.
@@ -298,6 +314,23 @@ def reset_cv_owned_fields(cv: CVData) -> None:
     # GitHub and about_me data deliberately survives a CV swap, so their
     # hashes must survive too.
     cv.llm_input_hashes.pop("cv", None)
+    # AND the LinkedIn hash — because three of the lists cleared above are
+    # JOINTLY OWNED, not CV-owned.
+    #
+    # ``education``, ``certifications`` and ``job_titles`` are written by BOTH
+    # passes: the CV pass fills them, then ``enrich_cv_from_linkedin`` appends
+    # LinkedIn's entries into the same lists (they have no linkedin_* shelf of
+    # their own). Clearing them here while KEEPING the LinkedIn hash meant the
+    # LinkedIn pass was a cache hit on the re-run, contributed an empty list,
+    # and LinkedIn's degrees, certifications and roles were gone permanently —
+    # not recoverable by re-uploading the same LinkedIn PDF, because its text is
+    # unchanged so the hash still matches.
+    #
+    # The reasoning in the comment above is right for the linkedin_* shelves,
+    # which have their own home and genuinely survive a CV swap untouched. It is
+    # wrong for the three shared lists. Cost of the fix: one extra LinkedIn LLM
+    # call per CV upload. Cost of the bug: silent, permanent data loss.
+    cv.llm_input_hashes.pop("linkedin", None)
 
 
 # Scalar CVData fields the CV pass must NOT write, each with the reason it is

--- a/backend/tests/test_curation_is_lossless.py
+++ b/backend/tests/test_curation_is_lossless.py
@@ -1,0 +1,153 @@
+"""The LLM de-duplication pass must MERGE, never DELETE.
+
+`llm_merge_duplicates` rewrites three shelves the matching engines read —
+`education`, `job_titles` and `certifications` — and it is the only step in the
+whole extractor that can make a list shorter. Until 2026-08-12 its only guards
+were "the model returned something" and "it is not LONGER than the input", so
+ANY shorter answer was accepted and written to the profile.
+
+That is a live failure mode, not a hypothetical: the provider chain falls back
+to weaker models under rate limiting, and a lazy answer that returns one item
+from seven collapsed six real certifications into one, permanently, with no
+error and nothing comparing the result against what was stored.
+
+Every existing test of `run_two_pass_extraction` patches this function out with
+a passthrough, so the code path that rewrites three matching shelves had no
+coverage at all. These tests exercise it directly.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from src.services.profile.llm_curate import _merge_covers_input, llm_merge_duplicates
+
+
+def _reply(items):
+    async def _fake(prompt, system=None):
+        return {"items": list(items)}
+
+    return _fake
+
+
+class TestCoverageRule:
+    """The predicate on its own — merging rewrites wording, so the rule has to
+    be generous about phrasing and strict about disappearance."""
+
+    def test_a_genuine_reword_is_covered(self) -> None:
+        before = [
+            "Master of Science - Artificial Intelligence and Robotics - University of Hertfordshire",
+            "Master's degree, Artificial Intelligence and Robotics - University of Hertfordshire",
+        ]
+        after = ["MSc Artificial Intelligence and Robotics, University of Hertfordshire"]
+        assert _merge_covers_input(before, after) is True
+
+    def test_a_vanished_qualification_is_not_covered(self) -> None:
+        # The BEng is a DIFFERENT degree at a DIFFERENT university. Nothing in
+        # the output resembles it, so this is deletion wearing a merge's clothes.
+        before = [
+            "Master of Science - Artificial Intelligence - University of Hertfordshire",
+            "Bachelor of Engineering - Computer Science - Visvesvaraya Technological University",
+        ]
+        after = ["MSc Artificial Intelligence, University of Hertfordshire"]
+        assert _merge_covers_input(before, after) is False
+
+    def test_the_collapse_to_one_is_rejected(self) -> None:
+        before = [
+            "AWS Certified AI Practitioner",
+            "Accenture Data Analytics Job Simulation",
+            "Cognizant Artificial Intelligence Job Simulation",
+            "The Complete Python Bootcamp",
+            "Kaggle Certifications: Python, Pandas",
+            "Building with the Claude API",
+            "AI Fluency: Framework and Foundations",
+        ]
+        assert _merge_covers_input(before, ["AWS Certified AI Practitioner"]) is False
+
+
+class TestTheGuardActuallyFires:
+    """End to end through the real function, with only the provider stubbed."""
+
+    @pytest.mark.asyncio
+    async def test_a_deleting_merge_is_refused_and_the_original_kept(self) -> None:
+        items = [
+            "Master of Science - Artificial Intelligence - University of Hertfordshire",
+            "Bachelor of Engineering - Computer Science - Visvesvaraya Technological University",
+        ]
+        with patch(
+            "src.services.profile.llm_provider.llm_extract",
+            _reply(["MSc Artificial Intelligence, University of Hertfordshire"]),
+        ):
+            out = await llm_merge_duplicates(items, "education")
+        assert out == items, (
+            "a merge that dropped a degree nothing else mentions was accepted — "
+            "this is the shape that silently deleted real qualifications"
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_real_duplicate_still_merges(self) -> None:
+        """The guard must not turn the de-duplicator off: that would leave the
+        profile showing the same degree twice, which is the problem this
+        function exists to solve."""
+        items = [
+            "AI/ML Engineer Intern",
+            "AI / ML intern",
+        ]
+        with patch(
+            "src.services.profile.llm_provider.llm_extract",
+            _reply(["AI/ML Engineer Intern"]),
+        ):
+            out = await llm_merge_duplicates(items, "roles")
+        assert out == ["AI/ML Engineer Intern"]
+
+    @pytest.mark.asyncio
+    async def test_an_empty_answer_keeps_the_original(self) -> None:
+        with patch("src.services.profile.llm_provider.llm_extract", _reply([])):
+            out = await llm_merge_duplicates(["A degree", "B degree"], "education")
+        assert out == ["A degree", "B degree"]
+
+    @pytest.mark.asyncio
+    async def test_a_longer_answer_keeps_the_original(self) -> None:
+        with patch(
+            "src.services.profile.llm_provider.llm_extract",
+            _reply(["A degree", "B degree", "C invented"]),
+        ):
+            out = await llm_merge_duplicates(["A degree", "B degree"], "education")
+        assert out == ["A degree", "B degree"]
+
+
+class TestSharedListsSurviveACvSwap:
+    """`education`, `certifications` and `job_titles` are written by BOTH the CV
+    pass and the LinkedIn pass — LinkedIn has no shelf of its own for them.
+
+    `reset_cv_owned_fields` clears all three. It used to drop only the "cv"
+    cache key, so the LinkedIn pass was a cache hit on the re-run, contributed
+    an empty list, and LinkedIn's degrees and certifications were gone for good
+    — unrecoverable by re-uploading the same PDF, because its text is unchanged
+    so the hash still matches.
+    """
+
+    def test_reset_invalidates_the_linkedin_hash_too(self) -> None:
+        from src.services.profile.models import CVData
+        from src.services.profile.two_pass import reset_cv_owned_fields
+
+        cv = CVData(
+            raw_text="old cv",
+            education=["MSc from the CV", "BEng from LinkedIn"],
+            llm_input_hashes={
+                "cv": "aaa", "linkedin": "bbb", "github": "ccc", "about_me": "ddd",
+            },
+        )
+        reset_cv_owned_fields(cv)
+
+        assert "cv" not in cv.llm_input_hashes
+        assert "linkedin" not in cv.llm_input_hashes, (
+            "the LinkedIn hash survived a CV reset, so the LinkedIn pass will be "
+            "skipped on the re-run and its half of education/certifications/"
+            "job_titles is lost permanently"
+        )
+        # The passes that own their OWN shelves must still be spared — wiping
+        # those would be the opposite failure.
+        assert cv.llm_input_hashes.get("github") == "ccc"
+        assert cv.llm_input_hashes.get("about_me") == "ddd"

--- a/backend/tests/test_derived_shelves.py
+++ b/backend/tests/test_derived_shelves.py
@@ -1,0 +1,91 @@
+"""Two shelves are DERIVED VIEWS of other shelves. Pin them so they stay that way.
+
+The shelf audit found four duplicate pairs. Two were genuine defects and were
+fixed by deleting a copy (``skill_entry`` duplicated ``skill_tiering``;
+``industries`` was declared on both dataclasses). These two are different: they
+are stored derivations with real consumers, and they cause no wrong behaviour.
+
+    github_skills_inferred  == github_languages (by bytes) + github_topics
+    preferred_workplace     == work_arrangement, lower-cased
+
+Deleting either is the wrong trade. ``github_skills_inferred`` has genuine
+ASSIGNMENT writers (``github_enricher`` and the clear route), so making it a
+read-only property would break them — and ``two_pass`` mutates it in place, which
+a property would silently swallow. ``preferred_workplace`` is what the scoring
+dimension reads, with no frontend control of its own.
+
+So the risk worth guarding is not the duplication. It is DIVERGENCE: a derived
+field that quietly stops matching its source becomes a third, wrong truth that
+nothing can detect — the exact failure mode behind every other bug in this batch.
+These tests make divergence loud.
+"""
+from __future__ import annotations
+
+import pytest
+
+from src.services.profile.github_enricher import _infer_skills
+
+
+class TestGithubSkillsInferredIsPurelyDerived:
+    """It must hold NOTHING that ``github_languages`` + ``github_topics`` do not
+    already hold. The moment it does, it is a third source of truth and the
+    profile can disagree with itself."""
+
+    def test_it_is_exactly_languages_then_topics(self) -> None:
+        langs = {"Python": 900, "Rust": 100, "Shell": 5}
+        topics = {"machine-learning", "rag"}
+        got = _infer_skills(langs, topics)
+        assert got == ["Python", "Rust", "Shell", "machine learning", "rag"], (
+            "the derivation changed shape — anything it now adds is data that "
+            "exists in no other shelf, which makes this an independent fact "
+            "rather than a view"
+        )
+
+    def test_languages_are_ordered_by_bytes(self) -> None:
+        assert _infer_skills({"A": 1, "B": 50, "C": 10}, set())[0] == "B"
+
+    def test_it_invents_nothing_when_both_sources_are_empty(self) -> None:
+        assert _infer_skills({}, set()) == []
+
+    def test_every_entry_traces_back_to_a_source(self) -> None:
+        """The general form of the rule, not a fixed expected list: a future
+        change may reorder or reformat, but must never introduce a term that
+        neither source contains."""
+        langs = {"Python": 10, "Go": 5}
+        topics = {"data-engineering"}
+        derived = {s.lower() for s in _infer_skills(langs, topics)}
+        allowed = {k.lower() for k in langs} | {t.replace("-", " ") for t in topics}
+        assert derived <= allowed, f"invented: {sorted(derived - allowed)}"
+
+
+class TestPreferredWorkplaceMirrorsWorkArrangement:
+    """``preferred_workplace`` is the enum form of ``work_arrangement``, bridged
+    in the profile route because the scoring dimension reads the former while the
+    form writes the latter. Rule #29 makes the empty case the important one: an
+    unstated arrangement must NOT become a stated workplace preference."""
+
+    def _bridge(self, arrangement: str):
+        from src.services.profile.models import CVData, UserPreferences
+        from src.services.profile.preferences import sanitize_preferences
+
+        prefs = UserPreferences(work_arrangement=arrangement)
+        return sanitize_preferences(prefs, CVData())
+
+    @pytest.mark.parametrize("value", ["remote", "hybrid", "onsite"])
+    def test_a_stated_arrangement_agrees_with_the_workplace(self, value: str) -> None:
+        out = self._bridge(value)
+        if out.preferred_workplace is not None:
+            assert out.preferred_workplace == out.work_arrangement.lower(), (
+                "the two have diverged — the scorer and the prefilter would now "
+                "act on different answers to the same question"
+            )
+
+    def test_an_unstated_arrangement_never_becomes_a_preference(self) -> None:
+        """Rule #29 at its sharpest: silence must stay silence. A default written
+        here is indistinguishable from a choice the user made."""
+        out = self._bridge("")
+        assert not out.work_arrangement
+        assert out.preferred_workplace in (None, ""), (
+            "an empty work_arrangement produced a workplace preference — that is "
+            "a fake constraint the user never stated"
+        )

--- a/backend/tests/test_pillar1_data_loss.py
+++ b/backend/tests/test_pillar1_data_loss.py
@@ -14,7 +14,14 @@ import pytest
 from src.services.profile.models import CVData, UserPreferences, UserProfile
 
 _LI_FIELDS = ("linkedin_positions", "linkedin_languages", "linkedin_projects",
-              "linkedin_volunteer", "linkedin_courses")
+              "linkedin_volunteer", "linkedin_courses",
+              # Added 2026-08-12. Skills have the same two-pass shape as the
+              # five above and the same cache-hit failure, but the assignment
+              # sat one line OUTSIDE the llm_ran gate the original fix added —
+              # so a real profile's 13 LinkedIn skills collapsed to the 3 in the
+              # deterministic sidebar on any unrelated profile edit. The tuple
+              # not covering it is why the original fix looked complete.
+              "linkedin_skills")
 
 
 async def _noop(*a, **kw):
@@ -108,6 +115,11 @@ class TestLinkedInSectionsSurviveACacheHit:
             "projects": [{"title": "Thing"}],
             "volunteer": [{"role": "Mentor"}],
             "courses": [{"title": "K8s"}],
+            # Skills come from BOTH LinkedIn passes, so they belong in this
+            # cache-hit test exactly like the five sections above. They were
+            # absent from this payload, which is why the assignment sitting
+            # outside the llm_ran gate went unnoticed for four days.
+            "skills": ["LangGraph", "Multi-agent Systems"],
         }
 
         async def ran(*a, **kw):

--- a/backend/tests/test_prefilter_wiring.py
+++ b/backend/tests/test_prefilter_wiring.py
@@ -17,10 +17,25 @@ Measured against 2,000 live jobs and the owner's real profile (2026-08-09):
 """
 from __future__ import annotations
 
+import pytest
+
 from src.models import Job
-from src.services.prefilter import passes_prefilter
+from src.services.prefilter import location_ok, passes_prefilter
 from src.services.profile.models import CVData, UserPreferences, UserProfile
 from src.workers.tasks import _filter_profile_for
+
+
+def _job_at(location: str) -> Job:
+    """A job in a specific place - the location stage is what is under test."""
+    return Job(
+        title="Machine Learning Engineer",
+        company="Acme",
+        apply_url="https://example.com/1",
+        source="test",
+        date_found="2026-08-12",
+        location=location,
+        description="We use Rust.",
+    )
 
 
 def _job(title: str = "Machine Learning Engineer", desc: str = "We use Rust.") -> Job:
@@ -147,6 +162,65 @@ class TestACountryLevelPreferenceIsNotAConstraint:
         # London matches the country entry, so it survives — the user asking for
         # "UK or Manchester" wants UK-wide results.
         assert passes_prefilter(fp, _job()) is True
+
+
+class TestAnUnresolvablePlaceNeverDeletesTheFeed:
+    """PR #297 fixed the COUNTRY case and stopped one level too high.
+
+    Measured against the real predicate after #297 shipped:
+
+        "United Kingdom"  keeps everything   (the #297 fix)
+        "Greater London"  keeps London only  (and only because one string is a
+                                              substring of the other)
+        "West Midlands"   keeps NOTHING      (Birmingham is IN it)
+        "Yorkshire"       keeps NOTHING      (Leeds is IN it)
+        "South East"      keeps NOTHING
+
+    A county or region is the second most natural thing a UK user types after a
+    city, and it emptied the whole feed. The gazetteer decides this from DATA,
+    not a typed list of regions: it holds ~52k settlements and no administrative
+    divisions, so "can this gate compare the preference to a job location?" is
+    "is it in the gazetteer?".
+    """
+
+    def _fp(self, monkeypatch, locations):
+        profile = UserProfile(
+            cv_data=CVData(raw_text="x", skills=["python"]),
+            preferences=UserPreferences(preferred_locations=locations),
+        )
+        monkeypatch.setattr(
+            "src.workers.tasks._user_profile_for", lambda _uid: profile
+        )
+        return _filter_profile_for("u1")
+
+    @pytest.mark.parametrize(
+        "region", ["Greater London", "West Midlands", "Yorkshire", "South East"]
+    )
+    def test_a_region_or_county_keeps_the_feed(self, monkeypatch, region) -> None:
+        fp = self._fp(monkeypatch, [region])
+        for city in ("London", "Manchester", "Birmingham", "Leeds"):
+            assert location_ok(fp, _job_at(city)) is True, (
+                f"{region!r} deleted a job in {city!r} — a preference this gate "
+                "cannot resolve must never empty the feed"
+            )
+
+    def test_a_real_city_still_filters(self, monkeypatch) -> None:
+        """The fix must not turn the stage back into a no-op: a settlement the
+        user named is resolvable, so it genuinely constrains."""
+        fp = self._fp(monkeypatch, ["Manchester"])
+        assert location_ok(fp, _job_at("Manchester")) is True
+        assert location_ok(fp, _job_at("London")) is False
+
+    def test_a_missing_gazetteer_fails_open(self, monkeypatch) -> None:
+        """The image shipped without the gazetteer for weeks. If that recurs,
+        an unresolvable preference must pass, never delete."""
+        from src.services import prefilter as pf
+
+        monkeypatch.setattr(
+            pf, "_no_resolvable_place", lambda _prefs: True
+        )
+        fp = self._fp(monkeypatch, ["Manchester"])
+        assert location_ok(fp, _job_at("London")) is True
 
 
 class TestSkillsStayOutUntilMeasured:

--- a/backend/tests/test_shelf_registry.py
+++ b/backend/tests/test_shelf_registry.py
@@ -172,6 +172,22 @@ class TestMatchingCoverageDoesNotRegress:
     # career_domain and linkedin_summary into the judge and the vector.
     BASELINE = 50
 
+    def test_the_headline_number_is_broken_down_by_reach(self) -> None:
+        """A single "N shelves feed matching" figure counts a shelf the LLM
+        judge reads on a capped window the same as one the keyword engine reads
+        on every row. Those are not the same claim, and the flattering one is
+        the easy one to repeat. This pins the honest breakdown as something the
+        code computes rather than something a summary asserts."""
+        from src.services.profile.shelf_audit import matching_shelves, matching_tiers
+
+        tiers = matching_tiers()
+        assert set(tiers) == {"every_job", "judge_only", "semantic_only"}
+        total = sum(len(v) for v in tiers.values())
+        assert total == len(matching_shelves()), "a shelf fell out of every tier"
+        # The every-job tier is the one worth quoting: it changes the rank of
+        # every job in the feed. If it hits zero the engine is nominal.
+        assert tiers["every_job"], "no shelf reaches the engine that ranks every job"
+
     def test_matching_shelf_count_never_falls(self) -> None:
         current = sum(1 for n in shelf_names() if is_matching_shelf(n))
         assert current >= self.BASELINE, (
@@ -179,12 +195,33 @@ class TestMatchingCoverageDoesNotRegress:
             "stopped feeding the engines — find which consumer stopped reading it."
         )
 
-    def test_every_matching_role_is_a_real_role(self) -> None:
-        used = set()
+    def test_every_matching_role_is_actually_used(self) -> None:
+        """This test used to read ``used & MATCHING_ROLES - MATCHING_ROLES``.
+
+        ``&`` and ``-`` bind left to right at equal precedence, so that is
+        ``(used & M) - M`` — the empty set for EVERY possible value of ``used``.
+        It could not fail. It sat inside a regression class and read like
+        coverage, which is worse than no test: it is the exact assertion that
+        should have caught a declared matching role reading zero shelves.
+        """
+        used: set[str] = set()
         for name in shelf_names():
             used |= readers(name)
-        unknown = used & MATCHING_ROLES - MATCHING_ROLES
-        assert not unknown
+
+        # A role we CLAIM is a matching role must earn it by being read by at
+        # least one shelf. A role nobody reads inflates the headline "N shelves
+        # feed matching" with a module that contributes none of them.
+        idle = sorted(MATCHING_ROLES - used)
+        assert not idle, (
+            f"These roles are declared matching but read zero shelves: {idle}. "
+            "Wire them or remove them from MATCHING_ROLES — a role with no "
+            "reader makes the matching count claim more than it delivers."
+        )
+
+        from src.services.profile.shelf_audit import _ROLES
+
+        undefined = sorted(used - set(_ROLES.values()))
+        assert not undefined, f"readers() returned undefined roles: {undefined}"
 
 
 @pytest.mark.parametrize("name", list(shelf_names()))

--- a/backend/tests/test_shelf_registry.py
+++ b/backend/tests/test_shelf_registry.py
@@ -170,7 +170,7 @@ class TestMatchingCoverageDoesNotRegress:
     # nine matching modules); raised to 46 by the shelf-completeness batch, which
     # wired the LinkedIn evidence sections, cv_industries, cv_languages,
     # career_domain and linkedin_summary into the judge and the vector.
-    BASELINE = 49
+    BASELINE = 50
 
     def test_matching_shelf_count_never_falls(self) -> None:
         current = sum(1 for n in shelf_names() if is_matching_shelf(n))

--- a/backend/tests/test_shipped_data.py
+++ b/backend/tests/test_shipped_data.py
@@ -1,0 +1,99 @@
+"""Data the repo deliberately COMMITS must survive the Docker build.
+
+Two ignore files describe the same intent from opposite directions, and nothing
+made them agree. `.gitignore` ignores `data/` and then un-ignores
+`backend/data/uk_gazetteer/**` and `backend/data/job_signals/**` — the exemptions
+are the reason those files are in the repository at all. `.dockerignore` ignored
+`data/` with no exemptions, and the Dockerfile is `COPY . .`, so the image was
+built without precisely the files someone had gone out of their way to commit.
+
+Nothing failed. Both loaders degrade silently by design:
+
+    uk_gate._read()          -> frozenset()  when the file is absent
+    job_signals._load_terms() -> {}           when the file is absent
+
+So the UK gate (rule #30's entire basis) and the seniority / workplace
+detectors would answer "nothing" in production, with no exception and no log
+line, while passing every test on a developer machine where the files exist.
+
+This is the same shape as every other bug in this batch: two hand-maintained
+copies of one intent, drifting apart with nobody watching. The test is therefore
+DERIVED from `.gitignore` rather than hard-coding a list of directories — a
+third exemption added tomorrow is covered automatically.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_BACKEND = Path(__file__).resolve().parent.parent
+_REPO = _BACKEND.parent
+
+
+def _negations(path: Path) -> set[str]:
+    """Un-ignore patterns (`!...`) under a data/ directory, normalised.
+
+    Both files are read into the same namespace: `.gitignore` sits at the repo
+    root and writes `backend/data/...`, `.dockerignore` sits in `backend/` and
+    writes `data/...`. Stripping the `backend/` prefix makes them comparable.
+    """
+    if not path.exists():
+        return set()
+    out: set[str] = set()
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line.startswith("!"):
+            continue
+        pattern = line[1:].strip().lstrip("/")
+        pattern = re.sub(r"^backend/", "", pattern)
+        if pattern.startswith("data/"):
+            out.add(pattern.rstrip("/").removesuffix("/**"))
+    return out
+
+
+class TestTheImageShipsWhatTheRepoCommits:
+    def test_dockerignore_exempts_everything_gitignore_exempts(self) -> None:
+        wanted = _negations(_REPO / ".gitignore")
+        assert wanted, (
+            "no data/ exemptions found in .gitignore — if the committed "
+            "reference data moved, this test needs to move with it"
+        )
+        have = _negations(_BACKEND / ".dockerignore")
+        missing = sorted(wanted - have)
+        assert not missing, (
+            "These directories are deliberately committed to the repo but "
+            f"excluded from the Docker image: {missing}. The loaders degrade "
+            "silently on a missing file, so production answers 'nothing' with "
+            "no error while every local test passes."
+        )
+
+    @pytest.mark.parametrize("rel", ["data/uk_gazetteer", "data/job_signals"])
+    def test_the_committed_data_actually_exists(self, rel: str) -> None:
+        """The exemption is worthless if the directory is empty — that would
+        look identical to the bug it prevents."""
+        d = _BACKEND / rel
+        assert d.is_dir(), f"{rel} is exempted from both ignore files but absent"
+        files = [p for p in d.iterdir() if p.is_file() and p.suffix in (".txt", "")]
+        assert files, f"{rel} exists but ships no data files"
+
+
+class TestTheLoadersStillDegradeQuietly:
+    """Pins WHY this needed a test rather than being caught at runtime: neither
+    loader raises. If someone later makes them raise, that is an improvement —
+    but it should be a deliberate change, seen here first."""
+
+    def test_uk_gate_returns_empty_rather_than_raising(self) -> None:
+        from src.services import uk_gate
+
+        # A missing data directory yields empty sets, not an error — which is
+        # exactly why an image built without them looked healthy.
+        places, foreign, ambiguous = uk_gate._gazetteer()
+        for s in (places, foreign, ambiguous):
+            assert isinstance(s, frozenset)
+
+    def test_job_signals_returns_empty_dict_for_a_missing_file(self) -> None:
+        from src.services.job_signals import _load_terms
+
+        assert _load_terms("definitely-not-a-real-file.txt") == {}

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -201,6 +201,11 @@
             "title": "Companies",
             "type": "array"
           },
+          "cv_experience_level": {
+            "default": "",
+            "title": "Cv Experience Level",
+            "type": "string"
+          },
           "cv_positions": {
             "default": [],
             "items": {
@@ -218,6 +223,11 @@
             },
             "title": "Cv Projects",
             "type": "array"
+          },
+          "cv_right_to_work": {
+            "default": "",
+            "title": "Cv Right To Work",
+            "type": "string"
           },
           "education": {
             "default": [],

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -210,6 +210,15 @@
             "title": "Cv Positions",
             "type": "array"
           },
+          "cv_projects": {
+            "default": [],
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "title": "Cv Projects",
+            "type": "array"
+          },
           "education": {
             "default": [],
             "items": {

--- a/frontend/src/components/profile/CVViewer.tsx
+++ b/frontend/src/components/profile/CVViewer.tsx
@@ -553,6 +553,30 @@ export function CVViewer({
           </div>
         )}
 
+        {/* Seniority and right-to-work, as the CV states them. Both are read by
+            the LLM judge, so they were being SCORED ON while invisible to the
+            person they describe - the same gap that hid linkedin_summary, made
+            again one commit later on the shelves that replaced it. */}
+        {(cv.cv_experience_level || cv.cv_right_to_work) && (
+          <div className="mb-5">
+            <SectionLabel icon={Briefcase} text="Stated on your CV" />
+            <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 pl-5 text-xs">
+              {cv.cv_experience_level && (
+                <div className="contents">
+                  <dt className="text-muted-foreground">Seniority</dt>
+                  <dd className="text-foreground/85">{cv.cv_experience_level}</dd>
+                </div>
+              )}
+              {cv.cv_right_to_work && (
+                <div className="contents">
+                  <dt className="text-muted-foreground">Right to work</dt>
+                  <dd className="text-foreground/85">{cv.cv_right_to_work}</dd>
+                </div>
+              )}
+            </dl>
+          </div>
+        )}
+
         {/* Projects stated on the CV. A "Projects" heading was already
             recognised — as a boundary that stops a skills block — and then
             discarded. For a junior or career-changing candidate these are

--- a/frontend/src/components/profile/CVViewer.tsx
+++ b/frontend/src/components/profile/CVViewer.tsx
@@ -225,6 +225,17 @@ export function CVViewer({
   // (The showFullCV toggle and its highlight terms went with the "Full CV
   // Text" panel — that text now lives only in the CV Uploaded card.)
 
+  // Projects the CV states. Defensive field reads for the same reason as
+  // cv_positions: these rows are LLM output with no strict wire schema.
+  const cvProjects = ((cv.cv_projects ?? []) as Record<string, unknown>[])
+    .map((raw) => ({
+      name: strField(raw, "name"),
+      description: strField(raw, "description"),
+      technologies: strArrField(raw, "technologies"),
+      dates: strField(raw, "dates"),
+    }))
+    .filter((p) => p.name || p.description);
+
   const positions = (cv.cv_positions ?? [])
     .map((raw) => normalizePosition(raw as Record<string, unknown>))
     .filter((p) => p.company || p.title);
@@ -539,6 +550,42 @@ export function CVViewer({
                 </li>
               ))}
             </ul>
+          </div>
+        )}
+
+        {/* Projects stated on the CV. A "Projects" heading was already
+            recognised — as a boundary that stops a skills block — and then
+            discarded. For a junior or career-changing candidate these are
+            often the strongest evidence on the document. */}
+        {cvProjects.length > 0 && (
+          <div className="mb-5">
+            <SectionLabel icon={FolderKanban} text={`Projects (${cvProjects.length})`} />
+            <div className="space-y-3 pl-5">
+              {cvProjects.map((proj, i) => (
+                <div key={i}>
+                  <div className="flex flex-wrap items-baseline gap-x-2">
+                    <span className="text-sm font-medium text-foreground">{proj.name}</span>
+                    {proj.dates && (
+                      <span className="text-xs text-muted-foreground">{proj.dates}</span>
+                    )}
+                  </div>
+                  {proj.description && (
+                    <p className="text-xs leading-relaxed text-foreground/80">
+                      {proj.description}
+                    </p>
+                  )}
+                  {proj.technologies.length > 0 && (
+                    <div className="mt-1 flex flex-wrap gap-1">
+                      {proj.technologies.map((t, j) => (
+                        <Badge key={j} variant="secondary" className="text-[10px]">
+                          {t}
+                        </Badge>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
           </div>
         )}
 

--- a/frontend/src/lib/api-types.ts
+++ b/frontend/src/lib/api-types.ts
@@ -1557,6 +1557,11 @@ export interface components {
              */
             companies: string[];
             /**
+             * Cv Experience Level
+             * @default
+             */
+            cv_experience_level: string;
+            /**
              * Cv Positions
              * @default []
              */
@@ -1570,6 +1575,11 @@ export interface components {
             cv_projects: {
                 [key: string]: unknown;
             }[];
+            /**
+             * Cv Right To Work
+             * @default
+             */
+            cv_right_to_work: string;
             /**
              * Education
              * @default []

--- a/frontend/src/lib/api-types.ts
+++ b/frontend/src/lib/api-types.ts
@@ -1564,6 +1564,13 @@ export interface components {
                 [key: string]: unknown;
             }[];
             /**
+             * Cv Projects
+             * @default []
+             */
+            cv_projects: {
+                [key: string]: unknown;
+            }[];
+            /**
              * Education
              * @default []
              */


### PR DESCRIPTION
A full adversarial audit of the user side: six lenses, each finding refuted by a separate agent. **33 of 35 findings survived.** The most useful ones proved *me* wrong.

## The shrink was not a bug, and my guard was the wrong fix

I reported that a re-extraction shrank `job_titles` 3→2 and `education` 6→3, and guessed `load_profile` was duplicating on read. **Three lenses independently disproved that** against the real 10-version production history: `load_profile` is a pure deserialiser. The "6" is a **mid-run peak** — `enrich_cv_from_linkedin` re-appends LinkedIn's wordings, then `llm_merge_duplicates` collapses genuine near-duplicates back down. That is the feature working.

My refuse-to-write-on-shrink guard would have frozen *"Master of Science…"* and *"Master's degree, …"* into the profile as two separate degrees forever. **It is not shipped.**

The real defect underneath is different and worse: `llm_merge_duplicates` had **no lower bound**. Its only checks were "not empty" and "not longer than the input", so any shorter answer was accepted and written. A rate-limited model returning one item from seven silently deleted six certifications. It now must prove **coverage** — every entry it removes must still be represented by something it kept. Every existing test patched this function out, so the one step that can shorten three matching shelves had **no coverage at all**.

## Two data-loss bugs

| | |
|---|---|
| **Re-uploading a CV** deleted LinkedIn's education, certifications and job titles | Those three lists are written by *both* passes (LinkedIn has no shelf of its own for them), but the reset dropped only the `cv` cache key. The LinkedIn pass became a cache hit, contributed nothing, and the data was **unrecoverable by re-uploading the same PDF** — its text is unchanged, so the hash still matches. |
| **`linkedin_skills`** wiped on any unrelated profile edit | The 2026-08-08 `llm_ran` gate protected five sections. Skills have the same shape and the same failure, but the assignment sat **one line outside** the gate. On the owner's real profile that is 13 skills collapsing to 3. |

## Six were mine, from today

- `reset_cv_owned_fields` never cleared `cv_experience_level` / `cv_right_to_work` / `cv_projects` — uploading a **different person's CV** left the previous person's stated seniority and work authorisation. Confidently wrong is worse than missing. Now derived from the same source the merge uses.
- `embeddings` read key `title` from `cv_projects` while the CV pass writes `name` — projects reached the vector without their name *or* technology list.
- `test_every_matching_role_is_a_real_role` asserted `used & MATCHING_ROLES - MATCHING_ROLES`, which is `(used & M) - M` — **the empty set for every possible input.** It could not fail. Rewritten, and on its first real run it immediately caught the next item.
- **`feed` was a declared matching role while `feed.py` reads zero shelves** — pure inflation in the headline number.
- `cv_experience_level` and `cv_right_to_work` were read by the judge and shown nowhere — the same scored-on-but-invisible gap I fixed for `linkedin_summary` in #296 and **repeated one commit later**.

## "50 shelves feed matching" was misleading, so it's now computed

```
19  rank EVERY job      (scorer, search-keywords, tiering, prefilter)
22  reach only the judge (a capped window)
 9  reach only the vector
```

**19 is the number worth quoting.** A headline that cannot be recomputed from the code is exactly the kind of claim this batch keeps correcting.

## Region preferences still deleted the whole feed

#297 fixed the country case and stopped one level too high. Measured after it shipped:

```
United Kingdom  ->  keeps everything
West Midlands   ->  keeps NOTHING   (Birmingham is IN it)
Yorkshire       ->  keeps NOTHING   (Leeds is IN it)
```

The gazetteer answers this from **data**, not a typed list of regions (rule #30): it holds ~52k settlements and no admin divisions, so a preference absent from it is one this gate cannot evaluate — it passes instead of deleting. A settlement still filters normally. Fails open if the gazetteer is missing, which has already happened once.

Gate: PASS — 314 backend targeted, 253 frontend, api-types drift clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6DsQH5EUxJc3Vnqz9YHgQ
