### PR TITLE
fix(harness): chain_check reads heredoc writers — 18 live wires on #348 were reported dead

### DIFF
--- a/scripts/chain_check.py
+++ b/scripts/chain_check.py
@@ -91,6 +91,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+from collections.abc import Iterator
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -233,6 +234,24 @@ _ANY_OUTPUT_KEY = re.compile(
     re.MULTILINE,
 )
 _MENTIONS_OUTPUT = re.compile(r"\$\{?GITHUB_OUTPUT")
+# A shell heredoc whose opening line ALSO redirects to $GITHUB_OUTPUT:
+#     python - <<'PY' >> "$GITHUB_OUTPUT"
+#     cat <<EOF >> "$GITHUB_OUTPUT"
+# The `\s` before `<<` is load-bearing. It is what separates a real heredoc from
+# the GHA multiline-output form `echo "body<<$d" >> "$GITHUB_OUTPUT"`, where the
+# `<<` is glued to the key and the following lines are a VALUE, not a script.
+_HEREDOC_OPEN = re.compile(
+    r"""^(?P<pre>.*?)\s<<-?\s*(?P<q>['"]?)(?P<delim>[A-Za-z_][A-Za-z0-9_]*)(?P=q)"""
+)
+_OUTPUT_REDIRECT = re.compile(r""">>\s*["']?\$\{?GITHUB_OUTPUT""")
+# Inside a python heredoc, a write is a print — never an `echo`. A checker that
+# knows only echo/printf reads such a step as writing NOTHING, and then reports
+# every live wire out of it as broken (see _iter_output_writes).
+_PY_OUTPUT_KEY = re.compile(
+    r"""^\s*(?:print|sys\.stdout\.write)\s*\(\s*[rbfu]*(?P<q>["'])(?P<key>[A-Za-z_][A-Za-z0-9_-]*)="""
+)
+# Inside a plain `cat <<EOF >> "$GITHUB_OUTPUT"` body the lines ARE the pairs.
+_PLAIN_OUTPUT_KEY = re.compile(r"""^\s*(?P<key>[A-Za-z_][A-Za-z0-9_-]*)=""")
 # A whole value that is one GHA expression comparison -> renders exactly true/false.
 _BOOL_EXPR = re.compile(r"^\$\{\{\s*[^}]*?(?:==|!=|>|<|>=|<=)[^}]*?\}\}$")
 
