### PR TITLE
fix(pillar1): extraction never re-ran, and the form invented an answer

### DIFF
--- a/backend/scripts/reextract_stale_profiles.py
+++ b/backend/scripts/reextract_stale_profiles.py
@@ -1,0 +1,149 @@
+"""Committed, reviewable replacement for FOUR throwaway re-extraction scripts.
+
+WHY THIS EXISTS. ``run_two_pass_extraction`` has exactly one caller in this
+codebase: a user-triggered save route, reached only when a user personally
+re-saves their profile. Nothing scheduled ever re-reads an EXISTING profile —
+so when ``EXTRACTOR_VERSION`` bumps because a prompt improved, every profile
+whose owner does not happen to re-save stays frozen at the OLD extraction,
+silently, forever.
+
+Production has already patched this FOUR separate times with uncommitted,
+throwaway scripts — their ``source_action`` values (``shelf_backfill_reextract``,
+``github_enrich_repair`` x2, ``backfill_linkedin_contact``,
+``backfill_linkedin_headline``) are visible in the live version history but
+none of those scripts, or those strings, exist anywhere in this repo. Worse:
+those scripts called ``save_profile()`` directly with a hand-patched field,
+which stamps a fresh ``updated_at`` while leaving ``llm_input_hashes``
+untouched — so the profile then LOOKS freshly updated while its extraction is
+still stale. That is what made a later investigation misdiagnose the cause.
+
+THIS SCRIPT is the honest replacement:
+  * Selects ONLY profiles ``two_pass.stale_extraction_inputs`` says are
+    actually behind — never a blanket re-extract. Each re-extraction is a
+    paid LLM call, so re-running everyone "just in case" is real money for
+    users whose extraction is already current.
+  * Re-extracts through ``run_two_pass_extraction`` — the SAME path a real
+    save takes — never a bespoke partial field patch. That bespoke-patch
+    pattern is the whole lesson of the four scripts this replaces.
+  * DRY-RUN BY DEFAULT. Prints what it would do; changes nothing without
+    ``--apply``.
+  * ``--limit N`` bounds how many STALE profiles get processed in one run —
+    the operator chooses how much to spend per invocation.
+  * Records a source_action distinct from every past ad-hoc value
+    ("stale_extractor_version_reextract"), so the version history says
+    plainly what touched the row.
+  * Safe to re-run: a profile already current (nothing in
+    ``stale_extraction_inputs``) is skipped, so running this twice in a row
+    is a no-op the second time.
+
+Follows the shape of ``scripts/cleanup_preference_pollution.py`` (dry-run
+default, ``--apply`` to write, plain per-profile print lines, a final
+summary) — read that file first if this one is unclear.
+
+Do NOT run this against production without the owner's go-ahead: each
+``--apply`` re-extraction is a real, billed LLM call. Never makes an LLM call
+under ``--limit 0`` / dry-run.
+
+Usage:
+    railway run -s Postgres bash -c \
+      'export DATABASE_URL="$DATABASE_PUBLIC_URL"; \
+       python scripts/reextract_stale_profiles.py [--user-id X] [--limit N] [--apply]'
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+if os.name == "nt":
+    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+
+# The source_action every re-extraction from this script is stamped with.
+# Deliberately distinct from every value in the live version history so a
+# later investigation can tell at a glance this ran (unlike the four
+# throwaway scripts it replaces, whose action strings don't exist anywhere
+# in the codebase to look up).
+SOURCE_ACTION = "stale_extractor_version_reextract"
+
+
+async def main(user_id: str | None, limit: int, apply: bool) -> int:
+    from src.services.profile.storage import (
+        list_profile_user_ids,
+        load_profile,
+        save_profile,
+    )
+    from src.services.profile.two_pass import (
+        run_two_pass_extraction,
+        stale_extraction_inputs,
+    )
+
+    user_ids = [user_id] if user_id else list_profile_user_ids()
+
+    scanned = 0
+    stale_count = 0
+    reextracted = 0
+    failed = 0
+
+    for uid in user_ids:
+        # NO truthiness test on `limit`. It was `if apply and limit and ...`,
+        # which makes `--limit 0` FALSY and therefore skips the cap entirely —
+        # so `--apply --limit 0`, the one invocation the docstring above
+        # promises "never makes an LLM call", would instead re-extract every
+        # stale profile in the database with no bound at all. Each of those is
+        # a real billed LLM call. 0 must mean "stop immediately", which a plain
+        # `>=` comparison gives for free.
+        if apply and reextracted + failed >= limit:
+            break
+        if not apply and stale_count >= limit:
+            break
+
+        profile = load_profile(uid)
+        if profile is None:
+            continue
+        scanned += 1
+
+        stale = stale_extraction_inputs(profile)
+        if not stale:
+            continue  # already current — the whole point of checking first
+        stale_count += 1
+        print(f"{uid}: stale = {', '.join(stale)}")
+
+        if not apply:
+            continue
+
+        try:
+            # THE SAME PATH a real save takes — never a bespoke field patch.
+            # That is the one lesson every throwaway predecessor script broke.
+            await run_two_pass_extraction(profile)
+            save_profile(profile, uid, SOURCE_ACTION)
+            reextracted += 1
+        except Exception as exc:  # noqa: BLE001 — one user's failure must not abort the sweep
+            failed += 1
+            print(f"  FAILED: {type(exc).__name__}: {str(exc)[:160]}")
+
+    print(
+        f"\nscanned {scanned} profile(s), {stale_count} stale"
+        + (f", {reextracted} re-extracted, {failed} failed" if apply else "")
+    )
+    if not apply:
+        print(f"\nDRY RUN — {stale_count} profile(s) would be re-extracted. "
+              "Re-run with --apply.")
+    return 0
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument(
+        "--user-id", default=None,
+        help="re-extract one user's profile; omit to scan every profile",
+    )
+    ap.add_argument(
+        "--limit", type=int, default=20,
+        help="max STALE profiles to process this run (bounds paid LLM calls)",
+    )
+    ap.add_argument("--apply", action="store_true")
+    a = ap.parse_args()
+    raise SystemExit(asyncio.run(main(a.user_id, a.limit, a.apply)))

--- a/backend/src/api/routes/profile.py
+++ b/backend/src/api/routes/profile.py
@@ -457,12 +457,59 @@ def _normalize_work_arrangement(value: object) -> str:
     return text if text in {"remote", "hybrid", "onsite"} else ""
 
 
+# The closed set this route will accept as a STATED experience level — the
+# exact five options the preferences form's Select offers (PreferencesForm.tsx:
+# entry/mid/senior/lead/executive). Anything outside it is not a real answer a
+# user could have picked through this form.
+#
+# scoring_dimensions._USER_EXPERIENCE_RANK recognises a much wider set
+# ("junior", "graduate", "sr", "head", "vp", ...) — that map exists to score
+# whatever string ends up in this field, including values from older data or
+# the CV-inferred fallback, not to define what THIS route should accept as a
+# freshly typed preference. Widening this set to match would let garbage like
+# "graduate" (not offered anywhere in the current UI) reach the DB looking
+# like a deliberate choice, which is the same failure this function exists to
+# stop.
+_VALID_EXPERIENCE_LEVELS = {"entry", "mid", "senior", "lead", "executive"}
+
+
+def _normalize_experience_level(value: object) -> str:
+    """Store an unrecognised experience level as SILENCE, not as a stated preference.
+
+    Mirrors ``_normalize_work_arrangement`` immediately above — same shape,
+    same seam. ``resolve_experience_level`` (scoring_dimensions.py) says
+    "typed always wins": a value in this field skips the CV-inferred fallback
+    entirely and drives ``seniority_score`` at full weight (up to 8 points,
+    either direction, on EVERY job) — the identical amplifier "any" had for
+    ``work_arrangement``. Before this function existed, ``_apply_preferences``
+    stored whatever the client posted with no check at all, so a typo, a stale
+    client sending a value the UI no longer offers, or a future free-text
+    field would reach the judge prompt and the semantic vector as though the
+    user had stated it.
+
+    NOT a fix for "a brand-new account saves 'mid' it never chose" — that
+    defect is the FRONTEND seeding a real, still-selectable dropdown value
+    (`prefsFromRaw`'s missing-key fallback) as if it were a default, fixed in
+    PreferencesForm.tsx/PreferencesForm.experience.test.tsx. "mid" stays in
+    ``_VALID_EXPERIENCE_LEVELS`` and round-trips normally here: it is a real
+    choice a user can make, so silencing it on the backend would drop that
+    choice for everyone who actually picks "Mid" — trading one data-loss bug
+    for a worse one.
+
+    Rule #29: an unstated preference is silence. An unrecognised string IS
+    unstated — the user cannot have meant something the form never offered.
+    """
+    text = value.strip().lower() if isinstance(value, str) else ""
+    return text if text in _VALID_EXPERIENCE_LEVELS else ""
+
+
 def _apply_preferences(preferences_json: str, profile: UserProfile) -> None:
     """Parse the preferences JSON form and set it on the profile.
 
     Fields the form does NOT carry (``github_username`` — set by the separate
-    GitHub route — plus ``needs_visa`` and ``work_arrangement``) fall back to the
-    EXISTING preferences so a routine preferences save never silently wipes them.
+    GitHub route — plus ``needs_visa``, ``work_arrangement`` and
+    ``experience_level``) fall back to the EXISTING preferences so a routine
+    preferences save never silently wipes them.
     """
     pref_dict = json.loads(preferences_json)
     existing = profile.preferences or UserPreferences()
@@ -492,7 +539,14 @@ def _apply_preferences(preferences_json: str, profile: UserProfile) -> None:
         work_arrangement=_normalize_work_arrangement(
             pref_dict.get("work_arrangement", existing.work_arrangement)
         ),
-        experience_level=pref_dict.get("experience_level", ""),
+        # Same partial-save shape as work_arrangement just above: an OMITTED
+        # key keeps the stored value, an explicit "" clears it. The old
+        # default of "" made no such distinction, so saving any OTHER field
+        # on the form (salary, locations, about_me...) silently wiped a
+        # previously-chosen experience level on every routine save.
+        experience_level=_normalize_experience_level(
+            pref_dict.get("experience_level", existing.experience_level)
+        ),
         negative_keywords=pref_dict.get("negative_keywords", []),
         about_me=pref_dict.get("about_me", ""),
         # normalize_github_username here too, not only in the dedicated GitHub

--- a/backend/src/core/observability.py
+++ b/backend/src/core/observability.py
@@ -9,8 +9,11 @@ one implementation instead of the API being the only observed process.
 
 from __future__ import annotations
 
+import logging
 import os
 from typing import Any
+
+logger = logging.getLogger("job360.observability")
 
 # H4 — request headers that must NEVER reach Sentry (credentials / session).
 _SENSITIVE_HEADERS = frozenset({"cookie", "authorization", "set-cookie"})
@@ -70,6 +73,28 @@ def init_sentry(*, component: str = "api") -> bool:
         os.environ.get("RAILWAY_ENVIRONMENT", "")
     )
     if not dsn or not is_prod:
+        # SAY SO. The return value used to be the only signal, and both call
+        # sites discard it, so a production process with no DSN reported nothing
+        # and announced nothing. An empty Sentry then reads as "no errors" when
+        # it may mean "never connected" — and those two look identical to
+        # everyone who checks. Found 2026-08-15 trying to answer "what do the
+        # extraction errors look like in Sentry?" and discovering there was no
+        # way to tell whether Sentry was even on.
+        #
+        # Only the REASON is logged, never the DSN — it is a credential.
+        if is_prod:
+            logger.error(
+                "error reporting is OFF for component=%s: running in production "
+                "but SENTRY_DSN is not set. Crashes here will be invisible in "
+                "Sentry, and an empty Sentry will look like a healthy service.",
+                component,
+            )
+        else:
+            logger.info(
+                "error reporting off for component=%s (not a deployed "
+                "production environment) — expected outside prod.",
+                component,
+            )
         return False
 
     import sentry_sdk
@@ -83,6 +108,15 @@ def init_sentry(*, component: str = "api") -> bool:
         traces_sample_rate=0.1,
     )
     sentry_sdk.set_tag("component", component)
+    # The positive half. Without it, "Sentry is quiet" is unfalsifiable: you
+    # cannot tell a healthy service from one that never connected. This line is
+    # the difference between an empty dashboard you can trust and one you cannot.
+    logger.info(
+        "error reporting ON for component=%s (environment=%s) — errors from "
+        "this process will reach Sentry.",
+        component,
+        os.environ.get("RAILWAY_ENVIRONMENT") or "production",
+    )
     # docs/fable/09 P2 — the /api/client-log bridge logs BROWSER-side events at
     # ERROR level ("job360.client"), and Sentry's logging integration turns any
     # ERROR log into a Sentry event. That flooded the BACKEND error stream with

--- a/backend/src/core/settings.py
+++ b/backend/src/core/settings.py
@@ -60,6 +60,13 @@ GITHUB_TOKEN = os.getenv("GITHUB_TOKEN", "")
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "") or os.getenv("openai_api_key", "")
 OPENAI_MODEL = os.getenv("OPENAI_MODEL", "gpt-4o-mini")
 GEMINI_API_KEY = os.getenv("GEMINI_API_KEY", "")
+# Env-overridable for the same reason OPENAI_MODEL is. It was HARDCODED as
+# "gemini-2.0-flash" in llm_provider.py, and Google retired that model: prod
+# Sentry PYTHON-FASTAPI-J, "404 This model models/gemini-2.0-flash is no longer
+# available", last seen 2026-08-11. A hardcoded model name is a dependency on
+# someone else's release schedule with no way to respond except a deploy —
+# which is why the fallback chain was dead and nobody noticed.
+GEMINI_MODEL = os.getenv("GEMINI_MODEL", "gemini-3.7-flash")
 GROQ_API_KEY = os.getenv("GROQ_API_KEY", "")
 CEREBRAS_API_KEY = os.getenv("CEREBRAS_API_KEY", "")
 

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -661,7 +661,18 @@ async def _embed_backfill_budget(db: Any, conn: Any, budget: int) -> int:
             # `encode_job`), and a probe for the real package would wrongly stop
             # a run that never needed it. Failing first, then escalating, can
             # only fire when embedding genuinely could not happen.
-            if not semantic_stack_installed():
+            # BOTH halves are required. Testing only "is the stack absent?"
+            # escalates on a failure that has nothing to do with it — CI caught
+            # exactly that: a test poisons ONE row with RuntimeError("encoder
+            # blew up") and expects the sweep to skip it and carry on, but CI
+            # also has no sentence-transformers installed, so the sweep
+            # abandoned instead. The message check is what makes this specific:
+            # it is the marker `embeddings._load_encoder` raises when the import
+            # fails, so an unrelated encoder error can never be mistaken for a
+            # missing package.
+            if "sentence-transformers is not installed" in str(
+                e
+            ) and not semantic_stack_installed():
                 logger.error(
                     "SEMANTIC_ENABLED is on but sentence-transformers is not "
                     "installed in this process — abandoning the embed backfill "

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -588,15 +588,6 @@ async def _embed_backfill_budget(db: Any, conn: Any, budget: int) -> int:
         vector_column_available,
     )
 
-    if not semantic_stack_installed():
-        logger.error(
-            "SEMANTIC_ENABLED is on but sentence-transformers is not installed in "
-            "this process — embedding is skipped entirely, so semantic search "
-            "cannot improve. Install the extra for THIS service "
-            "(pip install '.[semantic]'), or turn SEMANTIC_ENABLED off so the "
-            "gap is intentional rather than silent."
-        )
-        return 0
 
     try:
         vix = PgVectorIndex()
@@ -653,6 +644,35 @@ async def _embed_backfill_budget(db: Any, conn: Any, budget: int) -> int:
             )
             embedded += 1
         except Exception as e:  # noqa: BLE001
+            # ONE missing package must not read as N unrelated job failures.
+            #
+            # This is what the worker has actually been doing. Its image is
+            # built from Dockerfile.worker with a plain `pip install .` (no
+            # `[semantic]` extra) while the API image installs torch +
+            # `.[semantic]` — confirmed in the live Railway build log. Because
+            # sentence_transformers is imported lazily (rule #16), the module
+            # import SUCCEEDS and nothing complains at startup; the failure only
+            # surfaced here, per job, as an identical "job <id> failed" warning
+            # naming neither the cause nor the remedy. Semantic coverage sat at
+            # 687 of 9,977 with every instrument green.
+            #
+            # Detected HERE rather than as an upfront probe on purpose: callers
+            # may inject their own encoder (the backfill tests patch
+            # `encode_job`), and a probe for the real package would wrongly stop
+            # a run that never needed it. Failing first, then escalating, can
+            # only fire when embedding genuinely could not happen.
+            if not semantic_stack_installed():
+                logger.error(
+                    "SEMANTIC_ENABLED is on but sentence-transformers is not "
+                    "installed in this process — abandoning the embed backfill "
+                    "after 0 successes. Semantic search cannot improve while "
+                    "this is true. Install the extra for THIS service "
+                    "(pip install '.[semantic]'), or turn SEMANTIC_ENABLED off "
+                    "so the gap is intentional rather than silent. Underlying "
+                    "error: %s",
+                    e,
+                )
+                break
             logger.warning("embed backfill: job %s failed: %s", r[0], e)
     await db.commit()
     if embedded:

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -567,12 +567,36 @@ async def _embed_backfill_budget(db: Any, conn: Any, budget: int) -> int:
     logged and skipped — one bad row never stops the sweep. Returns embedded
     count. Callers gate on SEMANTIC_ENABLED.
     """
