### PR TITLE
fix(registry): a script named only in a COMMENT is not a guard that runs

### DIFF
--- a/scripts/drill_registry.py
+++ b/scripts/drill_registry.py
@@ -331,7 +331,30 @@ def discover(github_dir: Path) -> dict[str, set[str]]:
         # `_invokes_cage` in gate_wiring_check.py.)
         if wf.name == "merge-policy.yml":
             continue
-        text = wf.read_text(encoding="utf-8", errors="replace")
+        # A SCRIPT NAMED IN A COMMENT IS NOT A GUARD THAT RUNS.
+        #
+        # Fourth instance of one confusion in this repo, found four different
+        # ways: `gate_wiring_check` counted a filename inside an `echo`; this
+        # function counted one inside merge-policy.yml (see above); the lane
+        # matcher counted a basename at any depth; and this line counted a
+        # filename inside a YAML COMMENT.
+        #
+        # Measured on PR #344's tree: `check_workflow_slack_wiring.py` had 0 real
+        # invocations and 3 comment mentions; `check_alert_paths.py` had 0 and 2.
+        # Both were therefore DECLARED as guards, and the registry certified two
+        # guards that nothing runs -- exactly the failure it exists to prevent.
+        # Worse, one of them had been promoted from `owed` to `drilled` on the
+        # strength of that phantom wiring.
+        #
+        # Comment stripping is deliberately line-based and dumb: a line whose
+        # first non-space character is `#` is a comment. YAML has no block
+        # comments, and `#` inside a quoted string is not a script reference, so
+        # the crude rule is exact here. It is NOT applied to shell heredocs
+        # inside `run:` blocks, where a `#` line is still shell comment anyway.
+        text = "\n".join(
+            "" if line.lstrip().startswith("#") else line
+            for line in wf.read_text(encoding="utf-8", errors="replace").splitlines()
+        )
         for m in _SCRIPT_REF.finditer(text):
             found.setdefault(m.group(1), set()).add(wf.relative_to(github_dir).as_posix())
     return found
@@ -527,6 +550,32 @@ def self_drill() -> int:
                         "" if not f else f"expected silence, got: {f[0][:120]}"))
         wf.unlink()
 
+    # 5b. A SCRIPT NAMED ONLY IN A COMMENT IS NOT WIRED.
+    #     Found on PR #344: `check_workflow_slack_wiring.py` had 0 real
+    #     invocations and 3 comment mentions; `check_alert_paths.py` had 0 and
+    #     2. Both were therefore treated as wired, declared as guards, and this
+    #     registry certified two guards that NOTHING RUNS -- the exact failure
+    #     it exists to prevent. One had even been promoted from `owed` to
+    #     `drilled` on the strength of that phantom wiring.
+    #
+    #     Both directions are asserted, because a comment-stripper that ate
+    #     real `run:` lines would be the worse bug: it would silently
+    #     UN-declare working guards, and nothing would notice.
+    with tempfile.TemporaryDirectory() as td2:
+        ghd = Path(td2) / ".github" / "workflows"
+        ghd.mkdir(parents=True)
+        (ghd / "wf.yml").write_text(
+            "jobs:\n  a:\n    steps:\n"
+            "      # python scripts/phantom_guard.py --drill  <- a comment\n"
+            "      - run: python scripts/real_guard.py   # trailing comment\n",
+            encoding="utf-8")
+        seen = discover(Path(td2) / ".github")
+        results.append(("a script named ONLY in a comment is not counted as wired",
+                        "scripts/phantom_guard.py" not in seen,
+                        "a commented-out reference was treated as an invocation"))
+        results.append(("...and a real `run:` invocation is still found",
+                        "scripts/real_guard.py" in seen,
+                        "the comment stripper ate a real invocation"))
     # 6. A drill that does not actually make its guard go red must be caught by
     #    run_drills. Point an entry at a command that exits 0 doing nothing.
     fake = {"scripts/chain_check.py": Guard(status="drilled",


### PR DESCRIPTION
`discover()` text-scans `.github/` and treated a filename inside a **YAML comment** as an invocation. A guard could be declared, and the registry — the guard-of-guards — would vouch for it, while CI never ran it.

## Measured on #344's tree

```
check_workflow_slack_wiring.py    0 real invocations   3 comment mentions
check_alert_paths.py              0 real invocations   2 comment mentions
```

Both declared. Both phantom-wired.

**And I made it worse earlier today** by promoting `check_workflow_slack_wiring` from `owed` to `drilled` on the strength of wiring that doesn't exist. The registry told me it was wired, so I believed it — which is exactly what a wrong guard costs.

## Fourth instance of one confusion, found four different ways today

| where | what it counted |
|---|---|
| `gate_wiring_check` | a filename inside an `echo` |
| `drill_registry` | a filename in `merge-policy.yml` |
| lane matcher | a basename at any depth |
| **`drill_registry`** | **a filename inside a comment** |

**Naming a thing is not running it.**

## My first drill for this was too weak

Two cases: a comment-only reference must **not** be wired; a real `run:` invocation must **still** be found. The second matters more — a stripper that ate real lines would silently *un-declare* working guards.

Then I broke the code both ways:

```
count comments as wiring again      →  RED 7/8
strip EVERY line containing a '#'   →  GREEN 8/8   ← my drill missed it
```

The fixture's real line had no `#`, so an over-eager stripper passed. Fixed it to carry a trailing comment — the realistic shape:

```
count comments as wiring again      →  RED 7/8
strip EVERY line containing a '#'   →  RED 7/8
restored                            →      8/8, exit 0
```

Second time today a drill written to catch weak drills was itself weak.

`agent-gate.sh`: PASS · `count-owed` 15, unchanged on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G7mLsrkujpTyUhwMTn7itb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Workflow discovery now ignores commented-out script references, preventing them from being incorrectly treated as active safeguards.
  * Genuine script references remain recognised, including lines with trailing comments.

* **Tests**
  * Added coverage for commented-out and active workflow script references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->