### PR TITLE
fix(prefs): one workplace answer, tappable skill suggestions, and labels that match the code

### DIFF
--- a/backend/scripts/build_real_profiles.py
+++ b/backend/scripts/build_real_profiles.py
@@ -21,7 +21,7 @@ PEOPLE = [
         "linkedin": None,
         "github": None,
         "prefs": dict(experience_level="senior", work_arrangement="remote",
-                      preferred_workplace="remote", salary_min=50000, salary_max=85000,
+                      salary_min=50000, salary_max=85000,
                       needs_visa=True),
     },
     {
@@ -30,7 +30,7 @@ PEOPLE = [
         "linkedin": f"{ROOT}/User_info/Linkedin_pdf/rohith_Profile .pdf",
         "github": None,
         "prefs": dict(experience_level="senior", work_arrangement="hybrid",
-                      preferred_workplace="hybrid", salary_min=70000, salary_max=110000,
+                      salary_min=70000, salary_max=110000,
                       needs_visa=False),
     },
     {
@@ -39,7 +39,7 @@ PEOPLE = [
         "linkedin": f"{ROOT}/User_info/Linkedin_pdf/Sofia LinkedIn.pdf",
         "github": "sofiashajilekha",
         "prefs": dict(experience_level="junior", work_arrangement="remote",
-                      preferred_workplace="remote", salary_min=30000, salary_max=50000,
+                      salary_min=30000, salary_max=50000,
                       needs_visa=True),
     },
 ]

--- a/backend/scripts/fake_profiles.py
+++ b/backend/scripts/fake_profiles.py
@@ -304,7 +304,6 @@ def build_user_profile(spec: dict):
         salary_max=p.get("salary_max"),
         work_arrangement=p.get("workplace", ""),
         experience_level=p.get("experience_level", ""),
-        preferred_workplace=p.get("workplace"),
         needs_visa=bool(p.get("needs_visa", False)),
         github_username=spec.get("github_username", ""),
         about_me=spec["summary"],

--- a/backend/scripts/rater_panel.py
+++ b/backend/scripts/rater_panel.py
@@ -46,7 +46,7 @@ def _profile_text(uid):
     return (f"CANDIDATE: {cv.get('name')}\nTarget titles: {titles}\n"
             f"Skills: {skills}\nLevel: {p.get('experience_level')}, "
             f"salary {p.get('salary_min')}-{p.get('salary_max')}, "
-            f"workplace {p.get('preferred_workplace')}, needs_visa {p.get('needs_visa')}")
+            f"workplace {p.get('work_arrangement')}, needs_visa {p.get('needs_visa')}")
 
 
 def _jobs_for(uid, ids):

--- a/backend/scripts/shelf_xray.py
+++ b/backend/scripts/shelf_xray.py
@@ -105,7 +105,7 @@ def main() -> int:
         "education":  lambda c, p: c.get("education"),
         "salary":     lambda c, p: p.get("salary_min") or p.get("salary_max"),
         "location":   lambda c, p: p.get("preferred_locations") or c.get("location"),
-        "workplace":  lambda c, p: p.get("preferred_workplace") or p.get("work_arrangement"),
+        "workplace":  lambda c, p: p.get("work_arrangement"),
         "seniority":  lambda c, p: p.get("experience_level"),
         "visa":       lambda c, p: p.get("needs_visa") is not None,
         "domain":     lambda c, p: c.get("career_domain") or (p.get("industries") or c.get("industries")),

