### PR TITLE
fix(llm): a missing key can no longer look like an accuracy regression

### DIFF
--- a/.github/workflows/external-health.yml
+++ b/.github/workflows/external-health.yml
@@ -145,7 +145,10 @@ jobs:
           cat providers.md
           cat providers.md >> "$GITHUB_STEP_SUMMARY"
           echo "dead=$code" >> "$GITHUB_OUTPUT"
-          [ "$code" -le 1 ] || exit "$code" # exit 2 = nothing configured, fail LOUD
+          # 0 ok · 1 a key is dead · 3 a whole capability has NO key — 1 and 3
+          # are both reported as issues below, so the step itself stays green.
+          # 2 (the probe is blind) is the one that must fail the job LOUD.
+          case "$code" in 0 | 1 | 3) ;; *) exit "$code" ;; esac
 
       - name: Raise it, and hand it to triage
         if: always() && steps.probe.outputs.dead != ''
@@ -154,14 +157,21 @@ jobs:
           GH_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
+          code="${{ steps.probe.outputs.dead }}"
+          # TWO ALARMS, because they have TWO DIFFERENT FIXES (same lesson as
+          # accuracy-audit.yml). "dead" = a key we own stopped working -> rotate
+          # it. "missing" = we never had one -> create one, and three of the four
+          # are free. Blurring them sends the owner to the wrong page.
           if [ "${{ inputs.drill }}" = "true" ]; then
             title="DRILL: provider probe test - not a real problem"
+          elif [ "$code" = "3" ]; then
+            title="KEYS: no LLM provider is configured - the judge cannot run"
           else
             title="KEYS: a provider credential is dead"
           fi
           num=$(gh issue list --state open --json number,title \
                   --jq ".[] | select(.title==\"$title\") | .number" | head -1)
