### PR TITLE
fix(pillar1): three data-loss defects — a clear that didn't clear, a half-read CV cached forever, and data rendered nowhere

### DIFF
--- a/backend/src/api/routes/profile.py
+++ b/backend/src/api/routes/profile.py
@@ -823,40 +823,52 @@ def _clear_cv(cv: CVData) -> None:
     cv.llm_input_hashes.pop("cv", None)
 
 
+def _clear_prefixed(cv: CVData, prefix: str) -> None:
+    """Reset every CVData field owned by one input, found BY PREFIX.
+
+    WHY NOT A HAND-WRITTEN LIST. This was 18 named assignments, and it had
+    already fallen two fields behind the dataclass: `linkedin_summary` and
+    `linkedin_headline` were added, wired into the LLM judge and the semantic
+    vector, and never added here. Measured on the shipped code — after
+    "Clear LinkedIn", `linkedin_skills` and `linkedin_positions` were empty
+    while `linkedin_summary` still held the previous person's About paragraph
+    and `linkedin_headline` their tagline, both of which `profile_to_matcher_text`
+    then sent to the judge for every job.
+
+    Same failure as `reset_cv_owned_fields`, same root cause, third occurrence
+    across the file. Ownership is a PREFIX fact, so read it off the dataclass
+    and the list cannot fall behind again.
+
+    Each field goes back to what a fresh `CVData()` has, so the type is handled
+    for free — a `dict` shelf added tomorrow resets to `{}` without anyone
+    remembering it exists.
+    """
+    import copy
+    import dataclasses
+
+    pristine = CVData()
+    for f in dataclasses.fields(CVData):
+        if not f.name.startswith(prefix):
+            continue
+        default = getattr(pristine, f.name)
+        current = getattr(cv, f.name)
+        # In place for collections — same reason as reset_cv_owned_fields: a
+        # rebind orphans any reference taken before the call.
+        if isinstance(current, (list, dict)) and isinstance(default, (list, dict)):
+            current.clear()
+        else:
+            setattr(cv, f.name, copy.deepcopy(default))
+
+
 def _clear_linkedin(cv: CVData) -> None:
-    cv.linkedin_raw_text = ""
-    cv.linkedin_positions = []
-    cv.linkedin_skills = []
-    cv.linkedin_industry = ""
-    cv.linkedin_languages = []
-    cv.linkedin_projects = []
-    cv.linkedin_volunteer = []
-    cv.linkedin_courses = []
-    cv.linkedin_filename = ""
-    cv.linkedin_uploaded_at = ""
-    cv.linkedin_honors = []
-    cv.linkedin_publications = []
-    cv.linkedin_patents = []
-    cv.linkedin_organizations = []
-    cv.linkedin_test_scores = []
-    cv.linkedin_recommendations = []
-    cv.linkedin_interests = []
-    cv.linkedin_contact = {}
+    _clear_prefixed(cv, "linkedin_")
     cv.llm_input_hashes.pop("linkedin", None)
 
 
 def _clear_github(cv: CVData, prefs: UserPreferences) -> None:
-    cv.github_languages = {}
-    cv.github_topics = []
-    cv.github_skills_inferred = []
-    cv.github_frameworks = []
-    cv.github_llm_skills = []
-    cv.github_repos_brief = []
-    cv.github_bio = ""
-    cv.github_profile_readme = ""
-    cv.github_identity = {}
-    cv.github_connected_at = ""
+    _clear_prefixed(cv, "github_")
     cv.llm_input_hashes.pop("github", None)
+    # Lives on UserPreferences, not CVData, so the prefix sweep cannot reach it.
     prefs.github_username = ""  # the handle belongs to this section
 
 

--- a/backend/src/services/profile/two_pass.py
+++ b/backend/src/services/profile/two_pass.py
@@ -17,6 +17,7 @@ imported at module top so tests can monkeypatch them by name.
 from __future__ import annotations
 
 import asyncio
+import copy
 import hashlib
 import json
 import logging