--- a/backend/src/api/routes/profile.py
+++ b/backend/src/api/routes/profile.py
@@ -433,30 +433,49 @@ async def _capture_cv_raw(content: bytes, filename: str | None, profile: UserPro
             pass
 
 
+def _normalize_work_arrangement(value: object) -> str:
+    """Store "I don't mind" as SILENCE, not as the literal string "any".
+
+    The preferences select seeds itself at ``"any"`` and posts that value, so
+    "any" reached the database as though the user had stated a constraint. Two
+    consumers then read it RAW, not through the ``preferred_workplace`` property
+    that maps it to None:
+
+      * the LLM judge builds its prompt with ``if v:`` — a non-empty string — so
+        every judged job was told ``work_arrangement=any``, spending real tokens
+        to state a preference the user explicitly declined to make;
+      * the semantic vector appended "any" as a candidate token.
+
+    The property protects the keyword scorer, but a property cannot protect a
+    reader that bypasses it. Normalising on SAVE fixes it once, at the only
+    point where the sentinel can enter — and it holds for the CLI and any older
+    client too, which a frontend-side fix would not.
+
+    Rule #29: an unstated preference is silence. "Any" IS unstated.
+    """
+    text = value.strip().lower() if isinstance(value, str) else ""
+    return text if text in {"remote", "hybrid", "onsite"} else ""
+
+
 def _apply_preferences(preferences_json: str, profile: UserProfile) -> None:
     """Parse the preferences JSON form and set it on the profile.
 
     Fields the form does NOT carry (``github_username`` — set by the separate
-    GitHub route — plus ``preferred_workplace`` / ``needs_visa``) fall back to the
+    GitHub route — plus ``needs_visa`` and ``work_arrangement``) fall back to the
     EXISTING preferences so a routine preferences save never silently wipes them.
     """
     pref_dict = json.loads(preferences_json)
     existing = profile.preferences or UserPreferences()
 
-    # Bridge work_arrangement -> preferred_workplace (2026-08-08).
+    # The work_arrangement -> preferred_workplace bridge used to live here.
     #
-    # The model documents preferred_workplace as "the enum form of
-    # work_arrangement so the dimension scorer can match" — but nothing ever
-    # built that bridge. The form sends work_arrangement; the WORKPLACE scoring
-    # dimension (weight 6, workplace_score) reads preferred_workplace; there is
-    # no preferred_workplace control anywhere in the frontend. So the field the
-    # scorer reads stayed None for every user and the whole workplace dimension
-    # was permanently dead — the "dead pair" the shelf X-ray flagged was caused
-    # HERE, not by users failing to fill anything. Same vocabulary on both
-    # sides ("remote"/"hybrid"/"onsite"), so an empty string maps to None
-    # ("no preference" -> neutral score, per the model comment).
-    _wa = pref_dict.get("work_arrangement", "")
-    _derived_workplace = _wa.strip().lower() or None if isinstance(_wa, str) else None
+    # It existed because the form wrote one field and the scorer read another,
+    # so the workplace dimension was dead for every user until it was built.
+    # A bridge keeps two boxes holding one answer, and they drift: cli.py's
+    # setup-profile writes work_arrangement and has never written the other, so
+    # that entry point produced a divergent profile from the day it was written.
+    # preferred_workplace is now a derived @property on UserPreferences, so
+    # there is exactly one stored answer and the two cannot disagree.
     profile.preferences = UserPreferences(
         target_job_titles=pref_dict.get("target_job_titles", []),
         additional_skills=pref_dict.get("additional_skills", []),
@@ -465,7 +484,14 @@ def _apply_preferences(preferences_json: str, profile: UserProfile) -> None:
         industries=pref_dict.get("industries", []),
         salary_min=pref_dict.get("salary_min"),
         salary_max=pref_dict.get("salary_max"),
-        work_arrangement=pref_dict.get("work_arrangement", ""),
+        # An OMITTED key keeps the stored value; an explicit "" still clears it.
+        # The old default of "" meant any partial save wiped the answer, and
+        # the damage was hidden by the preferred_workplace fallback that this
+        # change removes — so without this line the workplace dimension would
+        # go dark again, which is the exact regression the bridge was added for.
+        work_arrangement=_normalize_work_arrangement(
+            pref_dict.get("work_arrangement", existing.work_arrangement)
+        ),
         experience_level=pref_dict.get("experience_level", ""),
         negative_keywords=pref_dict.get("negative_keywords", []),
         about_me=pref_dict.get("about_me", ""),
@@ -477,11 +503,6 @@ def _apply_preferences(preferences_json: str, profile: UserProfile) -> None:
         github_username=normalize_github_username(
             pref_dict.get("github_username") or existing.github_username or ""
         ),
-        # Explicit value wins (a future dedicated control); otherwise derive
-        # from work_arrangement; only then fall back to the stored value.
-        preferred_workplace=pref_dict.get("preferred_workplace")
-        or _derived_workplace
-        or existing.preferred_workplace,
         needs_visa=pref_dict.get("needs_visa", existing.needs_visa),
     )
     # Scrub extraction pollution before it is stored. The frontend autosaves the

--- a/backend/src/services/embeddings.py
+++ b/backend/src/services/embeddings.py
@@ -250,7 +250,9 @@ def profile_to_embedding_text(profile: Any) -> str:
     if prefs is not None:
         _add_all(getattr(prefs, "industries", []))
         _add_all(getattr(prefs, "preferred_locations", []))
-        for attr in ("preferred_workplace", "experience_level", "work_arrangement"):
+        # preferred_workplace dropped: it is derived from work_arrangement, so it
+        # only duplicated a token already in the vector text.
+        for attr in ("experience_level", "work_arrangement"):
             v = getattr(prefs, attr, None)
             if isinstance(v, str) and v.strip():
                 parts.append(v.strip())

--- a/backend/src/services/llm_matcher.py
+++ b/backend/src/services/llm_matcher.py
@@ -247,7 +247,9 @@ def profile_to_matcher_text(profile: Any) -> str:
 
     if prefs is not None:
         pref_bits: list[str] = []
-        for attr in ("experience_level", "work_arrangement", "preferred_workplace"):
+        # work_arrangement only — preferred_workplace is now derived FROM it, so
+        # listing both sent the judge the same answer twice on every job.
+        for attr in ("experience_level", "work_arrangement"):
             v = getattr(prefs, attr, None)
             if v:
                 pref_bits.append(f"{attr}={v}")

--- a/backend/src/services/profile/models.py
+++ b/backend/src/services/profile/models.py
@@ -510,13 +510,41 @@ class UserPreferences:
     about_me: str = ""
     github_username: str = ""
     # Pillar 2 Batch 2.9 — multi-dimensional scoring inputs.
-    # `preferred_workplace` is the enum form of `work_arrangement` so the
-    # dimension scorer can match against `JobEnrichment.workplace_type`
-    # without string juggling. None → user has no preference → neutral score.
     # `needs_visa` gates the visa scorer — when False the dim returns 0
     # (no reward for something the user doesn't need).
-    preferred_workplace: Optional[str] = None  # "remote" | "hybrid" | "onsite" | None
     needs_visa: bool = False
+
+    # Values the workplace scorer can actually match. A CLOSED set, because the
+    # job side of the comparison (`JobEnrichment.workplace_type`) is an enum —
+    # anything outside it can never match anything (rule #30's closed-set test).
+    _WORKPLACE_VALUES = frozenset({"remote", "hybrid", "onsite"})
+
+    @property
+    def preferred_workplace(self) -> Optional[str]:
+        """The enum form of ``work_arrangement``, DERIVED — not stored.
+
+        This was a second stored field holding the same answer, bridged into
+        place by the profile route. The user was answering one question ("do you
+        go in?") and the system kept two boxes for it, which is exactly how they
+        drifted: `cli.py`'s `setup-profile` sets `work_arrangement` and has never
+        set `preferred_workplace`, so that entry point produced a divergent
+        profile from the day it was written. A copy kept in step by discipline
+        eventually is not.
+
+        THE SENTINEL THIS FIXES. The form seeds itself at "any" and offers it as
+        a real option, but "any" is not one of the three values the scorer
+        knows, so `workplace_score` fell through every branch to 0 — while an
+        EMPTY preference returns the neutral 3. Choosing "I don't mind" scored
+        WORSE than saying nothing, on every job in the feed. That is rule #29
+        inverted: a stated "don't care" became a penalty.
+
+        The allowlist below is what makes that unrepresentable. Anything that is
+        not a matchable value — "any", "", whitespace, a future sentinel nobody
+        has invented yet — becomes None, which the scorer already treats as "no
+        preference, score neutral". Empty stays empty; it never guesses.
+        """
+        value = (self.work_arrangement or "").strip().lower()
+        return value if value in self._WORKPLACE_VALUES else None
 
 
 @dataclass

--- a/backend/src/services/profile/preferences.py
+++ b/backend/src/services/profile/preferences.py
@@ -117,6 +117,55 @@ _EXTRACTED_SKILL_SHELVES = (
 )
 
 
+def skills_already_held(cv_data: Any, prefs: Any = None) -> list[str]:
+    """Every skill the user demonstrably already has, from ONE definition.
+
+    Exists because two places needed this idea and each hand-maintained its own
+    list, which then drifted:
+
+      * ``sanitize_preferences`` strips an ``additional_skills`` entry that
+        duplicates an extracted shelf (``_EXTRACTED_SKILL_SHELVES``);
+      * ``llm_suggest_adjacent_skills`` only suggests skills the user does NOT
+        already have, and ``two_pass`` was building that "already have" set by
+        hand — from ``github_languages`` rather than ``github_skills_inferred``,
+        and omitting ``cv_skills_esco`` entirely.
+
+    ``github_skills_inferred`` is languages PLUS repo topics, so a topic-derived
+    skill ("rag") was invisible to the suggester and visible to the sanitizer.
+    Measured: it could be offered as a suggestion, accepted by the user, written
+    to ``additional_skills`` — and then stripped on the very next save. The chip
+    vanishes with nothing to explain it, which reads as the app losing input.
+
+    Both callers now read this, so the suggester can never offer something the
+    sanitizer will immediately take away.
+
+    Returns the skills in their ORIGINAL spelling, deduped case-insensitively.
+    The case matters: this list is also interpolated into the suggestion prompt,
+    and "pytorch, aws, sql" is a worse prompt than "PyTorch, AWS, SQL".
+    """
+    out: list[str] = []
+    seen: set[str] = set()
+
+    def _add(value: Any) -> None:
+        if isinstance(value, dict):  # ESCO entries are {name|skill|label: ...}
+            value = value.get("name") or value.get("skill") or value.get("label")
+        if not isinstance(value, str) or not value.strip():
+            return
+        text = value.strip()
+        key = text.casefold()
+        if key not in seen:
+            seen.add(key)
+            out.append(text)
+
+    for field in _EXTRACTED_SKILL_SHELVES:
+        for v in (_cv_get(cv_data, field, []) or []):
+            _add(v)
+    if prefs is not None:
+        for s in (getattr(prefs, "additional_skills", None) or []):
+            _add(s)
+    return out
+
+
 def _extracted_skills_index(cv_data: Any) -> set[str]:
     """Case-folded set of every skill already captured in an EXTRACTED shelf.
 

--- a/backend/src/services/profile/shelf_audit.py
+++ b/backend/src/services/profile/shelf_audit.py
@@ -330,16 +330,75 @@ def _scan(paths: Iterable[Path], shelves: frozenset[str]) -> dict[str, set[str]]
 
 
 @lru_cache(maxsize=1)
-def _reader_index() -> dict[str, set[str]]:
-    """shelf -> set of roles that read it."""
+def derived_shelves() -> dict[str, tuple[str, ...]]:
+    """Read-only VIEW name -> the stored shelf(s) it is computed from.
+
+    A derived shelf is a ``@property`` on one of the profile dataclasses. It has
+    no storage and no writer, so it is deliberately NOT in ``shelf_names()`` —
+    the "every shelf has a writer" rule would fail it, correctly, because
+    nothing can or should fill it.
+
+    But consumers still read it by name, and that read is a real read of the
+    shelf underneath. ``preferred_workplace`` is the live case: the keyword
+    scorer reads it on every job, while the stored answer is
+    ``work_arrangement``. Without this mapping the audit would report
+    ``work_arrangement`` as judge-only and miss that it ranks the entire feed —
+    the instrument would under-report the very thing it exists to measure.
+
+    DERIVED FROM THE SOURCE, never hand-listed: the property bodies are parsed
+    and every ``self.<shelf>`` they read becomes the mapping. A hand-typed map
+    here would be one more copy to drift, which is the bug class this whole
+    module was written to catch.
+    """
+    from src.services.profile import models as _models
+
     shelves = frozenset(shelf_names())
+    out: dict[str, tuple[str, ...]] = {}
+    try:
+        tree = ast.parse(Path(_models.__file__).read_text(encoding="utf-8"))
+    except (OSError, SyntaxError, TypeError):  # pragma: no cover - unreadable source
+        return out
+
+    for cls in (n for n in ast.walk(tree) if isinstance(n, ast.ClassDef)):
+        if cls.name not in {"CVData", "UserPreferences", "UserProfile"}:
+            continue
+        for fn in cls.body:
+            if not isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            if not any(
+                isinstance(d, ast.Name) and d.id == "property" for d in fn.decorator_list
+            ):
+                continue
+            sources = {
+                node.attr
+                for node in ast.walk(fn)
+                if isinstance(node, ast.Attribute)
+                and isinstance(node.value, ast.Name)
+                and node.value.id == "self"
+                and node.attr in shelves
+            }
+            if sources:
+                out[fn.name] = tuple(sorted(sources))
+    return out
+
+
+@lru_cache(maxsize=1)
+def _reader_index() -> dict[str, set[str]]:
+    """shelf -> set of roles that read it.
+
+    A read of a DERIVED view counts as a read of the shelf it is computed from,
+    because that is what it physically is.
+    """
+    shelves = frozenset(shelf_names())
+    derived = derived_shelves()
     index: dict[str, set[str]] = {name: set() for name in shelves}
-    for stem, found in _scan(_SRC.rglob("*.py"), shelves).items():
+    for stem, found in _scan(_SRC.rglob("*.py"), shelves | frozenset(derived)).items():
         role = _ROLES.get(stem)
         if not role:
             continue
         for name in found:
-            index[name].add(role)
+            for target in derived.get(name, (name,)):
+                index[target].add(role)
     return index
 
 

--- a/backend/src/services/profile/snapshot.py
+++ b/backend/src/services/profile/snapshot.py
@@ -85,7 +85,6 @@ def _raw_input_payload(cv_data: CVData, preferences: UserPreferences) -> dict[st
         "experience_level": preferences.experience_level,
         "negative_keywords": preferences.negative_keywords,
         "about_me": preferences.about_me,
-        "preferred_workplace": preferences.preferred_workplace,
         "needs_visa": preferences.needs_visa,
     }
 

--- a/backend/src/services/profile/two_pass.py
+++ b/backend/src/services/profile/two_pass.py
@@ -46,6 +46,7 @@ from src.services.profile.preferences import (
     deterministic_about_me_fields,
     llm_infer_from_about_me,
     merge_cv_and_preferences,
+    skills_already_held,
 )
 from src.services.profile.seniority import infer_experience_level
 
@@ -643,16 +644,20 @@ async def run_two_pass_extraction(profile: UserProfile) -> UserProfile:
 
     # Adjacent-skill SUGGESTIONS (opt-in, never auto-counted) from the full set of
     # skills the user actually has across all sources.
-    _all_skills = list(
-        dict.fromkeys(
-            (cv.skills or [])
-            + (cv.linkedin_skills or [])
-            + (cv.github_llm_skills or [])
-            + list((cv.github_languages or {}).keys())
-            + (prefs.additional_skills or [])
-        )
+    #
+    # This list USED to be hand-assembled here, and it disagreed with the list
+    # `sanitize_preferences` strips against: it read `github_languages` instead
+    # of `github_skills_inferred` (which is languages PLUS repo topics) and left
+    # out `cv_skills_esco`. So a topic-derived skill could be offered as a
+    # suggestion, accepted by the user, and then stripped from
+    # `additional_skills` on the very next save — the accepted chip just
+    # disappeared, with nothing on screen to explain it.
+    #
+    # Both sides now derive from `skills_already_held`, so the suggester cannot
+    # offer something the sanitizer will immediately take away.
+    cv.suggested_skills = await llm_suggest_adjacent_skills(
+        skills_already_held(cv, prefs)
     )
-    cv.suggested_skills = await llm_suggest_adjacent_skills(_all_skills)
 
     # ── Fold the freshly-extracted CV skills/titles into preferences ──
     # (Was done in the CV upload route; lives here now so the SINGLE extractor

--- a/backend/src/services/scoring_dimensions.py
+++ b/backend/src/services/scoring_dimensions.py
@@ -7,7 +7,12 @@ plan §4 Batch 2.9 (weights configurable via `core/settings.py`):
   seniority_score   (0-8)  — enriched seniority vs user's target experience
   salary_score      (0-10) — band overlap with UserPreferences.salary_min/max
   visa_score        (0-6)  — only awards when user needs sponsorship AND job offers
-  workplace_score   (0-6)  — Remote/Onsite/Hybrid match with UserPreferences.preferred_workplace
+  workplace_score   (0-6)  — Remote/Onsite/Hybrid match with
+                             UserPreferences.preferred_workplace, a property
+                             derived from the stored `work_arrangement`. It
+                             yields None for anything outside the three enum
+                             values, so the form's "any" default arrives as
+                             the neutral midpoint rather than a 0 (rule #29).
 
 Each scorer gracefully returns a neutral midpoint when its signal is missing
 (enrichment row absent, enum is "unknown", profile preference None).

--- a/backend/src/services/skill_matcher.py
+++ b/backend/src/services/skill_matcher.py
@@ -508,7 +508,10 @@ class JobScorer:
         Optional kwargs (Batch 2.9):
           * ``user_preferences`` — a `UserPreferences` dataclass with
             `salary_min`, `salary_max`, `experience_level`, `needs_visa`,
-            `preferred_workplace` fields consulted by the new dimensions.
+            `work_arrangement` fields consulted by the new dimensions.
+            (The workplace dimension reads `preferred_workplace`, which is
+            a read-only property derived from `work_arrangement` — there is
+            only one stored answer.)
           * ``enrichment_lookup`` — a callable `(job) -> JobEnrichment | None`
             that returns the enriched row for a given job. Defaults to a
             lambda that returns None (no enrichment dims contribute).

--- a/backend/tests/test_derived_shelves.py
+++ b/backend/tests/test_derived_shelves.py
@@ -1,23 +1,27 @@
 """Two shelves are DERIVED VIEWS of other shelves. Pin them so they stay that way.
 
-The shelf audit found four duplicate pairs. Two were genuine defects and were
-fixed by deleting a copy (``skill_entry`` duplicated ``skill_tiering``;
-``industries`` was declared on both dataclasses). These two are different: they
-are stored derivations with real consumers, and they cause no wrong behaviour.
-
     github_skills_inferred  == github_languages (by bytes) + github_topics
-    preferred_workplace     == work_arrangement, lower-cased
+    preferred_workplace     == work_arrangement, as a strict enum
 
-Deleting either is the wrong trade. ``github_skills_inferred`` has genuine
-ASSIGNMENT writers (``github_enricher`` and the clear route), so making it a
-read-only property would break them — and ``two_pass`` mutates it in place, which
-a property would silently swallow. ``preferred_workplace`` is what the scoring
-dimension reads, with no frontend control of its own.
+The risk is not the duplication. It is DIVERGENCE: a derived field that quietly
+stops matching its source becomes a third, wrong truth that nothing can detect —
+the failure mode behind most of this batch.
 
-So the risk worth guarding is not the duplication. It is DIVERGENCE: a derived
-field that quietly stops matching its source becomes a third, wrong truth that
-nothing can detect — the exact failure mode behind every other bug in this batch.
-These tests make divergence loud.
+The two are guarded DIFFERENTLY, on purpose, because only one of them could be
+collapsed:
+
+``github_skills_inferred`` stays a stored field. It has genuine ASSIGNMENT
+writers (``github_enricher`` and the clear route) that a read-only property would
+break, and ``two_pass`` mutates it in place, which a property would silently
+swallow. So divergence here is possible and the tests below have to catch it.
+
+``preferred_workplace`` was collapsed into a read-only property (2026-08-13).
+It had no writer of its own — the profile route bridged it from
+``work_arrangement`` on every save — so nothing was lost by deleting the storage,
+and divergence became structurally impossible instead of merely tested. Verified
+against production before shipping: 3 live profiles and 20 history versions, zero
+rows holding an answer only under the old key. What its tests guard now is the
+TRANSLATION, including the "any" sentinel that was scoring users a live penalty.
 """
 from __future__ import annotations
 
@@ -58,34 +62,109 @@ class TestGithubSkillsInferredIsPurelyDerived:
         assert derived <= allowed, f"invented: {sorted(derived - allowed)}"
 
 
-class TestPreferredWorkplaceMirrorsWorkArrangement:
-    """``preferred_workplace`` is the enum form of ``work_arrangement``, bridged
-    in the profile route because the scoring dimension reads the former while the
-    form writes the latter. Rule #29 makes the empty case the important one: an
-    unstated arrangement must NOT become a stated workplace preference."""
+class TestPreferredWorkplaceIsDerivedNotStored:
+    """``preferred_workplace`` is no longer a field. It is a read-only property
+    computed from ``work_arrangement``, so the two CANNOT diverge — divergence is
+    now a structural impossibility rather than something a test has to catch.
 
-    def _bridge(self, arrangement: str):
-        from src.services.profile.models import CVData, UserPreferences
-        from src.services.profile.preferences import sanitize_preferences
+    What this class guards instead is the TRANSLATION, which is still a real
+    decision with a real bug history:
 
-        prefs = UserPreferences(work_arrangement=arrangement)
-        return sanitize_preferences(prefs, CVData())
+      * only the three enum values the scorer understands may pass through;
+      * everything else — including the form's own ``"any"`` default — must come
+        out as None, i.e. as SILENCE, not as a stated preference.
+
+    The old test asserted the mirror conditionally (``if x is not None``), which
+    could pass while saying nothing. This one has no escape hatch.
+    """
+
+    def _prefs(self, arrangement: str):
+        from src.services.profile.models import UserPreferences
+
+        return UserPreferences(work_arrangement=arrangement)
+
+    def test_it_is_a_property_not_a_stored_field(self) -> None:
+        """The whole point of the collapse: there is exactly ONE place the
+        answer lives. A field here would let a writer set it independently and
+        re-open the divergence this class used to police."""
+        from dataclasses import fields
+
+        from src.services.profile.models import UserPreferences
+
+        names = {f.name for f in fields(UserPreferences)}
+        assert "preferred_workplace" not in names, (
+            "preferred_workplace is a stored field again — it can now hold an "
+            "answer that contradicts work_arrangement, with no way to tell which "
+            "one the user actually chose"
+        )
+        assert isinstance(
+            getattr(UserPreferences, "preferred_workplace", None), property
+        )
 
     @pytest.mark.parametrize("value", ["remote", "hybrid", "onsite"])
-    def test_a_stated_arrangement_agrees_with_the_workplace(self, value: str) -> None:
-        out = self._bridge(value)
-        if out.preferred_workplace is not None:
-            assert out.preferred_workplace == out.work_arrangement.lower(), (
-                "the two have diverged — the scorer and the prefilter would now "
-                "act on different answers to the same question"
-            )
+    def test_a_stated_arrangement_passes_through(self, value: str) -> None:
+        assert self._prefs(value).preferred_workplace == value
 
-    def test_an_unstated_arrangement_never_becomes_a_preference(self) -> None:
-        """Rule #29 at its sharpest: silence must stay silence. A default written
-        here is indistinguishable from a choice the user made."""
-        out = self._bridge("")
-        assert not out.work_arrangement
-        assert out.preferred_workplace in (None, ""), (
-            "an empty work_arrangement produced a workplace preference — that is "
-            "a fake constraint the user never stated"
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [("Remote", "remote"), ("  ONSITE  ", "onsite"), ("Hybrid", "hybrid")],
+    )
+    def test_case_and_padding_are_normalised(self, raw: str, expected: str) -> None:
+        """The scorer compares lower-case strings. A stored "Remote" used to
+        score as a non-match against its own value."""
+        assert self._prefs(raw).preferred_workplace == expected
+
+    @pytest.mark.parametrize("value", ["", "   ", "any", "Any", "flexible", "n/a"])
+    def test_anything_not_in_the_enum_is_silence(self, value: str) -> None:
+        """THE BUG THIS FIXES, and it was live.
+
+        The preferences form seeds the select at ``"any"``. That is the user
+        saying "I don't mind" — but ``workplace_score`` only branches on the
+        three enum values, so ``"any"`` fell past every branch and scored **0**,
+        while an EMPTY preference returns the neutral **3**. Choosing "I don't
+        mind" therefore scored worse, on every single job, than never answering.
+
+        Rule #29: an unstated preference must be silence, never a penalty.
+        """
+        assert self._prefs(value).preferred_workplace is None
+
+    def test_a_dont_mind_answer_scores_the_same_as_no_answer(self) -> None:
+        """The rule #29 violation stated as the outcome the user FELT, not as
+        the mechanism.
+
+        A real ``JobEnrichment`` on purpose. The obvious way to write this — a
+        ``{"workplace_type": "onsite"}`` dict — passes without proving anything,
+        because both branches return the neutral score before ever touching the
+        enrichment, so the wrong type is never noticed. That is the same
+        vacuous-pass shape this file replaced in the old test; a green tick from
+        a test that cannot fail is worse than no test.
+        """
+        from src.services.job_enrichment_schema import (
+            JobCategory,
+            JobEnrichment,
+            WorkplaceType,
+        )
+        from src.services.scoring_dimensions import workplace_score
+
+        onsite_job = JobEnrichment(
+            title_canonical="X",
+            category=JobCategory.SOFTWARE_ENGINEERING,
+            workplace_type=WorkplaceType.ONSITE,
+        )
+        silent = workplace_score(onsite_job, self._prefs("").preferred_workplace)
+        dont_mind = workplace_score(onsite_job, self._prefs("any").preferred_workplace)
+        stated = workplace_score(onsite_job, self._prefs("remote").preferred_workplace)
+
+        # The control: a STATED, opposite preference must still score lower.
+        # Without this the test would also pass if the scorer stopped
+        # discriminating at all.
+        assert stated < silent, (
+            "a remote preference no longer costs anything on an onsite job — "
+            "the dimension has gone flat and the assertion below is meaningless"
+        )
+        assert dont_mind == silent, (
+            f'"any" scored {dont_mind} but silence scored {silent} — saying '
+            f'"I don\'t mind" is punished relative to saying nothing. Before the '
+            f"collapse this was live: the raw \"any\" reached the scorer, matched "
+            f"no branch, and fell through to 0 on every job."
         )

--- a/backend/tests/test_engine_switches.py
+++ b/backend/tests/test_engine_switches.py
@@ -92,7 +92,7 @@ def test_engine1_off_with_engine2_dims_is_dims_only():
         salary_min=70000,
         salary_max=90000,
         experience_level="senior",
-        preferred_workplace="remote",
+        work_arrangement="remote",
         needs_visa=True,
     )
     scorer = JobScorer(

--- a/backend/tests/test_pillar1_data_loss.py
+++ b/backend/tests/test_pillar1_data_loss.py
@@ -69,7 +69,7 @@ class TestPreferencesSurviveTheMerge:
     def test_visa_and_workplace_survive(self) -> None:
         from src.services.profile.preferences import merge_cv_and_preferences
 
-        prefs = UserPreferences(needs_visa=True, preferred_workplace="remote",
+        prefs = UserPreferences(needs_visa=True, work_arrangement="remote",
                                 target_job_titles=["ML Engineer"])
         out = merge_cv_and_preferences(["Python"], ["ML Engineer"], prefs)
         assert out.needs_visa is True
@@ -84,7 +84,7 @@ class TestPreferencesSurviveTheMerge:
         from src.services.profile.preferences import merge_cv_and_preferences
 
         prefs = UserPreferences(
-            needs_visa=True, preferred_workplace="hybrid", salary_min=45000,
+            needs_visa=True, work_arrangement="hybrid", salary_min=45000,
             salary_max=90000, experience_level="mid", about_me="hello",
             github_username="someone", preferred_locations=["London"],
             negative_keywords=["sales"], excluded_skills=["php"],
@@ -303,32 +303,45 @@ class TestCertificationsAcceptBothShapes:
         assert cv.certifications == ["Real"]
 
 
-class TestWorkplaceBridge:
+class TestWorkplaceReachesTheScorer:
     """The WORKPLACE scoring dimension (weight 6) reads
-    `UserPreferences.preferred_workplace`, but the preferences form only ever
-    sent `work_arrangement`, and no control for `preferred_workplace` exists
-    anywhere in the frontend. The model documents preferred_workplace as "the
-    enum form of work_arrangement" — but nothing built that bridge, so the
-    field the scorer reads stayed None for every user and the whole dimension
-    was permanently dead. That was the workplace "dead pair" the shelf X-ray
-    flagged; the cause was here, not users failing to fill anything.
+    `UserPreferences.preferred_workplace`. The form only ever sent
+    `work_arrangement`, and no control for `preferred_workplace` ever existed in
+    the frontend — so for a long time the field the scorer reads stayed None for
+    every user and the dimension was permanently dead. That was the workplace
+    "dead pair" the shelf X-ray flagged; the cause was here, not users failing to
+    fill anything.
+
+    It was first fixed with a BRIDGE in this route (one field copied into
+    another on save). On 2026-08-13 the copy was deleted and
+    `preferred_workplace` became a read-only property derived from
+    `work_arrangement`, so there is now one stored answer and no way for the two
+    to disagree.
+
+    These tests are deliberately kept at the ROUTE level even though the
+    derivation is now in the model. The dimension went dark once already because
+    the form and the scorer were wired to different fields — an end-to-end
+    assertion is what catches that class of break, and a model-level unit test
+    would not have.
     """
 
-    def _apply(self, form: dict):
+    def _apply(self, form: dict, existing=None):
         import json
 
         from src.api.routes.profile import _apply_preferences
         from src.services.profile.models import CVData, UserPreferences, UserProfile
 
-        p = UserProfile(cv_data=CVData(), preferences=UserPreferences())
+        p = UserProfile(
+            cv_data=CVData(), preferences=existing or UserPreferences()
+        )
         _apply_preferences(json.dumps(form), p)
         return p.preferences
 
-    def test_work_arrangement_populates_preferred_workplace(self) -> None:
+    def test_work_arrangement_reaches_the_scorers_field(self) -> None:
         for value in ("remote", "hybrid", "onsite"):
             prefs = self._apply({"work_arrangement": value})
             assert prefs.preferred_workplace == value, (
-                f"{value}: the scorer's field was not bridged from the form"
+                f"{value}: the form's answer never reached the scorer's field"
             )
 
     def test_empty_stays_none_not_a_fake_preference(self) -> None:
@@ -336,6 +349,75 @@ class TestWorkplaceBridge:
         neutral score), never a manufactured value."""
         assert self._apply({"work_arrangement": ""}).preferred_workplace is None
         assert self._apply({}).preferred_workplace is None
+
+    def test_an_omitted_key_keeps_the_stored_answer(self) -> None:
+        """Deleting the stored field removed the route's fallback, so a partial
+        save — any client that posts a subset of the form — would have wiped the
+        user's answer and taken the dimension dark again. An ABSENT key keeps
+        what is stored; only an explicit value changes it."""
+        from src.services.profile.models import UserPreferences
+
+        stored = UserPreferences(work_arrangement="remote")
+        assert self._apply({"salary_min": 40000}, stored).work_arrangement == "remote"
+
+    def test_the_forms_any_sentinel_is_stored_as_silence(self) -> None:
+        """The select seeds at "any" and posts it, so "any" was stored as if the
+        user had stated a constraint.
+
+        The derived property protects the keyword scorer, but two consumers read
+        `work_arrangement` RAW and bypass it: the LLM judge builds its prompt
+        with a plain truthiness test, so every judged job was told
+        `work_arrangement=any` — paid tokens spent asserting a preference the
+        user explicitly declined to state — and the semantic vector appended
+        "any" as a candidate token.
+
+        So the sentinel has to die where it ENTERS, not at each reader.
+        """
+        out = self._apply({"work_arrangement": "any"})
+        assert out.work_arrangement == "", (
+            'the "any" sentinel was stored verbatim — the judge and the vector '
+            "read this field raw and will treat it as a stated preference"
+        )
+        assert out.preferred_workplace is None
+
+    def test_the_judge_is_not_told_about_an_unstated_preference(self) -> None:
+        """The outcome, asserted where the user actually pays for it: the prompt
+        text. A field-level assertion alone would not catch a future reader that
+        re-introduces the sentinel."""
+        from src.services.llm_matcher import profile_to_matcher_text
+        from src.services.profile.models import CVData, UserProfile
+
+        prefs = self._apply({"work_arrangement": "any"})
+        text = profile_to_matcher_text(
+            UserProfile(cv_data=CVData(), preferences=prefs)
+        )
+        assert "work_arrangement" not in text, (
+            "the judge prompt states a workplace preference the user declined "
+            f"to make. Prompt was:\n{text}"
+        )
+
+    def test_a_real_choice_still_reaches_the_judge(self) -> None:
+        """The control. Without it, deleting the line entirely would also pass
+        the test above."""
+        from src.services.llm_matcher import profile_to_matcher_text
+        from src.services.profile.models import CVData, UserProfile
+
+        prefs = self._apply({"work_arrangement": "remote"})
+        text = profile_to_matcher_text(
+            UserProfile(cv_data=CVData(), preferences=prefs)
+        )
+        assert "work_arrangement=remote" in text
+
+    def test_an_explicit_empty_string_still_clears_it(self) -> None:
+        """The other half, and the reason this is `.get(key, default)` rather
+        than `or`: the user must still be able to UNSET the answer. Rule #29
+        cuts both ways — a preference they cleared must go back to silence."""
+        from src.services.profile.models import UserPreferences
+
+        stored = UserPreferences(work_arrangement="remote")
+        out = self._apply({"work_arrangement": ""}, stored)
+        assert out.work_arrangement == ""
+        assert out.preferred_workplace is None
 
 
 class TestNeedsVisaRoundTripsThroughTheRoute:

--- a/backend/tests/test_pillar1_data_loss.py
+++ b/backend/tests/test_pillar1_data_loss.py
@@ -396,6 +396,33 @@ class TestWorkplaceReachesTheScorer:
             f"to make. Prompt was:\n{text}"
         )
 
