### PR TITLE
fix(tests): collect the re-score tasks that outlive the test that made them

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -190,6 +190,77 @@ def _close_leaked_app_db():
             dependencies._db = None
 
 
+def cancel_pending_rescores(tasks) -> int:
+    """Cancel every unfinished task in `tasks`, clear it, return how many.
+
+    Split out of the fixture below so it can be TESTED. A teardown hook that
+    only ever runs as a side effect of other tests is exactly the kind of guard
+    this repo keeps finding dead — see scripts/drill_registry.py.
+
+    Each task's loop is the request loop, not this thread's, so the cancel is
+    posted with `call_soon_threadsafe` rather than called directly.
+    """
+    if not tasks:
+        return 0
+    cancelled = 0
+    for task in list(tasks):
+        if task.done():
+            continue
+        try:
+            loop = task.get_loop()
+            if loop.is_closed():
+                continue
+            loop.call_soon_threadsafe(task.cancel)
+            cancelled += 1
+        except (RuntimeError, AttributeError):
+            # Loop already stopping or closed between the check and the call,
+            # or an object that is not a task. Either way there is nothing left
+            # to cancel.
+            continue
+    tasks.clear()
+    return cancelled
+
+
+@pytest.fixture(autouse=True)
+def _drain_leaked_rescore_tasks():
+    """Stop a re-score task from outliving the test whose schema it queries.
+
+    THE FLAKE THIS FIXES (issue #369). Three gate runs on 2026-08-23 failed with
+    ``relation "users" does not exist`` / ``relation "user_profiles" does not
+    exist``, each blaming a DIFFERENT test in ``test_profile_upload.py``, each
+    passing when that file ran alone. The gate log carries the whole chain:
+
+        queue.py:67   enqueue skipped: REDIS_URL is not set, so
+                      rescore_user_feed_task cannot be queued
+        profile.py:94 rescore: background re-score FAILED, feed left on a stale
+                      profile_version: OperationalError('relation
+                      "user_profiles" does not exist')
+
+    i.e. no Redis in tests -> `_run_rescore_in_process` -> `asyncio.create_task`,
+    pinned in `_rescore_bg_tasks` and never awaited. The test ends, the per-test
+    schema is dropped, and the orphan then queries a schema that is gone. The
+    failure is attributed to WHATEVER TEST IS RUNNING NOW, which is why it looked
+    random: the blamed test is innocent.
+
+    It is a RACE, not a certainty — a task that finishes inside its own request
+    is harmless, which is why the same batch passes and fails on different runs.
+
+    The fallback itself is correct and deliberate (issue #271: losing the work is
+    worse than doing it fragilely). What was missing is that nothing collected
+    the tasks it leaves behind.
+
+    Cancelling rather than draining: the task's loop belongs to the request and
+    this synchronous teardown cannot drive it, and a full-feed re-score is not
+    work a unit test needs finished. `_rescore_finished` logs the cancellation,
+    so the tasks stay audible rather than vanishing.
+    """
+    yield
+
+    from src.api.routes import profile as _profile
+
+    cancel_pending_rescores(getattr(_profile, "_rescore_bg_tasks", None))
+
+
 # Pinned test timestamp — avoid non-determinism from datetime.now() leaking
 # into fixture-built Job objects. Tier-A #7.
 _TEST_NOW = datetime(2026, 4, 23, 12, 0, 0, tzinfo=timezone.utc)