@@ -331,48 +332,42 @@ def reset_cv_owned_fields(cv: CVData) -> None:
     ``github_*`` and ``about_me_inferred_skills``. Wiping those would silently
     delete work, which is the opposite failure.
     """
-    # Scoring-semantic — these reach SearchConfig and change what matches.
-    cv.skills.clear()
-    cv.job_titles.clear()
-    cv.companies.clear()
-    cv.education.clear()
-    cv.certifications.clear()
-    cv.cv_industries.clear()
-    cv.cv_languages.clear()
-    cv.cv_skills_esco.clear()
-    cv.summary = ""
-    cv.experience_text = ""
-
-    # Identity / display — the fields that put the wrong name on a tailored CV.
-    cv.name = ""
-    cv.headline = ""
-    cv.location = ""
-    cv.achievements.clear()
-
-    # Classified FROM the CV, so it belongs to the CV. ``None`` (not "") is the
-    # documented "not classified" sentinel on CVData.
-    cv.career_domain = None
-
-    # EVERY REMAINING CV-OWNED SCALAR, DERIVED — not hand-listed.
+    # EVERY CV-OWNED FIELD, DERIVED FROM THE DATACLASS — scalars AND collections.
     #
-    # This function's own docstring says its field list "must stay in lockstep
-    # with _merge_cv_llm_into". It did not. Three shelves added on 2026-08-10
-    # (cv_experience_level, cv_right_to_work, cv_projects) were merged in but
-    # never cleared here, so uploading a DIFFERENT person's CV left the previous
-    # person's stated seniority and work-authorisation on the profile — the
-    # exact failure this function exists to prevent, and worse than the missing
-    # data because it is confidently wrong.
+    # THIS LIST HAS NOW DRIFTED THREE TIMES, always the same way: a shelf is
+    # added, wired into the merge and into a reader, and nobody adds it here.
+    #   * 2026-08-07  career_domain
+    #   * 2026-08-10  cv_experience_level, cv_right_to_work, cv_projects
+    #   * 2026-08-15  cv_positions  <- found by running the real function
     #
-    # Both halves now read the same source, so the two cannot drift again.
-    for name in _cv_owned_scalars():
-        if getattr(cv, name, None):
-            setattr(cv, name, "")
-    cv.cv_projects.clear()
-
-    # Regenerated wholesale from the merged skill set on every two-pass run, but
-    # cleared so a failed re-extract cannot leave suggestions computed from a
-    # different person's skills.
-    cv.suggested_skills.clear()
+    # The 2026-08-10 round fixed only the SCALAR half by deriving it from
+    # ``dataclasses.fields``; the collections stayed hand-listed, so
+    # ``cv_positions`` (a ``list[dict]``, invisible to a scalar-only loop)
+    # survived every clear and every CV swap. Measured on the shipped code: a
+    # profile cleared through this function kept
+    # ``[{'company': 'ACME Ltd', 'title': 'Senior Engineer', ...}]`` while name,
+    # summary, skills and job_titles were all correctly emptied — and
+    # ``profile_to_matcher_text`` then fed that dated history to the LLM judge
+    # as the candidate's experience.
+    #
+    # Half a derivation is not a derivation. Resetting each field to the value a
+    # FRESH ``CVData()`` has removes the concept of a list entirely: a shelf
+    # added tomorrow is covered the moment it is declared, whatever its type.
+    # Collections are cleared IN PLACE, never rebound. Rebinding is visible
+    # through ``cv`` and looks equivalent, but it orphans any reference taken
+    # before the call — and there is a test pinning that identity
+    # (test_two_pass.py::test_reset_mutates_in_place_so_the_profile_keeps_its_object),
+    # which caught exactly this when the first version of the derivation used a
+    # blanket setattr. Scalars have no identity to preserve, so they are simply
+    # assigned their default.
+    pristine = CVData()
+    for name in _cv_owned_fields():
+        default = getattr(pristine, name)
+        current = getattr(cv, name)
+        if isinstance(current, (list, dict)) and isinstance(default, (list, dict)):
+            current.clear()
+        else:
+            setattr(cv, name, copy.deepcopy(default))
 
     # MUST be cleared with the fields it guards. The hash means "the LLM's
     # reading of this input is already merged into the fields above" — and we
@@ -416,7 +411,12 @@ _SCALAR_ANNOTATIONS = frozenset({"str", "Optional[str]"})
 
 
 def _cv_owned_scalars() -> tuple[str, ...]:
-    """Every plain-string CVData field the CV pass is allowed to fill.
+    """Every plain-string CVData field the CV pass is allowed to FILL.
+
+    Used by ``_merge_cv_llm_into``, which fills empty scalars only — collections
+    are unioned there by their own explicit rules, so this stays scalar-only.
+    For CLEARING, see ``_cv_owned_fields``: a reset must reach every type, and
+    restricting it to scalars is exactly how ``cv_positions`` survived.
 
     Fields belonging to the other passes are excluded by PREFIX rather than by
     name, so a new ``linkedin_*`` or ``github_*`` scalar can never be clobbered
@@ -432,6 +432,42 @@ def _cv_owned_scalars() -> tuple[str, ...]:
             continue
         if str(f.type) in _SCALAR_ANNOTATIONS:
             out.append(f.name)
+    return tuple(out)
+
+
+# Reset needs different handling from "back to the dataclass default", and each
+# entry must say why. Keep this as small as it can possibly be — every name here
+# is a field the derivation cannot protect.
+_RESET_HANDLED_SEPARATELY = frozenset(
+    {
+        # Only the "cv" and "linkedin" keys are dropped, deliberately, further
+        # down. Blanket-clearing it would discard the GitHub and about_me hashes
+        # too, forcing paid re-reads of inputs the user never touched.
+        "llm_input_hashes",
+    }
+)
+
+
+def _cv_owned_fields() -> tuple[str, ...]:
+    """EVERY CVData field the CV owns — scalars, lists and dicts alike.
+
+    The clearing counterpart to ``_cv_owned_scalars``. Same prefix-based
+    exclusions, but NO type filter: a reset that only understands strings leaves
+    every list and dict behind, which is precisely the defect this replaced
+    (``cv_positions`` survived a full profile clear and reached the LLM judge).
+
+    Ownership is decided by PREFIX, so a shelf added tomorrow is covered the day
+    it is declared — the one property that stops this drifting a fourth time.
+    """
+    import dataclasses as _dc
+
+    out: list[str] = []
+    for f in _dc.fields(CVData):
+        if f.name in _NOT_CV_OWNED_SCALARS or f.name in _RESET_HANDLED_SEPARATELY:
+            continue
+        if f.name.startswith(("linkedin_", "github_", "about_me_")):
+            continue
+        out.append(f.name)
     return tuple(out)
 
 

--- a/backend/src/services/profile/two_pass.py
+++ b/backend/src/services/profile/two_pass.py
@@ -188,7 +188,7 @@ def stale_extraction_inputs(profile: UserProfile) -> list[str]:
 
 
 def _pass_produced_data(key: str, res: Any) -> bool:
-    """Did an LLM pass return anything worth caching?
+    """Did an LLM pass return anything worth CACHING?
 
     A pass that returned an empty result from a NON-empty input is almost always
     a soft failure (a rate-limited provider answering with `{}` instead of
@@ -197,6 +197,13 @@ def _pass_produced_data(key: str, res: Any) -> bool:
 
     Shapes differ per input: the CV pass returns a ``CVData``; the others return
     dicts or lists. This reads the fields that actually matter for each.
+
+    Deliberately answers ONLY "is this worth caching" — NOT "is this worth
+    retrying". Those used to be the same question, and that was the bug: a CV
+    pass returning ``skills`` but ZERO ``cv_positions`` passes this check (skills
+    OR titles is enough), so it was graded a cache-worthy success even though a
+    whole section silently vanished. See ``_cv_pass_is_partial`` for the
+    retry-side question this function must NOT be asked.
     """
     if res is None:
         return False