+    def test_the_sentinel_never_becomes_a_search_location(self) -> None:
+        """The THIRD consumer that read this field raw, and the worst of them.
+
+        ``keyword_generator`` appends ``work_arrangement.capitalize()`` to the
+        search LOCATIONS list. "any" is truthy, so a place called "Any" was sent
+        to the job sources as somewhere the user wanted to work.
+
+        Three separate consumers bypassed the derived property — scorer-adjacent
+        keyword generation, the judge prompt, and the vector. That is the
+        argument for normalising on SAVE rather than at each reader: a fourth
+        consumer written next month gets the fix for free, and the property
+        alone would not have given it to any of these three.
+        """
+        from src.services.profile.keyword_generator import generate_search_config
+        from src.services.profile.models import CVData, UserProfile
+
+        prefs = self._apply({"work_arrangement": "any"})
+        cfg = generate_search_config(
+            UserProfile(
+                cv_data=CVData(job_titles=["ML Engineer"], skills=["python"]),
+                preferences=prefs,
+            )
+        )
+        assert "Any" not in cfg.locations, (
+            f'"Any" is being searched as a place. Locations: {cfg.locations}'
+        )
+
     def test_a_real_choice_still_reaches_the_judge(self) -> None:
         """The control. Without it, deleting the line entirely would also pass
         the test above."""

