### PR TITLE
fix(synthetic): kill the 30-day cookie treadmill — the workflow logs itself in

### DIFF
--- a/.github/workflows/synthetic-live.yml
+++ b/.github/workflows/synthetic-live.yml
@@ -4,14 +4,68 @@
 # human and, on any failure, screenshots it + logs the REASON into the server log system
 # (POST /api/client-log). Fails red → GitHub emails the owner (scheduled-workflow default).
 #
-# Public corners always run. Authed corners run only when the SMOKE_SESSION secret is set
-# to a VERIFIED synthetic account's job360_session cookie (prod email-verification can't be
-# automated in CI). See tests/synthetic/live-smoke.mjs.
+# Public corners always run. Authed corners run only after the robot LOGS ITSELF IN as a
+# dedicated synthetic account and the backend confirms whose account that is.
+#
+# ── The chore this removed ──────────────────────────────────────────────────────────
+# This used to run on SMOKE_SESSION: a `job360_session` cookie the owner pasted into a
+# repo secret by hand. Sessions expire after exactly 30 days with no renewal
+# (backend/src/services/auth/sessions.py:25), so that secret died on a clock and took the
+# check with it — 2026-08-09 → 2026-08-11, nine authed corners reported OK while the
+# browser sat on the login page. A recurring manual chore attached to a safety check is a
+# countdown on that check, and the owner is one person; he will eventually miss it.
+#
+# Now: SMOKE_EMAIL (repo VARIABLE) + SMOKE_PASSWORD (repo SECRET), set ONCE. The run logs
+# in through POST /api/auth/login every time. Nothing expires on a clock.
+# SMOKE_SESSION still works as a fallback, but the run now WARNS before it dies.
+#
+# ── Why the email is a variable and not a secret ────────────────────────────────────
+# GitHub masks secret values in logs. If the address were a secret, the refusal message
+# "refused to run as <address>" would print as "refused to run as ***" — the one fact you
+# need in order to fix it. It is an address, not a credential; the password is the secret.
+#
+# ── The safety rule (frontend/tests/synthetic/session-gate.mjs) ─────────────────────
+# The walk refuses to proceed unless the BACKEND says the session belongs to a synthetic
+# address. Not the string we were handed — the server's own answer, so it holds for the
+# pasted-cookie path too.
+#
+# ── The drill ───────────────────────────────────────────────────────────────────────
+# Run this workflow by hand with `drill: dead-session` or `drill: wrong-account` to prove
+# the check still goes RED. A synthetic monitor that cannot fail is the original bug.
+#
+# ── OWNER: one-time setup, then never again ─────────────────────────────────────────
+# 1. Create the robot account on prod. NO MAILBOX IS NEEDED — `POST /api/auth/register`
+#    takes an email + password and the account can sign in immediately
+#    (backend/tests/test_auth_routes.py::test_register_creates_user_but_does_not_auto_login).
+#    The nine corners this walks (dashboard/profile/jobs/pipeline/channels/settings/
+#    notifications) are gated on `require_user`, NOT `require_verified_user` — only
+#    `search.py:177` and `tailor.py` need a verified email, and neither is walked. So an
+#    unverified robot account is enough.
+#      curl -X POST https://<backend>/api/auth/register \
+#        -H 'Content-Type: application/json' \
+#        -d '{"email":"synthetic@job360.uk","password":"<a long random password>"}'
+# 2. Repo VARIABLE  SMOKE_EMAIL    = that address (must satisfy the synthetic rule).
+#    Repo SECRET    SMOKE_PASSWORD = that password.
+# 3. DELETE the SMOKE_SESSION secret. It exists only as a fallback and it is the chore.
+# 4. Run this workflow by hand once with `drill: dead-session` and confirm it goes RED.
+#    A guard nobody has ever seen fire is a guess.
+# Magic-link is NOT usable here: an account created that way gets a random unguessable
+# password (services/auth/magic_link.py:180-186), so it can never log in with one.
 name: synthetic-live
 on:
   schedule:
     - cron: "0 */6 * * *" # every 6h; tune to taste (authed run makes a real LLM call)
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      drill:
+        description: "Fire a DRILL instead of a real walk — proves this check can go RED."
+        type: choice
+        required: false
+        default: "none"
+        options:
+          - "none"
+          - "dead-session" # a syntactically valid but dead cookie -> must fail
+          - "wrong-account" # a NON-synthetic address -> must refuse before sending anything
 
 # Least-privilege token (CodeQL actions/missing-workflow-permissions):
 # these jobs only check out code and run tests/uploads — no repo writes.
@@ -35,11 +89,55 @@ jobs:
           npm ci
           npx playwright install --with-deps chromium
       - name: Walk live production
+        if: inputs.drill == '' || inputs.drill == 'none'
         env:
           SMOKE_BASE_URL: ${{ vars.SMOKE_BASE_URL }}
           SMOKE_API_URL: ${{ vars.SMOKE_API_URL }}
+          # Log in at run time — nothing here expires on a clock.
+          SMOKE_EMAIL: ${{ vars.SMOKE_EMAIL }}
+          SMOKE_PASSWORD: ${{ secrets.SMOKE_PASSWORD }}
+          # Legacy pasted-cookie fallback. Kept so this change can never make the
+          # check worse than it was; the run warns when it is nearing its 30 days.
           SMOKE_SESSION: ${{ secrets.SMOKE_SESSION }}
+          # Only the SCHEDULE demands an authed walk. Deleting the credentials would
+          # otherwise turn nine corners off silently and the run would stay green —
+          # which is exactly how the last three checks died. A hand-run
+          # (workflow_dispatch) may legitimately walk the public corners only.
+          SMOKE_REQUIRE_AUTHED: ${{ github.event_name == 'schedule' && '1' || '' }}
         run: node tests/synthetic/live-smoke.mjs
