### PR TITLE
docs: heal the index — 46 links pointed at files that had moved, not vanished

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,12 +13,12 @@ Start here to find the right doc fast.
 | I want to… | Read |
 |---|---|
 | **Understand the project fast** | [`../CLAUDE.md`](../CLAUDE.md) → [`../STATUS.md`](../STATUS.md) |
-| **Pick up where work left off** | [`IMPLEMENTATION_LOG.md`](IMPLEMENTATION_LOG.md) (read first) → [`../STATUS.md`](../STATUS.md) |
+| **Pick up where work left off** | [`IMPLEMENTATION_LOG.md`](harness/IMPLEMENTATION_LOG.md) (read first) → [`../STATUS.md`](../STATUS.md) |
 | **Run it locally** | [`../backend/README.md`](../backend/README.md) · [`../frontend/README.md`](../frontend/README.md) |
 | **Contribute / open a PR** | [`../CONTRIBUTING.md`](../CONTRIBUTING.md) |
-| **Debug a runtime problem** | [`troubleshooting.md`](troubleshooting.md) → [`pillars/runbook.md`](pillars/runbook.md) |
-| **Understand the architecture deeply** | [`pillars/`](pillars/README.md) (authoritative) → [`../ARCHITECTURE.md`](../ARCHITECTURE.md) |
-| **Know what's verified working** | [`CHECKLIST_KANBAN.md`](CHECKLIST_KANBAN.md) |
+| **Debug a runtime problem** | [`troubleshooting.md`](product/troubleshooting.md) → [`pillars/runbook.md`](product/pillars/runbook.md) |
+| **Understand the architecture deeply** | [`pillars/`](product/pillars/README.md) (authoritative) → [`../ARCHITECTURE.md`](../ARCHITECTURE.md) |
+| **Know what's verified working** | [`CHECKLIST_KANBAN.md`](harness/CHECKLIST_KANBAN.md) |
 
 ---
 
@@ -27,73 +27,73 @@ Start here to find the right doc fast.
 | Doc | What it is |
 |---|---|
 | [`../STATUS.md`](../STATUS.md) | Project phase, what's done/next, known issues. **The single current ground truth.** |
-| [`IMPLEMENTATION_LOG.md`](IMPLEMENTATION_LOG.md) | Append-only batch-by-batch completion log (Pillars 1–3 + steps). Read first when resuming. |
-| [`CHECKLIST_KANBAN.md`](CHECKLIST_KANBAN.md) | End-to-end live verification + structural audit — what's proven working, with evidence. |
+| [`IMPLEMENTATION_LOG.md`](harness/IMPLEMENTATION_LOG.md) | Append-only batch-by-batch completion log (Pillars 1–3 + steps). Read first when resuming. |
+| [`CHECKLIST_KANBAN.md`](harness/CHECKLIST_KANBAN.md) | End-to-end live verification + structural audit — what's proven working, with evidence. |
 
 ## 📘 Architecture & operations
 
 | Doc | What it is |
 |---|---|
-| [`STACK.md`](STACK.md) | Tech stack layer-by-layer: what we have vs what to add (Postgres, Docker, Stripe, etc.) + costs. |
-| [`llm_prod.md`](llm_prod.md) | Production LLM provider choice (researched 2026-07-08): why the 429s, provider comparison, GDPR split, recommended chain. TL;DR: Gemini 2.5 Flash single / +DeepSeek for cheap batch. |
-| [`STACK_checklist.md`](STACK_checklist.md) | Code-audited checklist: 27 built ✅ (with file proof) vs 21 to build ❌. |
-| [`UPGRADE_PLAN.md`](UPGRADE_PLAN.md) | Phase 1–3 execution plan (Postgres → deploy → monitoring): TDD + multi-agent, money + keys per phase. |
+| [`STACK.md`](product/STACK.md) | Tech stack layer-by-layer: what we have vs what to add (Postgres, Docker, Stripe, etc.) + costs. |
+| [`llm_prod.md`](harness/llm_prod.md) | Production LLM provider choice (researched 2026-07-08): why the 429s, provider comparison, GDPR split, recommended chain. TL;DR: Gemini 2.5 Flash single / +DeepSeek for cheap batch. |
+| [`STACK_checklist.md`](product/STACK_checklist.md) | Code-audited checklist: 27 built ✅ (with file proof) vs 21 to build ❌. |
+| [`UPGRADE_PLAN.md`](harness/UPGRADE_PLAN.md) | Phase 1–3 execution plan (Postgres → deploy → monitoring): TDD + multi-agent, money + keys per phase. |
 | [`../CLAUDE.md`](../CLAUDE.md) | Load-bearing architecture doc: data flow, module map, **28 hard rules**, scoring, env vars. |
 | [`../ARCHITECTURE.md`](../ARCHITECTURE.md) | Deep technical reference: directory tree, DB schema, data-flow diagrams, dependencies. |