@@ -209,6 +216,37 @@ def _pass_produced_data(key: str, res: Any) -> bool:
         return bool(d.get("skills") or d.get("positions") or d.get("education"))
     # github / about_me return a list[str] of inferred skills.
     return bool(res)
+
+
+def _cv_pass_is_partial(res: Any) -> bool:
+    """Did the CV pass yield SOME data but silently drop ``cv_positions``?
+
+    THE BUG THIS DETECTS (measured on a real profile, Rohith — see the retry
+    block's comment in ``run_two_pass_extraction``): "0 positions via the
+    concurrent API path, 7 in isolation". ``_pass_produced_data`` grades that
+    result a success — it returned skills — so it was cached and the user's
+    dated career history was gone for good, unrecoverable even by re-uploading
+    the identical CV (the input hash still matches).
+
+    A result with NO skills and NO titles is not "partial", it is EMPTY —
+    ``_pass_produced_data`` already sends that case to retry, and double-
+    counting it here would just fire the same retry logic twice for one cause.
+    Partial means the pass clearly ran and read the document (skills or titles
+    landed) but the one section that can silently go missing under load did.
+
+    CV-ONLY on purpose. LinkedIn's own positions are already inside
+    ``_pass_produced_data``'s OR (skills OR positions OR education), so a
+    LinkedIn result missing positions but present on skills is already not
+    "produced data" territory in the same way — its retry trigger is the
+    existing empty-check. GitHub and about_me each return a flat
+    ``list[str]`` with no named subsection that can go missing independently
+    of the whole list, so there is nothing to decide there.
+    """
+    if res is None:
+        return False
+    if not (getattr(res, "skills", None) or getattr(res, "job_titles", None)):
+        return False  # empty, not partial — the existing check already retries this
+    return not getattr(res, "cv_positions", None)
 
 
 def _already_read(cv: CVData, key: str, raw: Any) -> bool:
@@ -613,16 +651,26 @@ async def run_two_pass_extraction(profile: UserProfile) -> UserProfile:
         if prefs.about_me and not _cached["about_me"] else _none(),
     )
 
-    # RETRY A SOFT-EMPTY PASS ONCE, SEQUENTIALLY.
+    # RETRY A SOFT-EMPTY OR SOFT-PARTIAL PASS ONCE, SEQUENTIALLY.
     #
     # The four passes above run concurrently in one gather. On free-tier keys
     # that means up to four simultaneous LLM calls, and the providers
