### PR TITLE
fix(packaging): check every git-tracked data file against package-data, not just .gitignore's `!` lines

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -32,10 +32,14 @@ data/
 # because the running code is the site-packages copy.
 #
 # Adding a new shipped data directory? Put it under `src/data/`, declare it in
-# pyproject, and `tests/test_shipped_data.py` will check you did — it derives
-# the rule from `.gitignore` and fails on any committed data directory with no
-# delivery mechanism. Both failure modes here are invisible at runtime: empty
-# data, no exception (though both loaders now log an ERROR naming the path).
+# pyproject, and `tests/test_shipped_data.py` will check you did. It checks
+# twice: once per `!` line in `.gitignore`, and once per file git actually
+# TRACKS under `src/data/`. The second is the one that catches a NEW directory,
+# because `.gitignore`'s `!backend/src/data/` already un-ignores the whole
+# subtree — so a new directory is committable without a `!` line of its own and
+# the first check never sees it. Both failure modes here are invisible at
+# runtime: empty data, no exception (though both loaders now log an ERROR
+# naming the path).
 
 # Python caches
 __pycache__/

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -137,9 +137,11 @@ include = ["src*"]
 # `signal_backed_lookup` and `detect_seniority` answered UNKNOWN for every job.
 #
 # ANY new shipped data directory must be added here AND live under `src/`.
-# `tests/test_shipped_data.py` derives that rule from `.gitignore` and fails if
-# a committed data directory has no delivery mechanism. Verify by hand after
-# any packaging change with:
+# `tests/test_shipped_data.py` matches EVERY git-tracked file under `src/data/`
+# against the globs below, so an undeclared directory fails — and so does a new
+# EXTENSION in a declared one (`*.txt` and `NOTICE` are all that is listed, so a
+# `uk_places.json` would be dropped from the wheel just as silently).
+# Verify by hand after any packaging change with:
 #   pip wheel . --no-deps -w /tmp/wh
 #   python -c "import zipfile,glob;print('\n'.join(n for n in zipfile.ZipFile(glob.glob('/tmp/wh/job360-*.whl')[0]).namelist() if '/data/' in n))"
 [tool.setuptools.package-data]

--- a/backend/tests/test_shipped_data.py
+++ b/backend/tests/test_shipped_data.py
@@ -35,10 +35,28 @@ This test is DERIVED from `.gitignore` rather than hard-coding a list, and it
 asserts the RIGHT mechanism for each location — so a fourth exemption added
 tomorrow is covered automatically, and an exemption in a shape nobody has
 thought about FAILS rather than passing vacuously.