+
+      # ── THE DRILL ─────────────────────────────────────────────────────────────
+      # Fire the failure on purpose and assert the script EXITS NON-ZERO. Two loops
+      # in this repo were dead on arrival and only firing them deliberately revealed
+      # it, so every guard gets an entrance you can walk through.
+      #
+      # Neither drill needs a real credential: `dead-session` uses a made-up cookie
+      # (the signature cannot verify, so it is refused), and `wrong-account` is
+      # refused BEFORE any network call because the address is not synthetic — the
+      # dummy password is never transmitted.
+      - name: DRILL — prove this check can still go RED
+        if: inputs.drill != '' && inputs.drill != 'none'
+        env:
+          SMOKE_BASE_URL: ${{ vars.SMOKE_BASE_URL }}
+          SMOKE_API_URL: ${{ vars.SMOKE_API_URL }}
+          SMOKE_EMAIL: ${{ inputs.drill == 'wrong-account' && 'a-real-human@example.com' || '' }}
+          SMOKE_PASSWORD: ${{ inputs.drill == 'wrong-account' && 'not-a-real-password' || '' }}
+          SMOKE_SESSION: ${{ inputs.drill == 'dead-session' && 'deadbeef0123456789abcdef.an2pww.this-signature-is-not-valid' || '' }}
+        run: |
+          echo "DRILL: ${{ inputs.drill }} — the script MUST exit non-zero."
+          # GitHub runs `run:` blocks under `bash -e`, so a non-zero node exit would
+          # abort the step before we could check it. `set +e` is load-bearing here:
+          # a FAILING script is the PASSING outcome of a drill.
+          set +e
+          node tests/synthetic/live-smoke.mjs
+          code=$?
+          set -e
+          if [ "$code" -eq 0 ]; then
+            echo "::error::DRILL FAILED — live-smoke.mjs exited 0 on a deliberately broken session (${{ inputs.drill }}). The session gate is NOT working: a monitor that cannot go red reports OK about nothing."
+            exit 1
+          fi
+          echo "DRILL PASSED — the gate refused and the script exited $code." >> "$GITHUB_STEP_SUMMARY"
+
       - name: Upload report + failure screenshots
         if: always()
         uses: actions/upload-artifact@v7

--- a/backend/tests/test_auth_routes.py
+++ b/backend/tests/test_auth_routes.py
@@ -171,6 +171,54 @@ def test_login_happy_path_sets_cookie(client):
     assert "job360_session" in r.cookies
 
 
+def test_login_cookie_round_trips_to_me_and_names_the_owner(client):
+    """CONTRACT the live synthetic monitor stands on — do not break silently.
+
+    ``.github/workflows/synthetic-live.yml`` used to run on a ``job360_session``
+    cookie the owner pasted into a repo secret by hand every 30 days
+    (``SESSION_MAX_AGE_DAYS``). It now logs itself in instead, which needs exactly
+    two things to stay true:
+
+      1. ``POST /api/auth/login`` returns the session in a ``Set-Cookie`` header
+         named ``job360_session`` — the monitor reads the raw HEADER, not a
+         client-side cookie jar, so assert on the header.
+      2. Sending that value back on ``GET /api/auth/me`` returns the OWNER'S
+         EMAIL. That is the monitor's safety gate: it refuses to walk production
+         unless the backend itself says the session belongs to a synthetic
+         account. If ``/me`` stopped returning ``email``, the gate would refuse
+         every run — or, worse, a laxer gate would let the robot loose on a real
+         user's profile.
+
+    Value-presence, not schema-presence (rule #21): the email asserted here is
+    the real registered address, so a serializer returning ``""`` fails.
+    """
+    email = "synthetic+roundtrip@example.com"
+    client.post("/api/auth/register", json={"email": email, "password": "s3cretpassword"})
+    client.cookies.clear()
+
+    login = client.post("/api/auth/login", json={"email": email, "password": "s3cretpassword"})
+    assert login.status_code == 200, login.text
+
+    # (1) the raw Set-Cookie header, parsed the way the monitor parses it.
+    set_cookie = login.headers.get("set-cookie", "")
+    assert "job360_session=" in set_cookie, set_cookie
+    cookie_value = set_cookie.split("job360_session=", 1)[1].split(";", 1)[0]
+    assert cookie_value, "login returned an EMPTY session cookie"
+
+    # (2) that value alone identifies the owner — no cookie jar, header only.
+    client.cookies.clear()
+    me = client.get("/api/auth/me", headers={"Cookie": f"job360_session={cookie_value}"})
+    assert me.status_code == 200, me.text
+    assert me.json()["email"] == email
+
+    # And a session that is NOT this one must not resolve — the gate has to be
+    # able to say no, or it is decoration.
+    dead = client.get(
+        "/api/auth/me", headers={"Cookie": "job360_session=deadbeef.an2pww.not-a-signature"}
+    )
+    assert dead.status_code == 401
+
+
 # ----- me / logout -----------------------------------------------------
 
 def test_me_requires_session(client):

--- a/frontend/tests/synthetic/live-smoke.mjs
+++ b/frontend/tests/synthetic/live-smoke.mjs
@@ -7,17 +7,21 @@
 //
 //   Public corners (landing, login, register, legal)  → always run.
 //   Authed corners (dashboard, CV upload→extraction, jobs, tailor, pipeline, …)
-//        → run only when SMOKE_SESSION is set to a VERIFIED synthetic account's
-//          `job360_session` cookie (prod email-verification can't be automated in CI).
+//        → run only when the robot can LOG ITSELF IN as a dedicated synthetic
+//          account, and only after the backend confirms that is whose account it is.
+//          See session-gate.mjs for both gates and why they exist.
 //
 // Env:
 //   SMOKE_BASE_URL  frontend URL   (default: live prod frontend)
 //   SMOKE_API_URL   backend URL    (default: live prod backend)
-//   SMOKE_SESSION   verified synthetic account session cookie (enables authed corners)
+//   SMOKE_EMAIL     synthetic account address  ← repo VARIABLE (not secret: it must stay
+//                   readable in the log, or a refusal message reads "refused: ***")
+//   SMOKE_PASSWORD  synthetic account password ← repo SECRET. Set ONCE; nothing expires.
+//   SMOKE_SESSION   LEGACY fallback: a hand-pasted `job360_session` cookie. Still works,
+//                   but it dies after 30 days (sessions.py:25) — the run now warns before
+//                   that happens and tells you to switch to SMOKE_EMAIL/SMOKE_PASSWORD.
 //   SMOKE_ALLOW_WRITES  "1"/"true" to run MUTATING corners (CV upload → extraction).
-//        DEFAULT OFF → authed walk is READ-ONLY (only opens pages, never writes). Turn
-//        on ONLY for a throwaway synthetic account — NEVER a real user's cookie, or the
-//        6-hourly run would overwrite that user's profile + burn an LLM call each time.
+//        DEFAULT OFF → authed walk is READ-ONLY (only opens pages, never writes).
 //   SMOKE_OUT       artifact dir   (default: smoke-artifacts)
 //
 // Exit code: non-zero if ANY corner failed (so CI goes red + emails the owner).
@@ -26,11 +30,13 @@ import { chromium } from "playwright";
 import fs from "fs";
 import path from "path";
 