-    # rate-limit: one call gets a valid but EMPTY answer while the same input
-    # extracts fine when it runs alone (measured on Rohith — 0 positions via the
-    # concurrent API path, 7 in isolation). So any pass that RAN but produced no
-    # usable data is retried here one at a time, with no concurrent contention.
-    # Bounded: at most one extra call per empty input, and only when the input
-    # was non-empty and not cached.
+    # rate-limit: one call gets a valid but EMPTY (or, for CV, PARTIAL) answer
+    # while the same input extracts fine when it runs alone (measured on
+    # Rohith — 0 positions via the concurrent API path, 7 in isolation). So any
+    # pass that RAN but produced no usable data is retried here one at a time,
+    # with no concurrent contention.
+    #
+    # PARTIAL is CV-only and stricter than EMPTY: a CV pass that returned
+    # skills or titles PASSES `_pass_produced_data` (worth caching) even when
+    # `cv_positions` came back empty — that shape used to look like a success
+    # and cache forever with the user's dated career history silently gone.
+    # `_cv_pass_is_partial` names that shape; the swap below only takes the
+    # retry's answer when it actually recovered `cv_positions`, so a partial-
+    # but-richer first result is never traded for a thinner "recovery".
+    #
+    # Bounded: at most one extra call per empty-or-partial input, and only
+    # when the input was non-empty and not cached.
     _retryable = [
         ("cv", cv.raw_text, lambda: llm_cv_fields_from_text(cv.raw_text)),
         ("linkedin", cv.linkedin_raw_text, lambda: llm_linkedin_fields(cv.linkedin_raw_text)),
@@ -634,12 +682,35 @@ async def run_two_pass_extraction(profile: UserProfile) -> UserProfile:
     _results = {"cv": _llm_cv_res, "linkedin": _llm_li_res,
                 "github": _llm_gh_res, "about_me": _llm_pr_res}
     for _k, _raw, _call in _retryable:
-        if _raw and not _cached[_k] and not _pass_produced_data(_k, _results[_k]):
-            retried = await _safe(_call(), f"{_k} (retry)")
-            if _pass_produced_data(_k, retried):
-                logger.info("two_pass: %s pass was empty under load — sequential "
-                            "retry recovered it", _k)
+        if not _raw or _cached[_k]:
+            continue
+        _was_empty = not _pass_produced_data(_k, _results[_k])
+        # CV-only: a result that PASSED the caching check (skills or titles
+        # landed) can still be missing cv_positions — the shape that caused
+        # the Rohith bug (see the block comment above). Only CV has a section
+        # that can go missing independently of the rest of the pass; see
+        # `_cv_pass_is_partial`'s docstring for why the others don't.
+        _was_partial = _k == "cv" and not _was_empty and _cv_pass_is_partial(_results[_k])
+        if not (_was_empty or _was_partial):
+            continue
+        retried = await _safe(_call(), f"{_k} (retry)")
+        if _was_partial:
+            # A blanket replace here could trade a rich first result (more
+            # skills, a fuller summary) for a thinner retry that STILL has no
+            # positions — "repairing" nothing while throwing away what the
+            # first call got right. Only swap in when the retry actually
+            # recovered the missing piece.
+            if retried is not None and getattr(retried, "cv_positions", None):
+                logger.info("two_pass: cv pass had skills but lost cv_positions "
+                            "under load — sequential retry recovered them")
                 _results[_k] = retried
+            else:
+                logger.info("two_pass: cv retry did not recover cv_positions — "
+                            "keeping the original (still-useful) result")
+        elif _pass_produced_data(_k, retried):
+            logger.info("two_pass: %s pass was empty under load — sequential "
+                        "retry recovered it", _k)
+            _results[_k] = retried
     _llm_cv_res, _llm_li_res = _results["cv"], _results["linkedin"]
     _llm_gh_res, _llm_pr_res = _results["github"], _results["about_me"]
 

--- a/backend/tests/test_clear_leaves_nothing_behind.py
+++ b/backend/tests/test_clear_leaves_nothing_behind.py
@@ -1,0 +1,223 @@
+"""Clearing an input must leave NOTHING of it behind.
+
+THE DEFECT, reproduced on shipped code 2026-08-15 (third occurrence).
+
+Every "what this input owns" list in this project has been hand-maintained, and
+every one of them has fallen behind the dataclass:
+
+    2026-08-07  career_domain
+    2026-08-10  cv_experience_level, cv_right_to_work, cv_projects
+    2026-08-15  cv_positions, linkedin_summary, linkedin_headline
+
+The 2026-08-10 round fixed only the SCALAR half by deriving it from
+``dataclasses.fields``. Collections stayed hand-listed, so ``cv_positions`` — a
+``list[dict]``, invisible to a scalar-only loop — survived a full profile clear
+AND every CV re-upload. ``linkedin_summary`` and ``linkedin_headline`` were
+added later, wired into the LLM judge and the semantic vector, and never added
+to ``_clear_linkedin`` at all.
+
+Measured before the fix: after clearing everything, exactly three fields still
+held data, and ``profile_to_matcher_text`` emitted the previous person's dated
+work history and About paragraph into the judge prompt for every job.
+
+WHY THIS TEST IS SHAPED LIKE THIS. The old guard listed ten field names by hand
+and asserted each was empty. A test that names fields one at a time cannot catch
+a field nobody remembered — it has the identical blind spot as the code it
+guards, which is exactly how this recurred three times. So these tests never
+name a field to CLEAR. They fill every field on the dataclass programmatically,
+run the real clear, and demand the leftovers match a short, individually
+justified allowlist.
+"""
+from __future__ import annotations
+
+import dataclasses
+from typing import Any
+
+from src.services.profile.models import CVData, UserPreferences
+
+
+def _fill_every_field(cv: CVData) -> None:
+    """Put a non-empty value in EVERY field, whatever its type.
+
+    Derived from the dataclass, so a shelf added tomorrow is filled — and
+    therefore checked — without anyone editing this file.
+    """
+    for f in dataclasses.fields(CVData):
+        current = getattr(cv, f.name)
+        value: Any
+        if isinstance(current, str):
+            value = f"filled-{f.name}"
+        elif isinstance(current, bool):
+            value = True
+        elif isinstance(current, (int, float)):
+            value = 1
+        elif isinstance(current, dict):
+            value = {"filled": f.name}
+        elif isinstance(current, list):
+            value = [{"filled": f.name}] if "positions" in f.name or "projects" in f.name else [f"filled-{f.name}"]
+        elif current is None:
+            value = f"filled-{f.name}"
+        else:
+            continue
+        setattr(cv, f.name, value)
+
+
+def _non_empty(cv: CVData) -> set[str]:
+    return {f.name for f in dataclasses.fields(CVData) if getattr(cv, f.name)}
+
+
+class TestClearingTheCV:
+    """``reset_cv_owned_fields`` runs on the Clear button AND on every CV
+    re-upload, so a survivor here becomes another person's data presented as
+    yours."""
+
+    # Each entry is a field that SHOULD survive, with the reason. Anything not
+    # listed must be gone. Keep this list tiny and justified.
+    ALLOWED = {
+        "raw_text": "the caller overwrites it with the new CV immediately after",
+        "cv_filename": "upload receipt — the route stamps the NEW one straight "
+                       "after this call. The Clear button uses _clear_cv, which "
+                       "does empty it; that path is covered below.",
+        "cv_uploaded_at": "same upload receipt",
+        "llm_input_hashes": "only the cv/linkedin keys are dropped; github and "
+                            "about_me hashes must survive or we re-bill for "
+                            "inputs the user never touched",
+    }
+
+    def test_nothing_cv_owned_survives(self) -> None:
+        from src.services.profile.two_pass import reset_cv_owned_fields
+
+        cv = CVData()
+        _fill_every_field(cv)
+        reset_cv_owned_fields(cv)
+
+        survivors = _non_empty(cv)
+        # Everything belonging to ANOTHER input must survive — a CV swap must
+        # never silently delete the LinkedIn or GitHub work.
+        other_inputs = {
+            n for n in survivors
+            if n.startswith(("linkedin_", "github_", "about_me_"))
+        }
+        unexpected = survivors - other_inputs - set(self.ALLOWED)
+        assert not unexpected, (
+            f"these CV-owned fields survived the reset: {sorted(unexpected)}. "
+            "A new CV will now inherit them from the previous one — and "
+            "cv_positions in particular reaches the LLM judge as the "
+            "candidate's work history."
+        )
+
+    def test_the_other_inputs_are_not_collateral_damage(self) -> None:
+        """The control. A reset that wiped everything would pass the test above
+        while silently destroying the user's LinkedIn and GitHub data."""
+        from src.services.profile.two_pass import reset_cv_owned_fields
+
+        cv = CVData()
+        _fill_every_field(cv)
+        reset_cv_owned_fields(cv)
+
+        for prefix in ("linkedin_", "github_", "about_me_"):
+            kept = [
+                f.name for f in dataclasses.fields(CVData)
+                if f.name.startswith(prefix) and getattr(cv, f.name)
+            ]
+            assert kept, (
+                f"a CV reset destroyed every {prefix}* field. Those come from a "
+                "different upload the user did not touch; wiping them is silent "
+                "data loss."
+            )
+
+    def test_the_github_and_about_me_hashes_survive(self) -> None:
+        """Dropping them would force a paid re-read of inputs that did not
+        change."""
+        from src.services.profile.two_pass import reset_cv_owned_fields
+
+        cv = CVData(llm_input_hashes={"cv": "a", "linkedin": "b", "github": "c", "about_me": "d"})
+        reset_cv_owned_fields(cv)
+        assert sorted(cv.llm_input_hashes) == ["about_me", "github"]
+
+
+class TestClearingLinkedIn:
+    def test_nothing_linkedin_survives(self) -> None:
+        from src.api.routes.profile import _clear_linkedin
+
+        cv = CVData()
+        _fill_every_field(cv)
+        _clear_linkedin(cv)
+
+        survivors = [
+            f.name for f in dataclasses.fields(CVData)
+            if f.name.startswith("linkedin_") and getattr(cv, f.name)
+        ]
+        assert not survivors, (
+            f"these LinkedIn fields survived Clear LinkedIn: {survivors}. "
+            "linkedin_summary and linkedin_headline both reach the LLM judge, "
+            "so the previous person's words keep scoring the new person's jobs."
+        )
+
+    def test_it_does_not_touch_the_cv(self) -> None:
+        """The control — a sweep that was too greedy would delete the CV."""
+        from src.api.routes.profile import _clear_linkedin
+
+        cv = CVData()
+        _fill_every_field(cv)
+        # Realistic keys — the blanket filler puts junk in here, which would
+        # make the assertion below pass or fail for the wrong reason.
+        cv.llm_input_hashes = {"cv": "a", "linkedin": "b", "github": "c"}
+        _clear_linkedin(cv)
+        assert cv.skills and cv.name and cv.raw_text
+        # A LinkedIn clear must not force the CV to be re-extracted.
+        assert "cv" in cv.llm_input_hashes
+        assert "linkedin" not in cv.llm_input_hashes
+
+
+class TestClearingGitHub:
+    def test_nothing_github_survives(self) -> None:
+        from src.api.routes.profile import _clear_github
+
+        cv = CVData()
+        _fill_every_field(cv)
+        prefs = UserPreferences(github_username="someone")
+        _clear_github(cv, prefs)
+
+        survivors = [
+            f.name for f in dataclasses.fields(CVData)
+            if f.name.startswith("github_") and getattr(cv, f.name)
+        ]
+        assert not survivors, f"these GitHub fields survived: {survivors}"
+        assert prefs.github_username == "", (
+            "the handle lives on UserPreferences, outside the prefix sweep, and "
+            "must be cleared explicitly"
+        )
+
+
+class TestClearingEverything:
+    """What the owner actually clicks: 'Clear profile'. It runs all three."""
+
+    def test_a_full_clear_leaves_only_the_raw_inputs(self) -> None:
+        # The REAL button: profile.py's section="all" calls these three.
+        # Deliberately NOT reset_cv_owned_fields — that is the re-upload path,
+        # and using it here would quietly exempt the upload receipts from a test
+        # whose whole purpose is that nothing gets quietly exempted.
+        from src.api.routes.profile import _clear_cv, _clear_github, _clear_linkedin
+
+        cv = CVData()
+        _fill_every_field(cv)
+        prefs = UserPreferences(github_username="someone")
+
+        _clear_cv(cv)
+        _clear_linkedin(cv)
+        _clear_github(cv, prefs)
+
+        survivors = _non_empty(cv)
+        allowed = {
+            "llm_input_hashes",  # the about_me hash only, by this point
+            "about_me_inferred_skills",  # owned by preferences, cleared with them
+        }
+        unexpected = survivors - allowed
+        assert not unexpected, (
+            f"'Clear profile' left these behind: {sorted(unexpected)}. The "
+            "button exists so the owner can upload a CV and see exactly what "
+            "came out; anything surviving makes that experiment a lie, and "
+            "these fields are invisible on a cleared screen while still "
+            "reaching the scorer."
+        )

--- a/backend/tests/test_llm_input_cache.py
+++ b/backend/tests/test_llm_input_cache.py
@@ -51,7 +51,17 @@ def _run(profile: UserProfile, counter: _Counter, *, cv_fails: bool = False) -> 
         counter.cv += 1
         if cv_fails:
             raise RuntimeError("provider down")
-        return CVData(skills=["Epic"], job_titles=["Registered Nurse"])
+        # A real successful CV pass reads a dated role off the document too —
+        # this CV literally has one ("Staff Nurse, Royal London Hospital").
+        # Leaving cv_positions off this fixture would make every "successful"
+        # call look PARTIAL (skills/titles but no positions) to the new
+        # partial-CV retry, silently doubling every call count these cache
+        # tests assert on even though caching itself never changed.
+        return CVData(
+            skills=["Epic"],
+            job_titles=["Registered Nurse"],
+            cv_positions=[{"company": "Royal London Hospital", "title": "Staff Nurse"}],
+        )
 
     async def fake_li(text, *a, **kw):
         counter.linkedin += 1

--- a/backend/tests/test_partial_cv_pass_is_retried.py
+++ b/backend/tests/test_partial_cv_pass_is_retried.py
@@ -1,0 +1,103 @@
+"""A CV pass that returns skills but loses cv_positions must be RETRIED, not
+cached as a success.
+
+WHY THIS EXISTS. Four LLM passes run concurrently in one `asyncio.gather` in
+`run_two_pass_extraction`. Providers rate-limit, so one call can come back
+VALID but with a section silently missing — measured on a real profile: "0
+positions via the concurrent API path, 7 in isolation". The retry block exists
+for exactly that case, but its old trigger was `_pass_produced_data`, which
+answers a DIFFERENT question ("is this worth caching?", true on skills OR
+titles alone). A CV pass returning skills with zero `cv_positions` passed that
+check, so it was graded a success: no retry, and the input hash was cached —
+freezing the user's dated career history out of the profile with no recovery
+path (re-uploading the identical CV hits the same cache hash).
+
+This file pins the new, separate question: "is this CV result PARTIAL?" —
+`two_pass._cv_pass_is_partial`. It must fire on partial, stay silent on a
+complete pass (the control — without it, "always retry" would pass these
+tests too) and on a fully empty pass (that is a different, already-handled
+case, not partial), and never apply to the other three inputs, whose result
+shapes don't have a subsection that can go missing independently of the rest.
+"""
+
+from __future__ import annotations
+
+from src.services.profile import two_pass as tp
+from src.services.profile.models import CVData
+
+
+def test_skills_without_positions_is_partial():
+    """THE ROHITH SHAPE: skills/titles landed, cv_positions did not."""
+    res = CVData(skills=["Python"], job_titles=["Engineer"])
+    assert tp._cv_pass_is_partial(res) is True
+
+
+def test_titles_without_positions_is_also_partial():
+    """Either skills OR titles is enough to prove the pass ran and read the
+    document — cv_positions can still be the piece that silently dropped."""
+    res = CVData(job_titles=["Engineer"])
+    assert tp._cv_pass_is_partial(res) is True
+
+
+def test_a_complete_pass_is_not_partial():
+    """THE CONTROL. A CV result carrying skills AND cv_positions is a normal
+    success — without this test, a predicate that always returns True (i.e.
+    "always retry") would pass every other test in this file too."""
+    res = CVData(
+        skills=["Python"],
+        job_titles=["Engineer"],
+        cv_positions=[{"company": "Acme", "title": "Engineer"}],
+    )
+    assert tp._cv_pass_is_partial(res) is False
+
+
+def test_a_fully_empty_pass_is_not_double_counted_as_partial():
+    """An empty CVData() has no skills and no titles either — that is the
+    EMPTY case, already caught by `_pass_produced_data` in the retry loop.
+    Calling it "partial" too would just fire the same retry twice for one
+    cause, and (per the retry loop's swap rule) risks treating a genuinely
+    position-less CV as if it had recoverable data."""
+    assert tp._cv_pass_is_partial(CVData()) is False
+
+
+def test_none_result_is_not_partial():
+    """A pass that raised (`_safe` returns None) is EMPTY, not partial — the
+    existing empty-check already retries it; this predicate must not also
+    claim it."""
+    assert tp._cv_pass_is_partial(None) is False
+
+
+def test_non_cv_keys_are_never_partial():
+    """LinkedIn's own positions are already folded into `_pass_produced_data`
+    (skills OR positions OR education); GitHub/about_me each return a flat
+    list[str] with no subsection that can go missing on its own. Only the CV
+    shape is decidable, so the retry loop must never ask this question for
+    the other three keys — pinned here by construction: the predicate takes
+    no `key` argument at all, so there is nothing for a caller to get wrong
+    for "linkedin"/"github"/"about_me" other than simply not calling it. This
+    test documents that contract so a future edit adding a `key` parameter
+    has to consciously decide the other three stay excluded.
+    """
+    # A dict/list shaped like a LinkedIn/GitHub/about_me result has no
+    # `cv_positions` attribute at all — `_cv_pass_is_partial` must treat that
+    # as "not partial" rather than raising, which is exactly what lets the
+    # retry loop restrict the partial check to the "cv" key without this
+    # function needing to know which key it was called for.
+    assert tp._cv_pass_is_partial({"skills": ["Triage"], "positions": []}) is False
+    assert tp._cv_pass_is_partial(["Python", "Docker"]) is False
+
+
+def test_never_raises_on_an_odd_shape():
+    """This runs in the upload hot path — a crash here must never cost a user
+    their upload. Feed it shapes an LLM adapter could plausibly hand back on
+    a malformed response, and require a plain bool every time."""
+    for odd in (
+        None,
+        {},
+        [],
+        "",
+        0,
+        object(),
+        {"skills": None, "job_titles": None},
+    ):
+        assert tp._cv_pass_is_partial(odd) in (True, False)

--- a/frontend/src/app/profile/__tests__/extracted-without-cv.test.tsx
+++ b/frontend/src/app/profile/__tests__/extracted-without-cv.test.tsx
@@ -1,0 +1,168 @@
+/**
+ * Defect: LinkedIn/GitHub data is extracted, stored, and sent to the browser
+ * -- then rendered by nothing, whenever the user connects LinkedIn or GitHub
+ * BEFORE uploading a CV.
+ *
+ * Root cause: the "What we extracted" block in page.tsx was gated on
+ * `profile?.cv_detail`, which the backend only ever fills in when the CV's
+ * raw_text is non-empty (`_build_profile_response` in
+ * backend/src/api/routes/profile.py). LinkedIn and GitHub data arrive on the
+ * SAME response independently of the CV, so a LinkedIn-only or GitHub-only
+ * profile was carrying real content that the page threw away — the section
+ * just vanished, which reads as "the enrichment failed" even though it
+ * worked. The page's own copy calls LinkedIn/GitHub "Optional" (rule #29);
+ * the render must not silently require the one input it never asked for.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import ProfilePage from "../page";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock("@/lib/api", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/api")>()),
+  getProfile: vi.fn(),
+}));
+
+const BASE_SUMMARY = {
+  is_complete: false,
+  job_titles: [],
+  skills_count: 0,
+  cv_length: 0,
+  has_linkedin: true,
+  has_github: true,
+  education: [],
+  experience_level: "",
+  cv_filename: "",
+  cv_uploaded_at: "",
+  linkedin_filename: "linkedin-export.pdf",
+  linkedin_uploaded_at: "2026-08-10",
+  github_username: "ranjith-dev",
+  github_connected_at: "2026-08-10",
+  github_repo_count: 3,
+};
+
+// A LinkedIn export uploaded and a GitHub handle connected, but NO CV — the
+// exact order the defect report describes. cv_detail is null exactly like
+// the backend leaves it when cv.raw_text is empty.
+const NO_CV_PROFILE = {
+  summary: BASE_SUMMARY,
+  preferences: {},
+  ai_suggestions: [],
+  cv_detail: null,
+  skill_tiers: {},
+  skill_esco: {},
+  skill_provenance: {},
+  skills_by_source: {},
+  linkedin_subsections: {
+    positions: [
+      {
+        title: "Senior Backend Engineer",
+        company: "Acme Robotics",
+        start: "2022",
+        end: "Present",
+        description: "Owns the payments platform.",
+      },
+    ],
+  },
+  github_temporal: {
+    languages: { Python: 42000, TypeScript: 18000 },
+  },
+  github_detail: {
+    repos: [
+      {
+        name: "job-matcher",
+        language: "Python",
+        description: "A job matching engine",
+        topics: ["fastapi"],
+        stars: 12,
+        forks: 2,
+      },
+    ],
+  },
+};
+
+// Control case: everything NO_CV_PROFILE has, plus a real CV — the normal
+// case that must keep rendering exactly as before the gate was split.
+const WITH_CV_PROFILE = {
+  ...NO_CV_PROFILE,
+  summary: {
+    ...BASE_SUMMARY,
+    cv_length: 800,
+    cv_filename: "cv.pdf",
+    cv_uploaded_at: "2026-08-01",
+  },
+  cv_detail: {
+    achievements: [],
+    certifications: [],
+    companies: [],
+    cv_experience_level: "",
+    cv_positions: [],
+    cv_projects: [],
+    cv_right_to_work: "",
+    education: [],
+    experience_text: "",
+    extraction_score: {},
+    headline: "",
+    highlights: [],
+    job_titles: ["Backend Engineer"],
+    location: "",
+    name: "Ranjith",
+    raw_text: "Ranjith's CV text",
+    skills: ["Python"],
+    summary_text: "Backend engineer with 5 years experience.",
+  },
+};
+
+describe("ProfilePage — LinkedIn/GitHub render without a CV (Unit B)", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it("shows LinkedIn and GitHub content on screen when there is no CV", async () => {
+    const api = await import("@/lib/api");
+    vi.mocked(api.getProfile).mockResolvedValueOnce(
+      NO_CV_PROFILE as unknown as Awaited<ReturnType<typeof api.getProfile>>
+    );
+
+    render(<ProfilePage />);
+
+    // LinkedIn work history — proves the LinkedIn subsections rendered.
+    await waitFor(() => {
+      expect(screen.getByText("Senior Backend Engineer")).toBeInTheDocument();
+    });
+    expect(screen.getByText(/Acme Robotics/)).toBeInTheDocument();
+
+    // GitHub repo — proves the GitHub detail rendered too, in the same pass.
+    expect(screen.getByText("job-matcher")).toBeInTheDocument();
+
+    // The CV-only sections must stay silent (rule #29) -- there is no CV
+    // data to show -- but that must not have hidden the LinkedIn/GitHub
+    // sections above. "Skills Extracted" is CVViewer's CV-skills heading,
+    // only rendered when cv.skills is non-empty (unlike "professional
+    // summary", which also appears as PreferencesForm's about-me hint and
+    // would give a false positive here).
+    expect(screen.queryByText(/skills extracted/i)).not.toBeInTheDocument();
+  });
+
+  it("still renders everything (CV + LinkedIn + GitHub) when a CV is present", async () => {
+    const api = await import("@/lib/api");
+    vi.mocked(api.getProfile).mockResolvedValueOnce(
+      WITH_CV_PROFILE as unknown as Awaited<ReturnType<typeof api.getProfile>>
+    );
+
+    render(<ProfilePage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Ranjith")).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText("Backend engineer with 5 years experience.")
+    ).toBeInTheDocument();
+    expect(screen.getByText("Senior Backend Engineer")).toBeInTheDocument();
+    expect(screen.getByText("job-matcher")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -22,7 +22,7 @@ import {
   type ClearSection,
 } from "@/lib/api";
 import { ApiError, apiErrorMessage } from "@/lib/api-error";
-import type { ProfileResponse, PreferencesRequest } from "@/lib/types";
+import type { CVDetail, ProfileResponse, PreferencesRequest } from "@/lib/types";
 
 /** Human names for the clear toasts — "cv" is not what a person calls it. */
 const SECTION_LABEL: Record<ClearSection, string> = {
@@ -32,6 +32,67 @@ const SECTION_LABEL: Record<ClearSection, string> = {
   preferences: "Preferences",
   all: "Profile",
 };
+
+// ── "What we extracted" gate ────────────────────────────────
+//
+// cv_detail is ONLY populated when the CV's raw_text is non-empty
+// (_build_profile_response in backend/src/api/routes/profile.py). LinkedIn
+// and GitHub data arrive on the SAME response independently of the CV, so
+// gating the whole CVViewer on `cv_detail` alone hid real, paid-for,
+// already-fetched LinkedIn/GitHub content whenever a user connected either
+// of those BEFORE uploading a CV — the section just vanished, reading as a
+// failed enrichment. The page calls LinkedIn/GitHub "Optional" (rule #29);
+// the render must not silently require the one input it never demanded.
+//
+// CVViewer's own CV-only sections already stay silent on an empty CVDetail
+// (every one of them checks its own field), so passing this stand-in when
+// there is no CV is safe — it renders nothing extra, it just stops the
+// LinkedIn/GitHub sections from being hidden along with it.
+const EMPTY_CV_DETAIL: CVDetail = {
+  achievements: [],
+  certifications: [],
+  companies: [],
+  cv_experience_level: "",
+  cv_positions: [],
+  cv_projects: [],
+  cv_right_to_work: "",
+  education: [],
+  experience_text: "",
+  extraction_score: {},
+  headline: "",
+  highlights: [],
+  job_titles: [],
+  location: "",
+  name: "",
+  raw_text: "",
+  skills: [],
+  summary_text: "",
+};
+
+function hasLinkedinShelf(
+  sections: ProfileResponse["linkedin_subsections"] | undefined
+): boolean {
+  if (!sections) return false;
+  return Object.values(sections).some(
+    (rows) => Array.isArray(rows) && rows.length > 0
+  );
+}
+
+function hasGithubShelf(
+  temporal: ProfileResponse["github_temporal"] | undefined,
+  detail: ProfileResponse["github_detail"] | undefined
+): boolean {
+  const temporalHasContent = Object.values(temporal ?? {}).some(
+    (bucket) => bucket && typeof bucket === "object" && Object.keys(bucket).length > 0
+  );
+  if (temporalHasContent) return true;
+  return Object.values(detail ?? {}).some((value) => {
+    if (Array.isArray(value)) return value.length > 0;
+    if (typeof value === "string") return value.length > 0;
+    if (value && typeof value === "object") return Object.keys(value).length > 0;
+    return false;
+  });
+}
 
 // ── Completeness calculation ────────────────────────────────
 
@@ -389,14 +450,19 @@ export default function ProfilePage() {
                 The API already returns name/summary/skills/dated work
                 history/education/certs/LinkedIn detail/GitHub detail — this
                 was the only place none of it was ever rendered. Each
-                sub-section inside CVViewer renders only when it has data. */}
-            {profile?.cv_detail && (
+                sub-section inside CVViewer renders only when it has data.
+                Gated on ANY of the three shelves having content, not just
+                cv_detail — a LinkedIn or GitHub upload with no CV yet must
+                still show what it found (see EMPTY_CV_DETAIL above). */}
+            {(profile?.cv_detail ||
+              hasLinkedinShelf(profile?.linkedin_subsections) ||
+              hasGithubShelf(profile?.github_temporal, profile?.github_detail)) && (
               <CVViewer
-                cv={profile.cv_detail}
-                skillProvenance={profile.skill_provenance}
-                linkedinSubsections={profile.linkedin_subsections}
-                githubTemporal={profile.github_temporal}
-                githubDetail={profile.github_detail}
+                cv={profile?.cv_detail ?? EMPTY_CV_DETAIL}
+                skillProvenance={profile?.skill_provenance}
+                linkedinSubsections={profile?.linkedin_subsections}
+                githubTemporal={profile?.github_temporal}
+                githubDetail={profile?.github_detail}
               />
             )}
 


### PR DESCRIPTION
Three defects, each found by the layer-by-layer audit and each reproduced by running the real code before any fix.

## 1. "Clear profile" left three fields behind — and they reached the LLM judge

Third occurrence of one root cause: a hand-maintained "what this input owns" list falling behind the dataclass.

```
after the full Clear-profile sequence, these survived:
  cv_positions       your dated work history
  linkedin_summary   your LinkedIn About paragraph
  linkedin_headline  your tagline
```

All three were then emitted into the judge prompt for every job scored. The same gap fires on every **CV re-upload**, so a new CV could inherit the previous person's career history.

The 2026-08-10 round fixed only the *scalar* half by deriving it from `dataclasses.fields`; collections stayed hand-listed, and `cv_positions` is a `list[dict]`. Half a derivation is not a derivation. `linkedin_summary`/`linkedin_headline` were mine — reader wired, cleaner forgotten.

Now derived by prefix off the dataclass, so a shelf added tomorrow is covered the day it's declared. Collections clear **in place** (an existing test caught the first version rebinding them).

## 2. A CV pass that lost the work history was cached forever

The retry block exists for this exact failure — its comment measures *"0 positions via the concurrent API path, 7 in isolation"* — but its trigger asked the **caching** predicate, which returns True on `skills or job_titles`. So a pass with zero positions was graded a success: no retry, hash cached. Because the hash is keyed on the input text, **re-uploading the identical CV skipped the paid pass entirely** and the history was unrecoverable.

Split into two predicates: caching unchanged, a new CV-only partial check drives retrying.

**On the four cost-guard tests** (this change was reverted once for breaking them): the cause was the *fixture*, not the guard. The fake CV returned no positions even though its own text says "Staff Nurse, Royal London Hospital". The fixture now returns that position. **No assertion was touched** — the diff is a return value and a comment.

## 3. LinkedIn and GitHub data was fetched, paid for, sent — and rendered by nothing

The extracted-profile section was gated on `profile?.cv_detail`, which only populates when a CV exists. Connect GitHub or upload LinkedIn **before** a CV and everything was extracted, serialised, sent over the wire, then hidden — reading as a failed enrichment.

The page calls both inputs "Optional". Rule #29: the render must agree. Each section now asks for its own data.

## Verification

Every fix watched failing first:

- **#1** — new test fails against `origin/main` naming exactly `['cv_positions', 'linkedin_headline', 'linkedin_summary']`
- **#2** — patching the predicate to `return True` fails 4 of 7 new tests *including the control*
- **#3** — reverting `page.tsx` fails the new test while its control still passes

105 backend tests · 75 frontend profile tests · ruff clean · tsc clean · eslint clean · gate PASS

## Note on how #1's test is shaped

The old guard named ten fields by hand — the same blind spot as the code it guarded, which is how this recurred three times. The new one never names a field to clear: it fills every field on the dataclass programmatically, runs the real clear, and demands the leftovers match a short justified allowlist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6DsQH5EUxJc3Vnqz9YHgQ