+
+THAT DERIVATION HAS A HOLE, WHICH IS WHY THERE IS A SECOND ONE BELOW.
+`.gitignore`'s `!backend/src/data/` un-ignores the WHOLE subtree, so a new
+directory beneath it is committable with no `!` line of its own. Measured:
+
+    git check-ignore backend/src/data/newthing/terms.txt   -> rc 1, NOT ignored
+
+So the `!`-derived list above never sees such a directory, while
+`[tool.setuptools.package-data]` — an explicit per-directory list with no
+wildcard — does not ship it. Committed, unshipped, unchecked: instance four,
+pre-armed. The file-level check below therefore derives from what git actually
+TRACKS and matches every committed file against the real packaging globs. That
+also catches a new EXTENSION inside an already-declared directory: the only
+patterns are `*.txt` and `NOTICE`, so a `uk_places.json` added tomorrow would
+be dropped from the wheel exactly as silently, and no directory-level check
+could ever see it.
 """
 from __future__ import annotations
 
 import re
+import subprocess
+from collections.abc import Iterable, Sequence
 from pathlib import Path
 
 import pytest
@@ -75,6 +93,154 @@ def _negations(path: Path) -> set[str]:
 def _shipped_data_dirs() -> set[str]:
     """Every directory `.gitignore` goes out of its way to commit."""
     return {d for d in _negations(_REPO / ".gitignore") if d not in _CONTAINER_DIRS}
+
+
+def _glob_to_regex(pattern: str) -> re.Pattern[str]:
+    """Compile one setuptools package-data glob into a regex.
+
+    `*` matches inside ONE path segment and does NOT cross `/`, which is how
+    setuptools expands package-data. It is spelled out here instead of reusing
+    `fnmatch`, whose `*` DOES cross `/` — this repo already carries one matcher
+    where a `*` silently crossed a separator, and a lenient matcher here would
+    make the whole check pass vacuously.
+    """
+    out = ["^"]
+    i = 0
+    while i < len(pattern):
+        if pattern.startswith("**/", i):
+            out.append("(?:.*/)?")
+            i += 3
+            continue
+        char = pattern[i]
+        if char == "*":
+            out.append("[^/]*")
+        elif char == "?":
+            out.append("[^/]")
+        else:
+            out.append(re.escape(char))
+        i += 1
+    out.append("$")
+    return re.compile("".join(out))
+
+
+def _package_data_globs() -> list[str]:
+    """Every path `[tool.setuptools.package-data]` ships, relative to `backend/`.
+
+    Each key is a package name and each value a list of globs relative to that
+    package, so `src` + `data/job_signals/*.txt` becomes
+    `src/data/job_signals/*.txt`.
+
+    Raises:
+        RuntimeError: if no TOML parser is importable, so the check fails loudly
+            rather than skipping — a silent skip is the exact failure this file
+            exists to prevent.
+    """
+    try:
+        import tomllib
+    except ImportError as exc:  # pragma: no cover - Python < 3.11 only
+        raise RuntimeError(
+            "no tomllib (needs Python 3.11+; CI runs 3.12). This check must not "
+            "be skipped — skipping it is how the data went missing three times."
+        ) from exc
+
+    parsed = tomllib.loads((_BACKEND / "pyproject.toml").read_text(encoding="utf-8"))
+    package_data = parsed.get("tool", {}).get("setuptools", {}).get("package-data", {})
+    return [
+        f"{package.replace('.', '/')}/{pattern}"
+        for package, patterns in package_data.items()
+        for pattern in patterns
+    ]
+
+
+def _committed_src_data_files() -> list[str]:
+    """Files git TRACKS under `backend/src/data/`, relative to `backend/`.
+
+    Tracked is the right question, not on-disk. An untracked scratch file in one
+    of the many parallel worktrees must not fail the build, and a file that IS
+    committed is precisely the thing required to reach the wheel.
+
+    Raises:
+        RuntimeError: if git cannot be consulted, for the same reason as above —
+            an unanswerable check must be loud, never quietly empty.
+    """
+    try:
+        proc = subprocess.run(
+            ["git", "ls-files", "-z", "--", "src/data"],
+            cwd=_BACKEND,
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=60,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise RuntimeError(f"could not list git-tracked data files: {exc}") from exc
+    return sorted(path for path in proc.stdout.split("\0") if path)
+
+
+def _uncovered(files: Iterable[str], globs: Sequence[str]) -> list[str]:
+    """Return the files no packaging glob matches — i.e. absent from the wheel."""
+    compiled = [_glob_to_regex(glob) for glob in globs]
+    return sorted(f for f in files if not any(rx.match(f) for rx in compiled))
+
+
+class TestEveryCommittedDataFileReachesTheWheel:
+    """File-level net under the directory-level one above.
+
+    The directory check derives from `.gitignore`'s `!` lines; this one derives
+    from the git index, so it sees a data directory that was never named in
+    `.gitignore` at all, and a file whose EXTENSION no glob covers.
+    """
+
+    def test_it_is_reading_real_committed_files(self) -> None:
+        """Non-vacuity: an empty file list would pass every assertion below."""
+        files = _committed_src_data_files()
+        assert "src/data/uk_gazetteer/uk_places.txt" in files, (
+            "the gazetteer rule #30 is built on is not in the git index — either "
+            "the data moved and this check must move with it, or it really is "
+            f"uncommitted. Saw: {files}"
+        )
+
+    def test_the_globs_were_actually_parsed(self) -> None:
+        """Non-vacuity: an empty glob list would fail everything, not pass it —
+        but an empty FILE list plus empty globs would pass, so pin both."""
+        assert _package_data_globs(), (
+            "pyproject declares no package-data, so `pip install .` copies .py "
+            "files only and every data-driven service ships blind"
+        )
+
+    def test_no_committed_data_file_is_left_out_of_the_wheel(self) -> None:
+        """The load-bearing assertion: committed must imply shipped."""
+        missing = _uncovered(_committed_src_data_files(), _package_data_globs())
+        assert not missing, (
+            "these files are committed under backend/src/data/ but no "
+            "[tool.setuptools.package-data] glob matches them, so `pip install .` "
+            "leaves them out of the wheel. The loaders degrade to empty WITHOUT "
+            "raising, so production answers 'nothing' while every local test "
+            f"passes — issue #260 / #312 / #321, fourth time: {missing}"
+        )
+
+    def test_it_catches_a_data_directory_nobody_declared(self) -> None:
+        """Teeth. This is the case the .gitignore-derived check cannot see:
+        `!backend/src/data/` makes the file committable with no `!` line, so
+        only a file-level check notices it is missing from the wheel."""
+        assert _uncovered(
+            ["src/data/newthing/terms.txt"], _package_data_globs()
+        ) == ["src/data/newthing/terms.txt"]
+
+    def test_it_catches_a_new_extension_in_a_declared_directory(self) -> None:
+        """Teeth. `*.txt` and `NOTICE` are the only patterns for the gazetteer,
+        so a JSON build output beside them would be dropped from the wheel — a
+        directory-level check calls that directory covered and moves on."""
+        assert _uncovered(
+            ["src/data/uk_gazetteer/uk_places.json"], _package_data_globs()
+        ) == ["src/data/uk_gazetteer/uk_places.json"]
+
+    def test_a_star_does_not_cross_a_slash(self) -> None:
+        """Teeth on the matcher itself: a lenient `*` would call every nested
+        path covered and turn the whole class into a rubber stamp."""
+        rx = _glob_to_regex("src/data/uk_gazetteer/*.txt")
+        assert rx.match("src/data/uk_gazetteer/places.txt")
+        assert not rx.match("src/data/uk_gazetteer/nested/places.txt")
 
 
 class TestEveryCommittedDataDirHasAWayIntoTheImage:


### PR DESCRIPTION
## The assigned item was already fixed. Checking why exposed a live hole.

Item `product-data-committable` said `.gitignore:24`'s bare `data/` silently swallows new files under `backend/src/data/`, and asked for a `!backend/src/data/` negation.

**Measured on `7e16911` (this branch's base): that fix already landed.** `.gitignore:33` carries `!backend/src/data/`, added by PR #312 and extended by #321. Both acceptance criteria already hold:

```
git check-ignore backend/src/data/uk_gazetteer/NEWFILE.txt   -> rc 1, prints nothing   (committable)
git check-ignore backend/data/uk_gazetteer/x.txt             -> rc 0, prints the path  (still ignored)
```

**`.gitignore` is unchanged in this PR.** A correction for whoever wrote the item: its proof command used `git check-ignore -v`, which exits **0** here because `-v` reports *any* matching pattern including a `!` negation. Drop `-v` to discriminate ignored from not-ignored.

## The hole

`tests/test_shipped_data.py` decides what to check from the `!` lines in `.gitignore`. That derivation no longer describes what is committable — `!backend/src/data/` un-ignores the **whole subtree**, so a new directory beneath it needs no `!` line of its own.

All three legs measured:

| leg | command / value | result |
|---|---|---|
| git tracks it | `git check-ignore backend/src/data/newthing/terms.txt` | rc 1 — not ignored. **Looks landed.** |
| the wheel drops it | `[tool.setuptools.package-data]` = explicit list, no wildcard | **not shipped** |
| nothing complains | `_shipped_data_dirs()` = `{src/data/job_signals, src/data/uk_gazetteer}` | new dir absent — **guard passes vacuously** |

Committed, unshipped, unchecked — issue #260 / PR #312 / PR #321 for the **fourth** time, already armed. Both loaders degrade to empty *without raising* (`uk_gate._read -> frozenset()`, `job_signals._load_terms -> {}`), which is why the first three reached production green.

Same shape, smaller radius: the globs cover `*.txt` and `NOTICE` only, so a `uk_places.json` added beside the gazetteer would be dropped from the wheel too. **No directory-level check can ever see that one.**

## The fix

A second, **file-level** net beside the existing directory-level one. Purely additive — no existing test removed or weakened.

- Derives from the **git index** (`git ls-files -- src/data`), not `.gitignore`, so it sees a directory nobody declared.
- Matches every tracked file against the real package-data globs **parsed from pyproject**, not a substring check.
- Tracked, not on-disk: an untracked scratch file in one of the parallel worktrees must not fail the build, while a committed file is exactly what must reach the wheel.
- `*` compiles to `[^/]*` explicitly rather than via `fnmatch`, whose `*` crosses `/`. A lenient matcher would call every nested path covered and make the check a rubber stamp — this repo already carries one matcher where `*` crossed a separator silently.
- An unanswerable check (no `tomllib`, no git) now **raises** instead of skipping. A silent skip is the failure mode this file exists to prevent.

## Proof it has teeth, not just that it is green

```
real invariant                       -> []
job_signals glob removed             -> 3 files reported
NOTICE glob removed                  -> 1 file reported
undeclared dir  src/data/newthing/   -> reported
new extension   uk_places.json       -> reported
`*` across a slash                   -> does not match
```

Three of these are committed as tests, so non-vacuity is pinned rather than trusted.

Also corrected two comments that documented the old, **false** contract: `backend/.dockerignore` and `backend/pyproject.toml` both claimed the test "derives the rule from `.gitignore` and fails on any committed data directory with no delivery mechanism". It could not — that is precisely the hole above.

## Verification

```
python -m pytest -q -p no:randomly tests/test_shipped_data.py tests/test_job_signals.py tests/test_uk_gate.py
175 passed in 1.51s
```

- `ruff check tests/test_shipped_data.py` — All checks passed
- mypy ratchet runs on `src/` only (`scripts/mypy_ratchet.py:73`), so this test file is out of its scope
- `package-data` values re-parsed after the edit and byte-identical (comment-only change)
- Nothing deleted: `git diff --diff-filter=D` is empty

## Bounds — what I did NOT check

- **No wheel was built.** "package-data glob implies file in the wheel" is trusted from PR #321's recorded `pip wheel` output, not re-measured here.
- Only **this worktree's checkout** was scanned for other swallowed data directories; exactly one `data/` dir exists here (`backend/src/data`). Other branches may differ.
- The full suite was not run (Windows, O(n²)). Linux CI is the verifier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G7mLsrkujpTyUhwMTn7itb


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation to ensure committed data files are included in packaged releases.
  * Added checks for undeclared data directories, unsupported file extensions, and incorrect wildcard patterns.

* **Documentation**
  * Clarified the packaging and `.dockerignore` guidance for new data directories.
  * Documented how automated checks verify shipped data coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->