+import { acquireSession } from "./session-gate.mjs";
+
 const FE = (process.env.SMOKE_BASE_URL || "https://frontend-production-c608f.up.railway.app").replace(/\/+$/, "");
 const BE = (process.env.SMOKE_API_URL || "https://backend-production-80e8e.up.railway.app").replace(/\/+$/, "");
-const SESSION = process.env.SMOKE_SESSION || "";
 // READ-ONLY by default. Mutating corners (CV upload → extraction) run ONLY when this is
-// explicitly on — so pointing SMOKE_SESSION at a real account can never overwrite it.
+// explicitly on. Safe either way now: the authed walk cannot start at all unless the
+// BACKEND confirms the session belongs to a synthetic account (session-gate.mjs).
 const ALLOW_WRITES = /^(1|true|yes)$/i.test(process.env.SMOKE_ALLOW_WRITES || "");
 const OUT = process.env.SMOKE_OUT || "smoke-artifacts";
 fs.mkdirSync(OUT, { recursive: true });
@@ -38,6 +44,24 @@ fs.mkdirSync(OUT, { recursive: true });
 const results = [];
 let consoleErrors = [];
 let serverErrors = [];
+
+// ── Get a session BEFORE the browser opens ──────────────────────────────────
+// Logging in at run time is the whole point of this file's existence: it removes
+// the 30-day "paste a fresh cookie into a repo secret" chore, and a chore
+// attached to a safety check is a countdown on that check.
+//
+// A REFUSED result never yields a cookie, so nothing below can accidentally walk
+// production as somebody real.
+const AUTH = await acquireSession({
+  apiBase: BE,
+  email: process.env.SMOKE_EMAIL || "",
+  password: process.env.SMOKE_PASSWORD || "",
+  pastedCookie: process.env.SMOKE_SESSION || "",
+  // Scheduled runs demand a working synthetic login. Without this, deleting the
+  // secret would turn the authed half OFF silently and the run would stay green.
+  requireAuthed: /^(1|true|yes)$/i.test(process.env.SMOKE_REQUIRE_AUTHED || ""),
+});
+const SESSION = AUTH.status === "ok" ? AUTH.cookie : "";
 
 const browser = await chromium.launch();
 const ctx = await browser.newContext({ viewport: { width: 1440, height: 950 }, baseURL: FE });
@@ -130,13 +154,21 @@ async function gotoAuthed(p) {
   if (landed.startsWith("/login") || landed.startsWith("/register")) {
     throw new Error(
       `bounced to ${landed} — the walk is NOT authenticated, so nothing past this ` +
-      `point tests the logged-in app. Refresh the SMOKE_SESSION secret.`,
+      `point tests the logged-in app. The session gate passed just before this, so the ` +
+      `session died mid-walk or the frontend middleware disagrees with the backend.`,
     );
   }
 }
 const seeText = (re, timeout = 15000) => page.getByText(re).first().waitFor({ state: "visible", timeout });
 
-console.log(`\n=== LIVE SMOKE vs ${FE} ${SESSION ? "(authed)" : "(public only — no SMOKE_SESSION)"} ===`);
+const AUTH_LABEL =
+  AUTH.status === "ok"
+    ? `(authed as ${AUTH.email} via ${AUTH.mode})`
+    : AUTH.status === "refused"
+      ? "(public only — THE SESSION GATE REFUSED, see the failure below)"
+      : "(public only — no synthetic credentials configured)";
+console.log(`\n=== LIVE SMOKE vs ${FE} ${AUTH_LABEL} ===`);
+for (const w of AUTH.warnings) console.log(`  WARN  ${w}`);
 
 // ── PUBLIC corners (always) ──
 await corner("landing loads", async () => { await gotoOK("/"); await seeText(/job360/i); });
@@ -254,44 +286,32 @@ const AUTHED = [
   ["notifications", async () => { await gotoAuthed("/notifications"); await page.waitForTimeout(1500); }],
 ];
 
-// ── The session gate ────────────────────────────────────────────────────────
-// Ask the backend whether SMOKE_SESSION is still a real session BEFORE walking
-// nine authed corners with it. A dead cookie is a CONFIG problem with a one-line
-// fix (refresh the secret); letting it leak into the corners turns it into nine
-// misleading results and buries the actual cause. One honest red beats a puzzle.
-async function sessionIsLive() {
-  try {
-    const r = await fetch(`${BE}/api/auth/me`, {
-      headers: { Cookie: `job360_session=${SESSION}` },
-    });
-    return { ok: r.ok, status: r.status };
-  } catch (e) {
-    return { ok: false, status: `unreachable (${String(e && e.message ? e.message : e).slice(0, 80)})` };
-  }
-}
+// ── The session gate (decided in session-gate.mjs, reported here) ───────────
+// Two questions, both answered BEFORE walking nine authed corners:
+//   is this session alive?  (PR #313 — a dead cookie made nine corners lie)
+//   whose account is it?    (new — the backend names the owner; refuse a human)
+// Either way the failure is CONFIG, not an outage, and it says so — one honest
+// red beats a puzzle, and a red that blames production cries wolf.
+const GATE_CORNER = "synthetic session is live AND belongs to a robot account";
 