-| [`pillars/`](pillars/README.md) | **Authoritative** per-pillar deep reference (code-verified). See below. |
-| [`troubleshooting.md`](troubleshooting.md) | Dev-environment FAQ: port conflicts, SQLite locks, missing LLM keys, Redis on Windows. |
-| [`pillars/runbook.md`](pillars/runbook.md) | "I see a problem at 2am" operational guide — SQL queries + CLI commands. |
-| [`pillars/glossary.md`](pillars/glossary.md) | Plain-English definitions of every domain term. |
+| [`pillars/`](product/pillars/README.md) | **Authoritative** per-pillar deep reference (code-verified). See below. |
+| [`troubleshooting.md`](product/troubleshooting.md) | Dev-environment FAQ: port conflicts, SQLite locks, missing LLM keys, Redis on Windows. |
+| [`pillars/runbook.md`](product/pillars/runbook.md) | "I see a problem at 2am" operational guide — SQL queries + CLI commands. |
+| [`pillars/glossary.md`](product/pillars/glossary.md) | Plain-English definitions of every domain term. |
 
 ### The three pillars (`pillars/`)
 
 | Doc | Covers |
 |---|---|
-| [`pillars/README.md`](pillars/README.md) | Pillar overview + connection diagram (entry point). |
-| [`pillars/01-user-pillar.md`](pillars/01-user-pillar.md) | Auth, profile, feed, dashboard, notifications. |
-| [`pillars/02-search-and-match-engine.md`](pillars/02-search-and-match-engine.md) | The 6-stage pipeline: prefilter → scoring → dedup → enrich → store. |
-| [`pillars/03-job-providers.md`](pillars/03-job-providers.md) | 46 source classes / 47 registry keys, `BaseJobSource`, ATS catalog. |
+| [`pillars/README.md`](product/pillars/README.md) | Pillar overview + connection diagram (entry point). |
+| [`pillars/01-user-pillar.md`](product/pillars/01-user-pillar.md) | Auth, profile, feed, dashboard, notifications. |
+| [`pillars/02-search-and-match-engine.md`](product/pillars/02-search-and-match-engine.md) | The 6-stage pipeline: prefilter → scoring → dedup → enrich → store. |
+| [`pillars/03-job-providers.md`](product/pillars/03-job-providers.md) | 46 source classes / 47 registry keys, `BaseJobSource`, ATS catalog. |
 
 ## 📘 Product & strategy
 
 | Doc | What it is |
 |---|---|
-| [`PRD.md`](PRD.md) | Product requirements + vision. |
-| [`MONETIZATION_GAPS.md`](MONETIZATION_GAPS.md) | What's missing to charge money — payments, paywall, hosting, legal (code-verified gap analysis). |
-| [`feedback_loops_map.md`](feedback_loops_map.md) | The whole-tool map: 15 honest places to add feedback loops (signal + gate), across Pillars 1–3 + features, all answering to the master outcome loop. |
-| [`raw_feedback_loop.md`](raw_feedback_loop.md) | Design: turn the hardcoded skill/company/domain/location lists into self-growing data via a gated LLM feedback loop (kills the tech/UK ceiling). |
-| [`peruser_cv_coverletter.md`](peruser_cv_coverletter.md) | Design: per-job AI-tailored CV + cover letter that learns from your edits (per-user 2-layer learning + guardrails). ~80% built. |
-| [`post_application.md`](post_application.md) | Design: the "after you apply" co-pilot — interview prep, mock interview, skill-gap, follow-up email, outreach (offer/salary deliberately out). |
-| [`plans/2026-06-21-free-premium-plans.md`](plans/2026-06-21-free-premium-plans.md) | Free/Premium tier design (not yet built). |
-| [`References.md`](References.md) | Source-of-truth list of external references and research links. |
+| [`PRD.md`](product/PRD.md) | Product requirements + vision. |
+| [`MONETIZATION_GAPS.md`](product/MONETIZATION_GAPS.md) | What's missing to charge money — payments, paywall, hosting, legal (code-verified gap analysis). |
+| [`feedback_loops_map.md`](harness/feedback_loops_map.md) | The whole-tool map: 15 honest places to add feedback loops (signal + gate), across Pillars 1–3 + features, all answering to the master outcome loop. |
+| [`raw_feedback_loop.md`](harness/raw_feedback_loop.md) | Design: turn the hardcoded skill/company/domain/location lists into self-growing data via a gated LLM feedback loop (kills the tech/UK ceiling). |
+| [`peruser_cv_coverletter.md`](product/peruser_cv_coverletter.md) | Design: per-job AI-tailored CV + cover letter that learns from your edits (per-user 2-layer learning + guardrails). ~80% built. |
+| [`post_application.md`](product/post_application.md) | Design: the "after you apply" co-pilot — interview prep, mock interview, skill-gap, follow-up email, outreach (offer/salary deliberately out). |
+| [`plans/2026-06-21-free-premium-plans.md`](product/plans/2026-06-21-free-premium-plans.md) | Free/Premium tier design (not yet built). |
+| [`References.md`](harness/References.md) | Source-of-truth list of external references and research links. |
 
 ## 📘 Engine evaluation
 
 | Doc | What it is |
 |---|---|