--- a/backend/tests/test_preference_pollution.py
+++ b/backend/tests/test_preference_pollution.py
@@ -169,3 +169,98 @@ class TestExtractionNeverWritesAPreference:
         assert p.target_job_titles == [], p.target_job_titles
         assert p.preferred_locations == []
         assert p.industries == []
+
+
+class TestAnOfferedSuggestionSurvivesBeingAccepted:
+    """The suggester and the sanitizer must agree on "skills the user has".
+
+    They did not. Each hand-maintained its own list and they drifted:
+
+        suggester (two_pass) : skills, linkedin_skills, github_llm_skills,
+                               github_languages, additional_skills
+        sanitizer (this file): skills, linkedin_skills, github_llm_skills,
+                               github_skills_inferred, cv_skills_esco
+
+    ``github_skills_inferred`` is languages PLUS repo topics, so a topic-derived
+    skill was invisible to the suggester and visible to the sanitizer. That gap
+    becomes a user-visible defect the moment suggestions are tappable: the chip
+    is offered, accepted, written to ``additional_skills`` -- and stripped on the
+    very next save. It disappears with nothing on screen to explain it, which
+    reads as the app losing the user's input.
+
+    Measured before the fix: accepting "rag" left additional_skills == [].
+    Both sides now derive from ``skills_already_held``.
+    """
+
+    def _cv_with_a_topic_skill(self) -> CVData:
+        return CVData(
+            skills=["Python"],
+            github_topics=["rag"],
+            github_skills_inferred=["Python", "rag"],
+        )
+
+    def test_a_topic_derived_skill_is_never_offered(self) -> None:
+        """The fix at its source: the suggester's "already have" list must
+        include the topic-derived shelf, so "rag" is filtered out BEFORE it can
+        ever be shown as a suggestion."""
+        from src.services.profile.preferences import skills_already_held
+
+        held = {s.casefold() for s in skills_already_held(self._cv_with_a_topic_skill())}
+        assert "rag" in held, (
+            "the suggester's view of what the user already has still omits "
+            "github_skills_inferred, so it can offer a skill the sanitizer "
+            "will immediately strip"
+        )
+
+    def test_the_two_lists_cannot_drift_again(self) -> None:
+        """The STRUCTURAL guard, and the one that actually matters. Pinning the
+        symptom would let a sixth shelf be added to one list and not the other
+        tomorrow. This asserts the RELATIONSHIP instead: everything the
+        sanitizer strips as "already extracted" must be something the suggester
+        knows the user has."""
+        from src.services.profile.preferences import (
+            _extracted_skills_index,
+            skills_already_held,
+        )
+
+        cv = CVData(
+            skills=["Python"],
+            linkedin_skills=["Kubernetes"],
+            github_llm_skills=["Terraform"],
+            github_skills_inferred=["rag", "Go"],
+            cv_skills_esco=["data engineering"],
+        )
+        stripped = _extracted_skills_index(cv)
+        offered_against = {s.casefold() for s in skills_already_held(cv)}
+        missing = sorted(stripped - offered_against)
+        assert not missing, (
+            f"the sanitizer strips {missing} but the suggester does not know "
+            "the user has them, so each is a chip that can be offered, "
+            "accepted, and then silently deleted"
+        )
+
+    def test_an_accepted_suggestion_survives_the_next_save(self) -> None:
+        """The outcome, end to end. A skill the suggester WOULD offer (because
+        the user genuinely lacks it) must still be there after the save that
+        follows accepting it."""
+        from src.services.profile.preferences import skills_already_held
+
+        cv = self._cv_with_a_topic_skill()
+        held = {s.casefold() for s in skills_already_held(cv)}
+        assert "kubernetes" not in held, "premise broken: pick a skill the user lacks"
+
+        accepted = UserPreferences(additional_skills=["Kubernetes"])
+        out = sanitize_preferences(accepted, cv)
+        assert out.additional_skills == ["Kubernetes"], (
+            "a legitimately-offered suggestion was stripped on save -- accepting "
+            "a chip would appear to do nothing"
+        )
+
+    def test_the_prompt_keeps_the_original_spelling(self) -> None:
+        """``skills_already_held`` feeds the suggestion PROMPT as well as the
+        filter. Lower-casing it would quietly make the prompt worse
+        ("pytorch, aws") without failing anything."""
+        from src.services.profile.preferences import skills_already_held
+
+        cv = CVData(skills=["PyTorch", "AWS"], linkedin_skills=["SQL"])
+        assert skills_already_held(cv) == ["PyTorch", "AWS", "SQL"]

