### PR TITLE
fix(doc-sync): promote three routine findings into the guard, and prove every guard can fail

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,4 @@
+<!-- doc: LIVING | last-verified: 2026-08-24 by /sync -->
 # Contributing to Job360
 
 Thanks for helping improve Job360. This guide covers the conventions you need to
@@ -77,14 +78,14 @@ redeploy the previous SUCCESS build, then fix forward on a branch.
 
 ## Test-before-merge gate
 
-**Invariant baseline: ~1,409 collected (2 live deselected), 0 failing.**
+**Invariant baseline: 3,297 collected / 3,295 selected (2 `live` deselected), 0 failing.**
 
 A PR is mergeable only when:
 
 - `cd backend && python -m pytest -q -p no:randomly` reports **0 failing** and
-  **>= ~1,409 collected**. (The suite expands with every new source / feature;
-  the floor only moves up — Step-0 baseline was 600; Step-3 close-out at
-  ~1,409.)
+  **>= 3,297 collected**. (The suite expands with every new source / feature;
+  the floor only moves up — Step-0 baseline was 600, Step-3 close-out ~1,409,
+  and it stands at 3,297 as of 2026-08-24. Measure it, never quote it.)
 - `pre-commit run --all-files` is clean.
 - CI is green on the PR branch.
 - At least one reviewer has approved (or owner self-approval on
@@ -123,7 +124,7 @@ either live `scripts/` directory.
 ## Architecture + rules
 
 Read [`CLAUDE.md`](CLAUDE.md) at repo root before your first non-trivial change.
-It documents the 26 hard rules (no `user_id` on `jobs`, no lazy-breaking heavy
+It documents the 31 hard rules (no `user_id` on `jobs`, no lazy-breaking heavy
 imports, mandatory five-surface updates when adding sources, timezone-aware
 quiet-hours dispatch, account-mgmt session invalidation, etc.) plus the
 scoring algorithm and data-flow.

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,6 +1,7 @@
+<!-- doc: LIVING | last-verified: 2026-08-24 by /sync -->
 # Job360 Backend
 
-FastAPI backend for Job360. Async job aggregator across 47 sources + scoring +
+FastAPI backend for Job360. Async job aggregator across 41 sources + scoring +
 semantic retrieval. Serves the Next.js dashboard, runs the scheduled pipeline,
 and hosts the ARQ worker for notifications.
 
@@ -41,7 +42,7 @@ copy ..\.env.example ..\.env   # Windows
 ```
 
 Edit `../.env` to set your API keys, webhook URLs, and `FRONTEND_ORIGIN`.
-Free sources (39 of 47) work without any keys. See [`CLAUDE.md`](../CLAUDE.md)
+Free sources (33 of 41) work without any keys. See [`CLAUDE.md`](../CLAUDE.md)
 for the full env-var table.
 
 ## Run the API
@@ -64,11 +65,11 @@ uvicorn main:app --host 0.0.0.0 --port 8000
 ## Run the pipeline (CLI)
 
 ```bash
-python -m src.cli run                          # all 47 sources
+python -m src.cli run                          # all 41 sources
 python -m src.cli run --source arbeitnow       # single source
 python -m src.cli run --dry-run --log-level DEBUG
 python -m src.cli status                       # last-run summary
-python -m src.cli sources                      # list all 47 sources
+python -m src.cli sources                      # list all 41 sources
 python -m src.cli view --hours 24 --min-score 50
 python -m src.cli setup-profile --cv path/to/cv.pdf
 ```
@@ -81,10 +82,10 @@ Must pass from `backend/`:
 python -m pytest -q -p no:randomly
 ```
 
-Invariant: full suite passes, 0 failing. (Live count is **1000+ test functions**
-across 30+ files — run `python -m pytest --collect-only -q | tail -1` for the
-exact number; the 600 baseline you'll see referenced in older docs was the
-post-3.5.4 figure before Step 1 → Step 3 added their tests.) The
+Invariant: full suite passes, 0 failing. (Live count is **3,297 collected / 3,295 selected**
+(2 `live` deselected) across **217** `test_*.py` files — run
+`python -m pytest --collect-only -q -p no:randomly | tail -1` for the exact
+number, and defer to it rather than to any figure written down here.) The
 `-p no:randomly` flag keeps the default order deterministic (pytest-randomly is
 installed but opt-in).
 

--- a/docs/product/pillars/03-job-providers.md
+++ b/docs/product/pillars/03-job-providers.md
@@ -1,14 +1,15 @@
+<!-- doc: LIVING | last-verified: 2026-08-24 by /sync -->
 # Pillar 3 — Job Providers
 
-> **Audience.** Read this if you want to understand where Job360's raw job postings actually come from — the 46 source classes, the one base class they all inherit, the shared retry/rate-limit/conditional-fetch machinery, the ATS company-slug catalog, and how a posting becomes a normalised `Job` row in the shared catalog.
+> **Audience.** Read this if you want to understand where Job360's raw job postings actually come from — the 40 source classes, the one base class they all inherit, the shared retry/rate-limit/conditional-fetch machinery, the ATS company-slug catalog, and how a posting becomes a normalised `Job` row in the shared catalog.
 >
-> **Scope.** Covers code on `main`, post-Batch-3 source rotation and the **M6 rotation (2026-06)** that dropped 4 upstream-dead sources (jobtensor, comeet, gov_apprenticeships, aijobs_global) — gov_apprenticeships was later restored 2026-06-16 on the DfE Display Advert API v2. Current canonical counts: **46 classes / 47 registry keys / 46 instances**. Counts in this doc were verified against the files on disk and the test assertions.
+> **Scope.** Covers code on `main`, post-Batch-3 source rotation and the **M6 rotation (2026-06)** that dropped 4 upstream-dead sources (jobtensor, comeet, gov_apprenticeships, aijobs_global) — gov_apprenticeships was later restored 2026-06-16 on the DfE Display Advert API v2. Current canonical counts: **40 classes / 41 registry keys / 40 instances**. Counts in this doc were verified against the files on disk and the test assertions.
 
 ---
 
 ## 1. TL;DR — what the providers pillar does
 
-> *Job360 talks to 46 distinct job-source classes — keyed aggregators, free JSON APIs, company ATS boards, RSS/XML feeds, HTML scrapers, and a few one-offs. Every one inherits a single `BaseJobSource` that gives it retry-with-backoff, per-source rate limiting, optional conditional (ETag/304) fetching, and a UK/remote location filter for free. Each source's only real job is to implement one async method — `fetch_jobs() -> list[Job]` — turning whatever shape the upstream returns into the canonical `Job` dataclass. The orchestrator (Pillar 2) then scores, dedups, and stores them.*
+> *Job360 talks to 40 distinct job-source classes — keyed aggregators, free JSON APIs, company ATS boards, RSS/XML feeds, HTML scrapers, and a few one-offs. Every one inherits a single `BaseJobSource` that gives it retry-with-backoff, per-source rate limiting, optional conditional (ETag/304) fetching, and a UK/remote location filter for free. Each source's only real job is to implement one async method — `fetch_jobs() -> list[Job]` — turning whatever shape the upstream returns into the canonical `Job` dataclass. The orchestrator (Pillar 2) then scores, dedups, and stores them.*
 
 ### The count reconciliation (read this once, never wonder again)
 
@@ -16,17 +17,17 @@ Three numbers float around the codebase and they're all correct because they cou
 
 | Number | What it counts | Where |
 | --- | --- | --- |
-| **46** | Source *class files* on disk | `find src/sources -name '*.py'` minus `__init__`/`base` = 8+10+11+8+5+4 |
-| **47** | *Registry keys* in `SOURCE_REGISTRY` | `main.py:103-152` — `"glassdoor"` is a second key that aliases `JobSpySource` |
-| **46** | Live *instances* built per run | `SOURCE_INSTANCE_COUNT = 46` (`main.py:160`) — `indeed`+`glassdoor` collapse to one `JobSpySource` |
+| **40** | Source *class files* on disk | `find backend/src/sources -name '*.py'` minus `__init__`/`base` |
+| **41** | *Registry keys* in `SOURCE_REGISTRY` | `main.py` — `"glassdoor"` is a second key that aliases `JobSpySource` |
+| **40** | Live *instances* built per run | `SOURCE_INSTANCE_COUNT = 40` (`main.py:168`) — `indeed`+`glassdoor` collapse to one `JobSpySource` |
 
-So: **46 classes → 47 registry keys → 46 instances.** The single fork is Indeed/Glassdoor, both handled by `JobSpySource` in `other/indeed.py`. The test suite pins all of this — `test_cli.py` asserts `len(SOURCE_REGISTRY) == 47`, `test_api.py` asserts `sources_total == 47` in three places (CLAUDE.md rule #13).
+So: **40 classes → 41 registry keys → 40 instances.** The single fork is Indeed/Glassdoor, both handled by `JobSpySource` in `other/indeed.py`. The test suite pins all of this — `test_cli.py:55` asserts `len(SOURCE_REGISTRY) == 41`, `test_api.py` asserts `sources_total == 41` at `:43` and `:160` (CLAUDE.md rule #13). Measure these, never quote them: six sources were pruned on 2026-08-17 and this table said 46/47/46 for a week afterwards.
 
 ---
 
 ## Walkthrough — One source's fetch cycle (worked example)
 
-> Trace exactly what happens from the scheduler deciding it's time to poll `greenhouse` to a `Job` row landing back in the orchestrator. Uses Greenhouse because it's the cleanest of the ATS sources, but the same shape applies to all 46.
+> Trace exactly what happens from the scheduler deciding it's time to poll `greenhouse` to a `Job` row landing back in the orchestrator. Uses Greenhouse because it's the cleanest of the ATS sources, but the same shape applies to all 40.
 
 ### T+0 — Scheduler decides
 
@@ -178,7 +179,7 @@ def __init__(self, session: aiohttp.ClientSession, search_config=None):
 
 - `session` — one shared `aiohttp.ClientSession` across all sources (connection pooling).
 - `search_config=None` — when present, the source uses the user's dynamic keywords; when `None`, it falls back to the (now-empty) hard-coded defaults from `keywords.py`.
-- Rate limiter is pulled per-source from `RATE_LIMITS` (47 entries) with a safe `{concurrent:2, delay:1.0}` default.
+- Rate limiter is pulled per-source from `RATE_LIMITS` (41 entries) with a safe `{concurrent:2, delay:1.0}` default.
 
 ### 2.2 The three dynamic properties (`base.py:71-87`)
 
@@ -295,7 +296,7 @@ This tuple is the DB's UNIQUE constraint and the deduplicator's Layer-1 key. **C
 
 ## 4. The six source categories
 
-46 classes across 6 folders. The pattern each follows is the differentiator.
+40 classes across 6 folders. The pattern each follows is the differentiator.
 
 ### 4.1 Keyed APIs — `apis_keyed/` (8)
 
@@ -379,7 +380,7 @@ A `COMPANY_NAME_OVERRIDES` dict (~77 entries) maps ugly slugs (`darktracelimited
 
 ### 6.1 `RATE_LIMITS` — `backend/src/core/settings.py:93-146`
 
-47 entries (one per registry key), each `{source: {concurrent: int, delay: float}}`. Representative tuning:
+41 entries (one per registry key), each `{source: {concurrent: int, delay: float}}`. Representative tuning:
 
 | Source | concurrent | delay (s) | Why |
 | --- | --- | --- | --- |
@@ -411,7 +412,7 @@ Effect: at most `concurrent` parallel requests, with a minimum `delay` between a
 
 ## 7. Source rotations (Batch 3, then M6)
 
-Batch 3 rotated the roster: **−3 dropped, +5 added**, net 48 → 50 registry keys. The later **M6 rotation (2026-06)** then dropped 4 upstream-dead sources (jobtensor, comeet, gov_apprenticeships, aijobs_global), taking the registry **50 → 46** — gov_apprenticeships was later restored 2026-06-16 on the DfE Display Advert API v2, bringing it back to **47**. The Batch-3 tables below are kept as history; the M6 drops are flagged inline.
+Batch 3 rotated the roster: **−3 dropped, +5 added**, net 48 → 50 registry keys. The later **M6 rotation (2026-06)** then dropped 4 upstream-dead sources (jobtensor, comeet, gov_apprenticeships, aijobs_global), taking the registry **50 → 46** — gov_apprenticeships was later restored 2026-06-16 on the DfE Display Advert API v2, bringing it back to **47**. A further prune on 2026-08-17 dropped six upstream-dead sources, taking the registry **47 → 41**. The Batch-3 tables below are kept as history; the M6 drops are flagged inline.
 
 ### Dropped (verified absent from disk)
 
@@ -437,20 +438,20 @@ Adding/removing a source means moving **all five** together, or tests break:
 
 1. `src/main.py` — `SOURCE_REGISTRY` dict + `_build_sources()` list
 2. `src/core/settings.py` — `RATE_LIMITS` dict
-3. `tests/test_cli.py` — `len(SOURCE_REGISTRY) == 47` + the expected set
-4. `tests/test_api.py` — three `== 47` checks (`test_sources_returns_*`, `test_status_returns_counts`, `test_full_api_workflow`)
+3. `tests/test_cli.py` — `len(SOURCE_REGISTRY) == 41` + the expected set
+4. `tests/test_api.py` — two `== 41` checks (`:43`, `:160`)
 5. `CLAUDE.md` — the documented count
 
-All five are currently aligned at **47**.
+All five are currently aligned at **41**.
 
 ---
 
 ## 8. Testing — `backend/tests/test_sources.py` + friends
 
-- **`test_sources.py`** — 81 test functions covering all 47 keys. All HTTP mocked with `aioresponses` (rule #4 — the suite must run offline). A typical source test asserts: returns `list[Job]`, parses fields into the `Job` model, filters non-UK locations, handles an empty response (`jobs == []`), and (keyed sources) returns `[]` when the API key is `""`. Batch-3 sources have 3 tests each (`test_sources.py:1561-1688`): parse / empty / http-error.
+- **`test_sources.py`** — 110 test functions covering all 41 keys. All HTTP mocked with `aioresponses` (rule #4 — the suite must run offline). A typical source test asserts: returns `list[Job]`, parses fields into the `Job` model, filters non-UK locations, handles an empty response (`jobs == []`), and (keyed sources) returns `[]` when the API key is `""`. Batch-3 sources have 3 tests each (`test_sources.py:1561-1688`): parse / empty / http-error.
 - **`test_conditional_fetch.py`** — 11 tests for the shared ETag/Last-Modified/304 machinery, FIFO eviction at 256 entries, and the `nhs_jobs_xml` pilot proving `If-None-Match` is sent on the second call.
-- **`test_cli.py`** — `len(SOURCE_REGISTRY) == 47` + exact expected set.
-- **`test_api.py`** — the three hardcoded `== 47` assertions.
+- **`test_cli.py`** — `len(SOURCE_REGISTRY) == 41` + exact expected set.
+- **`test_api.py`** — the two hardcoded `== 41` assertions.
 
 There are **no** separate `test_ats*.py` / `test_feed*.py` files — all source tests live inline in `test_sources.py`.
 
@@ -568,7 +569,7 @@ backend/src/sources/
 
 backend/src/
 ├── models.py                       — Job dataclass + normalized_key() (rule #1)
-├── main.py:103-318                 — SOURCE_REGISTRY (47 keys) + _build_sources() + domain filter
+├── main.py                         — SOURCE_REGISTRY (41 keys) + _build_sources() + domain filter
 ├── core/
 │   ├── companies.py                — ~256 ATS slugs across 11 platforms + name overrides
 │   ├── settings.py:93-146          — RATE_LIMITS (47 entries)
@@ -578,8 +579,8 @@ backend/src/
 backend/tests/
 ├── test_sources.py                 — 81 tests, all sources, aioresponses-mocked
 ├── test_conditional_fetch.py       — 11 tests, ETag/304/FIFO + nhs_jobs_xml pilot
-├── test_cli.py                     — len(SOURCE_REGISTRY) == 47
-└── test_api.py                     — three == 47 assertions
+├── test_cli.py                     — len(SOURCE_REGISTRY) == 41
+└── test_api.py                     — two == 41 assertions
 ```
 
 ---

--- a/scripts/doc_sync_check.py
+++ b/scripts/doc_sync_check.py
@@ -110,6 +110,42 @@ def migration_head() -> int:
     return max(nums)
 
 
+def workflow_count() -> int:
+    """Number of GitHub Actions workflow files.
+
+    Promoted from the nightly doc-truth routine 2026-08-24, which found the
+    docs claiming 26 while three more had landed. A countable fact an LLM
+    re-discovers every night is a fact this script should hold for free.
+    """
+    return len(list((ROOT / ".github/workflows").glob("*.yml")))
+
+
+def test_file_count() -> int:
+    """Number of backend test_*.py files.
+
+    NOT the collected-test count. Collection imports conftest, which wants a
+    live Postgres, and this checker runs in a blocking CI step that must stay
+    fast and offline. The collected number stays the routine's job; the file
+    count is filesystem-only and cannot lie.
+    """
+    return len(list((ROOT / "backend/tests").glob("test_*.py")))
+
+
+def frontend_versions() -> tuple[str, str]:
+    """(next, react) exact versions from frontend/package.json.
+
+    Also promoted 2026-08-24: docs said Next.js 16.2.2 / React 19.2.4 while
+    package.json pinned 16.3.0 / 19.2.8. Only FULL x.y.z claims are matched,
+    so prose like "Next.js 16" stays legal.
+    """
+    import json
+
+    pkg = json.loads((ROOT / "frontend/package.json").read_text(encoding="utf-8"))
+    deps = pkg.get("dependencies", {})
+    clean = lambda v: str(v).lstrip("^~>=< ")  # noqa: E731
+    return clean(deps.get("next", "")), clean(deps.get("react", ""))
+
+
 def scorer_version() -> int:
     """SCORER_VERSION from backend/src/services/skill_matcher.py.
 
@@ -297,6 +333,13 @@ def main() -> int:
         ("registry", registry, r"Current count: \*\*(\d+)\*\*"),
         ("registry", registry, r"[Ll]ist all (\d+) sources"),
         ("registry", registry, r"(\d+) SOURCE_REGISTRY entries"),
+        # Added 2026-08-24 by scripts/doc_sync_mutation_test.py on its first
+        # full run. CLAUDE.md:44 phrases it "`SOURCE_REGISTRY` has 41 entries",
+        # which matched none of the five patterns above. Other docs DID claim
+        # it in a matching form, so the "nobody claims this fact" alarm stayed
+        # quiet and the number in the most-read doc in the repo was guarded by
+        # nothing at all.
+        ("registry", registry, r"SOURCE_REGISTRY`?\s+has\s+(\d+)\s+entries"),
         ("unique-classes", unique_classes, r"(\d+) unique source classes"),
         ("migration-head", mig_head, r"0000 → (\d{4})"),
         # Added 2026-08-03. The checker tracked THREE facts, so every other
@@ -312,6 +355,21 @@ def main() -> int:
         # misleads on exactly the constant that decides whether a user's feed
         # gets re-scored. `\*{0,2}` because the docs bold it.
         ("scorer-version", scorer_version(), r"SCORER_VERSION`?\s*=\s*\*{0,2}(\d+)"),
+        # Promoted from the nightly doc-truth routine 2026-08-24. Each of these
+        # was drift the LLM found by reading; they are countable, so they belong
+        # here where they cost nothing and are caught on every push.
+        ("workflows", workflow_count(), r"(\d+) workflows in"),
+        ("test-files", test_file_count(), r"across (\d+) `?test_\*\.py`? files"),
+    ]
+
+    # String-valued facts. Kept separate because the numeric loop below does
+    # int(m.group(1)); a version like "16.3.0" is not an int and must be
+    # compared as text.
+    next_ver, react_ver = frontend_versions()
+    text_checks = [
+        # Only FULL x.y.z claims match, so prose like "Next.js 16" stays legal.
+        ("nextjs-version", next_ver, r"Next\.js (\d+\.\d+\.\d+)"),
+        ("react-version", react_ver, r"React (\d+\.\d+\.\d+)"),
     ]
 
     drift: list[tuple[str, str, str, str, str]] = []  # file, line, fact, doc-says, code-says
@@ -338,6 +396,13 @@ def main() -> int:
                     if claimed != actual:
                         drift.append((rel, str(i), fact, str(claimed), str(actual)))
 
+        for fact, actual_text, pattern in text_checks:
+            for i, line in enumerate(lines, start=1):
+                for m in re.finditer(pattern, line, re.IGNORECASE):
+                    matches_per_fact[fact] = matches_per_fact.get(fact, 0) + 1
+                    if m.group(1) != actual_text:
+                        drift.append((rel, str(i), fact, m.group(1), actual_text))
+
         for phrase, why in FORBIDDEN_PHRASES:
             for i, line in enumerate(lines, start=1):
                 if phrase.lower() in line.lower():
@@ -363,7 +428,7 @@ def main() -> int:
 
     # A fact nobody claims anymore = the claim was reworded/deleted and this
     # checker just went blind to it. That is drift, not success.
-    for fact in {c[0] for c in checks}:
+    for fact in {c[0] for c in checks} | {c[0] for c in text_checks}:
         if matches_per_fact.get(fact, 0) == 0:
             drift.append(("(all docs)", "-", fact, "claim not found in any doc",
                           "reworded/removed — update checker patterns or restore the claim"))

--- a/scripts/doc_sync_check.py
+++ b/scripts/doc_sync_check.py
@@ -48,6 +48,18 @@ LIVING_DOCS = [
     # a guard blind to the exact bug it was written for.
     "frontend/CLAUDE.md",
     "frontend/README.md",
+    # Added 2026-08-24 by the coverage half of doc_sync_mutation_test.py, which
+    # asks the question this list could never ask itself: which docs state a
+    # guarded fact while sitting OUTSIDE it? All three were lying.
+    #   CONTRIBUTING.md         "the 26 hard rules"        (31)
+    #   backend/README.md       "list all 47 sources"      (41)
+    #   .../03-job-providers.md "SOURCE_REGISTRY (47"      (41), in ten places
+    # The last one is the worst: root CLAUDE.md calls docs/product/pillars/ the
+    # AUTHORITATIVE code-verified architecture reference, and it carried the
+    # pre-2026-08-17 source counts that started this whole audit.
+    "CONTRIBUTING.md",
+    "backend/README.md",
+    "docs/product/pillars/03-job-providers.md",
 ]
 
 # Prose lies that numbers can't catch. Each = (forbidden phrase, why).
@@ -321,7 +333,14 @@ def budget_only() -> int:
     return 1
 
 
-def main() -> int:
+def build_checks() -> tuple[list[tuple[str, int, str]], list[tuple[str, str, str]]]:
+    """Return (numeric checks, text checks).
+
+    Extracted from main() 2026-08-24 so scripts/doc_sync_mutation_test.py can
+    read the real patterns instead of keeping its own copy. A drill with a
+    duplicated pattern list stops testing this checker the moment the two
+    drift apart — which is the exact failure mode this whole file exists for.
+    """
     registry, unique_classes = registry_counts()
     mig_head = migration_head()
 
@@ -371,6 +390,13 @@ def main() -> int:
         ("nextjs-version", next_ver, r"Next\.js (\d+\.\d+\.\d+)"),
         ("react-version", react_ver, r"React (\d+\.\d+\.\d+)"),
     ]
+    return checks, text_checks
+
+
+def main() -> int:
+    checks, text_checks = build_checks()
+    registry, unique_classes = registry_counts()
+    mig_head = migration_head()
 
     drift: list[tuple[str, str, str, str, str]] = []  # file, line, fact, doc-says, code-says
     matches_per_fact: dict[str, int] = {}

--- a/scripts/doc_sync_mutation_test.py
+++ b/scripts/doc_sync_mutation_test.py
@@ -1,0 +1,86 @@
+"""Prove every doc_sync_check.py guard can actually go RED.
+
+A green drift report means one of two very different things: "the docs are
+correct", or "my regex matched nothing and I am watching an empty room". They
+are indistinguishable from the outside, and the second is how a stale number
+survives for months behind a passing check -- `SCORER_VERSION` sat at 4 in the
+docs while the code said 7, with a green tripwire the whole time.
+
+So each guard is broken ON PURPOSE, one at a time, and must report drift.
+Restore is byte-level (read_bytes/write_bytes): a text round-trip rewrites line
+endings on Windows and would leave the tree dirty after a "successful" run.
+
+Usage (from repo root):
+    python scripts/doc_sync_mutation_test.py
+
+Exit 0 = every guard proven able to fail. Exit 1 = at least one guard is blind.
+"""
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(os.environ["JOB360_ROOT"]) if os.environ.get("JOB360_ROOT") else Path(__file__).resolve().parents[1]
+
+# (doc, regex with ONE capture group, replacement that lies, fact name in the report)
+CASES: list[tuple[str, str, str, str]] = [
+    ("CLAUDE.md", r"SOURCE_REGISTRY`? has (\d+) entries", "SOURCE_REGISTRY` has 999 entries", "registry"),
+    ("CLAUDE.md", r"(\d+) unique source classes", "999 unique source classes", "unique-classes"),
+    ("CLAUDE.md", r"SCORER_VERSION`?\s*=\s*\*{0,2}(\d+)", "SCORER_VERSION` = **999", "scorer-version"),
+    ("CLAUDE.md", r"(\d+) workflows in", "999 workflows in", "workflows"),
+    ("ARCHITECTURE.md", r"across (\d+) `?test_\*\.py`? files", "across 999 test_*.py files", "test-files"),
+    ("frontend/CLAUDE.md", r"Next\.js (\d+\.\d+\.\d+)", "Next.js 1.2.3", "nextjs-version"),
+    ("frontend/CLAUDE.md", r"React (\d+\.\d+\.\d+)", "React 4.5.6", "react-version"),
+]
+
+
+def main() -> int:
+    failures: list[str] = []
+
+    for rel, pattern, replacement, fact in CASES:
+        path = ROOT / rel
+        if not path.exists():
+            failures.append(f"{fact}: {rel} does not exist")
+            continue
+
+        original = path.read_bytes()
+        text = original.decode("utf-8", errors="replace")
+        mutated, n = re.subn(pattern, replacement, text, count=1)
+
+        if n == 0:
+            # The doc no longer makes this claim at all. Either the claim was
+            # reworded (so the guard is now blind) or the pattern is wrong.
+            failures.append(f"{fact}: no claim matching /{pattern}/ in {rel} — guard watches nothing")
+            continue
+
+        try:
+            path.write_bytes(mutated.encode("utf-8"))
+            proc = subprocess.run(
+                [sys.executable, str(ROOT / "scripts" / "doc_sync_check.py")],
+                capture_output=True,
+                text=True,
+                cwd=str(ROOT),
+            )
+            if fact in proc.stdout:
+                print(f"PASS  {fact:16s} went RED when {rel} lied")
+            else:
+                failures.append(f"{fact}: stayed GREEN on a broken {rel} — the guard is blind")
+        finally:
+            path.write_bytes(original)
+
+    print()
+    if failures:
+        print("MUTATION TEST FAILED — these guards cannot fail, so they prove nothing:")
+        for f in failures:
+            print("  " + f)
+        return 1
+
+    print(f"All {len(CASES)} guards proven able to go RED.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/doc_sync_mutation_test.py
+++ b/scripts/doc_sync_mutation_test.py
@@ -25,6 +25,13 @@ from pathlib import Path
 
 ROOT = Path(os.environ["JOB360_ROOT"]) if os.environ.get("JOB360_ROOT") else Path(__file__).resolve().parents[1]
 
+# The drift report and these findings quote doc text full of arrows and
+# em-dashes. A Windows console defaults to cp1252 and this script died mid-report
+# on a single "→" -- a guard that crashes has not failed safe, it has stopped
+# answering, which is the very thing this file exists to prevent.
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+
 # (doc, regex with ONE capture group, replacement that lies, fact name in the report)
 CASES: list[tuple[str, str, str, str]] = [
     ("CLAUDE.md", r"SOURCE_REGISTRY`? has (\d+) entries", "SOURCE_REGISTRY` has 999 entries", "registry"),
@@ -35,6 +42,54 @@ CASES: list[tuple[str, str, str, str]] = [
     ("frontend/CLAUDE.md", r"Next\.js (\d+\.\d+\.\d+)", "Next.js 1.2.3", "nextjs-version"),
     ("frontend/CLAUDE.md", r"React (\d+\.\d+\.\d+)", "React 4.5.6", "react-version"),
 ]
+
+
+def unwatched_claims() -> list[str]:
+    """Find docs that state a guarded fact but are NOT in LIVING_DOCS.
+
+    The other half of this drill, and the one the registry specifically asks
+    for: "a doc it is not watching". The checker has shipped blind exactly this
+    way before -- frontend/CLAUDE.md carried a stale "The 28 hard rules" while
+    being absent from LIVING_DOCS, so the one file with the wrong number was
+    the one file the guard could not see.
+
+    Planting a lie only proves the docs on the LIST are scanned. It says
+    nothing about a doc that should be on the list and isn't. This does.
+    """
+    sys.path.insert(0, str(ROOT / "scripts"))
+    import doc_sync_check as dsc  # noqa: PLC0415
+
+    watched = {w.replace("\\", "/") for w in dsc.LIVING_DOCS}
+    patterns = [p for _, _, p in dsc.build_checks()[0]]
+
+    # graphify-out/ holds dated, machine-generated graph snapshots. They are
+    # frozen records of what the repo looked like on a day, so a "stale" number
+    # in one is correct, not drift. Archives are excluded for the same reason.
+    # graphify-out/ holds dated machine-generated graph snapshots; docs/harness/
+    # fable/ and reviews/ hold dated audit and review records. All three are
+    # FROZEN accounts of what was true on a day. A "stale" number in a dated
+    # record is correct — rewriting it would falsify the record. Only LIVING
+    # docs owe agreement with today's code.
+    skip_dirs = (
+        "node_modules", ".git", "_archive", "archive",
+        "graphify-out", "fable", "reviews",
+    )
+
+    findings: list[str] = []
+    for path in ROOT.rglob("*.md"):
+        parts = path.parts
+        if any(skip in parts for skip in skip_dirs):
+            continue
+        rel = path.relative_to(ROOT).as_posix()
+        if rel in watched:
+            continue
+        text = path.read_text(encoding="utf-8", errors="replace")
+        for pat in patterns:
+            m = re.search(pat, text, re.IGNORECASE)
+            if m:
+                findings.append(f"{rel} claims /{pat}/ -> {m.group(0)!r} but is not in LIVING_DOCS")
+                break
+    return findings
 
 
 def main() -> int:
@@ -61,15 +116,26 @@ def main() -> int:
             proc = subprocess.run(
                 [sys.executable, str(ROOT / "scripts" / "doc_sync_check.py")],
                 capture_output=True,
-                text=True,
+                # Explicit utf-8, never text=True: that decodes with the
+                # machine's locale (cp1252 on Windows), and the drift report
+                # is full of em-dashes. Caught by scripts/encoding_guard.py --
+                # this file's first draft printed "MUTATION TEST FAILED <?>".
+                encoding="utf-8",
+                errors="replace",
                 cwd=str(ROOT),
             )
-            if fact in proc.stdout:
+            if fact in (proc.stdout or ""):
                 print(f"PASS  {fact:16s} went RED when {rel} lied")
             else:
                 failures.append(f"{fact}: stayed GREEN on a broken {rel} — the guard is blind")
         finally:
             path.write_bytes(original)
+
+    # Second half of the drill: docs that make a guarded claim while sitting
+    # outside LIVING_DOCS. Planting a lie proves the LISTED docs are scanned;
+    # this proves nothing that matters is missing from the list.
+    for finding in unwatched_claims():
+        failures.append(f"unwatched-claim: {finding}")
 
     print()
     if failures:


### PR DESCRIPTION
Two halves: teach the cheap deterministic checker what the nightly LLM routine had to re-discover by reading, then prove the checker can actually go red.

## Promoted from scout to guard

The nightly doc-truth routine found docs claiming **26 workflows** (27 on disk), **1,288 collected tests** (3,297), and **Next.js 16.2.2 / React 19.2.4** (package.json pins 16.3.0 / 19.2.8). All three are *countable*.

Paying an LLM every night to re-find a fact a filesystem call can hold is the wrong split of labour. The routine is a **scout** that discovers new invariants; this script is the **guard** that holds them for free on every push.

Added `workflow_count()`, `test_file_count()`, `frontend_versions()`, plus a separate `text_checks` pass — the numeric loop does `int(m.group(1))` and `16.3.0` is not an int. Only full `x.y.z` claims match, so prose like "Next.js 16" stays legal.

**Deliberately not added:** the collected-test count. Collection imports `conftest`, which wants a live Postgres, and this checker runs in a *blocking* CI step that must stay fast and offline. The file count is filesystem-only and cannot lie; the collected count stays the routine's job.

## Guards that can fail (issue #359)

A green drift report means one of two very different things — *"the docs are correct"* or *"my regex matched nothing and I am watching an empty room"* — and from outside they look identical. That second case is how `SCORER_VERSION` sat at 4 in the docs while the code said 7, behind a passing check.

`scripts/doc_sync_mutation_test.py` breaks each guarded claim on purpose, one at a time, and asserts the report goes red. Restore is byte-level; a text round-trip rewrites line endings on Windows and leaves the tree dirty after a "successful" run.

**It found a real blind spot on its first full run.** The `registry` guard carries five patterns, and not one matches the phrasing `CLAUDE.md:44` actually uses:

```
`SOURCE_REGISTRY` has 41 entries but 40 unique source classes
```

Other docs claim the same fact in a form that *does* match, so the "nobody claims this fact anymore" alarm stayed quiet — and **the source count in the most-read doc in the repo was guarded by nothing at all.** A sixth pattern closes it; it now goes red.

## Verified

```
PASS  registry         went RED when CLAUDE.md lied
PASS  unique-classes   went RED when CLAUDE.md lied
PASS  scorer-version   went RED when CLAUDE.md lied
PASS  workflows        went RED when CLAUDE.md lied
PASS  test-files       went RED when ARCHITECTURE.md lied
PASS  nextjs-version   went RED when frontend/CLAUDE.md lied
PASS  react-version    went RED when frontend/CLAUDE.md lied

All 7 guards proven able to go RED.
```

Working tree byte-identical after the run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6DsQH5EUxJc3Vnqz9YHgQ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated contribution, backend, and Job Providers documentation with current verification dates, test counts, source totals, registry details, and baseline metrics.
  * Improved checks to keep documented workflow, test-file and frontend version details aligned with the project.
  * Added detection for outdated or missing documentation claims.

* **Tests**
  * Added automated validation that confirms documentation safeguards detect deliberate changes and restore affected files safely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->