### PR TITLE
fix(csp-test): assert substrings with toContain — the regexes tripped a HIGH CodeQL alert

### DIFF
--- a/frontend/src/lib/__tests__/security-headers.test.ts
+++ b/frontend/src/lib/__tests__/security-headers.test.ts
@@ -25,16 +25,26 @@ describe("SECURITY_HEADERS (M15)", () => {
   });
 
   it("includes a Content-Security-Policy with frame-ancestors 'none'", () => {
-    expect(CONTENT_SECURITY_POLICY).toMatch(/frame-ancestors 'none'/);
+    expect(CONTENT_SECURITY_POLICY).toContain("frame-ancestors 'none'");
   });
 
+  // These assert that a SUBSTRING is present in the CSP header, so `toContain`
+  // says exactly that. They used `toMatch` with unanchored regexes, which CodeQL
+  // flags as `js/regex/missing-regexp-anchor` (HIGH) -- a rule aimed at host
+  // VALIDATION, where an unanchored pattern lets `evil-sentry.io.attacker.com`
+  // through. Here nothing is being validated; a header string is being searched.
+  //
+  // Dismissing it as a false positive would have been defensible and worse: the
+  // alert blocked PR #258 for a file that PR does not touch, and a security check
+  // that is permanently red for a known-benign reason is one nobody reads. The
+  // assertion is clearer this way regardless.
   it("CSP connect-src allows Sentry ingest domains", () => {
-    expect(CONTENT_SECURITY_POLICY).toMatch(/sentry\.io/);
+    expect(CONTENT_SECURITY_POLICY).toContain("sentry.io");
   });
 
   it("CSP connect-src allows PostHog EU + US cloud hosts", () => {
-    expect(CONTENT_SECURITY_POLICY).toMatch(/eu\.i\.posthog\.com/);
-    expect(CONTENT_SECURITY_POLICY).toMatch(/us\.i\.posthog\.com/);
+    expect(CONTENT_SECURITY_POLICY).toContain("eu.i.posthog.com");
+    expect(CONTENT_SECURITY_POLICY).toContain("us.i.posthog.com");
   });
 
   it("CSP worker-src allows same-origin blob workers (PostHog)", () => {
@@ -42,6 +52,6 @@ describe("SECURITY_HEADERS (M15)", () => {
     // which has no blob: — so PostHog's blob Web Worker was blocked with a
     // console error on EVERY page load. Allow self + blob: for workers only
     // (NOT in script-src — page scripts stay locked to 'self').
-    expect(CONTENT_SECURITY_POLICY).toMatch(/worker-src 'self' blob:/);
+    expect(CONTENT_SECURITY_POLICY).toContain("worker-src 'self' blob:");
   });
 });


### PR DESCRIPTION
`js/regex/missing-regexp-anchor` (**HIGH**) on `frontend/src/lib/__tests__/security-headers.test.ts:37`, blocking **#258** — a PR that doesn't touch this file.

## It's a false positive, and that's the point

The rule targets host **validation**, where an unanchored pattern lets `evil-sentry.io.attacker.com` through. Nothing is validated here — five assertions search a CSP header string for a substring. `toContain` says exactly that.

## Why not just dismiss it

Dismissing as won't-fix was one click and defensible. But the alert was blocking an unrelated PR, and **a security check that sits permanently red for a known-benign reason is one nobody reads** — which is how the next alert, the real one, gets waved through.

Cheaper to remove the pattern than to teach everyone to ignore the light.

```
security-headers.test.ts     7 passed
toMatch(/.../) occurrences   5 → 0
agent-gate.sh                PASS · frontend 339 passed / 49 files
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G7mLsrkujpTyUhwMTn7itb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved security-header test assertions for more reliable validation of content security policies and permitted hosts.
  - Added explanatory documentation to clarify the testing approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->