--- a/backend/tests/test_profile.py
+++ b/backend/tests/test_profile.py
@@ -179,7 +179,7 @@ class TestPreferences:
             cv_data=CVData(),
             preferences=UserPreferences(
                 github_username="ranjith36963",
-                preferred_workplace="remote",
+                work_arrangement="remote",
                 needs_visa=True,
             ),
         )

--- a/backend/tests/test_scorer.py
+++ b/backend/tests/test_scorer.py
@@ -1073,7 +1073,7 @@ class TestScoreBreakdown:
             salary_max=80000,
             experience_level="senior",
             needs_visa=True,
-            preferred_workplace="remote",
+            work_arrangement="remote",
         )
         scorer = JobScorer(self._config(), user_preferences=prefs)
         breakdown = scorer.score(self._job())

--- a/backend/tests/test_scoring_dimensions.py
+++ b/backend/tests/test_scoring_dimensions.py
@@ -262,7 +262,7 @@ def test_jobscorer_with_enrichment_scores_higher_than_without():
         salary_min=70000,
         salary_max=90000,
         experience_level="senior",
-        preferred_workplace="remote",
+        work_arrangement="remote",
         needs_visa=True,
     )
     great_enrichment = _enrichment(
@@ -309,7 +309,7 @@ def test_jobscorer_enrichment_lookup_returning_none_falls_back_to_base():
         date_found=today,
     )
     config = SearchConfig(job_titles=["ML Engineer"], primary_skills=["python", "pytorch"])