--- a/backend/tests/test_rescore_task_leak.py
+++ b/backend/tests/test_rescore_task_leak.py
@@ -1,0 +1,127 @@
+"""A re-score task must not outlive the test whose schema it queries.
+
+ISSUE #369. Three gate runs on 2026-08-23 failed with `relation "users" does
+not exist` / `relation "user_profiles" does not exist`, each blaming a DIFFERENT
+test in `test_profile_upload.py`, each passing when that file ran alone. The
+gate log carries the whole chain:
+
+    queue.py:67    enqueue skipped: REDIS_URL is not set, so
+                   rescore_user_feed_task cannot be queued
+    profile.py:94  rescore: background re-score FAILED, feed left on a stale
+                   profile_version: OperationalError('relation
+                   "user_profiles" does not exist')
+
+No Redis in tests, so `_maybe_trigger_rescore` falls back to
+`_run_rescore_in_process`, which does `asyncio.create_task(...)` and never
+awaits it. The test ends, conftest drops the per-test schema, and the orphan
+then queries a schema that is gone — attributed to whatever test is running by
+then. The blamed test is innocent, which is why it looked random.
+
+It is a RACE: a task that finishes inside its own request is harmless. That is
+why the same batch passes on one run and fails on the next, and why a plain
+"run it twice and see" proves nothing. These tests make the race deterministic
+by giving the re-score something slow to do.
+
+Rule #4-safe: no HTTP, no DB, no network — this exercises the teardown helper
+against real asyncio tasks.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from tests.conftest import cancel_pending_rescores
+
+
+def _make_pending_task(loop: asyncio.AbstractEventLoop) -> asyncio.Task:
+    """A task that will not finish on its own inside a test."""
+
+    async def _never():
+        # NOT asyncio.sleep: conftest's `_instant_asyncio_sleep` makes every
+        # sleep return immediately, so a "task that never finishes" built on
+        # sleep finishes on the first tick and this test would assert nothing.
+        # A test helper defeated by another test helper.
+        await asyncio.Event().wait()
+
+    return loop.create_task(_never())
+
+
+class TestTheTeardownActuallyCollectsThem:
+    @pytest.mark.asyncio
+    async def test_a_pending_task_is_cancelled_and_the_set_emptied(self) -> None:
+        loop = asyncio.get_running_loop()
+        tasks = {_make_pending_task(loop) for _ in range(3)}
+        held = list(tasks)
+
+        assert cancel_pending_rescores(tasks) == 3
+        assert tasks == set(), "the tracking set must not keep growing across tests"
+
+        # The cancel is POSTED to the loop, so it lands on the next tick.
+        await asyncio.sleep(0)
+        await asyncio.gather(*held, return_exceptions=True)
+        assert all(t.cancelled() for t in held), (
+            "THE LEAK: a task survived teardown and will run against a schema "
+            "that has already been dropped"
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_finished_task_is_left_alone(self) -> None:
+        """NEGATIVE CONTROL. A re-score that completed inside its own request is
+        the HARMLESS case — cancelling it would turn a success into a logged
+        `was CANCELLED — feed left stale`, i.e. manufacture the alarm."""
+        loop = asyncio.get_running_loop()
+
+        async def _quick():
+            return "done"
+
+        done = loop.create_task(_quick())
+        await done
+        tasks = {done}
+
+        assert cancel_pending_rescores(tasks) == 0, "a finished task was cancelled"
+        assert done.result() == "done"
+        assert not done.cancelled()
+
+    def test_an_empty_or_absent_set_is_not_an_error(self) -> None:
+        """The fixture runs after EVERY test, including the thousands that never
+        touch a profile route. It must be free and silent there."""
+        assert cancel_pending_rescores(None) == 0
+        assert cancel_pending_rescores(set()) == 0
+
+
+class TestTheRealRouteLeaksWithoutIt:
+    """The end-to-end half: drive the actual fallback and show it leaves a task."""
+
+    @pytest.mark.asyncio
+    async def test_the_in_process_fallback_leaves_a_tracked_task(
+        self, monkeypatch
+    ) -> None:
+        import src.api.routes.profile as profile_route
+
+        started = asyncio.Event()
+
+        async def _slow_rescore(user_id):
+            started.set()
+            await asyncio.Event().wait()  # see _make_pending_task on why not sleep
+
+        # Patch the symbol `_run_rescore_in_process` imports at call time.
+        import src.services.rescore as rescore_mod
+
+        monkeypatch.setattr(rescore_mod, "rescore_user_feed", _slow_rescore)
+        profile_route._rescore_bg_tasks.clear()
+
+        profile_route._run_rescore_in_process("user-369")
+        await asyncio.wait_for(started.wait(), timeout=5)
+
+        pending = [t for t in profile_route._rescore_bg_tasks if not t.done()]
+        assert pending, (
+            "the fallback did not leave a tracked task — if this ever fails, the "
+            "leak is gone and this whole file can go with it"
+        )
+
+        held = list(profile_route._rescore_bg_tasks)
+        assert cancel_pending_rescores(profile_route._rescore_bg_tasks) == len(pending)
+        await asyncio.sleep(0)
+        await asyncio.gather(*held, return_exceptions=True)
+        assert all(t.cancelled() for t in held)


### PR DESCRIPTION
Closes #369.

## The flake

Three gate runs on 2026-08-23 failed with `relation "users" does not exist` / `relation "user_profiles" does not exist`, each blaming a **different** test in `test_profile_upload.py`, each passing when that file ran alone.

The gate log carries the whole chain:

```
queue.py:67    enqueue skipped: REDIS_URL is not set, so
               rescore_user_feed_task cannot be queued
profile.py:94  rescore: background re-score FAILED, feed left on a stale
               profile_version: OperationalError('relation "user_profiles"
               does not exist')
```

```
test posts a profile change
  └─> _maybe_trigger_rescore()  →  no Redis  →  _run_rescore_in_process()
        └─> asyncio.create_task(...), pinned in _rescore_bg_tasks, never awaited

test ends  →  conftest drops the per-test schema

the orphan wakes up, queries a schema that is gone,
and the failure lands on WHATEVER TEST IS RUNNING BY THEN
```

The blamed test is innocent. That is why it looked random and why it moved around.

## It is a race, so a green run is not evidence

A re-score that finishes inside its own request is harmless. I ran the 4-file batch **with and without** this fix: **192 passed both times.** I am not offering that as proof, and a "run it twice" check would not have proved anything either.

## What is actually proven

`cancel_pending_rescores()` is split out of the fixture so it can be tested directly against real asyncio tasks, with the race made deterministic. Drilled both ways:

```
drain does nothing (the pre-fix state)    -> 2 failed
cancel finished tasks too (over-correct)  -> 1 failed  (the negative control)
restored                                  -> 4 passed
```

The negative control is the half that matters: a re-score that **completed** must not be cancelled, or teardown manufactures the `was CANCELLED — feed left stale` alarm the module logs.

## Choices

- **Cancel, not drain.** The task's loop belongs to the request; a synchronous teardown cannot drive it. A full-feed re-score is not work a unit test needs finished.
- **The fallback is untouched.** #271 decided that losing the work is worse than doing it fragilely. Production has Redis and takes the ARQ path — this is a harness bug only.

## Gotcha, recorded in the test

The first version built its never-finishing task on `asyncio.sleep(3600)` — and conftest's own `_instant_asyncio_sleep` made it return immediately, so the "task that never finishes" finished on the first tick and the test asserted nothing. **A test helper defeated by another test helper.** It uses `asyncio.Event().wait()` now.

Gate: 4 passed, ruff clean, frontend green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FEs1dix6f5imaMkuxuAAgd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of re-scoring operations by ensuring unfinished background tasks are cancelled and cleaned up safely.
  * Prevented stale in-process tasks from affecting subsequent operations or system state.

* **Tests**
  * Added coverage for pending-task cancellation, completed-task handling, empty task collections, and fallback re-scoring scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->