-    from src.services.embeddings import MODEL_NAME, encode_job  # noqa: PLC0415 — lazy (rule #16)
+    # PREFLIGHT — say it ONCE, loudly, before the loop.
+    #
+    # The caller has already checked SEMANTIC_ENABLED, so reaching here means
+    # semantic is switched ON. If the stack is not installed in this process,
+    # every single job below would raise, be caught by the per-job handler, and
+    # log an identical "job <id> failed" warning that names neither the cause
+    # nor the fix. That is exactly what the worker has been doing: its image is
+    # built from Dockerfile.worker with a plain `pip install .`, so the daily
+    # refresh_catalog cron ingests jobs it can never embed. Coverage sat at 687
+    # of 9,977 with no error anywhere — the failure was real and invisible.
+    from src.services.embeddings import (  # noqa: PLC0415 — lazy (rule #16)
+        MODEL_NAME,
+        encode_job,
+        semantic_stack_installed,  # noqa: PLC0415
+    )
     from src.services.job_enrichment import load_enrichment  # noqa: PLC0415
     from src.services.pg_vector_index import (  # noqa: PLC0415
         PgVectorIndex,
         vector_column_available,
     )
+
+    if not semantic_stack_installed():
+        logger.error(
+            "SEMANTIC_ENABLED is on but sentence-transformers is not installed in "
+            "this process — embedding is skipped entirely, so semantic search "
+            "cannot improve. Install the extra for THIS service "
+            "(pip install '.[semantic]'), or turn SEMANTIC_ENABLED off so the "
+            "gap is intentional rather than silent."
+        )
+        return 0
 
     try:
         vix = PgVectorIndex()

--- a/backend/src/services/embeddings.py
+++ b/backend/src/services/embeddings.py
@@ -45,6 +45,34 @@ _CHUNK_OVERLAP_WORDS = 50
 _ENCODER: Optional[object] = None
 
 
+def semantic_stack_installed() -> bool:
+    """Is the optional semantic stack actually importable in THIS process?
+
+    WHY THIS EXISTS (measured 2026-08-15). The API image installs
+    ``.[semantic]`` plus torch; the WORKER image installs plain ``.`` —
+    confirmed in the live Railway build log, which shows
+    ``load build definition from backend/Dockerfile.worker`` followed by
+    ``pip install --no-cache-dir .``. So the daily ``refresh_catalog`` cron
+    ingests jobs on a machine that cannot embed them.
+
+    It failed in the worst possible shape: ``sentence_transformers`` is
+    imported lazily (rule #16), so the module import SUCCEEDS and the failure
+    only surfaces per job, inside the loop, where it is caught and logged as
+    ``embed backfill: job <id> failed``. One missing package therefore produced
+    a storm of identical per-job warnings, none of which named the cause or the
+    remedy — and semantic coverage sat at 687 of 9,977 jobs while every
+    instrument stayed green.
+
+    A capability that is switched ON but structurally impossible must say so
+    once, loudly, with the fix — not fail quietly a hundred times.
+    """
+    try:
+        import sentence_transformers  # noqa: F401, PLC0415 — probe only (rule #16)
+    except ImportError:
+        return False
+    return True
+
+
 def _load_encoder() -> object:
     """Lazy-load the sentence-transformers encoder. CLAUDE.md rule #11."""
     global _ENCODER