@@ -242,15 +261,64 @@ _GH_WORKFLOW_RUN = re.compile(r"gh\s+workflow\s+run\s+(?P<target>[A-Za-z0-9_.\-/
 _DISPATCH_INPUT = re.compile(r"-f\s+(?P<key>[A-Za-z0-9_-]+)=")
 
 
+def _iter_output_writes(run: str) -> Iterator[tuple[int, str, str]]:
+    """Yield (1-indexed line, key, op) for every $GITHUB_OUTPUT write in `run`.
+
+    `op` is "=" when the value sits on that same line, and "<<" when it does not
+    (a heredoc body), which is exactly the distinction _parse_writes needs to
+    decide whether it may enumerate the literal values.
+
+    There are TWO writer shapes in this repo and the checker must read both:
+
+        echo "key=value" >> "$GITHUB_OUTPUT"        <- flat
+        python - <<'PY' >> "$GITHUB_OUTPUT"         <- heredoc body
+        print(f"key={value}")
+        PY
+
+    A shape the checker cannot read is indistinguishable from a step that writes
+    nothing, so every live wire out of that step gets reported as severed. That
+    is a false negative in the INSTRUMENT, and it is the same failure this whole
+    script exists to catch: an instrument must count the way its consumer does.
+
+    Heredoc bodies are only read when the OPENING line also redirects to
+    $GITHUB_OUTPUT, so a heredoc writing a temp file is never mistaken for one
+    writing outputs.
+    """
+    if not run:
+        return
+    delim: str | None = None
+    body_is_python = False
+    for n, line in enumerate(run.splitlines(), start=1):
+        if delim is not None:
+            if line.strip() == delim:
+                delim = None
+                continue
+            body = _PY_OUTPUT_KEY if body_is_python else _PLAIN_OUTPUT_KEY
+            hit = body.match(line)
+            if hit is not None:
+                # The value is an f-string / shell interpolation. We will not
+                # pretend to evaluate it, so it is unknowable — the same
+                # contract the `key<<EOF` multiline form already has.
+                yield n, hit.group("key"), "<<"
+            continue
+        opener = _HEREDOC_OPEN.match(line)
+        if opener is not None and _OUTPUT_REDIRECT.search(line):
+            delim = opener.group("delim")
+            body_is_python = "python" in opener.group("pre")
+            continue
+        for m in _ANY_OUTPUT_KEY.finditer(line):
+            yield n, m.group("key"), m.group("op")
+
+
 def _parse_writes(run: str) -> dict[str, set[str] | None]:
     """Which output keys can this run: block set, and to which literal values."""
     if not run or not _MENTIONS_OUTPUT.search(run):
         return {}
     writes: dict[str, set[str] | None] = {}
-    for m in _ANY_OUTPUT_KEY.finditer(run):
-        writes.setdefault(m.group("key"), set())
-        if m.group("op") == "<<":  # heredoc body — value is unknowable here
-            writes[m.group("key")] = None
+    for _, key, op in _iter_output_writes(run):
+        writes.setdefault(key, set())
+        if op == "<<":  # heredoc body — value is unknowable here
+            writes[key] = None
     for m in _ECHO_TO_OUTPUT.finditer(run):
         key, raw = m.group("key"), m.group("val").strip().strip('"').strip("'")
         current = writes.get(key, set())
@@ -281,10 +349,9 @@ def _write_depth(run: str, key: str) -> int:
     """
     if not run or not key:
         return 0
-    for n, line in enumerate(run.splitlines(), start=1):
-        for m in _ANY_OUTPUT_KEY.finditer(line):
-            if m.group("key") == key:
-                return n
+    for n, found, _ in _iter_output_writes(run):
+        if found == key:
+            return n
     return 0
 
 
@@ -892,11 +959,49 @@ def main(argv: list[str] | None = None) -> int:
 class Drill:
     name: str
     mechanism: str
-    target: str  # workflow file to mutate
+    target: str  # workflow file to mutate, or to CREATE when `create` is set
     before: str
     after: str
     expect_check: str
     expect_in_message: str
+    # A synthetic workflow written into the copy instead of mutating a real one.
+    # Needed for shapes no workflow in THIS repo happens to use yet: without it
+    # the checker's blind spots can only be found by a branch that trips them.
+    create: str | None = None
+    # This drill must add ZERO findings. Used for a shape the checker is
+    # supposed to read correctly — the false-POSITIVE direction.
+    expect_silent: bool = False
+
+
+# A producer that writes its outputs from a python heredoc. Nothing in .github/
+# uses this shape today, so only a synthetic file can hold the checker to it.
+# The wire here is REAL: `parse` prints `readyz_url=`, the job output reads it.
+_HEREDOC_OK = """\
+name: drill — heredoc writer (synthetic)
+on:
+  workflow_dispatch:
+jobs:
+  policy:
+    runs-on: ubuntu-latest
+    outputs:
+      readyz_url: ${{ steps.parse.outputs.readyz_url }}
+    steps:
+      - name: Parse the dial
+        id: parse
+        run: |
+          python - <<'PY' >> "$GITHUB_OUTPUT"
+          print(f"readyz_url={watch['readyz_url']}")
+          PY
+"""
+
+# The same shape with the wire genuinely cut: the producer prints `readyz_url`,
+# the consumer reads `readyz_urlx`. Teaching the checker to READ heredocs must
+# not teach it to EXCUSE them — a fix that silences the shape wholesale would
+# make this drill pass by going blind, which is the failure it is here to catch.
+_HEREDOC_BROKEN = _HEREDOC_OK.replace(
+    "readyz_url: ${{ steps.parse.outputs.readyz_url }}",
+    "readyz_url: ${{ steps.parse.outputs.readyz_urlx }}",
+)
 
 
 DRILLS = [
@@ -926,6 +1031,27 @@ DRILLS = [
         after="steps.token.outputs.have == 'yes'",
         expect_check="W5",
         expect_in_message="'yes'",
+    ),
+    Drill(
+        name="heredoc writer is READ, not mistaken for silence",
+        mechanism="W1 must stay QUIET — the producer really does write these keys",
+        target="drill-heredoc-ok.yml",
+        before="",
+        after="",
+        expect_check="",
+        expect_in_message="",
+        create=_HEREDOC_OK,
+        expect_silent=True,
+    ),
+    Drill(
+        name="heredoc writer with the wire actually cut",
+        mechanism="W1 — reading heredocs must not mean excusing them",
+        target="drill-heredoc-broken.yml",
+        before="",
+        after="",
+        expect_check="W1",
+        expect_in_message="steps.parse.outputs.readyz_urlx",
+        create=_HEREDOC_BROKEN,
     ),
 ]
 
@@ -957,7 +1083,7 @@ def run_drill(root: Path, disabled: set[str]) -> int:
         base = Path(tmp) / "base"
         base.mkdir(parents=True)
         _copy_github(root, base)
-        baseline, _, parse_errors = run_checks(base, disabled)
+        baseline, baseline_wfs, parse_errors = run_checks(base, disabled)
         if parse_errors:
             print(f"  drill cannot run: baseline copy has parse errors: {parse_errors}")
             return 2
@@ -972,34 +1098,57 @@ def run_drill(root: Path, disabled: set[str]) -> int:
             work.mkdir(parents=True)
             _copy_github(root, work)
             target = work / ".github" / "workflows" / drill.target
-            text = target.read_text(encoding="utf-8")
 
-            # A mutation that did not apply would make the drill pass vacuously.
-            # That is precisely how a self-test becomes a lie, so it is fatal.
-            if drill.before not in text:
-                failed.append(f"{drill.name}: MUTATION DID NOT APPLY — "
-                              f"anchor {drill.before!r} not found in {drill.target}. "
-                              f"The drill is stale, not passing.")
-                print(f"  [FAIL] {drill.name}: anchor missing, drill is stale")
-                continue
-            mutated = text.replace(drill.before, drill.after, 1)
-            if mutated == text:
-                failed.append(f"{drill.name}: replacement was a no-op")
-                continue
-            target.write_text(mutated, encoding="utf-8")
+            if drill.create is not None:
+                # A synthetic workflow. Adding a FILE is the mutation here, so
+                # the anchor check cannot apply — but the vacuity risk is the
+                # same, so the file must really have been loaded as a workflow.
+                if target.exists():
+                    failed.append(f"{drill.name}: {drill.target} already exists in .github/workflows — "
+                                  f"the synthetic drill would be overwriting a real workflow.")
+                    print(f"  [FAIL] {drill.name}: target name collides with a real workflow")
+                    continue
+                target.write_text(drill.create, encoding="utf-8")
+            else:
+                text = target.read_text(encoding="utf-8")
 
-            findings, _, errs = run_checks(work, disabled)
+                # A mutation that did not apply would make the drill pass vacuously.
+                # That is precisely how a self-test becomes a lie, so it is fatal.
+                if drill.before not in text:
+                    failed.append(f"{drill.name}: MUTATION DID NOT APPLY — "
+                                  f"anchor {drill.before!r} not found in {drill.target}. "
+                                  f"The drill is stale, not passing.")
+                    print(f"  [FAIL] {drill.name}: anchor missing, drill is stale")
+                    continue
+                mutated = text.replace(drill.before, drill.after, 1)
+                if mutated == text:
+                    failed.append(f"{drill.name}: replacement was a no-op")
+                    continue
+                target.write_text(mutated, encoding="utf-8")
+
+            findings, work_wfs, errs = run_checks(work, disabled)
             new = [f for f in findings if f.key() not in baseline_keys]
 
-            if drill is CONTROL:
+            # The created file must have PARSED. An unparseable synthetic
+            # workflow is silently ignored by load_workflows, which would make
+            # `expect_silent` pass while proving nothing at all.
+            if drill.create is not None and len(work_wfs) != len(baseline_wfs) + 1:
+                failed.append(f"{drill.name}: the synthetic workflow was not loaded "
+                              f"({len(work_wfs)} workflows vs baseline {len(baseline_wfs)}). "
+                              f"The drill proved nothing.")
+                print(f"  [FAIL] {drill.name}: synthetic workflow never parsed")
+                continue
+
+            if drill is CONTROL or drill.expect_silent:
                 if new or errs:
-                    failed.append(f"{drill.name}: a comment-only edit produced "
-                                  f"{len(new)} new finding(s) — the checker reacts to CHANGE, "
-                                  f"not to breakage")
+                    failed.append(f"{drill.name}: an edit that breaks NOTHING produced "
+                                  f"{len(new)} new finding(s) — the checker is reporting a wire "
+                                  f"as dead that is demonstrably live: {[f.render().strip() for f in new]}")
                     print(f"  [FAIL] {drill.name}: {[f.render().strip() for f in new]}")
                 else:
                     passed += 1
-                    print(f"  [PASS] {drill.name}\n         edited {drill.target}, "
+                    verb = "created" if drill.create is not None else "edited"
+                    print(f"  [PASS] {drill.name}\n         {verb} {drill.target}, "
                           f"0 new findings — the checker stayed quiet, as it must.")
                 continue
 
@@ -1019,7 +1168,8 @@ def run_drill(root: Path, disabled: set[str]) -> int:
                 continue
             passed += 1
             print(f"  [PASS] {drill.name} ({drill.mechanism})")
-            print(f"         broke: {drill.target}: {drill.before[:60]}")
+            broke = f"added {drill.target} with the wire cut" if drill.create is not None else drill.before[:60]
+            print(f"         broke: {drill.target}: {broke}")
             print(f"         RED ->{hit[0].render().lstrip()}")
 
         print("\n" + "=" * 72)


### PR DESCRIPTION
## What this fixes

`Chain wires (harness)` fails on **PR #348** (`feat/two-lane-cage`) in 6 seconds with 18 broken wires. All 18 are in one file the cage adds, `.github/workflows/post-merge-watch.yml`, and **all 18 are false**. The workflow is correct. The checker cannot read it.

`scripts/chain_check.py` decided what a step writes to `$GITHUB_OUTPUT` with `_ANY_OUTPUT_KEY`, a regex that only matched lines beginning `echo` or `printf`. `post-merge-watch.yml` writes its outputs from a python heredoc instead:

```yaml
run: |
  python - <<'PY' >> "$GITHUB_OUTPUT"
  print(f"readyz_url={watch['readyz_url']}")
  PY
```

`print(...)` is neither `echo` nor `printf`, so `_parse_writes` returned `{}` and W1 reported all nine live wires out of that step as severed — *"it writes: nothing"*.

This is a **false negative in the instrument**, and it is the exact failure `chain_check.py` was written to catch: an instrument must count the way its consumer does. Left alone it is worse than the red — once someone silences it, the repo's post-merge prod watchdog ships with its wires permanently unchecked.

## Mechanism of the fix

Key discovery moves into one generator, `_iter_output_writes`, now shared by `_parse_writes` and `_write_depth` so the two cannot drift apart. It walks the `run:` block line by line, and when a heredoc's **opening line also redirects to `$GITHUB_OUTPUT`** it reads the body:

- python heredoc (`python`/`python3` in the opener) → `print(...)` / `sys.stdout.write(...)`
- plain heredoc (`cat <<EOF >> "$GITHUB_OUTPUT"`) → bare `key=` lines

Deliberate boundaries:

- A heredoc redirecting **anywhere else** is ignored, so a heredoc writing a temp file is never mistaken for one writing outputs.
- The `\s` before `<<` is load-bearing: it separates a real shell heredoc from the GHA multiline form `echo "body<<$d" >> "$GITHUB_OUTPUT"`, whose body is a *value*, not a script.
- Heredoc keys carry op `"<<"` — value unknowable — the same contract `key<<EOF` already had. So **W5 stays quiet rather than guessing** at literals it cannot evaluate.

## The drill — both directions, because only one of them is the trap

This repo's law is that a guard nobody has watched fail is indistinguishable from a guard that cannot fail. `Drill` gains `create` (write a *synthetic* workflow instead of mutating a real one — necessary because **no workflow on `main` uses this shape yet**) and `expect_silent`, plus an anti-vacuity guard: the synthetic file must actually parse and load, or the drill fails rather than passing on a file nobody read.

Two new drills pin both directions:

| drill | asserts |
|---|---|
| heredoc writer is READ, not mistaken for silence | a **correct** heredoc producer adds **zero** findings — the bug fixed here |
| heredoc writer with the wire actually cut | a heredoc producer with the wire **genuinely cut** still goes **RED as W1** |

The second is the one that matters. A "fix" that silenced this shape wholesale would clear the red *and* make the checker permanently blind to it. That drill fails if anyone ever does that.

## Measured (every line below is a command I ran)

```
main tree            python scripts/chain_check.py --no-map
                     -> 22 workflows, 21 wires, 0 broken, 1 suspect   exit 0
                     IDENTICAL before and after this change

cage tree (#348)     python scripts/chain_check.py --root <copy of cage .github> --no-map
                     before: 26 workflows, 22 wires, 18 broken, 1 suspect   exit 1
                     after : 26 workflows, 22 wires,  0 broken, 1 suspect   exit 0

counter-test         cut ONE real key in the cage's post-merge-watch.yml
                     (print poll_seconds= -> print poll_secondsX=)
                     -> 2 broken, exit 1, both W1 naming steps.parse.outputs.poll_seconds,
                        and it now lists all 9 keys it reads instead of "nothing"

drill                python scripts/chain_check.py --drill                    -> 6/6 passed, exit 0
meta-drill           python scripts/chain_check.py --drill --break-checker W1  -> 4/6, exit 1
                     (BOTH W1 drills fail when W1 is blinded — the new drill is load-bearing)

lint                 ruff: 7 findings before, 7 after — all pre-existing, none on changed lines
```

The CI log on #348 (`gh run view 32230340923 --log-failed`) prints `chain_check: 26 workflows, 22 handoff wires, 18 broken, 1 suspect` — byte-identical to the local reproduction, so the failure fixed here **is** the failure CI reports.

## Scope

One file, `scripts/chain_check.py`. Nothing under `backend/` or `frontend/` imports it (`grep -rn chain_check backend/` hits only `.ruff_cache` binaries), so no backend test is affected. CI runs `ruff`/`mypy` with `working-directory: backend`, so root `scripts/` is gated only by the two `Chain wires (harness)` steps in `ci.yml` — both run above and both pass.

---

# Landing plan for the harness branch stack (#336, #343–#348)

Not changed by this PR — recorded here because this PR removes one blocker from it. **Every merge below is a release: Railway auto-deploys `main` to job360.uk.**

State read live with `gh pr list`:

| PR | head | base | state | review |
|---|---|---|---|---|
| #336 | `feat/every-guard-declares-its-drill` | `main` | MERGEABLE / **CLEAN** | UNREVIEWED |
| #343 | `feat/the-sprawl-has-a-broom` | #336 | MERGEABLE / **CLEAN** | UNREVIEWED |
| #344 | `feat/main-can-finally-speak` | #336 | MERGEABLE / **CLEAN** | UNREVIEWED |
| #345 | `feat/the-gate-that-is-switched-off` | #336 | MERGEABLE / **CLEAN** | UNREVIEWED |
| #346 | `feat/findings-become-fixes` | #336 | MERGEABLE / **CLEAN** | UNREVIEWED |
| #347 | `feat/automerge-that-earns-it` | #336 | MERGEABLE / UNSTABLE | UNREVIEWED |
| #348 | `feat/two-lane-cage` | `main` | MERGEABLE / UNSTABLE | UNREVIEWED |

### Order

1. **#336 first.** It is the only source of `scripts/drill_registry.py`, which the cage references in four files (`merge_cage.py:345` shells out to it with `--count-owed`; also `lane.py:299`, `cage_blockers.py:425`, `data_only.py:9`). Expect zero conflicts.
2. **#343 → #344 → #345 → #346**, re-basing each onto `main` as the one below lands. All four are additive and CLEAN.
3. **#347** last of the stack.
4. **#348 (the cage) LAST**, then merge `main` into it.

### Landing the cage before #336 is the one silently-bad outcome

Nothing goes red. `merge_cage.py:391` models a missing instrument as `R_ABSENT`, and with the ratchet absent on *both* sides `merge_cage.py:898` reports **"does not exist in this lineage … NOT compared"**. The guards-that-can-fail ratchet would ship measuring nothing, quietly. Order is the only thing preventing that.

### `merge_cage.py` is a 1,926-line near-twin — UNION-merge it

`merge_cage.py` is 1,926 lines on **both** #347 and the cage, and 1,387 on #336. **Never `--ours` / `--theirs` wholesale.** Last time that was done in this repo, "theirs" was right in only 4 of 12 files, and the real breakage hid in the files git merged *cleanly*.

After merging, **hand-read the 8 files git will NOT flag**: `STATUS.md`, `scripts/checker_scorecard.py`, `scripts/cage_replay.py`, `scripts/gate_wiring_check.py`, `scripts/revert_gear.py`, `.github/workflows/pr-advisor.yml`, `.github/workflows/revert-main.yml`, `.github/workflows/checker-scorecard.yml`.

### The `Advise (never merges)` red on #347 and #348 is a bootstrap deadlock, not a defect

`.github/workflows/pr-advisor.yml:125-126` refuses to run unless `scripts/merge_cage.py` is **already on the default branch**. `merge_cage.py` is not on `main` (`git cat-file -e origin/main:scripts/merge_cage.py` → absent) and can only get there by merging a PR. The gate blocks its own arrival. This is an **owner-judgement override**, not something a branch can fix.

With this PR merged, `Chain wires (harness)` on #348 goes green, leaving `Advise` as its only red.

### Still open on the cage (not fixed here — out of this PR's scope)

- `scripts/stale_path_check.py` reports 2 false positives (`.github/merge-policy.yml:93`, `scripts/lane.py:359`) — historical prose in comments naming a renamed path.
- `stale_path_check.py`, `lane.py` and `data_only.py` have **zero references** in `.github/` or `Makefile`. Per this repo's own law, an artifact with no notifier dies.
- The cage moves 192 files including 109 renames. `scripts/branch_prune.sh` and `scripts/health-daily.sh` still name `docs/maintenance/`, and the cage's own `stale_path_check` does not catch them.

Refs #348, #336, #343, #344, #345, #346, #347

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G7mLsrkujpTyUhwMTn7itb


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection of workflow output writes in redirected Python and plain text heredocs.
  - More accurately handles named outputs and unknown values during validation.
  - Reporting now clearly distinguishes newly created files from modified files.

- **Tests**
  - Added validation scenarios for correctly configured and broken heredoc output wiring.
  - Expanded checks to cover workflow creation, parsing, updates and expected no-issue results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->