-          if [ "${{ steps.probe.outputs.dead }}" = "1" ]; then
+          if [ "$code" = "1" ] || [ "$code" = "3" ]; then
             { cat providers.md
               echo
               echo "- Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
@@ -174,6 +184,22 @@ jobs:
             else
               gh issue comment "$num" --body-file body.md
             fi
-          elif [ -n "$num" ]; then
-            gh issue close "$num" --comment "Every configured credential authenticated as of run ${{ github.run_id }}. (auto-close)"
+          elif [ "$code" = "0" ]; then
+            # ONLY a real green run may close an alarm. This used to be a bare
+            # `elif`, so exit 2 — the probe measured NOTHING and said so — would
+            # auto-close the open alarm: a blind run silently reporting all-clear,
+            # which is the exact failure shape this repo keeps paying for.
+            # Both titles close here: whichever fix the owner applied (rotated a
+            # dead key, or created a first one), a clean probe proves it worked.
+            for t in "KEYS: a provider credential is dead" \
+                     "KEYS: no LLM provider is configured - the judge cannot run"; do
+              n=$(gh issue list --state open --json number,title \
+                    --jq ".[] | select(.title==\"$t\") | .number" | head -1)
+              # `if`, not `[ -n "$n" ] && ...` — under `set -e` a false test as
+              # the last command of a loop body kills the whole step.
+              if [ -n "$n" ]; then
+                gh issue close "$n" \
+                  --comment "Every configured credential authenticated as of run ${{ github.run_id }}. (auto-close)"
+              fi
+            done
           fi

--- a/backend/scripts/eval_ranking.py
+++ b/backend/scripts/eval_ranking.py
@@ -55,7 +55,19 @@ GEM = 70
 # So config failure gets its OWN marker, its OWN exit code (3), and its own
 # alarm in accuracy-audit.yml. Exit 2 stays reserved for "we measured, and the
 # number is bad".
-LLM_KEY_VARS = ("OPENAI_API_KEY", "GEMINI_API_KEY", "GROQ_API_KEY", "CEREBRAS_API_KEY")
+#
+# The four names and the wording of the fix are NOT re-typed here. They come
+# from the one preflight every LLM path shares
+# (``llm_provider.require_llm_key``), so a fifth provider added to the chain
+# cannot be missed by this alarm — and so this script reports the SAME truth
+# the judge acts on: ``settings.py`` also accepts a lowercase ``openai_api_key``,
+# which a raw ``os.environ["OPENAI_API_KEY"]`` check here would have called
+# missing while the judge was happily using it.
+from src.services.profile.llm_provider import (  # noqa: E402
+    NO_LLM_KEY_MESSAGE,
+    configured_llm_keys,
+)
+
 INSTRUMENT_BROKEN = "INSTRUMENT BROKEN"
 RC_BROKEN = 3
 RC_REGRESSED = 2
@@ -63,7 +75,7 @@ RC_REGRESSED = 2
 
 def _missing_llm_key() -> bool:
     """True when NOT ONE provider key is set — the judge cannot make a single call."""
-    return not any(os.environ.get(v) for v in LLM_KEY_VARS)
+    return not configured_llm_keys()
 
 
 async def main(user_id: str | None, top_n: int, buried_n: int) -> int:
@@ -73,11 +85,9 @@ async def main(user_id: str | None, top_n: int, buried_n: int) -> int:
     # connection, samples 160 rows and burns a minute to discover the same thing.
     if _missing_llm_key():
         print(
-            f"{INSTRUMENT_BROKEN}: no LLM API key in the environment — "
-            f"{', '.join(LLM_KEY_VARS)} are ALL empty, so the judge cannot make a "
-            "single call. This is a CONFIG failure, NOT an accuracy regression: "
-            "nothing was measured. In GitHub Actions an unset secret renders as an "
-            "empty string, so set one of these as a repo Actions secret and re-run.",
+            f"{INSTRUMENT_BROKEN}: {NO_LLM_KEY_MESSAGE} "
+            "For this instrument that means NOT an accuracy regression — no "
+            "ranking number was produced at all.",
             flush=True,
         )
         return RC_BROKEN

--- a/backend/src/services/llm_matcher.py
+++ b/backend/src/services/llm_matcher.py
@@ -29,7 +29,7 @@ from pydantic import BaseModel, Field
 from src.models import Job
 from src.repositories import pg
 from src.repositories.db_retry import with_write_retry
-from src.services.profile.llm_provider import llm_extract_validated
+from src.services.profile.llm_provider import LLMKeyMissing, llm_extract_validated
 
 logger = logging.getLogger("job360.services.llm_matcher")
 
@@ -440,9 +440,30 @@ async def match_batch(
                     )
                 tel.record_verdict(verdict.fit_score)
                 return verdict
+            except LLMKeyMissing:
+                # NEVER swallowed as a per-job failure. It is the SAME config
+                # fault for every job in the batch, and swallowing it per job is
+                # the masquerade that cost a week of eval data: N warnings, zero
+                # verdicts, and a caller counting "judged 0/160" reading a
+                # missing credential as a quality problem. Re-raised and
+                # surfaced by the gather below.
+                raise
             except Exception as e:  # noqa: BLE001 — judge failure must not kill the run
                 tel.failed += 1
                 logger.warning("match_batch: judge failed for job %s: %s", job_id, e)
                 return None
 
-    return await asyncio.gather(*[_one(j) for j in jobs])
+    # ``return_exceptions=True`` on purpose. A bare gather propagates the FIRST
+    # exception and abandons its siblings mid-flight — on this ONE shared
+    # psycopg connection that is finding C2's bug again (it surfaced in test as
+    # a WinError 10038 during teardown). Let every judge settle, THEN speak.
+    outcomes = await asyncio.gather(*[_one(j) for j in jobs], return_exceptions=True)
+    for out in outcomes:
+        if isinstance(out, LLMKeyMissing):
+            # One config fault, raised once, carrying the four key names and the
+            # fix — instead of N log lines that look like N bad judgments.
+            # Both live callers still catch Exception (main.py
+            # _run_matcher_stage, rescore.py gem-rescue), so the run survives;
+            # what changes is that their line now names the cause.
+            raise out
+    return [None if isinstance(o, BaseException) else o for o in outcomes]

--- a/backend/src/services/llm_matcher.py
+++ b/backend/src/services/llm_matcher.py
@@ -459,11 +459,18 @@ async def match_batch(
     # a WinError 10038 during teardown). Let every judge settle, THEN speak.
     outcomes = await asyncio.gather(*[_one(j) for j in jobs], return_exceptions=True)
     for out in outcomes:
-        if isinstance(out, LLMKeyMissing):
-            # One config fault, raised once, carrying the four key names and the
-            # fix — instead of N log lines that look like N bad judgments.
+        if isinstance(out, BaseException):
+            # ANYTHING that escapes `_one` is meant to escape: it already
+            # swallows ordinary per-job errors itself, so what is left is the
+            # LLMKeyMissing config fault (raised once, carrying the four key
+            # names and the fix, instead of N lines that look like N bad
+            # judgments) or a BaseException like CancelledError, which must
+            # never be turned into a quiet ``None`` by `return_exceptions=True`.
             # Both live callers still catch Exception (main.py
             # _run_matcher_stage, rescore.py gem-rescue), so the run survives;
-            # what changes is that their line now names the cause.
+            # what changes is that their log line now names the cause.
             raise out
-    return [None if isinstance(o, BaseException) else o for o in outcomes]
+    # The loop above raised on every exception, so nothing is filtered out here
+    # — order and length are preserved. Written as a comprehension so the type
+    # narrows without a cast.
+    return [o for o in outcomes if not isinstance(o, BaseException)]

--- a/backend/src/services/profile/llm_provider.py
+++ b/backend/src/services/profile/llm_provider.py
@@ -49,6 +49,15 @@ class LLMError(RuntimeError):
     callers that catch ``RuntimeError``/``Exception`` keep working unchanged."""
 
 
+class LLMKeyMissing(LLMError):  # noqa: N818 — reads better than ...Error
+    """NOT ONE provider key is set, so no call was ever made.
+
+    A CONFIG fault, not a result. It is deliberately its own type because every
+    caller downstream has to tell it apart from "we asked and the answer was
+    bad" — and for a week nobody could. See ``require_llm_key``.
+    """
+
+
 class LLMRateLimited(LLMError):  # noqa: N818 — reads better than ...Error
     """Every provider failed AND at least one was rate-limited / quota-exhausted.
 
@@ -199,6 +208,80 @@ def reset_dead_providers() -> None:
     _DEAD_PROVIDERS.clear()
 
 
+# ── The shared no-key preflight ─────────────────────────────────────────────
+#
+# A MISSING KEY IS NOT A BAD RESULT. Measured cost of confusing the two: the
+# weekly ranking eval reported "audit produced no judgments — treating as
+# failure" for a WEEK (runs 31107748440 + 31368793516). The ranking was fine.
+# No judge key was set — GitHub renders an unset Actions secret as an EMPTY
+# string — and every one of the 160 calls died instantly. The alarm filed it as
+# an ACCURACY REGRESSION (issue #238), which is the most expensive wrong alarm
+# there is: it sends a one-person team debugging the product instead of the
+# config.
+#
+# The check lives HERE, at the one point every path must pass through, for two
+# reasons: it cannot be bypassed by a caller written next month, and it fires
+# BEFORE any provider is tried (the old version only checked after the loop, so
+# the answer arrived at the bottom of a pile of provider errors).
+#
+# Everything downstream — the judge, the CV parser, the weekly eval, the daily
+# key probe — reads the four names from LLM_KEY_VARS so a fifth provider cannot
+# be added to the chain and forgotten by the alarm.
+LLM_KEY_VARS: tuple[str, ...] = (
+    "OPENAI_API_KEY",
+    "GEMINI_API_KEY",
+    "GROQ_API_KEY",
+    "CEREBRAS_API_KEY",
+)
+
+NO_LLM_KEY_MESSAGE = (
+    "No LLM API key configured — this is a CONFIG failure, NOT a bad result. "
+    f"Looked for {', '.join(LLM_KEY_VARS)}: ALL {len(LLM_KEY_VARS)} are empty, so "
+    "not one call was made and NOTHING was measured. Any ONE of them unblocks it "
+    "— GEMINI_API_KEY, GROQ_API_KEY and CEREBRAS_API_KEY have a free tier and all "
+    "four SDKs are already installed (backend/pyproject.toml). Set one in .env, or "
+    "as a repo Actions secret: in GitHub Actions an UNSET secret renders as an "
+    "EMPTY string, which is exactly how this hides."
+)
+
+# One alarm per process, not one per job. 160 identical ERROR events is how a
+# real alarm gets muted. Cleared by ``reset_llm_key_alarm`` (tests, re-probe).
+_KEY_ALARM_LOGGED = False
+
+
+def reset_llm_key_alarm() -> None:
+    """Allow the no-key ERROR to be logged again. For tests and re-probes."""
+    global _KEY_ALARM_LOGGED
+    _KEY_ALARM_LOGGED = False
+
+
+def configured_llm_keys() -> list[str]:
+    """NAMES (never values) of the provider keys that are actually set."""
+    return [name for name in LLM_KEY_VARS if globals().get(name)]
+
+
+def require_llm_key() -> None:
+    """Raise ``LLMKeyMissing`` when not one provider key is set.
+
+    Also logs ERROR once per process. That is the belt to the exception's
+    braces: both live callers of the judge swallow exceptions on purpose so a
+    provider blip cannot kill a run (``main.py`` ``_run_matcher_stage`` and
+    ``rescore.py`` gem-rescue), and Sentry raises an issue from an ERROR log —
+    so the config fault escapes even down a path that eats the raise.
+
+    Reads the MODULE globals, not ``os.environ``, so it tells the same truth the
+    provider chain acts on: ``settings.py`` also accepts a lowercase
+    ``openai_api_key``, and tests patch these names directly.
+    """
+    global _KEY_ALARM_LOGGED
+    if configured_llm_keys():
+        return
+    if not _KEY_ALARM_LOGGED:
+        _KEY_ALARM_LOGGED = True
+        logger.error("%s", NO_LLM_KEY_MESSAGE)
+    raise LLMKeyMissing(NO_LLM_KEY_MESSAGE)
+
+
 def _note_provider_failure(name: str, exc: BaseException) -> None:
     """Log one provider's failure and, if it is permanent, stop using it.
 
@@ -232,11 +315,13 @@ async def llm_extract(prompt: str, system: str = "") -> dict[str, Any]:
     backoff (see ``_attempt``).
 
     Raises:
-        RuntimeError: no provider key configured.
+        LLMKeyMissing: not one provider key is configured (a CONFIG fault —
+            checked FIRST, before any provider is tried).
         LLMRateLimited: all providers failed AND >=1 was rate-limited — retry
             later; callers MUST NOT persist an empty result on this.
         LLMAllProvidersFailed: all providers failed for non-rate-limit reasons.
     """
+    require_llm_key()
     errors: list[str] = []
     rate_limited = False
 
@@ -259,12 +344,8 @@ async def llm_extract(prompt: str, system: str = "") -> dict[str, Any]:
             rate_limited = rate_limited or _is_rate_limit(e)
             _note_provider_failure(name, e)
 
-    if not (OPENAI_API_KEY or GEMINI_API_KEY or GROQ_API_KEY or CEREBRAS_API_KEY):
-        raise RuntimeError(
-            "No LLM API key configured. Set OPENAI_API_KEY (recommended), or a free tier "
-            "GEMINI_API_KEY / GROQ_API_KEY / CEREBRAS_API_KEY in .env."
-        )
-
+    # No no-key check here: ``require_llm_key`` already ran at the top, so
+    # reaching this point means keys EXIST and the providers themselves failed.
     detail = "; ".join(errors)
     if rate_limited:
         raise LLMRateLimited(f"All LLM providers failed (rate-limited): {detail}")
@@ -280,9 +361,11 @@ async def llm_extract_fast(prompt: str, system: str = "") -> dict[str, Any]:
     taxonomy as ``llm_extract``.
 
     Raises:
-        RuntimeError: no provider key configured.
+        LLMKeyMissing: not one provider key is configured (same shared preflight
+            as ``llm_extract`` — this door must not have a weaker check).
         LLMRateLimited / LLMAllProvidersFailed: as in ``llm_extract``.
     """
+    require_llm_key()
     errors: list[str] = []
     rate_limited = False
 
@@ -305,11 +388,7 @@ async def llm_extract_fast(prompt: str, system: str = "") -> dict[str, Any]:
             rate_limited = rate_limited or _is_rate_limit(e)
             _note_provider_failure(name, e)
 
-    if not (OPENAI_API_KEY or GEMINI_API_KEY or GROQ_API_KEY or CEREBRAS_API_KEY):
-        raise RuntimeError(
-            "No LLM API key configured. Set OPENAI_API_KEY (recommended) or a free tier key in .env."
-        )
-
+    # See ``llm_extract``: the no-key case never reaches here.
     detail = "; ".join(errors)
     if rate_limited:
         raise LLMRateLimited(f"All LLM providers failed (rate-limited): {detail}")

--- a/backend/tests/test_llm_matcher.py
+++ b/backend/tests/test_llm_matcher.py
@@ -242,6 +242,47 @@ async def test_match_batch_persists_skips_and_survives_errors(mem_db):
     assert len(calls) == 2
 
 
+@pytest.mark.asyncio
+async def test_match_batch_does_not_swallow_a_missing_key_as_a_judged_nothing(mem_db):
+    """A missing key is not a per-job judge failure — it is the SAME fault for
+    every job, and swallowing it per job is exactly the masquerade that cost a
+    week of eval data.
+
+    Before: no key -> N warnings "judge failed for job X" -> ``[None, None]``.
+    A caller counting verdicts sees "judged 0/2" and reads a quality problem.
+    After: the config fault escapes as itself, once.
+    """
+    import src.services.profile.llm_provider as lp
+
+    conn = mem_db
+    uid = "user-nokey-001"
+    ids = []
+    for title in ("Job A", "Job B"):
+        cur = await conn.execute(
+            "INSERT INTO jobs(title, company, apply_url, source, date_found) "
+            "VALUES (?,?,?,?,?)",
+            (title, "CorpA", f"https://a.com/{title}", "greenhouse", _NOW),
+        )
+        ids.append(cur.lastrowid)
+        await conn.execute(
+            "INSERT INTO user_feed(user_id, job_id, score, bucket) VALUES (?,?,?,?)",
+            (uid, ids[-1], 50, "top"),
+        )
+    await conn.commit()
+
+    jobs = []
+    for title, jid in zip(("Job A", "Job B"), ids):
+        j = _make_job(title=title)
+        j.id = jid  # type: ignore[attr-defined]
+        jobs.append(j)
+
+    # conftest._offline_openai already blanks all four keys — the production
+    # shape of an unset GitHub secret. No fn is injected, so the real chain runs.
+    lp.reset_llm_key_alarm()
+    with pytest.raises(lp.LLMKeyMissing):
+        await match_batch(jobs, user_id=uid, profile_text="p", conn=conn)
+
+
 def test_flag_defaults_off(monkeypatch):
     monkeypatch.delenv("MATCHER_ENABLED", raising=False)
     import importlib

--- a/backend/tests/test_llm_matcher.py
+++ b/backend/tests/test_llm_matcher.py
@@ -283,6 +283,39 @@ async def test_match_batch_does_not_swallow_a_missing_key_as_a_judged_nothing(me
         await match_batch(jobs, user_id=uid, profile_text="p", conn=conn)
 
 
+@pytest.mark.asyncio
+async def test_match_batch_still_propagates_cancellation(mem_db):
+    """Guard on the `return_exceptions=True` above. It lets every judge settle
+    before speaking, which is right — but it also turns a child's exception into
+    a VALUE, and silently eating a CancelledError is how a shutdown hangs.
+    Anything that escapes `_one` (which already swallows ordinary errors itself)
+    must still come out."""
+    conn = mem_db
+    uid = "user-cancel-001"
+    cur = await conn.execute(
+        "INSERT INTO jobs(title, company, apply_url, source, date_found) VALUES (?,?,?,?,?)",
+        ("Cancel Job", "CorpA", "https://a.com/c", "greenhouse", _NOW),
+    )
+    jid = cur.lastrowid
+    await conn.execute(
+        "INSERT INTO user_feed(user_id, job_id, score, bucket) VALUES (?,?,?,?)",
+        (uid, jid, 50, "top"),
+    )
+    await conn.commit()
+
+    job = _make_job(title="Cancel Job")
+    job.id = jid  # type: ignore[attr-defined]
+
+    async def cancelled(prompt, schema, system):
+        raise asyncio.CancelledError
+
+    with pytest.raises(asyncio.CancelledError):
+        await match_batch(
+            [job], user_id=uid, profile_text="p", conn=conn,
+            llm_extract_validated_fn=cancelled,
+        )
+
+
 def test_flag_defaults_off(monkeypatch):
     monkeypatch.delenv("MATCHER_ENABLED", raising=False)
     import importlib

--- a/backend/tests/test_missing_llm_key_is_loud.py
+++ b/backend/tests/test_missing_llm_key_is_loud.py
@@ -1,0 +1,285 @@
+"""A MISSING KEY MUST NEVER LOOK LIKE A BAD RESULT.
+
+THE INCIDENT. The weekly ranking eval reported "audit produced no judgments —
+treating as failure" for a WEEK (runs 31107748440, 31368793516). Nothing was
+wrong with the ranking. No judge key was set: GitHub renders an unset Actions
+secret as an EMPTY string, `llm_provider` raised only after the provider loop,
+and every caller swallowed that raise per-item into "the judge returned
+nothing". A config error wearing a quality-regression costume is the most
+expensive wrong alarm there is — it sends a solo founder debugging the product
+instead of the config.
+
+PR #313 fixed exactly one workflow. These tests fix the SHAPE, at the place the
+failure actually happens (``llm_provider.require_llm_key``), so a caller written
+tomorrow inherits the loud version for free.
+
+Every test here is offline (rule #4): no key is ever set to a real value, and
+every provider call is mocked or unreachable.
+"""
+from __future__ import annotations
+
+import importlib.util
+import logging
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+import src.services.profile.llm_provider as lp
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _blank_all_keys(monkeypatch) -> None:
+    """The production shape: every provider key renders as an empty string."""
+    for name in ("OPENAI_API_KEY", "GEMINI_API_KEY", "GROQ_API_KEY", "CEREBRAS_API_KEY"):
+        monkeypatch.setattr(lp, name, "")
+
+
+# ---------------------------------------------------------------------------
+# 1. The shared preflight — one place, four names, an instruction
+# ---------------------------------------------------------------------------
+
+
+def test_the_four_key_names_live_in_one_shared_constant():
+    """One list, so a fifth provider cannot be added to the chain and forgotten
+    by the alarm. The chain itself is built from these same names."""
+    assert lp.LLM_KEY_VARS == (
+        "OPENAI_API_KEY",
+        "GEMINI_API_KEY",
+        "GROQ_API_KEY",
+        "CEREBRAS_API_KEY",
+    )
+
+
+@pytest.mark.asyncio
+async def test_llm_extract_with_no_keys_raises_a_missing_key_error(monkeypatch):
+    """The headline test. All four empty -> a dedicated exception that NAMES
+    every variable it looked for, says they were ALL empty, and says what to do.
+
+    It must NOT be the generic "all providers failed" error: that reads as "we
+    tried and the providers are down", which is a different fix.
+    """
+    _blank_all_keys(monkeypatch)
+    lp.reset_llm_key_alarm()
+
+    with pytest.raises(lp.LLMKeyMissing) as exc:
+        await lp.llm_extract("judge this job")
+
+    msg = str(exc.value)
+    for name in lp.LLM_KEY_VARS:
+        assert name in msg, f"the error must name {name} — it is one of the fixes"
+    assert "ALL" in msg, "must say all four were empty, not just 'no key'"
+    assert "CONFIG" in msg.upper(), "must label itself a config failure"
+    assert "free tier" in msg.lower(), "must say the cheap way out"
+    # Not a quality signal, and not the 'providers are down' signal.
+    assert not isinstance(exc.value, lp.LLMAllProvidersFailed)
+    assert "All LLM providers failed" not in msg
+
+
+@pytest.mark.asyncio
+async def test_llm_extract_fast_shares_the_same_preflight(monkeypatch):
+    """The fast (bulk-scoring) path is a second door to the same chain. It must
+    not have its own, weaker version of the check."""
+    _blank_all_keys(monkeypatch)
+    lp.reset_llm_key_alarm()
+
+    with pytest.raises(lp.LLMKeyMissing) as exc:
+        await lp.llm_extract_fast("score this job")
+
+    for name in lp.LLM_KEY_VARS:
+        assert name in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_preflight_fires_before_any_provider_is_touched(monkeypatch):
+    """Cheap and early: with no key there is nothing to try, so the chain must
+    not walk providers first. (The old code checked only AFTER the loop.)"""
+    _blank_all_keys(monkeypatch)
+    lp.reset_llm_key_alarm()
+
+    with patch.object(lp, "_call_openai", new_callable=AsyncMock) as o, \
+         patch.object(lp, "_call_gemini", new_callable=AsyncMock) as g, \
+         patch.object(lp, "_call_groq", new_callable=AsyncMock) as q, \
+         patch.object(lp, "_call_cerebras", new_callable=AsyncMock) as c:
+        with pytest.raises(lp.LLMKeyMissing):
+            await lp.llm_extract("x")
+    assert not any(m.called for m in (o, g, q, c))
+
+
+@pytest.mark.asyncio
+async def test_missing_key_is_logged_at_error_so_prod_cannot_swallow_it(
+    monkeypatch, caplog
+):
+    """Sentry turns an ERROR log into an issue. Even if a caller swallows the
+    exception (main.py:490 and rescore.py:449 both catch Exception), the ERROR
+    line still escapes — that is the belt to the exception's braces.
+
+    Once per process, not once per job: 160 identical Sentry events is how an
+    alarm gets muted.
+    """
+    _blank_all_keys(monkeypatch)
+    lp.reset_llm_key_alarm()
+
+    with caplog.at_level(logging.ERROR, logger="job360.profile.llm_provider"):
+        for _ in range(3):
+            with pytest.raises(lp.LLMKeyMissing):
+                await lp.llm_extract("x")
+
+    errors = [r for r in caplog.records if r.levelno >= logging.ERROR]
+    assert len(errors) == 1, f"expected exactly one ERROR, got {len(errors)}"
+    for name in lp.LLM_KEY_VARS:
+        assert name in errors[0].getMessage()
+
+
+# ---------------------------------------------------------------------------
+# 2. No crying wolf — a present key must not trip any of this
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_one_free_key_is_enough_and_the_preflight_stays_quiet(monkeypatch, caplog):
+    """ANY ONE of the four unblocks the judge. Proven with a free-tier key
+    (GROQ), not the paid one — the owner's cheapest fix must be a real fix."""
+    _blank_all_keys(monkeypatch)
+    monkeypatch.setattr(lp, "GROQ_API_KEY", "fake-groq-key")
+    lp.reset_llm_key_alarm()
+    lp.reset_dead_providers()
+
+    with caplog.at_level(logging.ERROR, logger="job360.profile.llm_provider"), \
+         patch.object(lp, "_call_groq", new_callable=AsyncMock,
+                      return_value={"fit_score": 80}) as groq:
+        out = await lp.llm_extract("judge this job")
+
+    assert out == {"fit_score": 80}
+    assert groq.await_count == 1
+    assert not [r for r in caplog.records if r.levelno >= logging.ERROR], \
+        "a working key must produce no config alarm"
+
+
+@pytest.mark.parametrize(
+    ("key_name", "call_name"),
+    [
+        ("GEMINI_API_KEY", "_call_gemini"),
+        ("GROQ_API_KEY", "_call_groq"),
+        ("CEREBRAS_API_KEY", "_call_cerebras"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_each_free_tier_key_alone_really_reaches_a_provider(
+    monkeypatch, key_name, call_name
+):
+    """"Use a free key" must be advice that WORKS, not advice that sounds nice.
+
+    The owner is told any ONE of the four unblocks the judge and that three are
+    free. This pins that claim to the code: each free key ALONE routes to its
+    own provider. It is not hypothetical — OpenAI was the documented PRIMARY
+    provider for months while its SDK was undeclared, so the import raised,
+    the chain swallowed it, and OpenAI silently never ran (pyproject.toml:30-44).
+    """
+    _blank_all_keys(monkeypatch)
+    monkeypatch.setattr(lp, key_name, "fake-key")
+    lp.reset_llm_key_alarm()
+    lp.reset_dead_providers()
+
+    with patch.object(lp, call_name, new_callable=AsyncMock,
+                      return_value={"ok": True}) as provider:
+        assert await lp.llm_extract("x") == {"ok": True}
+        assert provider.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_a_real_provider_outage_is_still_not_a_missing_key(monkeypatch):
+    """The other side of the mistake: keys present but every provider down must
+    stay 'providers failed', never 'no key'. Otherwise we would send the owner
+    to the secrets page for an outage."""
+    _blank_all_keys(monkeypatch)
+    monkeypatch.setattr(lp, "GROQ_API_KEY", "fake-groq-key")
+    lp.reset_llm_key_alarm()
+    lp.reset_dead_providers()
+
+    with patch.object(lp, "_call_groq", new_callable=AsyncMock,
+                      side_effect=Exception("groq 500")):
+        with pytest.raises(lp.LLMAllProvidersFailed):
+            await lp.llm_extract("x")
+
+
+# ---------------------------------------------------------------------------
+# 3. The instruments that report on the judge must not inherit the masquerade
+# ---------------------------------------------------------------------------
+
+
+def test_eval_ranking_reuses_the_shared_key_list_instead_of_its_own_copy():
+    """The weekly accuracy instrument kept its own private copy of the four
+    names. Two lists drift; then a fifth provider is alarmed on by one and not
+    the other. Static check on purpose: importing the script sets a Windows
+    event-loop policy at module level."""
+    text = (_REPO_ROOT / "backend" / "scripts" / "eval_ranking.py").read_text(
+        encoding="utf-8"
+    )
+    assert "from src.services.profile.llm_provider import" in text
+    assert "NO_LLM_KEY_MESSAGE" in text and "configured_llm_keys" in text
+    assert '"OPENAI_API_KEY", "GEMINI_API_KEY"' not in text, \
+        "the private duplicate of the key list is still there"
+
+
+def _load_provider_probe():
+    """Import scripts/provider_probe.py by path (it is stdlib-only, no package)."""
+    path = _REPO_ROOT / "scripts" / "provider_probe.py"
+    spec = importlib.util.spec_from_file_location("_probe_under_test", path)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["_probe_under_test"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_provider_probe_watches_exactly_the_same_four_names():
+    """The probe is stdlib-only on purpose (external-health.yml never installs
+    the backend), so it cannot import the shared constant and re-types the list.
+    Pin the two together here — otherwise a fifth provider gets added to the
+    chain and the daily probe keeps reporting on four."""
+    mod = _load_provider_probe()
+    assert tuple(mod.LLM_KEY_VARS) == lp.LLM_KEY_VARS
+
+
+def test_provider_probe_goes_red_when_every_llm_key_is_absent(monkeypatch, capsys):
+    """THE DAILY BLIND SPOT (external-health.yml, cron 07:10). Absence was a
+    footnote: with all four LLM keys unset but ONE other credential present, the
+    probe printed "Every configured credential authenticated" and exited 0 —
+    green, daily, forever, while the judge could not make a single call.
+
+    Network is stubbed: this test makes no HTTP call.
+    """
+    mod = _load_provider_probe()
+    for name in ("OPENAI_API_KEY", "GROQ_API_KEY", "CEREBRAS_API_KEY", "GEMINI_API_KEY",
+                 "REED_API_KEY", "ADZUNA_APP_ID", "ADZUNA_APP_KEY", "PROBE_FORCE_RED"):
+        monkeypatch.delenv(name, raising=False)
+    # One NON-LLM credential present — this is what made the probe look healthy.
+    monkeypatch.setenv("RESEND_API_KEY", "stub-not-a-real-key")
+    monkeypatch.setenv("SMTP_FROM", "login@job360.uk")
+    monkeypatch.setattr(mod, "_probe", lambda *a, **k: ("ok", "stubbed"))
+
+    rc = mod.main()
+    out = capsys.readouterr().out
+
+    assert rc != 0, "no LLM key at all must not be a green run"
+    for name in ("OPENAI_API_KEY", "GEMINI_API_KEY", "GROQ_API_KEY", "CEREBRAS_API_KEY"):
+        assert name in out
+    assert "free tier" in out.lower()
+
+
+def test_provider_probe_stays_green_when_one_llm_key_is_present(monkeypatch, capsys):
+    """No crying wolf: one free key configured and healthy -> exit 0."""
+    mod = _load_provider_probe()
+    for name in ("OPENAI_API_KEY", "CEREBRAS_API_KEY", "GEMINI_API_KEY",
+                 "REED_API_KEY", "ADZUNA_APP_ID", "ADZUNA_APP_KEY", "PROBE_FORCE_RED"):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv("GROQ_API_KEY", "stub-not-a-real-key")
+    monkeypatch.setenv("RESEND_API_KEY", "stub-not-a-real-key")
+    monkeypatch.setenv("SMTP_FROM", "login@job360.uk")
+    monkeypatch.setattr(mod, "_probe", lambda *a, **k: ("ok", "stubbed"))
+
+    assert mod.main() == 0
+    assert "authenticated" in capsys.readouterr().out

--- a/scripts/product_assertions.py
+++ b/scripts/product_assertions.py
@@ -283,8 +283,19 @@ def main() -> int:
                     FROM user_feed
                 """)
                 judged, total = cur.fetchone()
+                # "zero" reads as a quality problem and is almost never one.
+                # CHECK THE CREDENTIAL FIRST: with no LLM key set, the judge
+                # cannot make a single call, so this column is NULL everywhere
+                # and every downstream report calls it bad ranking. That
+                # confusion cost a week of eval data (issue #238). This script
+                # reads the PROD DB, not prod's env, so it cannot see the key
+                # itself - external-health.yml's provider probe can, and now
+                # goes red when all four are empty.
                 rows.append(("rows with an LLM verdict", f"{judged}/{total}",
-                             "ok" if judged > 0 else "zero - the judge never ran"))
+                             "ok" if judged > 0
+                             else "zero - CHECK THE LLM KEY FIRST (OPENAI/GEMINI/"
+                                  "GROQ/CEREBRAS_API_KEY): no key = no call = no "
+                                  "verdict, which is config, not quality"))
                 # Same asymmetry as above: "never ran" may just mean the flag is
                 # off, but "ran and then stopped" is a fault no matter what the
                 # flags say — and it was previously unalarmable.

--- a/scripts/provider_probe.py
+++ b/scripts/provider_probe.py
@@ -29,8 +29,11 @@ DESIGN RULES:
 
 CONTRACT:
     exit 0  every configured provider authenticated
-    exit 1  at least one is dead -> raise
+    exit 1  at least one is dead (rotate it) -> raise
     exit 2  the probe itself is broken / nothing was configured to probe
+    exit 3  a whole CAPABILITY has no credential at all (create one) -> raise.
+            Different fix from exit 1, so a different alarm: 1 means a key we
+            own stopped working, 3 means we never had one.
 """
 
 from __future__ import annotations
@@ -46,6 +49,27 @@ if hasattr(sys.stdout, "reconfigure"):
 
 TIMEOUT = int(os.getenv("PROBE_TIMEOUT_S", "25"))
 FORCE_RED = os.getenv("PROBE_FORCE_RED", "") == "1"
+
+# ── The one exception to "absent is not broken" ──────────────────────────────
+#
+# ABSENT IS NOT BROKEN — unless EVERY provider of a capability is absent. Then
+# the capability is DOWN, and it is down silently, which is worse than a dead
+# key: a dead key at least 401s somewhere.
+#
+# Measured shape of the bug this fixes: with all four LLM keys unset but ONE
+# other credential present (Resend is always configured — it is the login path),
+# `results` was non-empty, so this probe printed "Every configured credential
+# authenticated" and exited 0. GREEN. DAILY. FOREVER. Meanwhile the judge could
+# not make a single call, and the weekly eval was filing that as an accuracy
+# regression. The four names were reported in a footnote that reads as
+# reassurance: "absent is not broken".
+#
+# These four names are the same list as `llm_provider.LLM_KEY_VARS`. They are
+# re-typed here ONLY because this script is deliberately stdlib-only — it runs
+# in external-health.yml with no `pip install` of the backend at all — so it
+# cannot import the shared constant. `backend/tests/test_missing_llm_key_is_loud.py`
+# pins the two lists together so they cannot drift apart in silence.
+LLM_KEY_VARS = ("OPENAI_API_KEY", "GEMINI_API_KEY", "GROQ_API_KEY", "CEREBRAS_API_KEY")
 
 
 def _probe(url: str, headers: dict[str, str], payload: dict | None = None) -> tuple[str, str]:
@@ -203,6 +227,9 @@ def main() -> int:
         )
         return 2
 
+    # A whole capability with no credential at all is DOWN, not "off".
+    no_llm_key = all(not env(name) for name in LLM_KEY_VARS)
+
     dead = [r for r in results if r[1] == "DEAD"]
     print("# Provider key probe — is every credential still alive?\n")
     print("| provider | verdict | detail |")
@@ -212,6 +239,30 @@ def main() -> int:
         print(f"| `{name}` | {mark} | {detail} |")
     if absent:
         print(f"\n_Not configured, so not probed (absent is not broken): {', '.join(absent)}._")
+
+    if no_llm_key:
+        print("\n## No LLM provider is configured at all — the judge is DOWN\n")
+        print(
+            f"::error::All {len(LLM_KEY_VARS)} LLM keys are empty "
+            f"({', '.join(LLM_KEY_VARS)}) — the judge, CV parsing and job "
+            "enrichment cannot make a single call."
+        )
+        print(
+            "\nThis is a CONFIG failure, not a quality problem — and it is the one "
+            "case where absence IS breakage, because there is no fallback left. It "
+            "is also invisible everywhere else: scoring silently falls back to "
+            "keywords, `llm_fit_score` stays NULL, and the weekly accuracy audit "
+            "reports it as a RANKING REGRESSION (that is exactly what happened for a "
+            "week — issue #238).\n"
+        )
+        print(
+            "**Any ONE of the four fixes it, and three are free:** `GEMINI_API_KEY`, "
+            "`GROQ_API_KEY`, `CEREBRAS_API_KEY` all have a free tier, and all four "
+            "SDKs are already installed (`backend/pyproject.toml`). `OPENAI_API_KEY` "
+            "is the paid primary. Add one as a repo Actions secret AND to the Railway "
+            "backend/worker services — an unset Actions secret renders as an EMPTY "
+            "string, which is how this hid."
+        )
 
     if dead:
         print("\n## Dead credentials\n")
@@ -225,6 +276,13 @@ def main() -> int:
             "link is the only way in."
         )
         return 1
+
+    if no_llm_key:
+        # Its OWN code, deliberately. "Rotate the dead key" and "you never had a
+        # key" are different jobs for the human, and an alarm that blurs them
+        # sends him to the wrong page — which is the whole failure this file is
+        # here to stop.
+        return 3
 
     print("\nEvery configured credential authenticated.")
     return 0

--- a/scripts/provider_probe.py
+++ b/scripts/provider_probe.py
@@ -219,16 +219,39 @@ def main() -> int:
     if FORCE_RED:
         results.append(("DRILL", "DEAD", "forced red to prove the chain — no key is actually broken"))
 
+    # ORDER IS LOAD-BEARING. This check used to sit BELOW the `if not results`
+    # guard, which made the whole LLM alarm dead on arrival: an environment with
+    # no provider secrets at all returns 2 from that guard and never reaches
+    # here. Measured on the live scheduled run 31683129750 (2026-08-13T08:40) —
+    # `no provider credentials are configured` + exit 2 — and external-health has
+    # conclusion=failure on 8 of 8 runs since 2026-08-06. It has NEVER been green.
+    #
+    # So the promised "within 24 hours an issue appears saying no LLM key is
+    # configured" would never have happened: the job would just go red the same
+    # way it already does, with no issue and no triage. An environment with zero
+    # secrets trivially has zero LLM keys — that is the SAME alarm, not a
+    # separate blind-probe case, and it must be reported as such.
+    no_llm_key = all(not env(name) for name in LLM_KEY_VARS)
+
     if not results:
         print("::error::no provider credentials are configured, so nothing could be probed.")
         print(
             "This is a BLIND result, not a clean one. Add the provider keys as repo "
             "secrets, or this loop will report success forever while proving nothing."
         )
+        if no_llm_key:
+            print()
+            print("## No LLM provider is configured at all — the judge is DOWN")
+            print()
+            print(
+                "None of " + ", ".join("`" + n + "`" for n in LLM_KEY_VARS) + " is set. "
+                "Any ONE of them unblocks the judge; GROQ, GEMINI and CEREBRAS have "
+                "free tiers. Until one is set, every ranking eval reports "
+                "'produced no judgments' — which reads as a QUALITY regression and "
+                "is not one."
+            )
+            return 3
         return 2
-
-    # A whole capability with no credential at all is DOWN, not "off".
-    no_llm_key = all(not env(name) for name in LLM_KEY_VARS)
 
     dead = [r for r in results if r[1] == "DEAD"]
     print("# Provider key probe — is every credential still alive?\n")

--- a/scripts/user_journey_audit.py
+++ b/scripts/user_journey_audit.py
@@ -269,7 +269,15 @@ def main() -> int:
         if not f.get("has_linkedin") and not f.get("has_github"):
             warnings.append(f"{who} has CV only - no LinkedIn or GitHub signal")
         if f.get("llm_verdicts", 0) == 0:
-            warnings.append(f"{who} has no AI verdicts - the judge never ran for them")
+            # Name the cheap cause first. "The judge never ran" sounds like a
+            # product fault; the usual truth is that no LLM key is set, so the
+            # judge could not make one call. Reading the second as the first is
+            # what cost a week of eval data (issue #238).
+            warnings.append(
+                f"{who} has no AI verdicts - the judge never ran for them. "
+                "CHECK THE CONFIG BEFORE THE PRODUCT: with none of "
+                "OPENAI/GEMINI/GROQ/CEREBRAS_API_KEY set, this is exactly what "
+                "a missing credential looks like from the database")
 
     if warnings:
         print("## Working, but degraded\n")


### PR DESCRIPTION
The weekly ranking eval reported *"audit produced no judgments — treating as failure"* for a **week**. The truth was that no judge key was set. A missing credential was reported as a **quality regression** — the most expensive kind of wrong alarm, because it sends you debugging your product instead of your config.

## One preflight where every path must cross

`llm_provider.require_llm_key()` now runs FIRST inside `llm_extract` and `llm_extract_fast` — it used to be a duplicated check AFTER the provider loop, so the real answer arrived buried under provider errors. It raises a dedicated `LLMKeyMissing`, names all four variables, and says what to do.

All 11 modules that touch the chain funnel through those two functions, so a caller written next month inherits it for free.

Masquerade sites closed: `llm_matcher.match_batch` no longer swallows it per job (N warnings + "judged 0/160" is what read as a quality problem), and `eval_ranking.py` drops its private copy of the four names.

## The detector this branch added was itself dead on arrival

Caught by adversarial review, and it is the same pattern this whole week has been about:

```
provider_probe.py    if not results: return 2      <- returns HERE
                     no_llm_key = ...              <- never reached
```

An env with no provider secrets — **exactly what your CI is** — returned 2 and never reached the alarm. Live proof: run `31683129750` (2026-08-13) exits 2, and `external-health` is `failure` on **8 of 8 runs since 2026-08-06**. It has never once been green.

So the promised *"within 24 hours an issue appears"* would never have happened. Fixed by computing it above the guard and reporting from there. Proven in the real condition, not a stub:

```
env -u OPENAI_API_KEY -u GEMINI_API_KEY -u GROQ_API_KEY -u CEREBRAS_API_KEY ...
  -> "## No LLM provider is configured at all — the judge is DOWN"
  -> exit 3        (was: exit 2, silent)
```

**Correction to the branch's own premise:** it claimed the probe had been GREEN daily while proving nothing. It was **RED daily and nobody read it** — a different failure mode, and one this PR does not solve.

## What you do, once

Set **any one** of `GROQ_API_KEY` / `GEMINI_API_KEY` / `CEREBRAS_API_KEY` (free tiers) or `OPENAI_API_KEY` (paid), as a repo Actions secret and on the Railway backend + worker. Not recurring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G7mLsrkujpTyUhwMTn7itb