-if (SESSION) {
-  const gate = await sessionIsLive();
-  if (gate.ok) {
-    for (const [name, fn] of AUTHED) await corner(name, fn);
-  } else {
-    const reason =
-      `SMOKE_SESSION is not a valid session — GET ${BE}/api/auth/me returned ${gate.status}. ` +
-      `The cookie is set but dead (expired or revoked), so every protected page would ` +
-      `redirect to /login and each corner would "pass" against the sign-in card. ` +
-      `FIX: log in as the synthetic account, copy its fresh job360_session cookie, and ` +
-      `update the SMOKE_SESSION repo secret. This is NOT a production outage.`;
-    results.push({ corner: "synthetic session is valid (SMOKE_SESSION)", ok: false, reason });
-    console.log(`  FAIL  synthetic session is valid (SMOKE_SESSION) — ${reason}`);
-    for (const [name] of AUTHED) {
-      results.push({ corner: name, ok: null, reason: "BLOCKED — SMOKE_SESSION is dead; not walked (a pass here would be a lie)" });
-      console.log(`  SKIP  ${name} — blocked by a dead SMOKE_SESSION`);
-    }
+if (AUTH.status === "ok") {
+  for (const [name, fn] of AUTHED) await corner(name, fn);
+  // A pasted cookie still works, but it is on a countdown. Surface that as a
+  // real (non-fatal) result so the owner is told BEFORE it dies, not after.
+  for (const w of AUTH.warnings) {
+    results.push({ corner: "session will not expire on a clock", ok: null, reason: w });
+  }
+} else if (AUTH.status === "refused") {
+  results.push({ corner: GATE_CORNER, ok: false, reason: AUTH.reason });
+  console.log(`  FAIL  ${GATE_CORNER} — ${AUTH.reason}`);
+  for (const [name] of AUTHED) {
+    results.push({ corner: name, ok: null, reason: "BLOCKED — the session gate refused; not walked (a pass here would be a lie)" });
+    console.log(`  SKIP  ${name} — blocked by the session gate`);
   }
 } else {
   for (const [name] of AUTHED) {
-    results.push({ corner: name, ok: null, reason: "SKIPPED — set SMOKE_SESSION (a verified synthetic account cookie) to walk authed corners" });
-    console.log(`  SKIP  ${name} — no SMOKE_SESSION`);
+    results.push({ corner: name, ok: null, reason: AUTH.reason });
+    console.log(`  SKIP  ${name} — no synthetic credentials configured`);
   }
 }
 
@@ -300,9 +320,28 @@ await browser.close();
 const failed = results.filter((r) => r.ok === false);
 const passed = results.filter((r) => r.ok === true);
 const skipped = results.filter((r) => r.ok === null);
-fs.writeFileSync(path.join(OUT, "report.json"), JSON.stringify({ ts: new Date().toISOString(), frontend: FE, backend: BE, authed: !!SESSION, results }, null, 2));
+fs.writeFileSync(
+  path.join(OUT, "report.json"),
+  JSON.stringify(
+    {
+      ts: new Date().toISOString(),
+      frontend: FE,
+      backend: BE,
+      authed: !!SESSION,
+      // HOW the session was obtained, and WHO the backend says it belongs to —
+      // never the cookie itself. `mode: "login"` is the no-expiry path.
+      sessionMode: AUTH.mode,
+      sessionOwner: AUTH.email,
+      warnings: AUTH.warnings,
+      results,
+    },
+    null,
+    2,
+  ),
+);
 
 console.log(`\n=== RESULT: ${passed.length} ok · ${failed.length} FAIL · ${skipped.length} skipped ===`);
 for (const f of failed) console.log(`  ✗ ${f.corner}: ${f.reason}`);
+for (const w of AUTH.warnings) console.log(`  ! ${w}`);
 console.log(`report + screenshots → ${OUT}/`);
 process.exit(failed.length ? 1 : 0);

--- a/frontend/tests/synthetic/session-gate.mjs
+++ b/frontend/tests/synthetic/session-gate.mjs
@@ -1,0 +1,372 @@
+// How the live smoke test GETS a session — and the safety gate that decides
+// whether it is allowed to use one.
+//
+// ── Why this file exists ────────────────────────────────────────────────────
+// Until now the authed half of the smoke ran on SMOKE_SESSION: a raw
+// `job360_session` cookie the owner pasted into a repo secret by hand. Sessions
+// have a HARD 30-day expiry with no sliding renewal
+// (backend/src/services/auth/sessions.py:25 `SESSION_MAX_AGE_DAYS = 30`,
+// resolve_session refuses on `expires_at <= now` at :86), so that secret dies on
+// a clock. It already did: 2026-08-09 → 2026-08-11 nine authed corners reported
+// OK while the robot stared at the sign-in card.
+//
+// A recurring manual chore attached to a safety check is a check with a
+// countdown on it. So: LOG IN AT RUN TIME instead. `POST /api/auth/login`
+// (backend/src/api/routes/auth.py:215-276) takes email + password and returns the
+// session cookie in one request — no mailbox, no magic link, nothing to paste
+// every 30 days. The owner sets a password ONCE.
+//
+// ── The safety rule (enforced here, in code — not in a comment) ─────────────
+// This walk must never touch a real user's account. Two independent gates:
+//
+//   1. BEFORE the password is sent anywhere, the address must look synthetic.
+//      A real user's password is never transmitted, and no session is ever
+//      minted for a real account.
+//   2. AFTER a session exists (however it was obtained — login OR a pasted
+//      cookie), we ask the BACKEND whose account it is (`GET /api/auth/me`) and
+//      refuse unless the server's own answer is a synthetic address. This is
+//      the load-bearing one: it checks the account the session actually grants,
+//      not the string we were handed.
+//
+// Gate 2 covers the pasted-cookie path too, which was previously unguarded.
+
+// Hard expiry of a session, mirrored from the backend so the pasted-cookie
+// fallback can warn BEFORE it dies. Source of truth:
+// backend/src/services/auth/sessions.py:25.
+export const SESSION_MAX_AGE_DAYS = 30;
+
+// Warn once fewer than this many days remain on a pasted cookie.
+export const REFRESH_WARNING_DAYS = 7;
+
+export const SYNTHETIC_RULE_TEXT =
+  'the local part (before "@") must contain "synthetic" as a whole token, ' +
+  'delimited by + . - or _ — e.g. "synthetic@job360.uk" or ' +
+  '"you+synthetic@gmail.com". "you@gmail.com" and "synthetics@x.com" do NOT match.';
+
+/**
+ * The safety rule. True only for an address that was deliberately created for
+ * this robot.
+ *
+ * Deliberately a rule in CODE, not an env-var allowlist: an allowlist that
+ * lives in repo settings can be widened without review, and the whole point is
+ * that a stray value can never aim this at a human's account. Widening this
+ * needs a commit and a diff.
+ *
+ * Plus-tagging is accepted because it is the practical way to own a real,
+ * deliverable mailbox for the robot (gmail `+tag` lands in the same inbox) while
+ * still being a genuinely SEPARATE `users` row — `users.email` is the identity
+ * (auth.py:249 matches on `LOWER(email)`), so `you+synthetic@x.com` can never
+ * resolve to `you@x.com`'s account.
+ *
+ * @param {unknown} email
+ * @returns {boolean}
+ */
+export function isSyntheticEmail(email) {
+  if (typeof email !== "string") return false;
+  const at = email.lastIndexOf("@");
+  if (at <= 0 || at === email.length - 1) return false;
+  const local = email.slice(0, at).toLowerCase();
+  // "synthetic" as its own token: at a boundary on both sides. `synthetics`
+  // and `notsynthetic` are rejected — near-misses must not squeak through.
+  return /(^|[+._-])synthetic([+._-]|$)/.test(local);
+}
+
+/**
+ * Read the Set-Cookie header(s) off a fetch Response as an array.
+ * Node 20+ has `Headers.getSetCookie()`; everything else needs a fallback,
+ * because a plain `.get("set-cookie")` folds multiple cookies into one string.
+ *
+ * @param {{ headers: any }} res
+ * @returns {string[]}
+ */
+export function readSetCookie(res) {
+  const h = res && res.headers;
+  if (!h) return [];
+  if (typeof h.getSetCookie === "function") return h.getSetCookie();
+  if (typeof h.raw === "function") return h.raw()["set-cookie"] || [];
+  const one = typeof h.get === "function" ? h.get("set-cookie") : null;
+  return one ? [one] : [];
+}
+
+/**
+ * Pull one cookie's VALUE out of a list of Set-Cookie header lines.
+ *
+ * @param {string[]} lines
+ * @param {string} name
+ * @returns {string} "" when absent
+ */
+export function pickCookie(lines, name) {
+  for (const line of lines || []) {
+    const first = String(line).split(";")[0];
+    const eq = first.indexOf("=");
+    if (eq < 0) continue;
+    if (first.slice(0, eq).trim() !== name) continue;
+    return first.slice(eq + 1).trim();
+  }
+  return "";
+}
+
+/**
+ * When was this session cookie signed?
+ *
+ * The cookie is `<session_id>.<timestamp>.<hmac>` — itsdangerous
+ * `TimestampSigner` (sessions.py:29). The middle field is the signing time as
+ * big-endian bytes, base64url without padding, and itsdangerous 2.x uses a
+ * plain unix epoch (verified against the installed itsdangerous 2.2.0). No
+ * secret is needed to READ it — only to trust it. We use it purely to say
+ * "this pasted cookie is N days old", never as an auth decision.
+ *
+ * @param {string} cookie
+ * @returns {number|null} epoch milliseconds, or null if unparseable
+ */
+export function cookieIssuedAtMs(cookie) {
+  const parts = String(cookie || "").split(".");
+  if (parts.length !== 3) return null;
+  const b64 = parts[1].replace(/-/g, "+").replace(/_/g, "/");
+  if (!b64) return null;
+  let buf;
+  try {
+    buf = Buffer.from(b64 + "=".repeat((4 - (b64.length % 4)) % 4), "base64");
+  } catch {
+    return null;
+  }
+  if (buf.length === 0 || buf.length > 8) return null;
+  let secs = 0;
+  for (const byte of buf) secs = secs * 256 + byte;
+  // Sanity bound: 2020-01-01 .. 2100-01-01. Anything outside is not a timestamp.
+  if (secs < 1577836800 || secs > 4102444800) return null;
+  return secs * 1000;
+}
+
+/**
+ * Days left before a pasted cookie hits the hard 30-day wall. null if unknown.
+ *
+ * @param {string} cookie
+ * @param {number} nowMs
+ * @returns {number|null}
+ */
+export function daysUntilSessionExpiry(cookie, nowMs) {
+  const issued = cookieIssuedAtMs(cookie);
+  if (issued === null) return null;
+  const expires = issued + SESSION_MAX_AGE_DAYS * 86400_000;
+  return (expires - nowMs) / 86400_000;
+}
+
+/**
+ * Get a session for the authed walk, and decide whether we are allowed to use it.
+ *
+ * @param {object} o
+ * @param {string} o.apiBase           backend origin (no trailing slash)
+ * @param {string} [o.email]           synthetic account address
+ * @param {string} [o.password]        synthetic account password
+ * @param {string} [o.pastedCookie]    legacy SMOKE_SESSION fallback
+ * @param {boolean} [o.requireAuthed]  scheduled runs: "nothing configured" is a FAILURE
+ * @param {Function} [o.fetchFn]       injected for tests
+ * @param {number} [o.nowMs]           injected for tests
+ * @returns {Promise<{status:"ok"|"refused"|"absent", cookie:string, email:string,
+ *                    mode:string, reason:string, warnings:string[]}>}
+ *   "ok"      → walk the authed corners
+ *   "refused" → a RED failure; something is wrong and must be said out loud
+ *   "absent"  → nothing configured; skip the authed corners (not a failure)
+ */
+export async function acquireSession({
+  apiBase,
+  email = "",
+  password = "",
+  pastedCookie = "",
+  requireAuthed = false,
+  fetchFn = fetch,
+  nowMs = Date.now(),
+}) {
+  const warnings = [];
+  let cookie = "";
+  let mode = "";
+
+  if (email || password) {
+    mode = "login";
+    if (!email || !password) {
+      return {
+        status: "refused",
+        cookie: "",
+        email: "",
+        mode,
+        reason:
+          "SMOKE_EMAIL and SMOKE_PASSWORD must be set TOGETHER — one without the " +
+          "other cannot log in. Set both (SMOKE_EMAIL is a repo variable, " +
+          "SMOKE_PASSWORD a repo secret) or neither.",
+        warnings,
+      };
+    }
+    // GATE 1 — refuse BEFORE the password leaves this process. If the address
+    // is a human's, we must not transmit their password nor mint a session.
+    if (!isSyntheticEmail(email)) {
+      return {
+        status: "refused",
+        cookie: "",
+        email,
+        mode,
+        reason:
+          `SMOKE_EMAIL (${email}) does not look like a dedicated synthetic account, ` +
+          `so this run REFUSED to log in — no password was sent. This robot walks ` +
+          `production every 6 hours and (with SMOKE_ALLOW_WRITES) uploads a CV; ` +
+          `pointed at a human it would trample their real profile. Rule: ${SYNTHETIC_RULE_TEXT} ` +
+          `FIX: register a dedicated account and point SMOKE_EMAIL at it.`,
+        warnings,
+      };
+    }
+    let res;
+    try {
+      res = await fetchFn(`${apiBase}/api/auth/login`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email, password }),
+      });
+    } catch (e) {
+      return {
+        status: "refused",
+        cookie: "",
+        email,
+        mode,
+        reason: `POST ${apiBase}/api/auth/login was unreachable: ${String(e && e.message ? e.message : e).slice(0, 120)}`,
+        warnings,
+      };
+    }
+    if (!res.ok) {
+      const hint =
+        res.status === 401
+          ? "the password is wrong, or the account does not exist yet — register it once, " +
+            "then set SMOKE_PASSWORD."
+          : res.status === 429
+            ? "locked out by the brute-force throttle (auth.py:232). It clears itself; " +
+              "if it keeps happening the password is wrong."
+            : "unexpected — check the backend is up.";
+      return {
+        status: "refused",
+        cookie: "",
+        email,
+        mode,
+        reason: `login as the synthetic account failed — POST /api/auth/login returned HTTP ${res.status}. ${hint} This is NOT a production outage for real users.`,
+        warnings,
+      };
+    }
+    cookie = pickCookie(readSetCookie(res), "job360_session");
+    if (!cookie) {
+      return {
+        status: "refused",
+        cookie: "",
+        email,
+        mode,
+        reason:
+          "login returned HTTP 200 but no `job360_session` cookie. The login route is " +
+          "supposed to set one (auth.py:271 `_set_session_cookie`) — if that stopped " +
+          "happening, NO real user can sign in either. Treat as a live incident.",
+        warnings,
+      };
+    }
+  } else if (pastedCookie) {
+    // Legacy fallback: a hand-pasted cookie. Still supported so this change can
+    // never make the check worse than it was — but it is on a countdown, so say so.
+    mode = "pasted-cookie";
+    cookie = pastedCookie;
+    const left = daysUntilSessionExpiry(cookie, nowMs);
+    if (left === null) {
+      warnings.push(
+        "SMOKE_SESSION is set but its age could not be read, so this check cannot warn " +
+          "you before it expires. Switch to SMOKE_EMAIL + SMOKE_PASSWORD (a login has no expiry).",
+      );
+    } else if (left <= 0) {
+      warnings.push(
+        `SMOKE_SESSION was signed ${(SESSION_MAX_AGE_DAYS - left).toFixed(1)} days ago and the ` +
+          `hard limit is ${SESSION_MAX_AGE_DAYS} days — it is ALREADY EXPIRED.`,
+      );
+    } else if (left <= REFRESH_WARNING_DAYS) {
+      warnings.push(
+        `SMOKE_SESSION expires in ${left.toFixed(1)} days (hard ${SESSION_MAX_AGE_DAYS}-day limit, ` +
+          `no renewal). Refresh it NOW, or better: set SMOKE_EMAIL + SMOKE_PASSWORD and delete ` +
+          `the secret — a login never expires on a clock.`,
+      );
+    } else {
+      warnings.push(
+        `Running on a hand-pasted SMOKE_SESSION; it dies in ${left.toFixed(1)} days and will need ` +
+          `pasting again. Set SMOKE_EMAIL + SMOKE_PASSWORD to end that chore.`,
+      );
+    }
+  } else {
+    // NOTHING CONFIGURED. On a scheduled run this is the QUIETEST way for the
+    // monitor to die: delete the secret and every authed corner "skips", the run
+    // is green, and nine corners of production stop being watched with nobody
+    // told. A monitor that silently downgrades itself is the same disease as one
+    // that cannot go red — so on the schedule, say it out loud.
+    return {
+      status: requireAuthed ? "refused" : "absent",
+      cookie: "",
+      email: "",
+      mode: "none",
+      reason:
+        "no synthetic credentials configured, so NINE authed corners of production are " +
+        "not being watched at all. Set SMOKE_EMAIL (repo variable) + SMOKE_PASSWORD " +
+        "(repo secret) to a dedicated synthetic account. This is NOT a production outage.",
+      warnings,
+    };
+  }
+
+  // ── GATE 2 — ask the SERVER whose account this session is ──────────────────
+  // Also the liveness check PR #313 added: a dead cookie is a CONFIG problem
+  // with a one-line fix, and letting it leak into nine corners buries the cause.
+  let me;
+  try {
+    me = await fetchFn(`${apiBase}/api/auth/me`, {
+      headers: { Cookie: `job360_session=${cookie}` },
+    });
+  } catch (e) {
+    return {
+      status: "refused",
+      cookie,
+      email,
+      mode,
+      reason: `GET ${apiBase}/api/auth/me was unreachable: ${String(e && e.message ? e.message : e).slice(0, 120)}`,
+      warnings,
+    };
+  }
+  if (!me.ok) {
+    return {
+      status: "refused",
+      cookie,
+      email,
+      mode,
+      reason:
+        `the session is not valid — GET /api/auth/me returned ${me.status}. Every protected ` +
+        `page would redirect to /login and each corner would "pass" against the sign-in card, ` +
+        `so the authed walk is BLOCKED instead. ` +
+        (mode === "pasted-cookie"
+          ? "FIX: stop pasting cookies — set SMOKE_EMAIL + SMOKE_PASSWORD and this cannot happen again."
+          : "The login just succeeded, so a session that is instantly invalid points at the backend, not at config.") +
+        " This is NOT a production outage.",
+      warnings,
+    };
+  }
+  let body = {};
+  try {
+    body = await me.json();
+  } catch {
+    /* fall through — an unreadable body means an unverifiable owner */
+  }
+  const owner = typeof body?.email === "string" ? body.email : "";
+  if (!isSyntheticEmail(owner)) {
+    return {
+      status: "refused",
+      cookie,
+      email: owner,
+      mode,
+      reason:
+        `the session belongs to ${owner || "an account whose email could not be read"}, which is ` +
+        `NOT a dedicated synthetic account — REFUSING to walk production as it. The backend ` +
+        `itself named this owner (GET /api/auth/me), so this holds no matter how the session ` +
+        `was obtained. Rule: ${SYNTHETIC_RULE_TEXT} ` +
+        `FIX: point SMOKE_EMAIL/SMOKE_PASSWORD at a throwaway account.`,
+      warnings,
+    };
+  }
+
+  return { status: "ok", cookie, email: owner, mode, reason: "", warnings };
+}