-    prefs = UserPreferences(preferred_workplace="remote", needs_visa=False)
+    prefs = UserPreferences(work_arrangement="remote", needs_visa=False)
 
     with_prefs = JobScorer(
         config,
@@ -364,7 +364,7 @@ def test_jobscorer_dim_bonus_caps_at_100():
         salary_min=70000,
         salary_max=90000,
         experience_level="senior",
-        preferred_workplace="remote",
+        work_arrangement="remote",
         needs_visa=True,
     )
     perfect = _enrichment(

--- a/backend/tests/test_shelf_registry.py
+++ b/backend/tests/test_shelf_registry.py
@@ -170,7 +170,20 @@ class TestMatchingCoverageDoesNotRegress:
     # nine matching modules); raised to 46 by the shelf-completeness batch, which
     # wired the LinkedIn evidence sections, cv_industries, cv_languages,
     # career_domain and linkedin_summary into the judge and the vector.
-    BASELINE = 50
+    #
+    # 50 -> 49 on 2026-08-13, and this is the ONE legitimate reason to lower a
+    # ratchet that is otherwise up-only. No engine lost an input. Two shelf NAMES
+    # collapsed into one: ``preferred_workplace`` was a stored copy of
+    # ``work_arrangement``, written by a bridge in the profile route on every
+    # save. It is now a read-only property, so the pair is one shelf that every
+    # consumer reads, and the audit counts it once instead of twice.
+    #
+    # The proof that nothing went dark is in the READER SET, not the count:
+    # ``work_arrangement`` now lists ``scorer`` among its readers, which it never
+    # did before, because a read of a derived view is folded into its source (see
+    # ``shelf_audit.derived_shelves``). Deduplication should lower this number.
+    # A shelf falling out of matching should not, and still fails the test below.
+    BASELINE = 49
 
     def test_the_headline_number_is_broken_down_by_reach(self) -> None:
         """A single "N shelves feed matching" figure counts a shelf the LLM
@@ -230,3 +243,57 @@ def test_every_shelf_has_both_a_writer_and_a_reader(name: str) -> None:
     assert writers(name), f"{name}: nothing can write it"
     if name not in ALLOWED_UNREAD:
         assert readers(name), f"{name}: nothing reads it"
+
+
+class TestDerivedViewsAreFoldedIntoTheirSource:
+    """Rule 5, added 2026-08-13 with the workplace collapse.
+
+    A ``@property`` on a profile dataclass is a VIEW: no storage, no writer, so
+    it is correctly absent from ``shelf_names()`` — rule 1 would fail it, and
+    should. But consumers read it BY NAME, and that read is a real read of the
+    shelf underneath.
+
+    Miss that and the audit lies in the direction that flatters it: the stored
+    shelf looks less used than it is. ``work_arrangement`` would have reported
+    as judge-and-vector-only while in fact it ranks every job in the feed
+    through ``preferred_workplace``.
+    """
+
+    def test_the_mapping_is_parsed_from_the_source_not_hand_listed(self) -> None:
+        """The point of deriving it: a property renamed or repointed tomorrow
+        updates this map for free. A hand-typed dict would be one more copy to
+        drift — the exact bug class this module exists to catch."""
+        from src.services.profile.shelf_audit import derived_shelves
+
+        assert derived_shelves().get("preferred_workplace") == ("work_arrangement",)
+
+    def test_a_derived_view_is_not_itself_a_shelf(self) -> None:
+        """It has no writer and never can have one. Counting it as a shelf would
+        force a permanent exemption in rule 1 — the honest answer is that it is
+        not a shelf at all."""
+        from src.services.profile.shelf_audit import derived_shelves
+
+        for view in derived_shelves():
+            assert view not in shelf_names(), (
+                f"{view} is a property AND a stored field — one of the two is a "
+                "copy that can disagree with the other"
+            )
+
+    def test_reading_the_view_credits_the_source(self) -> None:
+        """The assertion that actually protects the audit's honesty. The keyword
+        scorer reads ``prefs.preferred_workplace``; ``work_arrangement`` is what
+        holds that answer, so ``work_arrangement`` must show the scorer."""
+        assert "scorer" in readers("work_arrangement"), (
+            "work_arrangement lost its every-job reader — either the scorer "
+            "stopped reading the workplace preference, or the derived-view fold "
+            "broke and the audit is now under-reporting this shelf's reach"
+        )
+
+    def test_every_derived_view_points_at_real_shelves(self) -> None:
+        from src.services.profile.shelf_audit import derived_shelves
+
+        names = set(shelf_names())
+        for view, sources in derived_shelves().items():
+            assert sources, f"{view}: derived from nothing"
+            unknown = sorted(set(sources) - names)
+            assert not unknown, f"{view}: derived from non-shelves {unknown}"

--- a/docs/pillar1_data_design.md
+++ b/docs/pillar1_data_design.md
@@ -78,7 +78,7 @@ UserProfile
 | target_job_titles · additional_skills · excluded_skills | U | targeting |
 | preferred_locations · industries · negative_keywords | U | filters |
 | salary_min · salary_max | U | pay range |
-| work_arrangement · **preferred_workplace** | U | remote/hybrid/office |
+| work_arrangement | U | remote/hybrid/onsite. `preferred_workplace` is a read-only property derived from it, not a second stored field (2026-08-13). |
 | experience_level · **needs_visa** | U | level + visa |
 | about_me | U | free text |
 | **about_me_inferred_skills** | L | skills the LLM mines from about_me |

--- a/docs/pillars/01-user-pillar.md
+++ b/docs/pillars/01-user-pillar.md
@@ -252,7 +252,9 @@ Free-text and select fields the user fills in on `/profile`:
 - `negative_keywords` (e.g. "intern", "junior")
 - `about_me` (free-form), `github_username`
 - `needs_visa` (boolean)
-- `preferred_workplace` (Pillar 2 addition)
+- `preferred_workplace` — DERIVED, not stored: a read-only property over
+  `work_arrangement` (2026-08-13). It was a stored copy kept in step by a
+  bridge in the profile route; the copy is gone, so the two cannot diverge.
 
 ### 3.3 The data model — `backend/src/services/profile/models.py`
 

--- a/docs/pillars/02-search-and-match-engine.md
+++ b/docs/pillars/02-search-and-match-engine.md
@@ -78,7 +78,7 @@ UserPreferences(
     work_arrangement="remote",  # she prefers fully remote
     experience_level="senior",
     needs_visa=False,
-    preferred_workplace="remote",
+    work_arrangement="remote",   # preferred_workplace derives from this
 )
 ```
 

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -369,6 +369,11 @@ export default function ProfilePage() {
               {/* Right column: Preferences */}
               <PreferencesForm
                 preferences={profile?.preferences ?? {}}
+                // Suggestions are rendered INSIDE the form, next to Additional
+                // Skills, so a tap edits local state and rides the form's own
+                // debounced save. They used to sit further down this page as
+                // dead chips whose helper text told the user to retype them.
+                suggestions={profile?.ai_suggestions ?? []}
                 onSave={handleSavePreferences}
                 onClear={profile ? () => handleClear("preferences") : undefined}
                 loading={loadingProfile}
@@ -392,13 +397,7 @@ export default function ProfilePage() {
 
             {/* ── Your Skills (grouped by source) ────────── */}
             {(() => {
-              const bySource =
-                (profile as unknown as {
-                  skills_by_source?: Record<string, string[]>;
-                })?.skills_by_source ?? {};
-              const aiSuggestions =
-                (profile as unknown as { ai_suggestions?: string[] })
-                  ?.ai_suggestions ?? [];
+              const bySource = profile?.skills_by_source ?? {};
               const GROUPS: {
                 key: string;
                 label: string;
@@ -430,8 +429,10 @@ export default function ProfilePage() {
                   (bySource[g.key] ?? []).map((s) => s.toLowerCase())
                 )
               ).size;
-              const hasAny = total > 0 || aiSuggestions.length > 0;
-              if (!hasAny) return null;
+              // Suggestions no longer keep this block alive: they moved into
+              // the preferences form. This panel shows skills the user HAS, so
+              // with none of those there is nothing to show.
+              if (total === 0) return null;
               return (
                 <div className="animate-fade-in-up glass-card rounded-xl p-6">
                   <h2 className="font-heading text-base font-semibold mb-1 text-foreground">
@@ -466,32 +467,6 @@ export default function ProfilePage() {
                     })}
                   </div>
 
-                  {/* AI Suggestions — opt-in, never counted in matching */}
-                  {aiSuggestions.length > 0 && (
-                    <div className="mt-5 border-t border-border/50 pt-4">
-                      <p className="mb-1 text-xs font-semibold uppercase tracking-wider text-primary">
-                        AI suggestions
-                      </p>
-                      <p className="mb-2 text-xs text-muted-foreground">
-                        Related skills that fit your profile. These aren&apos;t
-                        counted — add the ones you actually have under{" "}
-                        <span className="text-foreground">
-                          Additional Skills
-                        </span>
-                        .
-                      </p>
-                      <ul className="flex flex-wrap gap-1.5">
-                        {aiSuggestions.map((skill) => (
-                          <li
-                            key={`ai-${skill}`}
-                            className="rounded-full border border-dashed border-primary/40 bg-primary/5 px-2.5 py-0.5 text-xs font-medium text-primary/90"
-                          >
-                            + {skill}
-                          </li>
-                        ))}
-                      </ul>
-                    </div>
-                  )}
                 </div>
               );
             })()}

--- a/frontend/src/components/profile/PreferencesForm.suggestions.test.tsx
+++ b/frontend/src/components/profile/PreferencesForm.suggestions.test.tsx
@@ -1,0 +1,251 @@
+/**
+ * Suggested skills, and the "words to avoid" control.
+ *
+ * The extractor proposes adjacent skills. They used to render further down the
+ * profile page as plain <li> chips with no click handler, under helper text
+ * telling the user to retype them by hand into Additional Skills. So the
+ * feature's whole value — "we found skills you probably have" — cost the user
+ * a manual copy each time, and most people simply never did it.
+ *
+ * They now live INSIDE this form, next to Additional Skills, and a tap adds
+ * one. That placement is the load-bearing part, not a cosmetic choice:
+ *
+ *   - a tap only changes LOCAL state, so the form's existing debounced save
+ *     persists it, and five taps cost ONE save. Handling the tap in the parent
+ *     page would mean one save per chip — and every preferences save triggers a
+ *     paid re-extraction, rate-limited to 12/hour.
+ *   - the parent re-renders PreferencesForm with a BRAND-NEW `preferences`
+ *     object after any save (the backend returns `asdict(...)`), which re-fires
+ *     the hydration effect and overwrites every local field. A parent-side
+ *     accept handler would therefore wipe whatever the user was part-way
+ *     through typing elsewhere in the form.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { PreferencesForm } from "./PreferencesForm";
+
+const initial = {
+  target_job_titles: ["ML Engineer"],
+  additional_skills: ["Python"],
+  about_me: "",
+};
+
+describe("PreferencesForm — suggested skills", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("renders nothing when there are no suggestions", () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    render(
+      <PreferencesForm
+        preferences={initial}
+        suggestions={[]}
+        onSave={onSave}
+        loading={false}
+      />
+    );
+    expect(screen.queryByText(/skills that often go with yours/i)).toBeNull();
+  });
+
+  it("shows a suggestion as a real, tappable control", () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    render(
+      <PreferencesForm
+        preferences={initial}
+        suggestions={["Kubernetes"]}
+        onSave={onSave}
+        loading={false}
+      />
+    );
+    // getByRole("button"), not getByText: the entire defect was that these
+    // rendered as inert list items. A <li> would pass a text query and fail
+    // the user.
+    expect(
+      screen.getByRole("button", { name: /add kubernetes to additional skills/i })
+    ).toBeTruthy();
+  });
+
+  it("tapping a suggestion adds it and auto-saves once", async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    render(
+      <PreferencesForm
+        preferences={initial}
+        suggestions={["Kubernetes"]}
+        onSave={onSave}
+        loading={false}
+      />
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /add kubernetes to additional skills/i })
+    );
+    expect(onSave).not.toHaveBeenCalled(); // debounced, like every other edit
+
+    await act(async () => {
+      vi.advanceTimersByTime(900);
+    });
+
+    expect(onSave).toHaveBeenCalledTimes(1);
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({ additional_skills: ["Python", "Kubernetes"] })
+    );
+  });
+
+  it("accepting several suggestions costs ONE save, not one per tap", async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    render(
+      <PreferencesForm
+        preferences={initial}
+        suggestions={["Kubernetes", "Terraform", "Airflow"]}
+        onSave={onSave}
+        loading={false}
+      />
+    );
+
+    for (const skill of ["Kubernetes", "Terraform", "Airflow"]) {
+      fireEvent.click(
+        screen.getByRole("button", {
+          name: new RegExp(`add ${skill} to additional skills`, "i"),
+        })
+      );
+    }
+
+    await act(async () => {
+      vi.advanceTimersByTime(900);
+    });
+
+    // Every preferences save triggers a paid re-extraction (rate-limited to
+    // 12/hour). Three saves for three taps would burn a quarter of the user's
+    // hourly budget on adding three words.
+    expect(onSave).toHaveBeenCalledTimes(1);
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        additional_skills: ["Python", "Kubernetes", "Terraform", "Airflow"],
+      })
+    );
+  });
+
+  it("a taken suggestion stops being offered", async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    render(
+      <PreferencesForm
+        preferences={initial}
+        suggestions={["Kubernetes"]}
+        onSave={onSave}
+        loading={false}
+      />
+    );
+
+    const chip = screen.getByRole("button", {
+      name: /add kubernetes to additional skills/i,
+    });
+    fireEvent.click(chip);
+
+    expect(
+      screen.queryByRole("button", {
+        name: /add kubernetes to additional skills/i,
+      })
+    ).toBeNull();
+  });
+
+  it("never offers a skill the user already listed, whatever the case", () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    render(
+      <PreferencesForm
+        preferences={initial}
+        // The stored skill is "Python"; the extractor proposes "python".
+        suggestions={["python", "Kubernetes"]}
+        onSave={onSave}
+        loading={false}
+      />
+    );
+
+    expect(
+      screen.queryByRole("button", { name: /add python to additional skills/i })
+    ).toBeNull();
+    expect(
+      screen.getByRole("button", { name: /add kubernetes to additional skills/i })
+    ).toBeTruthy();
+  });
+
+  it("does not save merely because suggestions were rendered", async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    render(
+      <PreferencesForm
+        preferences={initial}
+        suggestions={["Kubernetes"]}
+        onSave={onSave}
+        loading={false}
+      />
+    );
+    await act(async () => {
+      vi.advanceTimersByTime(2000);
+    });
+    // Showing an option is not the user choosing it (rule #29). A save here
+    // would also cost a re-extraction on every page load.
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it("a suggestion chip is not mistaken for a save button", () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    render(
+      <PreferencesForm
+        preferences={initial}
+        suggestions={["Kubernetes"]}
+        onSave={onSave}
+        loading={false}
+      />
+    );
+    // The form's contract is that it has NO manual save control; a chip whose
+    // accessible name drifted into "save ..." would quietly break that test's
+    // meaning rather than that test.
+    expect(
+      screen.queryByRole("button", { name: /save preferences/i })
+    ).toBeNull();
+  });
+});
+
+describe("PreferencesForm — words to avoid in job titles", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("is on screen and reaches negative_keywords when used", async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    render(
+      <PreferencesForm preferences={initial} onSave={onSave} loading={false} />
+    );
+
+    const box = screen.getByPlaceholderText(/sales, recruiter/i);
+    fireEvent.change(box, { target: { value: "sales" } });
+    fireEvent.keyDown(box, { key: "Enter" });
+
+    await act(async () => {
+      vi.advanceTimersByTime(900);
+    });
+
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({ negative_keywords: ["sales"] })
+    );
+  });
+
+  it("describes what the penalty actually does", () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    render(
+      <PreferencesForm preferences={initial} onSave={onSave} loading={false} />
+    );
+    // The mechanism, verified in skill_matcher.py, is a 30-point deduction on a
+    // whole-word TITLE match — not a filter. The old name "Negative Keywords"
+    // read like one, which is a promise the code does not keep: the job still
+    // appears. If the copy ever drifts back to implying removal, this fails.
+    const help = screen.getByText(/drops 30 points/i);
+    expect(help.textContent).toMatch(/title/i);
+    expect(help.textContent).toMatch(/doesn't hide it/i);
+  });
+});

--- a/frontend/src/components/profile/PreferencesForm.tsx
+++ b/frontend/src/components/profile/PreferencesForm.tsx
@@ -28,6 +28,17 @@ import type { PreferencesRequest } from "@/lib/types";
 
 interface PreferencesFormProps {
   preferences: Record<string, unknown>;
+  /** Adjacent skills the extractor proposed. Shown as one-tap chips beside
+   *  Additional Skills.
+   *
+   *  These live INSIDE this form on purpose. Accepting one only changes local
+   *  state, so the existing debounced auto-save persists it — several taps cost
+   *  ONE save. Handling the tap in the parent instead would mean a save per
+   *  chip (each one triggering a paid re-extraction), and the resulting
+   *  `setProfile` would hand this component a brand-new `preferences` object,
+   *  re-firing the hydration effect and wiping whatever the user was part-way
+   *  through typing in any other field. */
+  suggestions?: string[];
   onSave: (prefs: PreferencesRequest) => Promise<void>;
   /** Empty every typed preference. Undoable from History. Omitted when there
    *  is no profile yet — there is nothing to clear. */
@@ -46,6 +57,10 @@ interface TagInputProps {
   placeholder?: string;
   description?: string;
   variant?: "default" | "destructive";
+  /** One-tap chips shown under the input. Already-added ones are hidden. */
+  suggestions?: string[];
+  suggestionsLabel?: string;
+  suggestionsHint?: string;
 }
 
 function TagInput({
@@ -56,19 +71,36 @@ function TagInput({
   placeholder = "Type and press Enter",
   description,
   variant = "default",
+  suggestions,
+  suggestionsLabel,
+  suggestionsHint,
 }: TagInputProps) {
   const [inputValue, setInputValue] = useState("");
 
+  // Shared by typing and by tapping a suggestion. It used to live inline in
+  // addTag; a suggestion handler that re-implemented the comparison would
+  // eventually disagree with it and let "Python" sit next to "python".
+  const appendTag = useCallback(
+    (value: string) => {
+      const trimmed = value.trim();
+      if (!trimmed) return;
+      if (tags.some((t) => t.toLowerCase() === trimmed.toLowerCase())) return;
+      onChange([...tags, trimmed]);
+    },
+    [tags, onChange]
+  );
+
   const addTag = useCallback(() => {
-    const trimmed = inputValue.trim();
-    if (!trimmed) return;
-    if (tags.some((t) => t.toLowerCase() === trimmed.toLowerCase())) {
-      setInputValue("");
-      return;
-    }
-    onChange([...tags, trimmed]);
+    appendTag(inputValue);
     setInputValue("");
-  }, [inputValue, tags, onChange]);
+  }, [appendTag, inputValue]);
+
+  // Hide a suggestion once it has been taken, so the row shrinks as the user
+  // works through it and never offers something already on the list.
+  const openSuggestions = (suggestions ?? []).filter(
+    (s) =>
+      s.trim() && !tags.some((t) => t.toLowerCase() === s.trim().toLowerCase())
+  );
 
   const removeTag = useCallback(
     (index: number) => {
@@ -134,6 +166,38 @@ function TagInput({
           <Plus className="h-3.5 w-3.5" />
         </Button>
       </div>
+
+      {openSuggestions.length > 0 && (
+        <div className="pt-1">
+          {suggestionsLabel && (
+            <p className="mb-1 text-xs font-semibold uppercase tracking-wider text-primary">
+              {suggestionsLabel}
+            </p>
+          )}
+          {suggestionsHint && (
+            <p className="mb-2 text-xs text-muted-foreground">
+              {suggestionsHint}
+            </p>
+          )}
+          <div className="flex flex-wrap gap-1.5">
+            {openSuggestions.map((s) => (
+              <button
+                key={`suggest-${s}`}
+                type="button"
+                // Not "add" / "save" in the accessible name: the form's tests
+                // assert there is no button matching /save preferences/i, and
+                // this control must stay clearly distinct from one.
+                aria-label={`Add ${s} to ${label}`}
+                onClick={() => appendTag(s)}
+                className="inline-flex items-center gap-1 rounded-full border border-dashed border-primary/40 bg-primary/5 px-2.5 py-0.5 text-xs font-medium text-primary/90 transition-colors hover:border-primary/70 hover:bg-primary/10"
+              >
+                <Plus className="h-3 w-3" />
+                {s}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
     </div>
   );
 }
@@ -202,6 +266,7 @@ const AUTOSAVE_DELAY_MS = 800;
 
 export function PreferencesForm({
   preferences,
+  suggestions,
   onSave,
   onClear,
   loading,
@@ -365,6 +430,9 @@ export function PreferencesForm({
           onChange={setAdditionalSkills}
           placeholder="e.g. Python, SQL, Terraform"
           description="Skills beyond what your CV contains"
+          suggestions={suggestions}
+          suggestionsLabel="Skills that often go with yours"
+          suggestionsHint="Tap any you actually have. Nothing is added until you tap."
         />
 
         {/* Excluded Skills input removed from UI (owner, 2026-08-08) — the
@@ -485,10 +553,21 @@ export function PreferencesForm({
 
         <Separator />
 
-        {/* Negative Keywords input removed from UI (owner, 2026-08-08) — the
-            negative_keywords field, scoring penalty, and payload key are kept
-            fully intact; every existing user's value is empty in prod, so
-            hiding the control drops no data and changes no live score. */}
+        {/* ── Words to avoid in job titles ────────── */}
+        {/* Restored 2026-08-13 with copy that matches what the code does.
+            Verified in skill_matcher.py: the check reads job.title ONLY (never
+            the description), matches whole words (so "sales" does not match
+            "Wholesale"), and subtracts a flat 30 points on the first match —
+            it never hides the job. The old label "Negative Keywords" implied a
+            filter, which is why the copy below says "ranked lower" instead. */}
+        <TagInput
+          label="Words to avoid in job titles"
+          tags={negativeKeywords}
+          onChange={setNegativeKeywords}
+          placeholder="e.g. sales, recruiter"
+          description="A job whose TITLE contains one of these drops 30 points. It still shows up — this pushes it down the list, it doesn't hide it."
+          variant="destructive"
+        />
 
         {/* ── About Me ───────────────────────────── */}
         <div className="space-y-2">

--- a/frontend/src/components/profile/PreferencesForm.tsx
+++ b/frontend/src/components/profile/PreferencesForm.tsx
@@ -157,8 +157,14 @@ function prefsFromRaw(raw: Record<string, unknown>): PreferencesRequest {
     industries: asArr(raw.industries),
     salary_min: raw.salary_min != null ? Number(raw.salary_min) : null,
     salary_max: raw.salary_max != null ? Number(raw.salary_max) : null,
+    // "any" is this form's WORD for "not set"; the server's word is "". Both
+    // read-points must agree, or the saved baseline ("") would never match the
+    // form state ("any") and the dirty check would report unsaved changes on a
+    // freshly loaded, untouched form.
     work_arrangement:
-      typeof raw.work_arrangement === "string" ? raw.work_arrangement : "any",
+      typeof raw.work_arrangement === "string" && raw.work_arrangement
+        ? raw.work_arrangement
+        : "any",
     experience_level:
       typeof raw.experience_level === "string" ? raw.experience_level : "mid",
     negative_keywords: asArr(raw.negative_keywords),
@@ -237,7 +243,11 @@ export function PreferencesForm({
     setIndustries(p.industries ?? []);
     setSalaryMin(p.salary_min != null ? String(p.salary_min) : "");
     setSalaryMax(p.salary_max != null ? String(p.salary_max) : "");
-    setWorkArrangement(p.work_arrangement ?? "any");
+    // `||`, not `??`: the server now stores "I don't mind" as "" rather than the
+    // literal "any", because "any" was reaching the LLM judge as a stated
+    // constraint. `??` only falls back on null/undefined, so an empty string
+    // would leave this select showing nothing at all.
+    setWorkArrangement(p.work_arrangement || "any");
     setExperienceLevel(p.experience_level ?? "mid");
     setNeedsVisa(p.needs_visa === true);
     setNegativeKeywords(p.negative_keywords ?? []);


### PR DESCRIPTION
Three commits. Started as the workplace collapse; two more defects turned up on the way, both live.

---

## 1. "I don't mind" was scoring worse than saying nothing

The workplace preference lived in **two** fields — `work_arrangement` (what the form wrote) and `preferred_workplace` (what the scorer read) — kept in step by a bridge in the profile route. They drifted: `cli.py setup-profile` writes only the first and never wrote the second.

Collapsing them exposed a live scoring bug. The select seeds at `"any"` and saved that word literally, but the scorer only knows three words. Measured against an onsite job:

| stored `work_arrangement` | reached the scorer as | score |
|---|---|---|
| `''` (never answered) | `''` | **3** — neutral |
| `'any'` ("I don't mind") | `'any'` | **0** — penalty |
| `'remote'` (a real conflict) | `'remote'` | 0 |

**Choosing "I don't mind" scored the same as actively wanting the opposite, and worse than staying silent** — on every job, for every user. Rule #29 says an unstated preference costs nothing.

`preferred_workplace` is now a read-only property over `work_arrangement`. The sentinel is normalised **where it enters** (`_apply_preferences`), because a property cannot protect readers that bypass it — and **three** did:

- the **LLM judge** was told `work_arrangement=any` on every judged job (paid tokens asserting a preference the user declined to make);
- the **vector** appended "any" as a candidate token;
- **`keyword_generator` sent a place called "Any" to the job sources** as somewhere the user wanted to work.

Also removed the route's `.get(key, "")` default — deleting the stored field removed the fallback masking it, so a partial save would have wiped the answer. An **absent** key keeps what is stored; an explicit `""` still clears it.

**Safety:** checked production first — 3 live profiles + 20 history versions, **zero** rows with an answer only under the old key. Nothing to backfill. All three deserialisers filter to declared fields, so old rows still load.

---

## 2. Suggested skills were a dead end

The extractor proposes adjacent skills. They rendered as plain `<li>` chips with **no click handler**, under helper text telling the user to retype them by hand.

They now sit **inside** the preferences form beside Additional Skills, and a tap adds one. The placement is load-bearing, not cosmetic:

- a tap changes only **local** state, so the existing debounced save persists it and five taps cost **one** save. Every preferences save triggers a paid re-extraction (12/hour cap) — a save-per-chip would burn a quarter of the user's hourly budget on three words.
- the parent hands the form a **brand-new** `preferences` object after any save (`asdict(...)`), re-firing the hydration effect and overwriting every local field. A parent-side accept handler would silently wipe whatever the user was mid-typing elsewhere. **That race is untested, and an adversarial pass over the plan is what found it.**

### The defect this would have shipped

The suggester and the sanitizer each hand-maintained their own "skills the user already has" list, and they had drifted:

```
suggester : skills, linkedin_skills, github_llm_skills, github_languages, additional_skills
sanitizer : skills, linkedin_skills, github_llm_skills, github_skills_inferred, cv_skills_esco
```

`github_skills_inferred` is languages **plus repo topics**, so a topic-derived skill was invisible to the suggester and visible to the sanitizer. **Measured:** offer "rag", accept it, and `additional_skills` came back `[]`. The chip would appear and then vanish on the next save with nothing to explain it.

Both now derive from `skills_already_held`. The test asserts the **relationship** — everything the sanitizer strips must be something the suggester knows about — so a sixth shelf added to one list cannot drift again.

---

## 3. "Negative Keywords" is back, renamed

Removed 2026-08-08 while the field, payload key and penalty stayed live. It returns as **"Words to avoid in job titles"**, with copy matching what the code does — verified in `skill_matcher.py`: reads `job.title` **only** (never the description), whole-word (so "sales" does not match "Wholesale"), flat **-30** on first match. It never hides the job. The old name implied a filter, which is a promise the code does not keep.

---

## Verification

- 407 backend tests across the **symbol-based** blast radius (19 files) — selected by symbol, not by diff, because diff-based selection has missed a caller before
- 18 preferences-form tests (10 new), ruff clean, tsc clean, eslint clean, `[gate] PASS`
- Prod query for orphaned rows; before/after judge-prompt and search-location output captured

**One flaky run, reported honestly:** one backend run hit a `UniqueViolation` in `test_e2e_lifecycle`. It did not reproduce on a re-run of the identical set (407 passed), and that run took 9m38 against the clean tree's 5m08 — contention, not this change.

**A test of mine that passed for the wrong reason:** my first version of the workplace-scoring test passed a dict where a `JobEnrichment` belonged, and both branches returned before touching it. Fixed to use a real one, plus a control so a flattened scorer cannot fake a pass.

## Registry movement

71 → 70 shelves, 50 → 49 matching, every-job 19 → 18. The ratchet is documented **up-only** and this lowers it; deduplication is the one legitimate reason. No engine lost an input. Proof is in the reader set, not the count: `work_arrangement` now lists `scorer`, which it never did before. The audit learned to fold a derived view into its source — **parsed from the property bodies**, not hand-listed, and it found `highlights` on its own.

## Not in scope (noticed, not fixed)

`experience_level` defaults to `"mid"` in the same form — a manufactured preference with the same rule #29 shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6DsQH5EUxJc3Vnqz9YHgQ