--- a/backend/src/services/profile/llm_provider.py
+++ b/backend/src/services/profile/llm_provider.py
@@ -15,6 +15,7 @@ from pydantic import BaseModel, ValidationError
 from src.core.settings import (
     CEREBRAS_API_KEY,
     GEMINI_API_KEY,
+    GEMINI_MODEL,
     GROQ_API_KEY,
     OPENAI_API_KEY,
     OPENAI_MODEL,
@@ -446,7 +447,13 @@ async def _call_gemini(prompt: str, system: str) -> dict[str, Any]:
     """Call Google Gemini API (free tier: 15 RPM, 1M tokens/day)."""
     import google.generativeai as genai
 
-    _model = "gemini-2.0-flash"
+    # Was hardcoded "gemini-2.0-flash", which Google retired. Prod Sentry
+    # PYTHON-FASTAPI-J: "404 This model models/gemini-2.0-flash is no longer
+    # available", last seen 2026-08-11 — so this entire fallback had been dead,
+    # and the only visible symptom was one line in an error nobody read.
+    # Overridable now (like OPENAI_MODEL) so the next retirement is an env var,
+    # not a deploy.
+    _model = GEMINI_MODEL
     t0 = _time.monotonic()
     try:
         genai.configure(api_key=GEMINI_API_KEY)
@@ -482,7 +489,13 @@ async def _call_groq(prompt: str, system: str) -> dict[str, Any]:
     """Call Groq API (free tier: 30 RPM, 14.4K tokens/day on llama3)."""
     from groq import AsyncGroq
 
-    _model = "llama-3.3-70b-versatile"
+    # Overridable like every other provider here (CEREBRAS_MODEL directly
+    # below, OPENAI_MODEL / GEMINI_MODEL in settings). The value is unchanged —
+    # Groq's live failure was an EXPIRED KEY, not a bad model (prod Sentry:
+    # "401 Invalid API Key, code: expired_api_key"). This only removes the
+    # rot risk, which is not hypothetical: the hardcoded Gemini model beside it
+    # was retired by Google and killed that fallback silently.
+    _model = os.getenv("GROQ_MODEL", "llama-3.3-70b-versatile")
     t0 = _time.monotonic()
     try:
         client = AsyncGroq(api_key=GROQ_API_KEY)

--- a/backend/src/services/profile/shelf_audit.py
+++ b/backend/src/services/profile/shelf_audit.py
@@ -92,6 +92,19 @@ _ROLES: dict[str, str] = {
     "jobs": "api",
     "tailor": "tailor",
     "snapshot": "api",
+    # two_pass.py was in _WRITER_ROLES but MISSING here, so every READ performed
+    # by the extraction orchestrator — the single most shelf-heavy module on the
+    # user side — was invisible to readers(). Found 2026-08-15 while auditing a
+    # doc that called `llm_input_hashes` a dead, unread shelf: it is read at
+    # two_pass.py:220, `cv.llm_input_hashes.get(key) == _input_hash(raw)`, a
+    # real value comparison that decides whether a PAID LLM call is skipped.
+    # The instrument reported only {"api"} for it, and the doc believed the
+    # instrument.
+    #
+    # NOT a matching role: two_pass decides what gets extracted and cached, it
+    # never ranks a job. Adding it here fixes the "is anything reading this?"
+    # answer without touching the matching count.
+    "two_pass": "extraction",
 }
 
 # Roles whose consumer can change what a user actually sees. Every one of these

--- a/backend/src/services/profile/two_pass.py
+++ b/backend/src/services/profile/two_pass.py
@@ -119,6 +119,73 @@ def _input_hash(raw: Any) -> str:
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
 
+def stale_extraction_inputs(profile: UserProfile) -> list[str]:
+    """Which of ``profile``'s raw inputs were last read by an OLDER extractor
+    than the one running right now.
+
+    WHY THIS EXISTS. ``run_two_pass_extraction`` has exactly one caller in
+    this codebase — a user-triggered save route (five handlers in
+    ``api/routes/profile.py``). Nothing scheduled ever re-reads an EXISTING
+    profile, so bumping ``EXTRACTOR_VERSION`` for a prompt fix reaches only
+    the users who happen to re-save; everyone else stays frozen on the old
+    extraction forever, silently. This has already been "fixed" four times in
+    production with throwaway, uncommitted scripts that called
+    ``save_profile()`` directly — which stamps a fresh ``updated_at`` while
+    leaving ``llm_input_hashes`` untouched, so the profile then LOOKS freshly
+    updated while its extraction is still stale. None of those four scripts,
+    or the ``source_action`` values they wrote, exist in this repo — a
+    profile that "looks recent" tells you nothing here.
+
+    This is the read-only check a real sweep (``scripts/
+    reextract_stale_profiles.py``) uses to find who ACTUALLY needs a re-run,
+    so it never has to blanket re-extract every profile — each re-extraction
+    is a paid LLM call.
+
+    Mirrors the exact four-input map ``run_two_pass_extraction`` builds
+    (cv / linkedin / github / about_me) and reuses ``_already_read`` — the
+    hashing algorithm is defined ONCE, there, and never reimplemented here.
+    "Stale" is precisely the inverse of "already read". A key with NO raw
+    input is never stale: there is nothing to extract, so an unfilled field
+    must never look like backlog (rule #29 — an empty shelf is not a broken
+    one).
+
+    Takes the whole ``UserProfile`` rather than just ``CVData`` because one
+    of the four raw inputs (``about_me``) lives on ``UserPreferences``, not
+    on ``CVData`` — even though its cache hash is stored on
+    ``cv.llm_input_hashes`` alongside the other three. Splitting it out would
+    either reimplement half of ``run_two_pass_extraction``'s input map or
+    silently drop about_me from the sweep, which is exactly the kind of gap
+    this function exists to catch.
+
+    Returns the stale keys, e.g. ``["cv", "about_me"]``, or ``[]`` when every
+    input the profile actually has is current.
+    """
+    cv = profile.cv_data
+    prefs = profile.preferences
+
+    # Same "does this input actually have content?" gate run_two_pass_extraction
+    # uses before it will even attempt a pass — a dict with all-empty values
+    # (github's shape) must not count as "present" just because the dict
+    # itself is non-empty.
+    _has_github = bool(cv.github_repos_brief or cv.github_bio or cv.github_profile_readme)
+    inputs: dict[str, tuple[bool, Any]] = {
+        "cv": (bool(cv.raw_text), cv.raw_text),
+        "linkedin": (bool(cv.linkedin_raw_text), cv.linkedin_raw_text),
+        "github": (_has_github, {
+            "repos": cv.github_repos_brief,
+            "bio": cv.github_bio,
+            "readme": cv.github_profile_readme,
+        }),
+        "about_me": (bool(prefs.about_me), prefs.about_me),
+    }
+
+    stale: list[str] = []
+    for key, (has_input, raw) in inputs.items():
+        if has_input and not _already_read(cv, key, raw):
+            stale.append(key)
+    return stale
+
+
 def _pass_produced_data(key: str, res: Any) -> bool:
     """Did an LLM pass return anything worth caching?
 

--- a/backend/tests/test_embed_backfill.py
+++ b/backend/tests/test_embed_backfill.py
@@ -124,3 +124,95 @@ async def test_backfill_survives_a_poison_row(tmp_path):
         assert n == 2, "the poison row must be skipped, the rest embedded"
     finally:
         await db.close()
+
+
+@pytest.mark.asyncio
+async def test_a_missing_semantic_stack_stops_the_sweep_loudly(tmp_path, caplog):
+    """ONE missing package must not read as N unrelated job failures.
+
+    The worker image is built from Dockerfile.worker with a plain
+    ``pip install .`` — no ``[semantic]`` extra — while the API image installs
+    torch + ``.[semantic]``. Confirmed in the live Railway build log. The worker
+    runs ``refresh_catalog``, so the process ingesting the most jobs is the one
+    that cannot embed them: 687 vectors for 9,977 jobs in production.
+
+    It survived because ``sentence_transformers`` is imported lazily (rule #16),
+    so the module import succeeds and the failure only appears per job as
+    "embed backfill: job <id> failed" — a warning naming neither the cause nor
+    the remedy, repeated for every row.
+
+    The escalation is deliberately NOT an upfront probe. The tests above inject
+    their own encoder and never need the real package; an upfront probe wrongly
+    abandoned those runs, which is how CI caught the first version of this fix.
+    It fires only after a real failure, when the stack is genuinely absent.
+    """
+    import builtins
+    import logging
+
+    from src import main as main_mod
+
+    db = await _full_db(str(tmp_path / "t.db"))
+    try:
+        for i in range(3):
+            await db.insert_job(_mk(i))
+        conn = db._db
+        await db.commit()
+
+        real_import = builtins.__import__
+
+        def _no_sentence_transformers(name, *args, **kwargs):
+            if name == "sentence_transformers" or name.startswith(
+                "sentence_transformers."
+            ):
+                raise ImportError("No module named 'sentence_transformers'")
+            return real_import(name, *args, **kwargs)
+
+        class _FakeVix:
+            def upsert(self, **kw):
+                pass
+
+        def encode_that_needs_the_missing_package(job, enrichment=None):
+            # What the real encoder does on the worker: raises because the
+            # package it lazily imports is not installed.
+            raise RuntimeError(
+                "sentence-transformers is not installed — run "
+                "`pip install '.[semantic]'` and retry."
+            )
+
+        async def fake_load_enrichment(conn_, jid):
+            return None
+
+        with patch("src.services.pg_vector_index.PgVectorIndex", return_value=_FakeVix()), \
+             patch("src.services.embeddings.encode_job",
+                   new=encode_that_needs_the_missing_package), \
+             patch("src.services.job_enrichment.load_enrichment", new=fake_load_enrichment), \
+             patch.object(builtins, "__import__", _no_sentence_transformers), \
+             caplog.at_level(logging.WARNING, logger="job360"):
+            n = await main_mod._embed_backfill_budget(db, conn, budget=10)
+
+        assert n == 0
+
+        errors = [r for r in caplog.records if r.levelno >= logging.ERROR]
+        assert errors, (
+            "a completely un-embeddable process logged no ERROR — this is the "
+            "silence that hid 6.9% coverage behind green instruments"
+        )
+        text = " ".join(r.getMessage() for r in errors).lower()
+        assert "sentence-transformers" in text and "semantic_enabled" in text, (
+            f"the error does not name the cause or the flag: {text[:200]}"
+        )
+
+        # It STOPPED rather than repeating itself once per row. Three jobs were
+        # queued; a per-job warning storm is exactly what this replaces.
+        per_job = [
+            r for r in caplog.records
+            if r.levelno == logging.WARNING
+            and "job" in r.getMessage()
+            and "failed" in r.getMessage()
+        ]
+        assert not per_job, (
+            f"still emitting per-job warnings ({len(per_job)}) instead of one "
+            "actionable error"
+        )
+    finally:
+        await db.close()

--- a/backend/tests/test_extractor_staleness.py
+++ b/backend/tests/test_extractor_staleness.py
@@ -1,0 +1,151 @@
+"""Extraction never re-runs on its own, so a prompt fix never reaches an
+existing user unless something notices their profile fell behind.
+
+WHY THIS FILE EXISTS. ``run_two_pass_extraction`` has exactly one caller in
+this codebase — a user-triggered save route. Nothing scheduled ever re-reads
+an EXISTING profile. So when ``EXTRACTOR_VERSION`` bumps because a prompt
+improved, every profile whose owner does not happen to re-save stays frozen
+at whatever the OLD prompt produced, silently, forever.
+
+This has already been "fixed" four separate times in production with
+throwaway, uncommitted scripts that called ``save_profile()`` directly —
+which stamps a fresh ``updated_at`` while leaving ``llm_input_hashes``
+untouched, so the profile then LOOKS freshly updated while its extraction is
+still stale. That is exactly the trap: nothing here may pass by accident just
+because a profile "looks recent".
+
+These tests pin ``stale_extraction_inputs`` — the read-only check that says
+which raw inputs on a profile were last read by an OLDER extractor than the
+one running now. No LLM call anywhere in this file (rule #4): staleness is a
+pure hash comparison.
+"""
+
+from __future__ import annotations
+
+from src.services.profile import two_pass as tp
+from src.services.profile.models import CVData, UserPreferences, UserProfile
+
+CV_TEXT = "Jane Okafor, Registered Nurse. Senior ICU experience."
+LI_TEXT = "Top Skills\nTriage\n"
+
+
+def _profile(**cv_kw) -> UserProfile:
+    return UserProfile(cv_data=CVData(**cv_kw), preferences=UserPreferences())
+
+
+def test_a_hash_from_the_current_version_is_not_stale():
+    """The common case: a profile that was extracted under the code running
+    right now must not be flagged — otherwise every fresh save would look
+    stale forever and the sweep script would burn a paid call on it for
+    nothing."""
+    p = _profile(raw_text=CV_TEXT)
+    p.cv_data.llm_input_hashes["cv"] = tp._input_hash(CV_TEXT)
+
+    assert tp.stale_extraction_inputs(p) == []
+
+
+def test_a_hash_from_an_older_version_is_stale():
+    """The exact defect this whole unit exists to fix: a profile extracted
+    under an OLDER EXTRACTOR_VERSION than the code now running must be
+    flagged, so a sweep can catch it up."""
+    p = _profile(raw_text=CV_TEXT)
+    # Build the hash the SAME way production did back when EXTRACTOR_VERSION
+    # was "1" — never reimplement the digest, just run it under the old value.
+    old_version_hash = tp._input_hash(CV_TEXT)  # computed at current version...
+    # ...then monkeypatch the module constant DOWN so this hash is what an
+    # older build would really have stored, and restore afterwards.
+    real_version = tp.EXTRACTOR_VERSION
+    try:
+        tp.EXTRACTOR_VERSION = "1"
+        old_version_hash = tp._input_hash(CV_TEXT)
+    finally:
+        tp.EXTRACTOR_VERSION = real_version
+
+    p.cv_data.llm_input_hashes["cv"] = old_version_hash
+    assert "cv" in tp.stale_extraction_inputs(p)
+
+
+def test_no_raw_input_means_not_stale_for_that_key():
+    """An empty shelf is not a broken one (rule #29). A profile with no
+    LinkedIn text at all must never be flagged for LinkedIn staleness — there
+    is nothing to extract, so treating it as backlog would make the sweep
+    burn a call trying to re-read nothing, or worse, look broken."""
+    p = _profile(raw_text=CV_TEXT)  # no linkedin_raw_text, no github, no about_me
+    assert p.cv_data.linkedin_raw_text == ""
+
+    stale = tp.stale_extraction_inputs(p)
+    assert "linkedin" not in stale
+    assert "github" not in stale
+    assert "about_me" not in stale
+
+
+def test_never_extracted_profile_with_raw_input_is_stale():
+    """A profile that has raw input but NO stored hash at all (never run
+    through the extractor once) must be treated as stale — it needs the
+    FIRST extraction, which the sweep should also catch."""
+    p = _profile(raw_text=CV_TEXT)
+    assert p.cv_data.llm_input_hashes == {}
+
+    assert "cv" in tp.stale_extraction_inputs(p)
+
+
+def test_bumping_the_version_makes_a_previously_current_profile_stale():
+    """THE REGRESSION THAT MATTERS. A profile extracted and hashed under
+    today's EXTRACTOR_VERSION is current right now. The moment the version is
+    bumped (a real prompt fix ships), that SAME stored hash must start
+    reading as stale — this is the exact mechanism that silently broke four
+    times in production, because nothing ever asked this question."""
+    p = _profile(raw_text=CV_TEXT)
+    p.cv_data.llm_input_hashes["cv"] = tp._input_hash(CV_TEXT)
+    assert tp.stale_extraction_inputs(p) == [], "sanity: current before the bump"
+
+    real_version = tp.EXTRACTOR_VERSION
+    try:
+        tp.EXTRACTOR_VERSION = str(int(real_version) + 1)
+        assert "cv" in tp.stale_extraction_inputs(p), (
+            "a version bump did not make a previously-current profile stale — "
+            "this is the whole class of bug this file exists to catch"
+        )
+    finally:
+        tp.EXTRACTOR_VERSION = real_version
+
+
+def test_about_me_and_github_participate_too():
+    """Staleness isn't CV-only — all four inputs the extractor reads
+    (cv/linkedin/github/about_me) must be checked, or a sweep built on this
+    helper would silently never catch up LinkedIn, GitHub or preferences."""
+    p = _profile(
+        raw_text=CV_TEXT,
+        linkedin_raw_text=LI_TEXT,
+        github_repos_brief=[{"name": "icu-tools"}],
+    )
+    p.preferences.about_me = "I like ICU work."
+    # Everything current except about_me, which has never been hashed.
+    p.cv_data.llm_input_hashes["cv"] = tp._input_hash(CV_TEXT)
+    p.cv_data.llm_input_hashes["linkedin"] = tp._input_hash(LI_TEXT)
+    p.cv_data.llm_input_hashes["github"] = tp._input_hash(
+        {"repos": [{"name": "icu-tools"}], "bio": "", "readme": ""}
+    )
+
+    stale = tp.stale_extraction_inputs(p)
+    assert stale == ["about_me"], stale
+
+
+def test_current_profile_across_all_four_inputs_is_fully_clean():
+    """A profile that is genuinely up to date on every input must come back
+    completely clean — the sweep script relies on an empty list meaning
+    'skip this user, nothing to do'."""
+    p = _profile(
+        raw_text=CV_TEXT,
+        linkedin_raw_text=LI_TEXT,
+        github_repos_brief=[{"name": "icu-tools"}],
+    )
+    p.preferences.about_me = "I like ICU work."
+    p.cv_data.llm_input_hashes["cv"] = tp._input_hash(CV_TEXT)
+    p.cv_data.llm_input_hashes["linkedin"] = tp._input_hash(LI_TEXT)
+    p.cv_data.llm_input_hashes["github"] = tp._input_hash(
+        {"repos": [{"name": "icu-tools"}], "bio": "", "readme": ""}
+    )
+    p.cv_data.llm_input_hashes["about_me"] = tp._input_hash("I like ICU work.")
+
+    assert tp.stale_extraction_inputs(p) == []

--- a/backend/tests/test_llm_models_are_overridable.py
+++ b/backend/tests/test_llm_models_are_overridable.py
@@ -1,0 +1,114 @@
+"""No provider may hardcode its model name.
+
+WHY (found in PRODUCTION Sentry, 2026-08-15, issue PYTHON-FASTAPI-J).
+
+The Gemini call had ``_model = "gemini-2.0-flash"`` written into the source.
+Google retired that model, and the live error was:
+
+    LLM provider 'gemini' looks PERMANENTLY misconfigured (NotFound: 404 This
+    model models/gemini-2.0-flash is no longer available...). SKIPPING it for
+    the rest of this process
+
+So that entire fallback had been dead. The only symptom was one line inside an
+error nobody was reading, and the extraction chain silently ran one provider
+short. In the same window the primary (OpenAI gpt-4o-mini) was hitting 429 rate
+limits and Groq was returning 401 expired_api_key — a three-deep fallback chain
+with every layer degraded, and no test could have caught any of it.
+
+A hardcoded model name is a dependency on somebody else's deprecation schedule
+with no response available except a code change and a deploy. Model names rot
+on a timescale of months; this repo's own CLAUDE.md makes the same point about
+never asserting live-world facts from memory.
+
+This does NOT pin WHICH model each provider uses — that is a cost and quality
+decision, and pinning it here would just move the rot into a test. It pins that
+each one can be changed WITHOUT a deploy.
+"""
+from __future__ import annotations
+
+import ast
+import pathlib
+
+import pytest
+
+_PROVIDER_SRC = (
+    pathlib.Path(__file__).resolve().parents[1]
+    / "src" / "services" / "profile" / "llm_provider.py"
+)
+
+_PROVIDER_FUNCS = ("_call_openai", "_call_gemini", "_call_groq", "_call_cerebras")
+
+
+def _model_assignment(func_name: str) -> ast.AST | None:
+    """The right-hand side of ``_model = ...`` inside a provider function."""
+    tree = ast.parse(_PROVIDER_SRC.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if node.name != func_name:
+            continue
+        for stmt in ast.walk(node):
+            if isinstance(stmt, ast.Assign):
+                for target in stmt.targets:
+                    if isinstance(target, ast.Name) and target.id == "_model":
+                        return stmt.value
+    return None
+
+
+@pytest.mark.parametrize("func_name", _PROVIDER_FUNCS)
+def test_the_model_is_not_a_string_literal(func_name: str) -> None:
+    """A bare string means the only way to react to a retirement is a deploy."""
+    value = _model_assignment(func_name)
+    assert value is not None, f"{func_name} has no `_model = ...` — has it moved?"
+    assert not (isinstance(value, ast.Constant) and isinstance(value.value, str)), (
+        f"{func_name} hardcodes its model name ({value.value!r}). When the "
+        "provider retires it, this fallback dies silently and the only fix is a "
+        "code change. Read it from an env-overridable setting instead — that is "
+        "exactly how gemini-2.0-flash killed the Gemini fallback in production."
+    )
+
+
+@pytest.mark.parametrize("func_name", _PROVIDER_FUNCS)
+def test_the_model_comes_from_something_configurable(func_name: str) -> None:
+    """The positive half. Without it, deleting the line entirely would also pass
+    the test above."""
+    value = _model_assignment(func_name)
+    src = ast.unparse(value)
+    configurable = (
+        "os.getenv" in src            # read straight from the environment
+        or src.endswith("_MODEL")     # a settings constant that reads getenv
+        or "_MODEL" in src
+    )
+    assert configurable, (
+        f"{func_name}'s model comes from {src!r}, which is neither an env var "
+        "nor a *_MODEL setting — it cannot be changed without a deploy."
+    )
+
+
+def test_every_model_setting_actually_reads_the_environment() -> None:
+    """The settings constants must be env-backed, not just named like it.
+
+    ``GEMINI_MODEL = "gemini-3.7-flash"`` would satisfy the two tests above
+    while being exactly as unchangeable as the literal it replaced.
+    """
+    settings_src = (
+        pathlib.Path(__file__).resolve().parents[1] / "src" / "core" / "settings.py"
+    ).read_text(encoding="utf-8")
+    tree = ast.parse(settings_src)
+
+    found: dict[str, str] = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id.endswith("_MODEL"):
+                found[target.id] = ast.unparse(node.value)
+
+    assert found, "no *_MODEL settings found at all — did they move?"
+    not_env_backed = {
+        name: src for name, src in found.items() if "os.getenv" not in src
+    }
+    assert not not_env_backed, (
+        f"these *_MODEL settings are constants, not env reads: {not_env_backed}. "
+        "Naming it like a setting does not make it changeable."
+    )

--- a/backend/tests/test_pillar1_data_loss.py
+++ b/backend/tests/test_pillar1_data_loss.py
@@ -487,6 +487,81 @@ class TestNeedsVisaRoundTripsThroughTheRoute:
         assert out.needs_visa is True
 
 
+class TestExperienceLevelIsNotWipedOrPolluted:
+    """`experience_level` reached `UserPreferences` via a bare
+    `pref_dict.get("experience_level", "")` -- no normalisation, and an
+    OMITTED key silently defaulted to "" exactly like an explicit clear.
+
+    Two separate bugs share that one line:
+
+      1. No validation. `resolve_experience_level` says "typed always wins" --
+         a typed value skips the CV-inferred fallback and drives
+         `seniority_score` at full weight (up to 8 points, either direction) on
+         every job. An unrecognised string reaching that seam the same way
+         "any" reached the workplace one is exactly the class of bug already
+         fixed one field over (`_normalize_work_arrangement`).
+      2. No partial-save protection. Because the fallback default was "" and
+         not the STORED value, saving anything else on the preferences form
+         (salary, locations, about_me...) silently wiped a previously-chosen
+         experience level -- the identical shape as the workplace regression
+         `TestWorkplaceReachesTheScorer` guards, one field over.
+
+    NOTE on "mid": the live defect proven for THIS field (a brand-new account
+    posting "mid" it never chose) is a FRONTEND bug -- `prefsFromRaw` in
+    PreferencesForm.tsx substitutes "mid" for a missing `experience_level`,
+    fixed in `PreferencesForm.experience.test.tsx`. "mid" is a real,
+    selectable option in the dropdown (same list as "entry"/"senior"/"lead"/
+    "executive"), so the backend must NOT silence it -- doing so would drop a
+    genuine choice for every user who actually picks "Mid", which is a worse
+    bug than the one being fixed. This class guards the backend's own half:
+    validating genuinely unrecognised strings and protecting partial saves.
+    """
+
+    def _apply(self, form: dict, existing=None):
+        import json
+
+        from src.api.routes.profile import _apply_preferences
+        from src.services.profile.models import CVData, UserPreferences, UserProfile
+
+        p = UserProfile(
+            cv_data=CVData(), preferences=existing or UserPreferences()
+        )
+        _apply_preferences(json.dumps(form), p)
+        return p.preferences.experience_level
+
+    def test_each_real_level_round_trips(self) -> None:
+        # The control: without it, "normalise everything to empty" would also
+        # pass every other test in this class.
+        for level in ("entry", "mid", "senior", "lead", "executive"):
+            assert self._apply({"experience_level": level}) == level, (
+                f"{level} is a real dropdown option and must survive a save"
+            )
+
+    def test_an_unrecognised_value_is_silenced(self) -> None:
+        # Not a real dropdown option. Before normalisation this reached the
+        # DB, the LLM judge prompt and the semantic vector as though the user
+        # had stated it -- the same failure `_normalize_work_arrangement`
+        # already fixed for "any".
+        assert self._apply({"experience_level": "ninja-wizard"}) == ""
+
+    def test_an_omitted_key_keeps_the_stored_answer(self) -> None:
+        """The partial-save bug: the old `.get(key, "")` treated an absent
+        key the same as an explicit clear, so saving any OTHER field on the
+        form silently wiped a previously-chosen experience level."""
+        from src.services.profile.models import UserPreferences
+
+        stored = UserPreferences(experience_level="senior")
+        assert self._apply({"salary_min": 40000}, stored) == "senior"
+
+    def test_an_explicit_empty_string_still_clears_it(self) -> None:
+        """Rule #29 cuts both ways -- a preference the user cleared must go
+        back to silence, not keep the old stored value forever."""
+        from src.services.profile.models import UserPreferences
+
+        stored = UserPreferences(experience_level="senior")
+        assert self._apply({"experience_level": ""}, stored) == ""
+
+
 class TestGithubUsernameFallbackIsNormalized:
     """github_username reaching the _apply_preferences fallback path was stored
     raw — a real user ended up with 'https:' (2026-08-08), which silently broke

--- a/backend/tests/test_reextract_stale_profiles_bounds.py
+++ b/backend/tests/test_reextract_stale_profiles_bounds.py
@@ -1,0 +1,129 @@
+"""The re-extraction sweep must never exceed the bound it was given.
+
+WHY THIS FILE EXISTS. Every ``--apply`` re-extraction is a real, billed LLM
+call across a user's four inputs, so ``--limit`` is not a convenience -- it is
+the spend cap. The first version of the script wrote its guard as
+
+    if apply and limit and reextracted + failed >= limit:
+
+which reads fine and is wrong: ``limit`` is used as a truthiness test, so
+``--limit 0`` is FALSY and the cap is skipped entirely. The one invocation the
+script's own docstring promises "never makes an LLM call" would instead have
+re-extracted every stale profile in the database, unbounded.
+
+Nothing about that is visible in a dry run, and it would not surface until an
+operator reached for the safest-looking flag during an incident. So the bound
+is pinned here rather than left to review.
+
+The whole DB and extraction layer is stubbed (rule #4) -- these tests must
+never touch Postgres and must never make a real LLM call.
+"""
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import pathlib
+import sys
+
+import pytest
+
+_SCRIPT = (
+    pathlib.Path(__file__).resolve().parents[1]
+    / "scripts"
+    / "reextract_stale_profiles.py"
+)
+
+
+def _load_script():
+    """Import the script by path -- backend/scripts/ is not a package."""
+    spec = importlib.util.spec_from_file_location("_reextract_script", _SCRIPT)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["_reextract_script"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class _Recorder:
+    """Counts how many profiles were actually put through extraction."""
+
+    def __init__(self) -> None:
+        self.extracted: list[str] = []
+        self.saved: list[str] = []
+
+
+@pytest.fixture()
+def sweep(monkeypatch):
+    """The script with every external edge replaced, returning (run, rec).
+
+    ``run(limit, apply)`` executes the sweep over 25 profiles that are ALL
+    stale, so any failure to honour the bound shows up immediately as a count.
+    """
+    mod = _load_script()
+    rec = _Recorder()
+
+    ids = [f"user-{i:02d}" for i in range(25)]
+
+    class _Profile:
+        def __init__(self, uid: str) -> None:
+            self.uid = uid
+
+    import src.services.profile.storage as storage
+    import src.services.profile.two_pass as two_pass
+
+    monkeypatch.setattr(storage, "list_profile_user_ids", lambda: ids)
+    monkeypatch.setattr(storage, "load_profile", lambda uid: _Profile(uid))
+    monkeypatch.setattr(
+        storage, "save_profile",
+        lambda profile, uid, action: rec.saved.append(uid),
+    )
+    # EVERY profile is stale, so the bound is the only thing that can stop it.
+    monkeypatch.setattr(two_pass, "stale_extraction_inputs", lambda p: ["cv"])
+
+    async def _fake_extract(profile):
+        rec.extracted.append(profile.uid)
+        return profile
+
+    monkeypatch.setattr(two_pass, "run_two_pass_extraction", _fake_extract)
+
+    def run(limit: int, apply: bool) -> int:
+        return asyncio.run(mod.main(None, limit, apply))
+
+    return run, rec
+
+
+class TestTheSpendCapIsHonoured:
+    def test_limit_zero_extracts_nothing(self, sweep) -> None:
+        """THE BUG. --limit 0 is the emergency stop, and it was the one value
+        that disabled the cap."""
+        run, rec = sweep
+        run(0, True)
+        assert rec.extracted == [], (
+            f"--limit 0 re-extracted {len(rec.extracted)} profiles. Each is a "
+            "billed LLM call, and the script's docstring promises none."
+        )
+        assert rec.saved == []
+
+    @pytest.mark.parametrize("limit", [1, 3, 10])
+    def test_it_never_exceeds_the_limit(self, sweep, limit: int) -> None:
+        """The general guarantee, not just the zero case -- a cap that holds
+        only at 0 would still overspend at every other value."""
+        run, rec = sweep
+        run(limit, True)
+        assert len(rec.extracted) == limit
+
+    def test_a_dry_run_never_extracts_at_any_limit(self, sweep) -> None:
+        """Dry run is the default, so this is the path an operator hits first.
+        It must report without spending anything."""
+        run, rec = sweep
+        run(10, False)
+        assert rec.extracted == []
+        assert rec.saved == []
+
+    def test_the_bound_is_not_vacuous(self, sweep) -> None:
+        """The control. Without it, a script that extracted NOTHING under any
+        setting would pass every assertion above while being useless."""
+        run, rec = sweep
+        run(5, True)
+        assert len(rec.extracted) == 5
+        assert rec.saved == rec.extracted

--- a/backend/tests/test_semantic_stack_preflight.py
+++ b/backend/tests/test_semantic_stack_preflight.py
@@ -25,10 +25,6 @@ backfill must stop immediately and say what is wrong and how to fix it.
 """
 from __future__ import annotations
 
-import logging
-
-import pytest
-
 
 class TestSemanticStackProbe:
     def test_it_reports_true_when_the_package_imports(self) -> None:
@@ -64,52 +60,32 @@ class TestSemanticStackProbe:
         assert embeddings.semantic_stack_installed() is False
 
 
-class TestBackfillStopsLoudlyWithoutTheStack:
-    """The OUTCOME, not the mechanism: no work attempted, and one actionable
-    ERROR rather than N unactionable warnings."""
+class TestTheMessageCarriesTheRemedy:
+    """The ERROR text is the whole point, so its content is pinned.
 
-    @pytest.mark.asyncio
-    async def test_it_returns_zero_and_logs_an_actionable_error(
-        self, monkeypatch, caplog
-    ) -> None:
-        import builtins
+    The warning it replaces said "embed backfill: job 4172 failed" — true, and
+    useless. An operator reading a hundred of those learns nothing about the
+    cause or the fix. If this message ever degrades back to a bare "failed",
+    the loud path is loud and still worthless.
+
+    The escalation itself is exercised where it lives, in
+    tests/test_embed_backfill.py, which owns the DB fixture for that function.
+    Duplicating that setup here would mean a second, drifting copy of it.
+    """
+
+    def test_the_wording_names_the_cause_and_both_ways_out(self) -> None:
+        import inspect
 
         from src import main as main_mod
 
-        real_import = builtins.__import__
-
-        def _no_sentence_transformers(name, *args, **kwargs):
-            if name == "sentence_transformers" or name.startswith("sentence_transformers."):
-                raise ImportError("No module named 'sentence_transformers'")
-            return real_import(name, *args, **kwargs)
-
-        monkeypatch.setattr(builtins, "__import__", _no_sentence_transformers)
-
-        # A DB/conn that would explode if touched. That is the point: the
-        # preflight must return BEFORE any query runs, so passing objects with
-        # no usable methods proves no work was attempted. A test that passed
-        # working fakes could not tell "stopped early" from "ran and found
-        # nothing".
-        class _Explodes:
-            def __getattr__(self, name):  # noqa: ANN001
-                raise AssertionError(
-                    f"backfill touched the database ({name}) despite the "
-                    "semantic stack being absent"
-                )
-
-        with caplog.at_level(logging.ERROR, logger="job360"):
-            embedded = await main_mod._embed_backfill_budget(
-                _Explodes(), _Explodes(), 50
-            )
-
-        assert embedded == 0
-
-        errors = [r for r in caplog.records if r.levelno >= logging.ERROR]
-        assert errors, "the failure was not raised to ERROR — it stays invisible"
-        text = " ".join(r.getMessage() for r in errors).lower()
-        # The message has to carry the REMEDY. An error that says "failed"
-        # without saying what to do is the same dead end as the warning storm
-        # it replaces.
-        assert "semantic_enabled" in text
-        assert "sentence-transformers" in text
-        assert "[semantic]" in text or "pip install" in text
+        source = inspect.getsource(main_mod._embed_backfill_budget).lower()
+        assert "semantic_enabled" in source, "does not name the flag that is on"
+        assert "sentence-transformers" in source, "does not name the missing package"
+        assert "[semantic]" in source, "does not give the install command"
+        # The second way out matters as much as the first: if embedding is not
+        # wanted on this service, the honest fix is to turn the flag OFF so the
+        # gap is a decision rather than a silent hole.
+        assert "turn semantic_enabled off" in source, (
+            "only offers 'install it' — an operator who does not want embedding "
+            "here is left with a permanent ERROR and no sanctioned way to clear it"
+        )

--- a/backend/tests/test_semantic_stack_preflight.py
+++ b/backend/tests/test_semantic_stack_preflight.py
@@ -1,0 +1,115 @@
+"""A capability switched ON but structurally impossible must say so LOUDLY.
+
+THE DEFECT, measured against production 2026-08-15.
+
+The API image installs ``.[semantic]`` plus torch. The WORKER image installs a
+plain ``.`` — confirmed in the live Railway build log:
+
+    load build definition from backend/Dockerfile.worker
+    RUN pip install --no-cache-dir --upgrade pip && pip install --no-cache-dir .
+
+The worker runs ``refresh_catalog``, the daily job-ingestion cron. So the
+process that pulls in the most new jobs is the one that cannot embed them.
+Semantic coverage in prod: 687 vectors for 9,977 jobs (6.9%).
+
+The shape of the failure is what made it survive. ``sentence_transformers`` is
+imported lazily (rule #16), so the MODULE import succeeds and nothing complains
+at startup. The ImportError only surfaces per job, deep inside the backfill
+loop, where a per-job handler catches it and logs
+``embed backfill: job <id> failed``. One missing package therefore produced a
+storm of identical warnings that named neither the cause nor the remedy, and
+every instrument stayed green.
+
+These tests pin the preflight: when semantic is ON and the stack is absent, the
+backfill must stop immediately and say what is wrong and how to fix it.
+"""
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+
+class TestSemanticStackProbe:
+    def test_it_reports_true_when_the_package_imports(self) -> None:
+        """The probe must reflect reality, not a flag. If the package is
+        installed here, saying "missing" would disable embedding on a machine
+        that can perfectly well do it."""
+        from src.services.embeddings import semantic_stack_installed
+
+        installed = semantic_stack_installed()
+        try:
+            import sentence_transformers  # noqa: F401
+            truth = True
+        except ImportError:
+            truth = False
+        assert installed is truth
+
+    def test_it_reports_false_when_the_import_fails(self, monkeypatch) -> None:
+        """Simulate the worker image. builtins.__import__ is patched rather than
+        sys.modules, because the probe's whole job is to survive the ImportError
+        that a genuinely absent package raises."""
+        import builtins
+
+        from src.services import embeddings
+
+        real_import = builtins.__import__
+
+        def _no_sentence_transformers(name, *args, **kwargs):
+            if name == "sentence_transformers" or name.startswith("sentence_transformers."):
+                raise ImportError("No module named 'sentence_transformers'")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", _no_sentence_transformers)
+        assert embeddings.semantic_stack_installed() is False
+
+
+class TestBackfillStopsLoudlyWithoutTheStack:
+    """The OUTCOME, not the mechanism: no work attempted, and one actionable
+    ERROR rather than N unactionable warnings."""
+
+    @pytest.mark.asyncio
+    async def test_it_returns_zero_and_logs_an_actionable_error(
+        self, monkeypatch, caplog
+    ) -> None:
+        import builtins
+
+        from src import main as main_mod
+
+        real_import = builtins.__import__
+
+        def _no_sentence_transformers(name, *args, **kwargs):
+            if name == "sentence_transformers" or name.startswith("sentence_transformers."):
+                raise ImportError("No module named 'sentence_transformers'")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", _no_sentence_transformers)
+
+        # A DB/conn that would explode if touched. That is the point: the
+        # preflight must return BEFORE any query runs, so passing objects with
+        # no usable methods proves no work was attempted. A test that passed
+        # working fakes could not tell "stopped early" from "ran and found
+        # nothing".
+        class _Explodes:
+            def __getattr__(self, name):  # noqa: ANN001
+                raise AssertionError(
+                    f"backfill touched the database ({name}) despite the "
+                    "semantic stack being absent"
+                )
+
+        with caplog.at_level(logging.ERROR, logger="job360"):
+            embedded = await main_mod._embed_backfill_budget(
+                _Explodes(), _Explodes(), 50
+            )
+
+        assert embedded == 0
+
+        errors = [r for r in caplog.records if r.levelno >= logging.ERROR]
+        assert errors, "the failure was not raised to ERROR — it stays invisible"
+        text = " ".join(r.getMessage() for r in errors).lower()
+        # The message has to carry the REMEDY. An error that says "failed"
+        # without saying what to do is the same dead end as the warning storm
+        # it replaces.
+        assert "semantic_enabled" in text
+        assert "sentence-transformers" in text
+        assert "[semantic]" in text or "pip install" in text

--- a/backend/tests/test_sentry_announces_itself.py
+++ b/backend/tests/test_sentry_announces_itself.py
@@ -1,0 +1,150 @@
+"""An empty Sentry must be falsifiable.
+
+WHY THIS EXISTS (found 2026-08-15, while trying to answer "what do the
+extraction errors look like in Sentry?").
+
+``init_sentry`` returns a bool saying whether error reporting actually turned
+on. BOTH call sites -- ``api/main.py:98`` and ``workers/settings.py:107`` --
+discarded it, and nothing was logged either way. So a production process whose
+``SENTRY_DSN`` was unset, misspelled, or dropped during a redeploy would report
+nothing, announce nothing, and look exactly like a healthy service.
+
+That is not a hypothetical: this module's own docstring records that the WORKER
+never initialised Sentry at all, so "Sentry looked healthy precisely where the
+worst failures happened". The fix then was to call init from the worker too.
+The gap that remained is that nobody can tell whether the call SUCCEEDED.
+
+It is the same shape as every other defect in this batch: silence that reads as
+health. A capability that is off must say it is off.
+
+Three states, and an operator must be able to tell them apart from the logs
+alone:
+  * ON in prod        -> INFO, so an empty Sentry can be trusted
+  * OFF in prod       -> ERROR, because it is a real operational hole
+  * off outside prod  -> INFO, because that is correct and expected
+"""
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+
+@pytest.fixture()
+def _prod(monkeypatch):
+    monkeypatch.setenv("APP_ENV", "production")
+    monkeypatch.delenv("RAILWAY_ENVIRONMENT", raising=False)
+
+
+def _messages(caplog, min_level: int) -> str:
+    return " ".join(
+        r.getMessage() for r in caplog.records if r.levelno >= min_level
+    ).lower()
+
+
+class TestItSaysWhichStateItIsIn:
+    def test_production_without_a_dsn_is_an_error(self, monkeypatch, caplog, _prod) -> None:
+        """The dangerous state. Anyone reading an empty Sentry needs to know it
+        was never connected, and needs it at a level that gets noticed."""
+        import src.core.settings as settings
+        from src.core.observability import init_sentry
+
+        monkeypatch.setattr(settings, "SENTRY_DSN", "", raising=False)
+
+        with caplog.at_level(logging.INFO, logger="job360"):
+            assert init_sentry(component="worker") is False
+
+        text = _messages(caplog, logging.ERROR)
+        assert text, "a production process with no DSN said nothing at ERROR"
+        assert "sentry_dsn" in text, "does not name the missing setting"
+        assert "worker" in text, "does not say WHICH component is unobserved"
+
+    def test_outside_production_is_only_informational(self, monkeypatch, caplog) -> None:
+        """The control. Local dev and the test suite are SUPPOSED to be off, so
+        shouting here would train everyone to ignore the message that matters."""
+        import src.core.settings as settings
+        from src.core.observability import init_sentry
+
+        monkeypatch.setattr(settings, "SENTRY_DSN", "a-dsn", raising=False)
+        monkeypatch.delenv("APP_ENV", raising=False)
+        monkeypatch.delenv("RAILWAY_ENVIRONMENT", raising=False)
+
+        with caplog.at_level(logging.INFO, logger="job360"):
+            assert init_sentry(component="api") is False
+
+        assert not _messages(caplog, logging.ERROR), (
+            "being off outside production is correct and must not raise an ERROR"
+        )
+        assert _messages(caplog, logging.INFO), "said nothing at all"
+
+    def test_a_working_setup_announces_itself(self, monkeypatch, caplog, _prod) -> None:
+        """The positive half, and the one that makes an empty Sentry mean
+        something. Without this line you cannot distinguish 'no errors' from
+        'never connected'."""
+        import src.core.settings as settings
+        from src.core.observability import init_sentry
+
+        monkeypatch.setattr(settings, "SENTRY_DSN", "https://k@example.test/1", raising=False)
+
+        captured: dict = {}
+
+        class _FakeSentry:
+            def init(self, **kw):
+                captured.update(kw)
+
+            def set_tag(self, *a, **kw):
+                pass
+
+        import sys
+
+        fake = _FakeSentry()
+        monkeypatch.setitem(sys.modules, "sentry_sdk", fake)
+        monkeypatch.setitem(
+            sys.modules,
+            "sentry_sdk.integrations.logging",
+            type("_M", (), {"ignore_logger": staticmethod(lambda name: None)})(),
+        )
+
+        with caplog.at_level(logging.INFO, logger="job360"):
+            assert init_sentry(component="api") is True
+
+        text = _messages(caplog, logging.INFO)
+        assert "error reporting on" in text, (
+            "a working Sentry setup is silent, so an empty dashboard stays "
+            "unfalsifiable"
+        )
+        assert "api" in text
+
+    def test_the_dsn_is_never_logged(self, monkeypatch, caplog, _prod) -> None:
+        """A DSN is a credential. The whole point of this file is to log MORE
+        about Sentry, which is exactly when a secret slips into a log line."""
+        import src.core.settings as settings
+        from src.core.observability import init_sentry
+
+        secret = "https://super-secret-key@o123.ingest.sentry.io/456"
+        monkeypatch.setattr(settings, "SENTRY_DSN", secret, raising=False)
+
+        captured: dict = {}
+
+        class _FakeSentry:
+            def init(self, **kw):
+                captured.update(kw)
+
+            def set_tag(self, *a, **kw):
+                pass
+
+        import sys
+
+        monkeypatch.setitem(sys.modules, "sentry_sdk", _FakeSentry())
+        monkeypatch.setitem(
+            sys.modules,
+            "sentry_sdk.integrations.logging",
+            type("_M", (), {"ignore_logger": staticmethod(lambda name: None)})(),
+        )
+
+        with caplog.at_level(logging.INFO, logger="job360"):
+            init_sentry(component="api")
+
+        everything = " ".join(r.getMessage() for r in caplog.records)
+        assert "super-secret-key" not in everything
+        assert secret not in everything

--- a/backend/tests/test_shelf_registry.py
+++ b/backend/tests/test_shelf_registry.py
@@ -72,10 +72,61 @@ class TestEveryShelfIsRead:
         )
 
     def test_the_allowlist_does_not_rot(self) -> None:
-        """An allowlisted shelf that HAS gained a reader must leave the list, or
-        the list slowly becomes a place where live fields hide."""
-        stale = [name for name in ALLOWED_UNREAD if readers(name)]
+        """An allowlisted shelf can go stale two ways, and both must be caught:
+
+        1. It names a shelf that HAS gained a reader — the exemption is no
+           longer needed and should be deleted, or the list becomes a place
+           where live fields hide.
+        2. It names a shelf that no longer EXISTS on either dataclass — a
+           rename or deletion left a dead entry exempting nothing.
+
+        ALLOWED_UNREAD is empty right now, and that is the healthy state:
+        every shelf currently earns its keep by being read. That also means
+        BOTH checks below pass vacuously against production data today — an
+        empty dict has no stale entries by definition. That is not what makes
+        this test meaningful; see ``test_the_rot_check_can_actually_fail``
+        immediately below, which proves the checking logic against a
+        fabricated entry so the day someone adds a real exemption, this test
+        is already known to bite.
+        """
+        known = frozenset(shelf_names())
+        unknown = [name for name in ALLOWED_UNREAD if name not in known]
+        stale = [name for name in ALLOWED_UNREAD if name in known and readers(name)]
+        assert not unknown, (
+            f"ALLOWED_UNREAD names shelves that no longer exist: {unknown}. "
+            "The field was renamed or removed — delete the exemption."
+        )
         assert not stale, f"ALLOWED_UNREAD is stale — these now have readers: {stale}"
+
+    def test_the_rot_check_can_actually_fail(self) -> None:
+        """Proof the assertions above are not vacuous.
+
+        With ALLOWED_UNREAD empty, ``test_the_allowlist_does_not_rot`` passes
+        no matter what the checking logic does — even a check that always
+        returned ``[]`` would look green forever, which is exactly the shape
+        of bug this whole file exists to catch (see the module docstring).
+        This test runs the SAME two checks against a fabricated allowlist
+        entry and confirms each one actually fires.
+        """
+        known = frozenset(shelf_names())
+        real_shelf_with_a_reader = next(name for name in shelf_names() if readers(name))
+
+        fake_allowlist = {
+            "not_a_real_shelf_name": "made up for this test",
+            real_shelf_with_a_reader: "pretend this used to be unread",
+        }
+
+        unknown = [name for name in fake_allowlist if name not in known]
+        stale = [name for name in fake_allowlist if name in known and readers(name)]
+
+        assert unknown == ["not_a_real_shelf_name"], (
+            "the unknown-shelf check did not fire against a name that isn't "
+            "a real shelf — it cannot protect against a renamed/deleted field"
+        )
+        assert stale == [real_shelf_with_a_reader], (
+            "the has-a-reader check did not fire against a shelf known to "
+            "have a reader — it cannot protect against a stale exemption"
+        )
 
 
 class TestNoPhantomReads:

--- a/docs/pillar1_data_design.md
+++ b/docs/pillar1_data_design.md
@@ -45,9 +45,9 @@ UserProfile
 | cv_skills_esco | L | skills mapped to the ESCO ontology |
 | raw_text | D | full CV text (for re-runs) |
 | extraction_score | D | quality metric |
-| career_domain 🔴 | L | *filled, no reader* |
-| cv_languages 🔴 | L | *filled, no reader* |
-| llm_input_hashes 🔴 | D | *cache key, no reader* |
+| career_domain | L | read by the semantic engine (`embeddings.py:208`) and the LLM judge (`llm_matcher.py:207`) |
+| cv_languages | L | read by the semantic engine (`embeddings.py:207`) and the LLM judge (`llm_matcher.py:200`) |
+| llm_input_hashes | D | cache key; read by `two_pass.py`'s `_already_read()` to skip a paid LLM call on unchanged input |
 
 ### Input 2 — LinkedIn → `CVData` (linkedin_*)
 | Shelf | Pass | What it holds |
@@ -97,4 +97,28 @@ Preferences ──→ typed, + about_me runs an LLM pass ─→ UserPreferences
 The container name `CVData` is a historical misnomer — it started as CV-only and grew to hold LinkedIn + GitHub too. Worth knowing when you read the code: `cv_data` in the DB is really "everything we extracted about the person."
 `─────────────────────────────────────────────────`
 
-🔴 = the 3 shelves that are filled but nothing reads them — dead weight, deliberately left, not gaps.
+🔴 = a shelf that is filled but nothing reads it — dead weight, deliberately left, not a gap.
+None currently qualify: every CVData/UserPreferences shelf has a real reader (see the
+correction below for the two that were wrongly marked, and for why the third candidate
+isn't dead either).
+
+Correction (2026-08-15): `career_domain` and `cv_languages` were marked 🔴 above but are
+NOT dead — verified by grep (`grep -rn "career_domain\|cv_languages" backend/src`) and
+confirmed live in `backend/src/services/embeddings.py:207-208` (semantic engine) and
+`backend/src/services/llm_matcher.py:200,207` (LLM judge). Both were wired in on
+2026-08-09 (see the comment at `embeddings.py:201-205`, which says so directly); this
+doc was never updated after that batch shipped.
+
+`llm_input_hashes` was ALSO wrongly marked 🔴 in an earlier pass of this same correction —
+that pass only checked `api/routes/profile.py`, where the field is `.pop()`-ed (a discard,
+not a read), and stopped there. It missed the field's actual consumer: `two_pass.py`'s
+`_already_read()` (`src/services/profile/two_pass.py:213-220`) does
+`cv.llm_input_hashes.get(key) == _input_hash(raw)` — a real value comparison that decides
+whether `run_two_pass_extraction` skips a paid LLM call because the input hasn't changed
+since the last pass. Called from both the per-input skip check (`two_pass.py:184`) and the
+cache-hit summary (`two_pass.py:556`). Note for whoever next runs the shelf audit tool over
+this file: `readers("llm_input_hashes")` currently returns only `{"api"}` and misses this —
+`two_pass.py` is registered in `shelf_audit._WRITER_ROLES` (as `"merge"`) but absent from
+`shelf_audit._ROLES`, so the tool never scans it for reads at all. That's a real gap in the
+instrument (confirmed: no shelf in the registry reports `"merge"` among its readers), not a
+signal that this field is unread — it is the module's core caching logic.

--- a/docs/pillars/01-user-pillar.md
+++ b/docs/pillars/01-user-pillar.md
@@ -2,7 +2,7 @@
 
 > **Audience.** Read this if you want to understand everything Job360 does *for a human end-user* — sign up, upload a CV, see matched jobs, track applications, get notified. This document covers no source-fetching internals and no scoring math; those are Pillars 2 and 3.
 >
-> **Scope.** Covers the code that exists on `main` as of 2026-05-28 (HEAD `a7a2268`). Where a surface is partially wired or carries a known gap, it is called out in the **Status** column.
+> **Scope.** Covers the code that exists on `main` as of 2026-08-14 (HEAD `09727e5`). Where a surface is partially wired or carries a known gap, it is called out in the **Status** column.
 
 ---
 
@@ -221,7 +221,7 @@ Writes to `DEFAULT_TENANT_ID` (the placeholder user). Used by single-tenant inst
 1. **Extract text** with `pdfplumber` (with font-size clustering for layout-aware section splitting — see `layout.segment_sections_from_words`) or `python-docx`.
 2. **Call an LLM** via `llm_extract_validated(prompt, CVSchema)` (`backend/src/services/profile/llm_provider.py`). The schema is enforced with Pydantic; on validation failure the prompt is re-sent up to 2× with the validation error appended so the model can self-correct.
 3. **Provider fallback chain**: Gemini → Groq → Cerebras. Whichever has a working API key wins. If all three fail, `RuntimeError` is raised — the system never silently degrades to regex parsing (the old `KNOWN_SKILLS` / `KNOWN_TITLE_PATTERNS` approach was deliberately removed in commits 804725c and 3ba1342).
-4. **ESCO normalisation** (only when `SEMANTIC_ENABLED=true`) maps free-text skills to canonical ESCO URIs.
+4. **ESCO normalisation code exists but has never run in production.** `_maybe_normalise_skills_via_esco()` (`cv_parser.py:804`) is a real no-op today: it needs both `SEMANTIC_ENABLED=true` AND a prebuilt embedding index at `backend/data/esco/`, and that directory has never been committed or generated (verified: `ls backend/data/esco` → does not exist). Root `CLAUDE.md` rule #28 states this as FACT (verified 2026-08-11): "no ontology is consulted... ESCO is inert scaffolding, never built or shipped." Reviving it means shipping the index artefacts, not flipping a flag.
 
 #### LinkedIn PDF — `backend/src/services/profile/linkedin_parser.py`
 
@@ -535,7 +535,7 @@ Legend: ✅ done & wired · 🟡 partial · ❌ planned but not built · ⚠️ 
 | LinkedIn "Save to PDF" import | ✅ | `linkedin_parser.py`, 2-of-3 detection heuristic |
 | GitHub enrichment with temporal weighting | ✅ | `github_enricher.py` — 3× weight for repos pushed in last year |
 | Dependency-file framework inference | ✅ | 7 file types parsed (package.json, requirements.txt, …) |
-| ESCO skill normalisation | 🟡 | only when `SEMANTIC_ENABLED=true`; off by default per CLAUDE.md rule #18 |
+| ESCO skill normalisation | ❌ | code path exists but the embedding index it needs (`backend/data/esco/`) was never built or shipped — inert scaffolding, not a flag flip. Root `CLAUDE.md` rule #28 (FACT, verified 2026-08-11). |
 | Multi-tenant SQLite storage | ✅ | `user_profiles` table (migration `0006`) |
 | Version history + restore (last 10) | ✅ | `user_profile_versions` (`0007`); restore is atomic and preserves history |
 | Legacy `data/user_profile.json` hydration | ✅ | non-destructive, runs on first DB read |
@@ -667,4 +667,9 @@ For completeness — these belong in the other two pillars and you won't find th
 
 ---
 
-*Last updated 2026-05-28. HEAD `a7a2268`. Backend test baseline 600p/0f/3s.*
+*Last updated 2026-08-15. HEAD `09727e5` (origin/main, 2026-08-14). Backend suite: 2,854 tests
+collected, 2 deselected (measured `python -m pytest --collect-only -q`, this session —
+per root `CLAUDE.md`: "never quote a test count from a doc, measure it"). Pass/fail count
+NOT verified this session (no local Postgres reachable — the suite needs `docker-compose.dev.yml`
+up on port 5433); do not carry the old "600p/0f/3s" figure forward, it predates this update by
+~2.5 months and was already off by roughly 5x collected-test count alone.*

--- a/frontend/src/app/profile/__tests__/completeness.test.tsx
+++ b/frontend/src/app/profile/__tests__/completeness.test.tsx
@@ -1,0 +1,66 @@
+/**
+ * Profile completeness meter — no double-counting a single answer.
+ *
+ * THE BUG, as measured. calcCompleteness paid a typed preferred job title
+ * TWICE: once for the 15% "Has job titles" bucket (`prefTitles.length > 0`),
+ * and again for the 15% "Has preferences" bucket, which OR'd in that exact
+ * same `prefTitles.length > 0` check. One answer, two buckets, 30% of the
+ * meter for something that should only earn 15%.
+ *
+ * This test pins a profile shape with ONLY a CV (40%) and ONE typed job title
+ * (15%) — nothing else filled in. The honest total is 55%. The bug would have
+ * read 70%, because the same job title paid for "Has preferences" too even
+ * though no actual preference field (work arrangement, experience level,
+ * about me) was ever set.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import ProfilePage from "../page";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock("@/lib/api", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/api")>()),
+  getProfile: vi.fn().mockResolvedValue({
+    summary: {
+      is_complete: false,
+      job_titles: [], // no CV-extracted titles
+      skills_count: 0,
+      cv_length: 100, // has a CV -> +40
+      has_linkedin: false,
+      has_github: false,
+      education: [],
+      experience_level: "",
+    },
+    preferences: {
+      target_job_titles: ["Data Scientist"], // the ONE typed answer -> +15
+      additional_skills: [],
+      // Nothing here counts as a real preference: "any" and "" are both
+      // "not chosen" (rule #29), and about_me is blank.
+      work_arrangement: "any",
+      experience_level: "",
+      about_me: "",
+    },
+    cv_detail: null,
+    skill_tiers: null,
+    skill_esco: {},
+  }),
+}));
+
+describe("ProfilePage — completeness meter does not double-count", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it("a CV plus one typed job title reads 55%, not 70%", async () => {
+    render(<ProfilePage />);
+
+    // 40 (CV) + 15 (job title, counted once) = 55. If the double-count bug
+    // were still present, the same title would also satisfy "Has
+    // preferences" and this would read 70%.
+    expect(await screen.findByText("55%")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -64,12 +64,17 @@ function calcCompleteness(profile: ProfileResponse | null): {
   if (summary.skills_count > 0 || prefSkills.length > 0) score += 15;
 
   // Has preferences (at least work arrangement or experience or about_me): 15%
+  //
+  // `prefTitles.length > 0` used to be OR'd in here too, but that is the exact
+  // same signal the "Has job titles" bucket above already pays for -- one
+  // typed title satisfied BOTH buckets, so the meter double-counted a single
+  // answer as 30% of completeness instead of 15%. Each bucket must measure a
+  // DISTINCT thing: this one now looks only at fields no other bucket counts.
   const prefs = preferences as Record<string, unknown>;
   const hasPrefs =
     (prefs?.work_arrangement && prefs.work_arrangement !== "any") ||
     (prefs?.experience_level && prefs.experience_level !== "") ||
-    (typeof prefs?.about_me === "string" && prefs.about_me.length > 0) ||
-    prefTitles.length > 0;
+    (typeof prefs?.about_me === "string" && prefs.about_me.length > 0);
   if (hasPrefs) score += 15;
 
   // Has LinkedIn: 7.5%

--- a/frontend/src/components/profile/PreferencesForm.excluded-companies.test.tsx
+++ b/frontend/src/components/profile/PreferencesForm.excluded-companies.test.tsx
@@ -1,0 +1,46 @@
+/**
+ * excluded_companies — a dead field, fully removed.
+ *
+ * VERIFIED before removing anything: a repo-wide grep for `excluded_companies`
+ * turned up ZERO matches anywhere in backend/ — no route, no scorer, no model
+ * field, no migration. The field was collected by this form (with no visible
+ * UI control — it was already hidden 2026-08-08) and sent on every autosave,
+ * discarded silently on arrival. This test pins the outcome the user's network
+ * tab would show: the saved payload no longer carries a key nobody reads.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { PreferencesForm } from "./PreferencesForm";
+
+describe("PreferencesForm — excluded_companies is not sent", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("omits excluded_companies from the autosave payload even when the stored profile has one", async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    render(
+      <PreferencesForm
+        // A pre-existing profile with a stored value, to prove this isn't
+        // passing only because the field was already empty.
+        preferences={{ excluded_companies: ["Acme Corp"] }}
+        onSave={onSave}
+        loading={false}
+      />
+    );
+
+    const about = screen.getByPlaceholderText(/Experienced data scientist/i);
+    fireEvent.change(about, { target: { value: "Looking for backend roles." } });
+
+    await act(async () => {
+      vi.advanceTimersByTime(900);
+    });
+
+    expect(onSave).toHaveBeenCalledTimes(1);
+    const sent = onSave.mock.calls[0][0];
+    expect("excluded_companies" in sent).toBe(false);
+  });
+});

--- a/frontend/src/components/profile/PreferencesForm.experience.test.tsx
+++ b/frontend/src/components/profile/PreferencesForm.experience.test.tsx
@@ -1,0 +1,89 @@
+/**
+ * Experience Level must not invent an answer for a brand-new account.
+ *
+ * THE BUG, as measured. A brand-new account has no profile row, so
+ * GET /profile 404s, page.tsx keeps `profile = null`, and passes
+ * `preferences={}` to this form. `prefsFromRaw` then substitutes "mid" for the
+ * missing experience_level, and the first save posts it as though the user had
+ * chosen it. The backend stores it verbatim -- `_apply_preferences` reads
+ * experience_level with a bare `.get(..., "")` and normalises nothing.
+ *
+ * "mid" is not inert. resolve_experience_level treats a typed value as
+ * authoritative ("typed always wins"), so seniority_score skips its neutral
+ * midpoint and runs the real curve at SENIORITY_WEIGHT=8 -- up to 8 points
+ * given or taken on every job. The same fake value is then stated to the LLM
+ * judge and appended to the semantic vector.
+ *
+ * Rule #29: an unstated preference is silence. This is the identical defect
+ * already fixed one field over for `work_arrangement`, whose "any" sentinel was
+ * reaching the judge as a real constraint. That fix was never copied here.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { PreferencesForm } from "./PreferencesForm";
+
+describe("PreferencesForm — experience level is never invented", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("a brand-new account does not save an experience level it never chose", async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    // Exactly what page.tsx passes when GET /profile 404s: `profile?.preferences ?? {}`.
+    render(<PreferencesForm preferences={{}} onSave={onSave} loading={false} />);
+
+    // Touch an UNRELATED field, the way a real user would while filling the form.
+    const about = screen.getByPlaceholderText(/Experienced data scientist/i);
+    fireEvent.change(about, { target: { value: "Looking for ML roles." } });
+
+    await act(async () => {
+      vi.advanceTimersByTime(900);
+    });
+
+    expect(onSave).toHaveBeenCalledTimes(1);
+    const sent = onSave.mock.calls[0][0];
+    expect(sent.experience_level).toBe("");
+  });
+
+  it("a real choice is still sent", async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    render(
+      <PreferencesForm
+        preferences={{ experience_level: "senior" }}
+        onSave={onSave}
+        loading={false}
+      />
+    );
+
+    const about = screen.getByPlaceholderText(/Experienced data scientist/i);
+    fireEvent.change(about, { target: { value: "x" } });
+    await act(async () => {
+      vi.advanceTimersByTime(900);
+    });
+
+    expect(onSave.mock.calls[0][0].experience_level).toBe("senior");
+  });
+
+  it("a stored empty value stays empty rather than becoming a default", async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    // What the backend actually returns once any profile row exists.
+    render(
+      <PreferencesForm
+        preferences={{ experience_level: "" }}
+        onSave={onSave}
+        loading={false}
+      />
+    );
+
+    const about = screen.getByPlaceholderText(/Experienced data scientist/i);
+    fireEvent.change(about, { target: { value: "y" } });
+    await act(async () => {
+      vi.advanceTimersByTime(900);
+    });
+
+    expect(onSave.mock.calls[0][0].experience_level).toBe("");
+  });
+});

--- a/frontend/src/components/profile/PreferencesForm.tsx
+++ b/frontend/src/components/profile/PreferencesForm.tsx
@@ -212,6 +212,16 @@ function TagInput({
 const asArr = (val: unknown): string[] =>
   Array.isArray(val) ? val.map(String) : [];
 
+// The Select can't display "nothing chosen" as a real selected option, so it
+// needs its OWN word for that state -- same trick work_arrangement plays with
+// "any" a few fields down. The difference: nothing on the backend translates
+// this back to "" the way `_normalize_work_arrangement` does for
+// work_arrangement -- `_apply_preferences` stores experience_level with a bare
+// `.get(pref_dict, "experience_level", "")`, no normalizer. So BOTH directions
+// of the "" <-> sentinel translation have to happen here, or the sentinel word
+// itself would be posted to the server as though the user had typed it.
+const EXPERIENCE_UNSET = "unspecified";
+
 function prefsFromRaw(raw: Record<string, unknown>): PreferencesRequest {
   return {
     target_job_titles: asArr(raw.target_job_titles),
@@ -229,11 +239,16 @@ function prefsFromRaw(raw: Record<string, unknown>): PreferencesRequest {
       typeof raw.work_arrangement === "string" && raw.work_arrangement
         ? raw.work_arrangement
         : "any",
+    // Rule #29: an unstated level is silence, never a guess. This is the WIRE
+    // value (fed to the auto-save baseline below), so it stays the server's
+    // own word -- "" for "not chosen" -- not the Select's display sentinel.
+    // Substituting "mid" here used to post a seniority the user never chose:
+    // it drives real scoring at SENIORITY_WEIGHT=8, is stated to the LLM
+    // judge, and goes into the semantic vector.
     experience_level:
-      typeof raw.experience_level === "string" ? raw.experience_level : "mid",
+      typeof raw.experience_level === "string" ? raw.experience_level : "",
     negative_keywords: asArr(raw.negative_keywords),
     about_me: typeof raw.about_me === "string" ? raw.about_me : "",
-    excluded_companies: asArr(raw.excluded_companies),
     needs_visa: raw.needs_visa === true,
   };
 }
@@ -253,7 +268,6 @@ function serializePrefs(p: PreferencesRequest): string {
     p.experience_level,
     p.negative_keywords,
     p.about_me,
-    p.excluded_companies,
     p.needs_visa,
   ]);
 }
@@ -279,10 +293,9 @@ export function PreferencesForm({
   const [salaryMin, setSalaryMin] = useState("");
   const [salaryMax, setSalaryMax] = useState("");
   const [workArrangement, setWorkArrangement] = useState("any");
-  const [experienceLevel, setExperienceLevel] = useState("mid");
+  const [experienceLevel, setExperienceLevel] = useState(EXPERIENCE_UNSET);
   const [negativeKeywords, setNegativeKeywords] = useState<string[]>([]);
   const [aboutMe, setAboutMe] = useState("");
-  const [excludedCompanies, setExcludedCompanies] = useState<string[]>([]);
   const [needsVisa, setNeedsVisa] = useState(false);
   const [saving, setSaving] = useState(false);
   // Distinct from `saving`: a failed auto-save used to fall back to the same
@@ -313,11 +326,16 @@ export function PreferencesForm({
     // constraint. `??` only falls back on null/undefined, so an empty string
     // would leave this select showing nothing at all.
     setWorkArrangement(p.work_arrangement || "any");
-    setExperienceLevel(p.experience_level ?? "mid");
+    // See EXPERIENCE_UNSET above: `p.experience_level` is the server's wire
+    // word ("" for "not chosen"). The Select needs an actual item selected,
+    // so an empty value becomes the display sentinel here -- and buildPrefs
+    // mirrors this translation back to "" on the way out. Both read-points
+    // must agree, or the dirty-check reports unsaved changes on a freshly
+    // loaded, untouched form.
+    setExperienceLevel(p.experience_level || EXPERIENCE_UNSET);
     setNeedsVisa(p.needs_visa === true);
     setNegativeKeywords(p.negative_keywords ?? []);
     setAboutMe(p.about_me ?? "");
-    setExcludedCompanies(p.excluded_companies ?? []);
     baselineRef.current = serializePrefs(p);
   }, [preferences]);
 
@@ -333,10 +351,14 @@ export function PreferencesForm({
       salary_min: salaryMin ? Number(salaryMin) : null,
       salary_max: salaryMax ? Number(salaryMax) : null,
       work_arrangement: workArrangement,
-      experience_level: experienceLevel,
+      // Mirror the EXPERIENCE_UNSET translation back the other way: the
+      // Select's display sentinel is a form-only word and must never reach
+      // the wire, or "unspecified" would be stored as though it were a real
+      // typed answer.
+      experience_level:
+        experienceLevel === EXPERIENCE_UNSET ? "" : experienceLevel,
       negative_keywords: negativeKeywords,
       about_me: aboutMe,
-      excluded_companies: excludedCompanies,
       needs_visa: needsVisa,
     }),
     [
@@ -351,7 +373,6 @@ export function PreferencesForm({
       experienceLevel,
       negativeKeywords,
       aboutMe,
-      excludedCompanies,
       needsVisa,
     ]
   );
@@ -526,6 +547,10 @@ export function PreferencesForm({
                 <SelectValue placeholder="Select..." />
               </SelectTrigger>
               <SelectContent>
+                {/* Form-only word for "not chosen" -- see EXPERIENCE_UNSET.
+                    Listed first since it is the actual starting state for
+                    every account until they pick one. */}
+                <SelectItem value={EXPERIENCE_UNSET}>No preference</SelectItem>
                 <SelectItem value="entry">Entry</SelectItem>
                 <SelectItem value="mid">Mid</SelectItem>
                 <SelectItem value="senior">Senior</SelectItem>
@@ -583,10 +608,12 @@ export function PreferencesForm({
           />
         </div>
 
-        {/* Excluded Companies input removed from UI (owner, 2026-08-08) — the
-            excluded_companies field, scoring zero-out, and payload key are kept
-            fully intact; every existing user's value is empty in prod, so
-            hiding the control drops no data and changes no live score. */}
+        {/* Excluded Companies removed entirely (not just the UI control) —
+            a grep of backend/src turned up ZERO consumers of the
+            `excluded_companies` key anywhere: no scorer, no route, no
+            model field. The prior comment here claimed a "scoring
+            zero-out" that does not exist in the code. Nothing ever read
+            this, so nothing is lost by no longer collecting or sending it. */}
 
         {/* ── Auto-save status ───────────────────────
             No "Save" button — preferences save automatically a moment after


### PR DESCRIPTION
Every defect here was **proven against production before a line was changed**, as asked. Three from the audit, two found while fixing them.

---

## 1. Extraction never re-runs — the big one

```
run_two_pass_extraction  →  ONE caller in src/:  profile.py:559
                            inside a save route a user must personally hit

worker crons (from the deployed worker's own startup line):
   nightly_ghost_sweep · refresh_catalog · notification_tick · enrichment_sweep
   ↑ none touch profiles

.github/ · migrations/ · scripts/  →  nothing
```

So bumping `EXTRACTOR_VERSION` for a prompt fix reaches only users who happen to re-save. **Everyone else stays frozen, silently, forever.** A live profile is stuck at extractor **v4** while the code is at **v6** — v5 and v6 have never run for it.

It has been papered over **four times** already. Production's version history records `shelf_backfill_reextract`, `github_enrich_repair` ×2, `backfill_linkedin_contact`, `backfill_linkedin_headline` — and `grep -rn` finds none of those strings anywhere in this repo. They were throwaway scripts.

Worse, they called `save_profile()` directly, stamping a fresh `updated_at` while leaving `llm_input_hashes` stale — **so a stale profile looks freshly updated.** That is exactly what made one audit lens misdiagnose this as a silently-failing LLM.

**Fix:** `two_pass.stale_extraction_inputs()` (reuses the existing digest, never reimplements it) plus a committed, dry-run-by-default sweep script with a `--limit` spend cap and a distinct `source_action` — a reviewable replacement for the four ghosts.

**Deliberately no cron.** Cadence and limit are a spend decision, not a mechanical one. Every re-extraction is a paid LLM call.

## 2. The form invented a seniority (rule #29)

A brand-new account — no profile row, `GET /profile` 404s, `page.tsx` passes `preferences={}` — posted `experience_level="mid"` the user never chose. Proven by a test that failed with `expected 'mid' to be ''`.

It is not inert: seniority scoring treats a typed value as authoritative (weight 8, ±8 on every job), and the same fake value went to the LLM judge and into the semantic vector.

The fix already existed **one field over** — `_normalize_work_arrangement`, from the "any" sentinel fix — and had never been copied across. Now mirrored. The route's default also changed from a bare `""` to the stored value, fixing a separate bug: any partial save silently wiped a stored `experience_level`.

## 3. The worker cannot embed, and said nothing

```
Dockerfile        (API)     torch + ".[semantic]"
Dockerfile.worker (worker)  pip install .          ← confirmed in the live build log
```

The worker runs `refresh_catalog`, so the process ingesting the most jobs is the one that cannot embed them — 687 of 9,977 (6.9%).

The failure shape is why it survived: `sentence_transformers` is imported lazily, so the module import **succeeds** and it only fails per job, inside the loop, where a per-job handler logs `embed backfill: job <id> failed`. One missing package produced a storm of identical warnings naming neither cause nor remedy.

**⚠️ This PR does NOT add the extra to the worker image.** That is real image size and build time — your call, not mine. What it does is make the failure **loud**: a preflight that logs one ERROR naming the cause and both ways out (install the extra, or turn `SEMANTIC_ENABLED` off so the gap is intentional rather than silent).

---

## Also fixed, found while fixing the above

| what | why it mattered |
|---|---|
| `reextract_stale_profiles.py` guarded its cap with `if apply and limit and ...` | `--limit 0` — the one invocation its own docstring promises "never makes an LLM call" — was **falsy**, so the cap was skipped entirely and it would re-extract every stale profile unbounded. Caught by the review pass. Pinned by a test I watched fail: `--limit 0 re-extracted 25 profiles` |
| `shelf_audit.py` had `two_pass` in `_WRITER_ROLES` but not `_ROLES` | Every read by the extraction orchestrator — the most shelf-heavy module on the user side — was invisible to `readers()`. It called `llm_input_hashes` read-only-by-"api" while `two_pass.py:220` compares its value to decide whether to skip a paid LLM call. A doc then believed the instrument. Matching count unchanged (49) |
| Completeness meter double-counted `target_job_titles` into two 15% buckets | A CV plus one typed title now reads **55%, not 70%** |
| `excluded_companies` collected and sent on every save | Backend has zero references to it. Removed |
| `test_the_allowlist_does_not_rot` iterated an empty dict | Its body never ran, so it could never fail. Rewritten, with a companion test proving the check fires against a fabricated entry |

## Verification

- 230 backend tests across the blast radius · 73 frontend profile tests
- ruff clean · tsc clean · eslint clean · `[gate] PASS`
- **Every new test was watched failing first.** Where an agent could not honestly claim that, it said so and I re-derived it

## What this does NOT fix

- **Sentry was never checked** in the audit — its MCP needs an OAuth round-trip no subagent could complete. No extraction-error signal has been examined.
- Whether `SEMANTIC_ENABLED` is on for the deployed services — `railway variables` is correctly permission-blocked, so the preflight above will answer it from the logs instead.
- **Coverage bound:** production holds two distinct CVs across three profiles, all driven by one person. Nothing here proves extraction works for a stranger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6DsQH5EUxJc3Vnqz9YHgQ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a safe option to identify and reprocess profiles with outdated extraction results, including dry runs and processing limits.
  * Added a “No preference” option for experience-level selections.
  * AI model selections can now be configured through environment settings.

* **Bug Fixes**
  * Experience-level preferences now preserve omitted values, clear explicit empty selections, and reject unsupported entries.
  * Profile completeness scores no longer double-count selected job titles.
  * Preference autosaves no longer include excluded companies.
  * Semantic processing stops early with a clear setup error when required capabilities are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->