-| [`engine_eval_report.md`](engine_eval_report.md) | Canonical ablation results (Run 8, n=100, bootstrap CIs) — drives engine selection. |
-| [`evaluation_report.md`](evaluation_report.md) | 10-gate production-readiness rubric (score banner notes it predates Step 3 — needs re-eval). |
+| [`engine_eval_report.md`](../harness/eval/engine_eval_report.md) | Canonical ablation results (Run 8, n=100, bootstrap CIs) — drives engine selection. |
+| [`evaluation_report.md`](../harness/eval/evaluation_report.md) | 10-gate production-readiness rubric (score banner notes it predates Step 3 — needs re-eval). |
 
 ## Roadmap & plans
 
 | Doc | Status | What it is |
 |---|---|---|
-| [`ExecutionOrder.md`](ExecutionOrder.md) | 🟢 | Seam-by-seam integration order; **Steps 4–6 (ops hardening) still pending.** |
-| [`plans/batch-2-decisions.md`](plans/batch-2-decisions.md) | 📘 | **Irreversible architectural choices** (ARQ, Apprise, polling, SQLite, session cookies). |
-| [`plans/batch-1-plan.md`](plans/batch-1-plan.md) · [`batch-2-plan.md`](plans/batch-2-plan.md) · [`batch-3-plan.md`](plans/batch-3-plan.md) | 🗄️ | Pillar 3 batch plans (shipped — kept as the log's linked history). |
+| [`ExecutionOrder.md`](harness/ExecutionOrder.md) | 🟢 | Seam-by-seam integration order; **Steps 4–6 (ops hardening) still pending.** |
+| [`plans/batch-2-decisions.md`](product/plans/batch-2-decisions.md) | 📘 | **Irreversible architectural choices** (ARQ, Apprise, polling, SQLite, session cookies). |
+| [`plans/batch-1-plan.md`](product/plans/batch-1-plan.md) · [`batch-2-plan.md`](product/plans/batch-2-plan.md) · [`batch-3-plan.md`](product/plans/batch-3-plan.md) | 🗄️ | Pillar 3 batch plans (shipped — kept as the log's linked history). |
 | `plans/batch-3.5*.md` | 🗄️ | Stabilisation sub-batches (IDOR fix, profile storage, conditional-cache pilot, test cleanup). |
-| [`step_3_plan.md`](step_3_plan.md) | 🗄️ | Step 3 endpoints + Settings UI — **completed** (closed at `origin/main 7194d0e`). |
+| [`step_3_plan.md`](harness/step_3_plan.md) | 🗄️ | Step 3 endpoints + Settings UI — **completed** (closed at `origin/main 7194d0e`). |
 | [`superpowers/`](superpowers/) | 🗄️ | Skill-driven plan + spec artefacts (channels/notifications overhaul). |
 
 ## 🗄️ Reviews (`reviews/`)
 
 Permanent reviewer verdicts for merged Pillar-3 batches — cited by `IMPLEMENTATION_LOG.md`:
-[`batch-1-review.md`](reviews/batch-1-review.md) · [`batch-2-review.md`](reviews/batch-2-review.md) · [`batch-3-review.md`](reviews/batch-3-review.md) · [`batch-3.5-review.md`](reviews/batch-3.5-review.md)
+[`batch-1-review.md`](harness/reviews/batch-1-review.md) · [`batch-2-review.md`](harness/reviews/batch-2-review.md) · [`batch-3-review.md`](harness/reviews/batch-3-review.md) · [`batch-3.5-review.md`](harness/reviews/batch-3.5-review.md)
 
 ## 🗄️ Research (`research/`)
 
 Background research that `IMPLEMENTATION_LOG.md` bridges to the shipped code (kept as canonical source material):
-[`pillar_1_report.md`](research/pillar_1_report.md) · [`pillar_2_report.md`](research/pillar_2_report.md) · [`pillar_3_report.md`](research/pillar_3_report.md) · [`pillar_3_batch_1`](research/pillar_3_batch_1.md)–[`4`](research/pillar_3_batch_4.md)
+[`pillar_1_report.md`](product/research/pillar_1_report.md) · [`pillar_2_report.md`](product/research/pillar_2_report.md) · [`pillar_3_report.md`](product/research/pillar_3_report.md) · [`pillar_3_batch_1`](product/research/pillar_3_batch_1.md)–[`4`](product/research/pillar_3_batch_4.md)
 
 ## 🤖 Autonomous maintenance loop (`maintenance/`)
 
@@ -101,17 +101,17 @@ Background research that `IMPLEMENTATION_LOG.md` bridges to the shipped code (ke
 
 | Doc | Role |
 |---|---|
-| [`maintenance/MISSIONS.md`](maintenance/MISSIONS.md) | **Canonical** mission list (the loop's task queue). |
-| [`maintenance/BACKLOG.md`](maintenance/BACKLOG.md) | Deferred work. |
-| [`maintenance/JOURNAL.md`](maintenance/JOURNAL.md) | Running activity log. |
-| [`maintenance/STATUS-DAILY.md`](maintenance/STATUS-DAILY.md) | Daily health report (GREEN/AMBER/RED). |
-| [`maintenance/HEALTH-SCHEDULE.md`](maintenance/HEALTH-SCHEDULE.md) | Health-check cadence. |
-| [`maintenance/REVIEW-PACKET.md`](maintenance/REVIEW-PACKET.md) | Integrator review bundle. |
-| [`maintenance/M7-codegen-research.md`](maintenance/M7-codegen-research.md) | OpenAPI→TS codegen research (decision pending). |
+| [`maintenance/MISSIONS.md`](harness/maintenance/MISSIONS.md) | **Canonical** mission list (the loop's task queue). |
+| [`maintenance/BACKLOG.md`](harness/maintenance/BACKLOG.md) | Deferred work. |
+| [`maintenance/JOURNAL.md`](harness/maintenance/JOURNAL.md) | Running activity log. |
+| [`maintenance/STATUS-DAILY.md`](harness/maintenance/STATUS-DAILY.md) | Daily health report (GREEN/AMBER/RED). |
+| [`maintenance/HEALTH-SCHEDULE.md`](harness/maintenance/HEALTH-SCHEDULE.md) | Health-check cadence. |
+| [`maintenance/REVIEW-PACKET.md`](harness/maintenance/REVIEW-PACKET.md) | Integrator review bundle. |
+| [`maintenance/M7-codegen-research.md`](harness/maintenance/M7-codegen-research.md) | OpenAPI→TS codegen research (decision pending). |
 
 ## 🛠️ Known debt
 
-- [`mypy_backlog.md`](mypy_backlog.md) — catalogued mypy strict-mode errors + chip-away order.
+- [`mypy_backlog.md`](harness/mypy_backlog.md) — catalogued mypy strict-mode errors + chip-away order.
 
 ## 🗄️ Archive (`_archive/`)
 


### PR DESCRIPTION
`docs/README.md` is the map of the doc estate, and **46 of its 52 links were dead**. Every doc-sync run reported the same 52 rows for weeks, so the daily report read as noise and both the Action and the new routine learned to step around it. A permanent finding is an ignored finding.

**Not one file was missing.** They were reorganised into `docs/harness/` and `docs/product/` during earlier sweeps, plus the eval set which left `docs/` entirely for the repo-root `harness/eval/`. The index never followed them.

## How they were resolved

From data, not by hand: index every `*.md` in the repo, then match each dead link by its full relative **shape** (path suffix), falling back to the shallowest basename match.

The suffix rule is load-bearing. Matching on basename alone silently resolved `pillars/README.md` to the **repo-root README.md** — which exists, and is completely the wrong document. A resolver that always returns something will happily return the wrong thing. That mapping was checked by hand and is now `product/pillars/README.md`.

## Verified

```
before: **52 drifted claim(s).**
after:  No drift — every doc claim matches the code, all stamps fresh. OK
rescan: links total=52  ok=52  resolvable=0  gone=0
```

Diff reads as 127/127 lines because git normalised CRLF→LF on write; the real content change is **42 lines, all link rewrites** (`git diff --ignore-cr-at-eol --numstat` → `42 42`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6DsQH5EUxJc3Vnqz9YHgQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation links to reflect the current structure.
  * Added guidance on implementation status, architecture, product strategy, evaluation, maintenance, and known technical debt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->