--- a/frontend/tests/synthetic/session-gate.test.mjs
+++ b/frontend/tests/synthetic/session-gate.test.mjs
@@ -1,0 +1,273 @@
+// THE DRILL, in unit form: prove the synthetic-live session gate can go RED.
+//
+// A synthetic monitor that cannot fail is the original bug. These tests fire
+// every wrong-way path deliberately and assert it is REFUSED — so the guard is
+// exercised on every CI run, not only on the day something breaks.
+//
+// The other half of the drill is end-to-end and lives in
+// .github/workflows/synthetic-live.yml (`workflow_dispatch` → drill: dead-session),
+// which runs the real script against real production with a corrupt session and
+// fails if the script exits 0.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  SESSION_MAX_AGE_DAYS,
+  acquireSession,
+  cookieIssuedAtMs,
+  daysUntilSessionExpiry,
+  isSyntheticEmail,
+  pickCookie,
+  readSetCookie,
+} from "./session-gate.mjs";
+
+const API = "https://backend.example";
+const SYNTH = "synthetic@job360.uk";
+
+/** Minimal fetch double. Routes by URL suffix. */
+function fakeFetch({ login, me }) {
+  const calls = [];
+  const fn = async (url, init) => {
+    calls.push({ url, init });
+    if (String(url).endsWith("/api/auth/login")) {
+      if (typeof login === "function") return login(init);
+      if (login instanceof Error) throw login;
+      return login;
+    }
+    if (String(url).endsWith("/api/auth/me")) {
+      if (me instanceof Error) throw me;
+      return me;
+    }
+    throw new Error(`unexpected URL ${url}`);
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+const res = (status, { setCookie = [], json = {} } = {}) => ({
+  ok: status >= 200 && status < 300,
+  status,
+  headers: { getSetCookie: () => setCookie },
+  json: async () => json,
+});
+
+const okLogin = (cookie = "sid.an2pww.sig") =>
+  res(200, { setCookie: [`job360_session=${cookie}; Path=/; HttpOnly; Secure`] });
+
+describe("isSyntheticEmail — the safety rule", () => {
+  it.each([
+    "synthetic@job360.uk",
+    "SYNTHETIC@JOB360.UK",
+    "ranjith+synthetic@gmail.com",
+    "smoke.synthetic@job360.uk",
+    "synthetic-bot@job360.uk",
+    "synthetic_1@job360.uk",
+  ])("accepts a dedicated robot address: %s", (e) => {
+    expect(isSyntheticEmail(e)).toBe(true);
+  });
+
+  it.each([
+    // The owner's real address — the account this must never touch.
+    "ranjithmaligaguruprakash@gmail.com",
+    "someone@job360.uk",
+    // Near-misses must NOT squeak through.
+    "synthetics@job360.uk",
+    "notsynthetic@job360.uk",
+    "resynthetic@job360.uk",
+    // The domain is not the local part: this is a real user at a cute domain.
+    "victim@synthetic.com",
+    "",
+    "@job360.uk",
+    "synthetic@",
+    null,
+    undefined,
+    123,
+  ])("refuses anything else: %s", (e) => {
+    expect(isSyntheticEmail(e)).toBe(false);
+  });
+});
+
+describe("acquireSession — GATE 1: never send a real user's password", () => {
+  it("refuses a non-synthetic SMOKE_EMAIL without making ANY network call", async () => {
+    const fn = fakeFetch({ login: okLogin(), me: res(200, { json: { email: "victim@gmail.com" } }) });
+    const r = await acquireSession({
+      apiBase: API,
+      email: "victim@gmail.com",
+      password: "hunter2",
+      fetchFn: fn,
+    });
+    expect(r.status).toBe("refused");
+    // The whole point of gate 1: the password never left the process.
+    expect(fn.calls).toHaveLength(0);
+    expect(r.reason).toMatch(/no password was sent/i);
+    expect(r.reason).toMatch(/trample their real profile/i);
+  });
+
+  it("refuses when only one of email/password is set", async () => {
+    const fn = fakeFetch({ login: okLogin(), me: res(200, { json: { email: SYNTH } }) });
+    const r = await acquireSession({ apiBase: API, email: SYNTH, password: "", fetchFn: fn });
+    expect(r.status).toBe("refused");
+    expect(fn.calls).toHaveLength(0);
+    expect(r.reason).toMatch(/TOGETHER/);
+  });
+});
+
+describe("acquireSession — GATE 2: the SERVER names the owner", () => {
+  it("refuses a session the backend says belongs to a real user", async () => {
+    // The dangerous case the old code could not see: a pasted cookie that is
+    // perfectly VALID but belongs to a human. /api/auth/me returns 200, so a
+    // liveness-only gate waves it through.
+    const fn = fakeFetch({ login: null, me: res(200, { json: { email: "ranjithmaligaguruprakash@gmail.com" } }) });
+    const r = await acquireSession({ apiBase: API, pastedCookie: "sid.an2pww.sig", fetchFn: fn });
+    expect(r.status).toBe("refused");
+    expect(r.reason).toMatch(/ranjithmaligaguruprakash@gmail\.com/);
+    expect(r.reason).toMatch(/REFUSING to walk production/);
+  });
+
+  it("refuses when /api/auth/me cannot be parsed (owner unverifiable)", async () => {
+    const fn = fakeFetch({
+      login: null,
+      me: {
+        ok: true,
+        status: 200,
+        headers: { getSetCookie: () => [] },
+        json: async () => {
+          throw new Error("not json");
+        },
+      },
+    });
+    const r = await acquireSession({ apiBase: API, pastedCookie: "sid.an2pww.sig", fetchFn: fn });
+    expect(r.status).toBe("refused");
+  });
+
+  it("refuses a DEAD session (401) — the 2026-08-09 bug, kept red", async () => {
+    const fn = fakeFetch({ login: null, me: res(401) });
+    const r = await acquireSession({ apiBase: API, pastedCookie: "sid.an2pww.sig", fetchFn: fn });
+    expect(r.status).toBe("refused");
+    expect(r.reason).toMatch(/returned 401/);
+    expect(r.reason).toMatch(/NOT a production outage/);
+  });
+
+  it("refuses when login succeeds but the backend then rejects the session", async () => {
+    const fn = fakeFetch({ login: okLogin(), me: res(401) });
+    const r = await acquireSession({ apiBase: API, email: SYNTH, password: "pw", fetchFn: fn });
+    expect(r.status).toBe("refused");
+  });
+});
+
+describe("acquireSession — the happy path", () => {
+  it("logs in, keeps the cookie, and proceeds when the owner is synthetic", async () => {
+    const fn = fakeFetch({ login: okLogin("abc.an2pww.sig"), me: res(200, { json: { email: SYNTH } }) });
+    const r = await acquireSession({ apiBase: API, email: SYNTH, password: "pw", fetchFn: fn });
+    expect(r.status).toBe("ok");
+    expect(r.cookie).toBe("abc.an2pww.sig");
+    expect(r.mode).toBe("login");
+    // No countdown warning: a login has no clock on it.
+    expect(r.warnings).toEqual([]);
+    const body = JSON.parse(fn.calls[0].init.body);
+    expect(body).toEqual({ email: SYNTH, password: "pw" });
+  });
+
+  it("refuses a login that returns 200 with no cookie (a real incident)", async () => {
+    const fn = fakeFetch({ login: res(200, { setCookie: [] }), me: res(200, { json: { email: SYNTH } }) });
+    const r = await acquireSession({ apiBase: API, email: SYNTH, password: "pw", fetchFn: fn });
+    expect(r.status).toBe("refused");
+    expect(r.reason).toMatch(/NO real user can sign in either/);
+  });
+
+  it("explains a 401 from login as config, not an outage", async () => {
+    const fn = fakeFetch({ login: res(401), me: res(200, { json: { email: SYNTH } }) });
+    const r = await acquireSession({ apiBase: API, email: SYNTH, password: "pw", fetchFn: fn });
+    expect(r.status).toBe("refused");
+    expect(r.reason).toMatch(/HTTP 401/);
+    expect(r.reason).toMatch(/NOT a production outage/);
+  });
+
+  it("skips (does not fail) when nothing is configured at all", async () => {
+    const fn = fakeFetch({ login: null, me: null });
+    const r = await acquireSession({ apiBase: API, fetchFn: fn });
+    expect(r.status).toBe("absent");
+    expect(fn.calls).toHaveLength(0);
+  });
+
+  it("FAILS instead of skipping when the schedule requires an authed walk", async () => {
+    // The quietest death: delete the secret, everything "skips", the run is
+    // green, and nine corners of production stop being watched with nobody told.
+    const fn = fakeFetch({ login: null, me: null });
+    const r = await acquireSession({ apiBase: API, requireAuthed: true, fetchFn: fn });
+    expect(r.status).toBe("refused");
+    expect(r.reason).toMatch(/NINE authed corners of production are not being watched/);
+  });
+});
+
+describe("pasted-cookie fallback still warns before the 30-day wall", () => {
+  // A real itsdangerous TimestampSigner cookie shape, minted with the installed
+  // itsdangerous 2.2.0: `<sid>.<base64url unix seconds>.<hmac>`.
+  const at = (epochSeconds) => {
+    const b = Buffer.alloc(4);
+    b.writeUInt32BE(epochSeconds);
+    return `deadbeef.${b.toString("base64url")}.sig`;
+  };
+
+  it("reads the signing time out of the cookie without any secret", () => {
+    // 1786620355 → "an2pww", verified against python itsdangerous 2.2.0.
+    expect(cookieIssuedAtMs("0123456789abcdef.an2pww.O5ob24")).toBe(1786620355 * 1000);
+  });
+
+  it.each(["", "no-dots", "a.b", "a.b.c.d", "a.!!!.c", "a.AAAAAAAAAAAAAAAA.c"])(
+    "returns null for an unparseable cookie: %s",
+    (c) => {
+      expect(cookieIssuedAtMs(c)).toBeNull();
+    },
+  );
+
+  it("warns loudly when a pasted cookie is nearly dead", async () => {
+    const now = 1_800_000_000_000;
+    const issued = Math.floor(now / 1000) - (SESSION_MAX_AGE_DAYS - 3) * 86400; // 3 days left
+    const fn = fakeFetch({ login: null, me: res(200, { json: { email: SYNTH } }) });
+    const r = await acquireSession({ apiBase: API, pastedCookie: at(issued), fetchFn: fn, nowMs: now });
+    expect(r.status).toBe("ok");
+    expect(r.warnings.join(" ")).toMatch(/expires in 3\.0 days/);
+    expect(r.warnings.join(" ")).toMatch(/Refresh it NOW/);
+  });
+
+  it("still nags on a fresh pasted cookie — the chore is the defect", async () => {
+    const now = 1_800_000_000_000;
+    const fn = fakeFetch({ login: null, me: res(200, { json: { email: SYNTH } }) });
+    const r = await acquireSession({
+      apiBase: API,
+      pastedCookie: at(Math.floor(now / 1000)),
+      fetchFn: fn,
+      nowMs: now,
+    });
+    expect(r.status).toBe("ok");
+    expect(r.warnings.join(" ")).toMatch(/end that chore/);
+  });
+
+  it("computes days remaining from the 30-day hard limit", () => {
+    const now = 1_800_000_000_000;
+    const issued = Math.floor(now / 1000) - 10 * 86400;
+    expect(daysUntilSessionExpiry(at(issued), now)).toBeCloseTo(20, 5);
+  });
+});
+
+describe("Set-Cookie parsing", () => {
+  it("picks the right cookie out of several", () => {
+    const lines = [
+      "other=1; Path=/",
+      "job360_session=abc.def.ghi; Path=/; HttpOnly; SameSite=lax; Secure",
+      "another=2",
+    ];
+    expect(pickCookie(lines, "job360_session")).toBe("abc.def.ghi");
+    expect(pickCookie(lines, "missing")).toBe("");
+    expect(pickCookie([], "job360_session")).toBe("");
+  });
+
+  it("reads Set-Cookie via getSetCookie, raw(), or a single header", () => {
+    expect(readSetCookie({ headers: { getSetCookie: () => ["a=1"] } })).toEqual(["a=1"]);
+    expect(readSetCookie({ headers: { raw: () => ({ "set-cookie": ["b=2"] }) } })).toEqual(["b=2"]);
+    expect(readSetCookie({ headers: { get: () => "c=3" } })).toEqual(["c=3"]);
+    expect(readSetCookie({ headers: { get: () => null } })).toEqual([]);
+    expect(readSetCookie({})).toEqual([]);
+  });
+});


### PR DESCRIPTION
**Before:** every 30 days, log in, open devtools, copy the raw `job360_session` cookie, paste it into a repo secret. Miss it and synthetic-live goes blind — which already happened for 3 days while 9 authed corners reported OK against a login page.

A recurring manual chore attached to a safety check is a check with a countdown on it.

**After:** the workflow logs in at run time. `POST /api/auth/login` (`auth.py:215-276`) takes email + password and returns the session cookie in one request — not magic-link only, so no mailbox access is needed anywhere. Set two things once, delete `SMOKE_SESSION`, never touch it again.

## Safety is in code, not in a comment — two independent gates

```
1. BEFORE the password leaves the process
     the address must be a dedicated synthetic one
     -> a human's password is never transmitted, no session ever minted
     verified live: ZERO network calls made on refusal

2. AFTER a session exists (by login OR by pasted cookie)
     ask the BACKEND whose account it is  ->  GET /api/auth/me
     refuse the walk unless the server's own answer is synthetic
```

Gate 2 is the one that matters: it does not trust the input, it asks the server. A pasted cookie for a real user fails it too.

## What you do, once

```
1. curl -X POST https://<backend>/api/auth/register \
     -H "Content-Type: application/json" \
     -d "{\\"email\\":\\"synthetic@job360.uk\\",\\"password\\":\\"<long random>\\"}"
2. gh variable set SMOKE_EMAIL     # the address
3. gh secret   set SMOKE_PASSWORD  # the password
4. delete the SMOKE_SESSION secret
```

Nothing expires on a clock after that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G7mLsrkujpTyUhwMTn7itb