### PR TITLE
fix(observability): four instruments that reported success about a different question

### DIFF
--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -188,18 +188,48 @@ async def _ghost_detection_pass(
     Returns {source_name: missed_count} for observability.
     """
     missed_by_source: dict[str, int] = {}
+
+    async def _warn_sweep_skipped(source_name: str, reason: str, detail: str) -> None:
+        """Name the cost of a skipped absence sweep, not just the skip.
+
+        PROD 2026-08-13: adzuna, linkedin and workday raise on EVERY run
+        (run_log.per_source_errors; workday's duration is pinned at the 240s
+        timeout). Skipping them is correct — a failed scrape must never be read
+        as "the jobs disappeared" — but the skip used to be a bare `continue`
+        with no log at all for the failure branch. So their listings stopped
+        ageing and were served as live indefinitely: 140 rows sat in
+        `staleness_state='active'` with `last_seen_at` 3-8 days old, and
+        because `consecutive_misses` never reached 2 the nightly ghost sweep
+        legitimately reported `transitioned: 0`. Every instrument said fine.
+        """
+        try:
+            frozen = await db.count_unexpired_jobs_for_source(source_name)
+        except Exception:  # noqa: BLE001 — observability must never break a run
+            frozen = -1
+        logger.warning(
+            "  %s: absence sweep SKIPPED (%s: %s) — %s live job(s) of this source "
+            "stopped ageing and are still served as active",
+            source_name,
+            reason,
+            detail,
+            frozen,
+        )
+
     for source, result in zip(sources, results):
         if isinstance(result, BaseException) or result is None:
+            await _warn_sweep_skipped(
+                source.name,
+                "fetch failed",
+                type(result).__name__ if isinstance(result, BaseException) else "no result",
+            )
             continue
         past = history.get(source.name, [])
         rolling_avg = (sum(past) / len(past)) if past else 0.0
         if rolling_avg > 0 and len(result) < completeness_threshold * rolling_avg:
-            logger.warning(
-                "  %s: result count (%s) below %.0f%% of 7-day avg (%.1f) — " "skipping absence sweep",
+            await _warn_sweep_skipped(
                 source.name,
-                len(result),
-                completeness_threshold * 100,
-                rolling_avg,
+                "incomplete scrape",
+                f"{len(result)} results < {completeness_threshold * 100:.0f}% of 7-day avg {rolling_avg:.1f}",
             )
             continue
         seen: set[tuple[str, str]] = {job.normalized_key() for job in result}

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -202,10 +202,23 @@ async def _ghost_detection_pass(
         because `consecutive_misses` never reached 2 the nightly ghost sweep
         legitimately reported `transitioned: 0`. Every instrument said fine.
         """
+        # `-1` IS NOT A COUNT. When the count itself failed this logged
+        # "-1 live job(s)" and swallowed the exception whole, so a reader could
+        # not tell a source-FETCH failure from a second failure in the DATABASE,
+        # and had no stack trace for either. A log line that exists to name a
+        # cost must not quietly invent the number. Say so, and record why.
+        # (CodeRabbit, PR #387.)
+        frozen: int | str
         try:
             frozen = await db.count_unexpired_jobs_for_source(source_name)
         except Exception:  # noqa: BLE001 — observability must never break a run
-            frozen = -1
+            frozen = "an unknown number of"
+            logger.warning(
+                "  %s: could not count this source's live jobs either — the "
+                "absence-sweep warning below has no number behind it",
+                source_name,
+                exc_info=True,
+            )
         logger.warning(
             "  %s: absence sweep SKIPPED (%s: %s) — %s live job(s) of this source "
             "stopped ageing and are still served as active",

--- a/backend/src/repositories/database.py
+++ b/backend/src/repositories/database.py
@@ -600,6 +600,24 @@ class JobDatabase:
         row = await cursor.fetchone()
         return int(row[0])
 
+    async def count_unexpired_jobs_for_source(self, source: str) -> int:
+        """How many of ``source``'s jobs are still being served as live.
+
+        Used only for observability: when a source's fetch fails, the absence
+        sweep is skipped for it (a failed scrape is not evidence that jobs
+        vanished), which means every one of these rows stops ageing and keeps
+        being presented as ``active``. Logging the COUNT turns "a source
+        failed" into "N live listings stopped ageing", which is the thing a
+        user actually feels.
+        """
+        cursor = await self._db.execute(
+            "SELECT COUNT(*) FROM jobs WHERE source = ? "
+            "AND (staleness_state IS NULL OR staleness_state != 'confirmed_expired')",
+            (source,),
+        )
+        row = await cursor.fetchone()
+        return int(row[0])
+
     async def log_run(
         self,
         stats: dict[str, Any],

--- a/backend/src/repositories/database.py
+++ b/backend/src/repositories/database.py
@@ -610,9 +610,17 @@ class JobDatabase:
         failed" into "N live listings stopped ageing", which is the thing a
         user actually feels.
         """
+        # THE SAME PREDICATE THE APP SERVES BY, not a looser one.
+        # This counted "anything not confirmed_expired", which sweeps in
+        # `possibly_stale` and `likely_stale` — rows `get_recent_jobs` does NOT
+        # serve (it takes `staleness_state IS NULL OR = 'active'`, database.py
+        # :761). So the warning overstated how many LIVE listings had stopped
+        # ageing: an instrument built to say what a user actually feels was
+        # counting rows no user can see. An instrument must count the way its
+        # consumer counts. (CodeRabbit, PR #387.)
         cursor = await self._db.execute(
             "SELECT COUNT(*) FROM jobs WHERE source = ? "
-            "AND (staleness_state IS NULL OR staleness_state != 'confirmed_expired')",
+            "AND (staleness_state IS NULL OR staleness_state = 'active')",
             (source,),
         )
         row = await cursor.fetchone()

--- a/backend/src/workers/tasks.py
+++ b/backend/src/workers/tasks.py
@@ -996,7 +996,11 @@ async def send_bundle(ctx: dict[str, Any], user_id: str) -> dict[str, int]:
         )
         pending = [dict(r) for r in await cur.fetchall()]
     except Exception:  # noqa: BLE001
-        return {"sent": 0, "failed": 0, "jobs_count": 0}
+        # Same trap as notification_tick: a dead query returned the dict that
+        # means "the digest queue is empty". Mark it as an error so the two are
+        # distinguishable in the worker log and in any future alert.
+        _log.exception("send_bundle: digest query failed for user_id=%s", user_id)
+        return {"sent": 0, "failed": 0, "jobs_count": 0, "error": 1}
 
     if not pending:
         return {"sent": 0, "failed": 0, "jobs_count": 0}
@@ -1265,7 +1269,13 @@ async def notification_tick(ctx: dict[str, Any]) -> dict[str, int]:
         )
         rules = [dict(r) for r in await cur.fetchall()]
     except Exception:  # noqa: BLE001
-        return {"checked": 0, "enqueued": 0}
+        # A crashed query used to return the SAME dict as "there are no rules",
+        # with no log line — so `{'checked': 0, 'enqueued': 0}` in the worker log
+        # meant either "idle" or "the notification system is down" and nothing
+        # could tell them apart. Say which. Still never re-raise: an ARQ cron
+        # that throws is retried blindly every 5 minutes.
+        _log.exception("notification_tick: rules query failed")
+        return {"checked": 0, "enqueued": 0, "error": 1}
 
     enqueued = 0
     for rule in rules:

--- a/backend/tests/test_ghost_sweep_skip_visibility.py
+++ b/backend/tests/test_ghost_sweep_skip_visibility.py
@@ -119,3 +119,70 @@ def test_healthy_source_does_not_log_a_freeze_warning(db, caplog):
     assert missed.get("reed") == 0
     text = " ".join(rec.getMessage() for rec in caplog.records)
     assert "froze" not in text and "stopped ageing" not in text
+
+
+# ---------------------------------------------------------------------------
+# The COUNT must mean what the warning says it means
+# ---------------------------------------------------------------------------
+
+
+def test_the_freeze_count_counts_only_jobs_the_app_actually_serves(db):
+    """`possibly_stale` and `likely_stale` rows are NOT live listings.
+
+    The warning above says "N live job(s) ... are still served as active", and
+    the number behind it came from `count_unexpired_jobs_for_source`, which
+    counted everything *not* `confirmed_expired`. But `get_recent_jobs` serves
+    only `staleness_state IS NULL OR = 'active'` — so the two mid-states were
+    counted as live while no user could see them, and the warning overstated
+    the damage.
+
+    That is this repo's recorded failure mode in miniature: an instrument that
+    does not count the way its consumer counts. It is worth pinning here rather
+    than trusting the SQL to stay in step, because the two predicates live in
+    different files and nothing else forces them to agree.
+    """
+    from src.repositories.database import JobDatabase  # noqa: F401 — fixture type
+
+    _seed(db, "reed", 4)
+
+    async def _mark(state: str, apply_url: str) -> None:
+        await db._db.execute(
+            "UPDATE jobs SET staleness_state = ? WHERE apply_url = ?",
+            (state, apply_url),
+        )
+        await db._db.commit()
+
+    # 4 seeded rows: leave one 'active', set one NULL (never classified — still
+    # served, by design), and move the other two into the mid-states.
+    asyncio.run(_mark("active", "https://x/reed/0"))
+    asyncio.run(_mark(None, "https://x/reed/1"))
+    asyncio.run(_mark("possibly_stale", "https://x/reed/2"))
+    asyncio.run(_mark("likely_stale", "https://x/reed/3"))
+
+    counted = asyncio.run(db.count_unexpired_jobs_for_source("reed"))
+    assert counted == 2, (
+        f"counted {counted}, expected 2 (the 'active' row and the NULL row). "
+        f"A count that includes possibly_stale/likely_stale reports listings the "
+        f"app does not serve, so the freeze warning overstates the live damage."
+    )
+
+
+def test_the_freeze_count_still_excludes_expired_rows(db):
+    """The other direction: a confirmed-expired row is not live either.
+
+    Tightening a predicate until it stops over-counting can quietly turn into
+    under-counting, so both edges are pinned.
+    """
+    _seed(db, "adzuna", 2)
+
+    async def _expire(apply_url: str) -> None:
+        await db._db.execute(
+            "UPDATE jobs SET staleness_state = 'confirmed_expired' WHERE apply_url = ?",
+            (apply_url,),
+        )
+        await db._db.commit()
+
+    asyncio.run(_expire("https://x/adzuna/0"))
+
+    counted = asyncio.run(db.count_unexpired_jobs_for_source("adzuna"))
+    assert counted == 1, f"counted {counted}, expected 1 — the expired row must not count"

--- a/backend/tests/test_ghost_sweep_skip_visibility.py
+++ b/backend/tests/test_ghost_sweep_skip_visibility.py
@@ -1,0 +1,121 @@
+"""A source that never fetches freezes its jobs as ACTIVE forever — say so.
+
+PRODUCTION EVIDENCE (prod Postgres, read-only, 2026-08-13):
+
+    SELECT source, consecutive_misses, count(*) , min(left(last_seen_at,10))
+    FROM jobs
+    WHERE (staleness_state='active' OR staleness_state IS NULL)
+      AND left(last_seen_at,10) < to_char(now() - interval '2 days','YYYY-MM-DD')
+    GROUP BY 1,2
+      ('workday',  0, 76, '2026-08-08')
+      ('linkedin', 0, 33, '2026-08-06')
+      ('linkedin', 1, 21, '2026-08-05')
+      ('adzuna',   1, 10, '2026-08-10')
+
+Every one of those 140 zombie rows belongs to one of the exactly three sources
+that raise on every run (``run_log.per_source_errors`` = {adzuna, linkedin,
+workday}; workday's duration is pinned at 240.0s, a timeout). Their
+``consecutive_misses`` never got past 1, so:
+
+    SELECT count(*) FROM jobs WHERE staleness_state='active'
+      AND consecutive_misses >= 2 AND now() - last_seen_at::timestamptz > '12h'
+      -> 0
+
+which is why ``nightly_ghost_sweep`` correctly reports
+``{'evaluated': 8783, 'transitioned': 0}``. The nightly sweep is NOT broken.
+The absence sweep upstream never ran for those sources: ``_ghost_detection_pass``
+skips a source whose fetch raised — deliberately, so a rate-limited scrape is
+not read as "the jobs vanished" — but it does it with a bare ``continue``, no
+log, no counter. A source can therefore fail forever and its listings are
+served as live forever, and nothing anywhere says so.
+
+This test does not change the skip decision (that is a product call: aging a
+job out removes it from what users see). It pins the VISIBILITY of the skip
+and of the number of live rows it froze.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import pytest
+
+
+class _FakeSource:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+@pytest.fixture
+def db():
+    from src.repositories.database import JobDatabase
+
+    database = JobDatabase(":memory:")
+    asyncio.run(database.init_db())
+    yield database
+    asyncio.run(database.close())
+
+
+def _seed(db, source: str, n: int) -> None:
+    from src.models import Job
+
+    async def _run() -> None:
+        for i in range(n):
+            await db.insert_job(
+                Job(
+                    title=f"T{i}",
+                    company=f"C{i}",
+                    apply_url=f"https://x/{source}/{i}",
+                    source=source,
+                    date_found="2026-08-01T00:00:00+00:00",
+                )
+            )
+
+    asyncio.run(_run())
+
+
+@pytest.mark.parametrize("bad_result", [RuntimeError("boom"), None], ids=["raised", "none"])
+def test_failed_source_logs_how_many_live_jobs_it_froze(db, caplog, bad_result):
+    from src.main import _ghost_detection_pass
+
+    _seed(db, "workday", 3)
+
+    async def _run():
+        with caplog.at_level(logging.WARNING):
+            return await _ghost_detection_pass(db, [_FakeSource("workday")], [bad_result], {})
+
+    missed = asyncio.run(_run())
+
+    # Unchanged decision: a failed scrape is still NOT absence evidence.
+    assert missed == {}
+
+    text = " ".join(rec.getMessage() for rec in caplog.records)
+    assert "workday" in text, "the skipped source was not named in any log line"
+    assert "3" in text, (
+        "the log did not say how many live jobs the skip froze — "
+        "'a source failed' is not actionable, 'N live jobs stopped ageing' is"
+    )
+
+
+def test_healthy_source_does_not_log_a_freeze_warning(db, caplog):
+    """No false alarm: a source that fetched fine must not produce the warning."""
+    from src.main import _ghost_detection_pass
+    from src.models import Job
+
+    job = Job(
+        title="A",
+        company="X",
+        apply_url="https://a",
+        source="reed",
+        date_found="2026-08-01T00:00:00+00:00",
+    )
+    asyncio.run(db.insert_job(job))
+
+    async def _run():
+        with caplog.at_level(logging.WARNING):
+            return await _ghost_detection_pass(db, [_FakeSource("reed")], [[job]], {})
+
+    missed = asyncio.run(_run())
+    assert missed.get("reed") == 0
+    text = " ".join(rec.getMessage() for rec in caplog.records)
+    assert "froze" not in text and "stopped ageing" not in text

--- a/backend/tests/test_silent_cron_failures.py
+++ b/backend/tests/test_silent_cron_failures.py
@@ -1,0 +1,74 @@
+"""A cron that crashes must not report the same thing as a cron with no work.
+
+PRODUCTION EVIDENCE (2026-08-13). ``notification_tick`` prints
+``{'checked': 0, 'enqueued': 0}`` 288 times a day in the Railway worker log.
+The prod DB says ``notification_rules`` has 0 rows, so today that output is
+honest — but the code produces the IDENTICAL dict when its only SELECT raises,
+and it logs nothing on the way out. So the one instrument that would ever show
+the notification system breaking is structurally incapable of showing it: a
+dead query and an empty table are byte-identical on the wire.
+
+Same shape in ``send_bundle``: a failed digest SELECT returns the very dict
+that means "nothing was queued".
+
+These tests pin the DISTINCTION, not the happy path. The success contract
+(``checked``/``enqueued``/``sent``/``failed``/``jobs_count``) is covered by
+tests/test_notification_tick.py and must keep passing unchanged.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import pytest
+
+from src.workers.tasks import notification_tick, send_bundle
+
+
+class _ExplodingDB:
+    """A connection whose every query raises — i.e. Postgres is gone.
+
+    Mimics just enough of the aiosqlite-shaped psycopg wrapper for the task
+    to reach its except branch.
+    """
+
+    def __init__(self) -> None:
+        self.row_factory: Any = None
+
+    async def execute(self, *args: Any, **kwargs: Any) -> Any:
+        raise RuntimeError("connection is closed")
+
+
+@pytest.mark.asyncio
+async def test_notification_tick_reports_a_failed_query_instead_of_checked_zero(caplog):
+    ctx = {"db": _ExplodingDB(), "enqueue": lambda *a, **k: None}
+
+    with caplog.at_level(logging.ERROR):
+        result = await notification_tick(ctx)
+
+    # It still must not raise — an ARQ cron that throws is retried blindly.
+    assert result["checked"] == 0
+    assert result["enqueued"] == 0
+    # ...but the failure must be DISTINGUISHABLE from "no rules exist".
+    assert result.get("error") == 1, (
+        "a crashed query returned the same dict as an empty notification_rules table"
+    )
+    assert any(
+        "notification_tick" in rec.getMessage() for rec in caplog.records
+    ), "the exception was swallowed with no log line"
+
+
+@pytest.mark.asyncio
+async def test_send_bundle_reports_a_failed_query_instead_of_sent_zero(caplog):
+    ctx = {"db": _ExplodingDB()}
+
+    with caplog.at_level(logging.ERROR):
+        result = await send_bundle(ctx, "alice")
+
+    assert result["sent"] == 0
+    assert result["failed"] == 0
+    assert result["jobs_count"] == 0
+    assert result.get("error") == 1, (
+        "a crashed digest query returned the same dict as an empty digest queue"
+    )
+    assert any("send_bundle" in rec.getMessage() for rec in caplog.records)

--- a/frontend/src/app/dashboard/__tests__/search-run-telemetry.test.tsx
+++ b/frontend/src/app/dashboard/__tests__/search-run-telemetry.test.tsx
@@ -65,9 +65,26 @@ function makeWrapper() {
   };
 }
 
-/** Find the single search_run capture, or undefined. */
+/**
+ * The single `search_run` capture, or undefined if none was emitted.
+ *
+ * ONE EVENT IS PART OF THE CONTRACT, so it is asserted rather than assumed.
+ * This used to be a bare `.find()`, which returns the FIRST of however many
+ * exist — the docstring said "the single capture" and the code accepted any
+ * number. A duplicate emit (a re-render, a second effect, a retry) would then
+ * pass every test here while doubling every funnel number downstream, which is
+ * exactly the kind of instrument-lying-quietly this PR is about.
+ * (CodeRabbit, PR #387.)
+ */
 function searchRunCall() {
-  return posthogMock.capture.mock.calls.find(([event]) => event === "search_run");
+  const calls = posthogMock.capture.mock.calls.filter(([event]) => event === "search_run");
+  if (calls.length > 1) {
+    throw new Error(
+      `search_run was captured ${calls.length} times; the contract is exactly one per ` +
+        `search. Every count derived from this event would be inflated by the duplicates.`,
+    );
+  }
+  return calls[0];
 }
 
 describe("dashboard search_run telemetry", () => {

--- a/frontend/src/app/dashboard/__tests__/search-run-telemetry.test.tsx
+++ b/frontend/src/app/dashboard/__tests__/search-run-telemetry.test.tsx
@@ -1,0 +1,137 @@
+/**
+ * `search_run` must describe the search, and must fire when the search FAILS.
+ *
+ * PRODUCTION EVIDENCE (PostHog, 2026-08-13). `read-data-schema
+ * {"kind":"event_properties","event_name":"search_run"}` returns ONLY
+ * posthog-js autocapture defaults ($browser, $pathname, $geoip_*). There is no
+ * result count, no duration, no outcome. Eight search_run events exist, from 2
+ * persons, and not one of them can be judged good or bad.
+ *
+ * Two consequences, both load-bearing:
+ *
+ *  1. The call site sits inside `if (status === "completed")`, so a FAILED
+ *     search, a 10-minute timeout, and the "Lost contact with the server while
+ *     searching" path (the ~60s event-loop block fixed in PR #123) all emit
+ *     NOTHING. The instrument cannot see the failure it most needs to see —
+ *     silence means "nobody searched" and "every search died" at once.
+ *  2. With no result count, a search that returns zero jobs is
+ *     indistinguishable from a good one.
+ *
+ * Search is the core product action. These tests pin that every terminal
+ * outcome is reported and that the event carries enough to judge it.
+ */
+
+import { render, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { posthogMock } = vi.hoisted(() => ({
+  posthogMock: {
+    __loaded: true,
+    capture: vi.fn(),
+    init: vi.fn(),
+    identify: vi.fn(),
+    reset: vi.fn(),
+    opt_in_capturing: vi.fn(),
+    opt_out_capturing: vi.fn(),
+  },
+}));
+vi.mock("posthog-js", () => ({ default: posthogMock }));
+
+const startSearchMock = vi.fn();
+const getSearchStatusMock = vi.fn();
+
+vi.mock("@/lib/api", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/api")>()),
+  getJobs: vi.fn().mockResolvedValue({ jobs: [], total: 0, filters_applied: {} }),
+  getStatus: vi.fn().mockResolvedValue({
+    jobs_total: 0,
+    last_run: null,
+    sources_active: 0,
+    sources_total: 0,
+    profile_exists: true,
+  }),
+  startSearch: (...args: unknown[]) => startSearchMock(...args),
+  getSearchStatus: (...args: unknown[]) => getSearchStatusMock(...args),
+}));
+
+import DashboardPage from "../page";
+
+function makeWrapper() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+  };
+}
+
+/** Find the single search_run capture, or undefined. */
+function searchRunCall() {
+  return posthogMock.capture.mock.calls.find(([event]) => event === "search_run");
+}
+
+describe("dashboard search_run telemetry", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    posthogMock.capture.mockReset();
+    startSearchMock.mockReset();
+    getSearchStatusMock.mockReset();
+    startSearchMock.mockResolvedValue({ run_id: "run-1" });
+    sessionStorage.clear();
+    // The Profile page's hand-off flag makes the dashboard start a search on
+    // mount — a stabler entry point than hunting for the Refresh button.
+    sessionStorage.setItem("job360_run_search", "1");
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  async function runAndWaitForCapture() {
+    render(<DashboardPage />, { wrapper: makeWrapper() });
+    await waitFor(() => expect(startSearchMock).toHaveBeenCalled());
+    await vi.advanceTimersByTimeAsync(3500);
+    await waitFor(() => expect(searchRunCall()).toBeDefined());
+    return searchRunCall()!;
+  }
+
+  it("reports how the search went — outcome and result counts", async () => {
+    getSearchStatusMock.mockResolvedValue({
+      run_id: "run-1",
+      status: "completed",
+      progress: "Done",
+      result: { total_found: 120, new_jobs: 7, sources_queried: 46 },
+    });
+
+    const [, props] = await runAndWaitForCapture();
+
+    expect(props).toMatchObject({ outcome: "completed", new_jobs: 7, total_found: 120 });
+    expect(typeof (props as { duration_ms?: unknown }).duration_ms).toBe("number");
+  });
+
+  it("still reports a search that FAILED (today it emits nothing)", async () => {
+    getSearchStatusMock.mockResolvedValue({
+      run_id: "run-1",
+      status: "failed",
+      progress: "Search failed",
+      result: null,
+    });
+
+    const [, props] = await runAndWaitForCapture();
+
+    expect(props).toMatchObject({ outcome: "failed" });
+  });
+
+  it("reports a search that returned nothing as zero, not as absence", async () => {
+    getSearchStatusMock.mockResolvedValue({
+      run_id: "run-1",
+      status: "completed",
+      progress: "Done",
+      result: { total_found: 0, new_jobs: 0, sources_queried: 46 },
+    });
+
+    const [, props] = await runAndWaitForCapture();
+
+    expect(props).toMatchObject({ outcome: "completed", new_jobs: 0, total_found: 0 });
+  });
+});

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -356,6 +356,32 @@ export default function DashboardPage() {
     setSearching(true);
     setSearchProgress("Starting search...");
 
+    // search_run telemetry. It used to be a bare `posthog.capture("search_run")`
+    // INSIDE the `status === "completed"` branch, with no properties at all. So
+    // PostHog could not tell a good search from a search that returned zero
+    // jobs, and a failed / timed-out / "Lost contact with the server" search
+    // (the ~60s event-loop block of PR #123) emitted NOTHING — the instrument
+    // was structurally blind to the exact failure it exists to catch. Report
+    // EVERY terminal outcome, and say how it went.
+    const searchStartedAt = Date.now();
+    let searchReported = false;
+    const reportSearchRun = (
+      outcome: "completed" | "failed" | "timed_out" | "lost_contact" | "start_failed",
+      result?: Record<string, unknown> | null
+    ) => {
+      if (searchReported) return; // exactly one event per search
+      searchReported = true;
+      const r = result ?? {};
+      posthog.capture("search_run", {
+        outcome,
+        duration_ms: Date.now() - searchStartedAt,
+        total_found: typeof r.total_found === "number" ? r.total_found : null,
+        new_jobs: typeof r.new_jobs === "number" ? r.new_jobs : null,
+        sources_queried: typeof r.sources_queried === "number" ? r.sources_queried : null,
+        mode: "hybrid",
+      });
+    };
+
     try {
       const { run_id } = await startSearch({ safe: false });
       setSearchProgress("Search running...");
@@ -385,6 +411,7 @@ export default function DashboardPage() {
         };
 
         if (Date.now() - pollStartedAt > MAX_POLL_MS) {
+          reportSearchRun("timed_out");
           stopPolling(
             "Search is taking longer than expected — we stopped waiting. Your results may still appear; try refreshing."
           );
@@ -405,9 +432,10 @@ export default function DashboardPage() {
                 ? "Search complete!"
                 : "Search failed"
             );
-            if (status.status === "completed") {
-              posthog.capture("search_run");
-            }
+            reportSearchRun(
+              status.status === "completed" ? "completed" : "failed",
+              status.result as Record<string, unknown> | null | undefined
+            );
             // Invalidate all job queries so both lists re-fetch with fresh data
             void queryClient.invalidateQueries({ queryKey: queryKeys.jobs() });
             // Clear message after a few seconds
@@ -420,6 +448,7 @@ export default function DashboardPage() {
           // on a spinner is worse than telling them.
           consecutiveErrors += 1;
           if (consecutiveErrors >= 20) {
+            reportSearchRun("lost_contact");
             stopPolling(
               "Lost contact with the server while searching. Please try again."
             );
@@ -427,6 +456,7 @@ export default function DashboardPage() {
         }
       }, POLL_INTERVAL_MS);
     } catch (err) {
+      reportSearchRun("start_failed");
       setSearching(false);
       setSearchProgress("");
       toast.apiError(err, "Failed to start search. Is the backend running?");

--- a/frontend/src/components/providers/PostHogProviderWrapper.test.tsx
+++ b/frontend/src/components/providers/PostHogProviderWrapper.test.tsx
@@ -1,0 +1,120 @@
+/**
+ * $pageview must be captured AFTER posthog.init(), never before.
+ *
+ * WHY THIS TEST EXISTS (production evidence, 2026-08-13).
+ * PostHog received $pageleave and $set events from /profile on four
+ * consecutive days (2026-08-10 → 2026-08-13) and ZERO $pageview events; the
+ * last $pageview of any kind was 2026-08-09T08:29:48Z. $pageleave is emitted
+ * by posthog-js itself (capture_pageleave: true) so it can only fire after
+ * init succeeded — proving the SDK was loaded and the wire to PostHog was
+ * fine. The hand-rolled half was the broken half.
+ *
+ * The mechanism is React effect ordering. PageViewTracker is a CHILD of
+ * PostHogProviderWrapper, and React runs child effects before parent effects
+ * (bottom-up). So on a fresh page load the child called
+ * posthog.capture("$pageview") before the parent called posthog.init() — and a
+ * capture before init is a silent no-op in posthog-js. The child's deps are
+ * [pathname, searchParams], neither of which changes afterwards, so the effect
+ * never re-ran and that page load produced no pageview at all. Only a
+ * client-side route change (which re-runs the effect after init) ever produced
+ * one, which is exactly why pageviews vanished when the only active person
+ * stopped navigating and just opened /profile directly.
+ *
+ * Consequence: every funnel whose first step is $pageview under-counts, and
+ * the "25 landing visitors → 2 register views" number is measured with a
+ * broken ruler.
+ */
+
+import { render, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { CONSENT_KEY } from "@/lib/consent";
+
+// ---------------------------------------------------------------------------
+// Mocks — hoisted before module evaluation
+// ---------------------------------------------------------------------------
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/profile",
+  useSearchParams: () => new URLSearchParams(""),
+}));
+
+// Order tape: every posthog call appends its name, so the test can assert the
+// SEQUENCE and not merely that both happened. vi.hoisted because vi.mock's
+// factory is lifted above the module's own top-level declarations.
+const { calls, posthogMock } = vi.hoisted(() => {
+  const tape: string[] = [];
+  const mock = {
+    __loaded: false,
+    init: vi.fn(() => {
+      tape.push("init");
+      mock.__loaded = true;
+    }),
+    capture: vi.fn((event: string) => {
+      tape.push(`capture:${event}`);
+    }),
+    opt_in_capturing: vi.fn(() => tape.push("opt_in")),
+    opt_out_capturing: vi.fn(() => tape.push("opt_out")),
+    reset: vi.fn(() => tape.push("reset")),
+  };
+  return { calls: tape, posthogMock: mock };
+});
+
+vi.mock("posthog-js", () => ({ default: posthogMock }));
+
+vi.mock("posthog-js/react", () => ({
+  PostHogProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+import { PostHogProviderWrapper } from "./PostHogProviderWrapper";
+
+describe("PostHogProviderWrapper — $pageview ordering", () => {
+  beforeEach(() => {
+    calls.length = 0;
+    posthogMock.__loaded = false;
+    posthogMock.init.mockClear();
+    posthogMock.capture.mockClear();
+    window.localStorage.clear();
+    vi.stubEnv("NEXT_PUBLIC_POSTHOG_KEY", "phc_test_key");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("captures $pageview on a first page load, and only after init", async () => {
+    window.localStorage.setItem(CONSENT_KEY, "accepted");
+
+    render(
+      <PostHogProviderWrapper>
+        <div>child</div>
+      </PostHogProviderWrapper>
+    );
+
+    await waitFor(() => expect(posthogMock.init).toHaveBeenCalledTimes(1));
+    await waitFor(() =>
+      expect(posthogMock.capture).toHaveBeenCalledWith("$pageview", expect.anything())
+    );
+
+    const initAt = calls.indexOf("init");
+    const pageviewAt = calls.indexOf("capture:$pageview");
+    expect(initAt).toBeGreaterThanOrEqual(0);
+    expect(pageviewAt).toBeGreaterThanOrEqual(0);
+    // The whole bug in one assertion: a capture that lands before init is lost.
+    expect(pageviewAt).toBeGreaterThan(initAt);
+  });
+
+  it("captures nothing at all when consent is not accepted", async () => {
+    window.localStorage.setItem(CONSENT_KEY, "declined");
+
+    render(
+      <PostHogProviderWrapper>
+        <div>child</div>
+      </PostHogProviderWrapper>
+    );
+
+    // Give any effect a chance to run before asserting absence.
+    await waitFor(() => expect(posthogMock.init).not.toHaveBeenCalled());
+    expect(posthogMock.capture).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/providers/PostHogProviderWrapper.test.tsx
+++ b/frontend/src/components/providers/PostHogProviderWrapper.test.tsx
@@ -72,8 +72,18 @@ describe("PostHogProviderWrapper — $pageview ordering", () => {
   beforeEach(() => {
     calls.length = 0;
     posthogMock.__loaded = false;
+    // EVERY spy, not the two this file happened to assert on first. `init` and
+    // `capture` were cleared and `opt_out_capturing` / `opt_in_capturing` /
+    // `reset` were not, so a call from an earlier test satisfied a later test's
+    // `toHaveBeenCalled()`. Caught by mutation-testing these cases: with the
+    // consent bug deliberately restored, three of them still passed — on
+    // evidence left behind by their predecessor. A test that can be satisfied
+    // by another test is not a test.
     posthogMock.init.mockClear();
     posthogMock.capture.mockClear();
+    posthogMock.opt_in_capturing.mockClear();
+    posthogMock.opt_out_capturing.mockClear();
+    posthogMock.reset.mockClear();
     window.localStorage.clear();
     vi.stubEnv("NEXT_PUBLIC_POSTHOG_KEY", "phc_test_key");
   });
@@ -116,5 +126,79 @@ describe("PostHogProviderWrapper — $pageview ordering", () => {
     // Give any effect a chance to run before asserting absence.
     await waitFor(() => expect(posthogMock.init).not.toHaveBeenCalled());
     expect(posthogMock.capture).not.toHaveBeenCalled();
+  });
+  // ── Consent withdrawal: the ORDER of the two calls is the whole rule ──────
+  //
+  // `reset()` clears the SDK's consent state. So `opt_out_capturing()` followed
+  // by `reset()` UNDOES the opt-out, and with `opt_out_capturing_by_default:
+  // false` the SDK is free to capture again while the application still reads
+  // "declined". Tracking a user who has withdrawn consent is the failure this
+  // guards, and both calls happening is not enough to prevent it — only their
+  // order is. (CodeRabbit, PR #387.)
+  it("opts out AFTER resetting, so the opt-out is not cleared again", async () => {
+    posthogMock.__loaded = true; // loaded earlier in this session
+    window.localStorage.setItem(CONSENT_KEY, "declined");
+
+    render(
+      <PostHogProviderWrapper>
+        <div>child</div>
+      </PostHogProviderWrapper>
+    );
+
+    await waitFor(() => expect(posthogMock.opt_out_capturing).toHaveBeenCalled());
+    const resetAt = calls.indexOf("reset");
+    const optOutAt = calls.indexOf("opt_out");
+    expect(resetAt).toBeGreaterThanOrEqual(0);
+    expect(optOutAt).toBeGreaterThanOrEqual(0);
+    expect(optOutAt).toBeGreaterThan(resetAt);
+  });
+
+  // ── EVERY non-accepted value must opt out, not just the string "declined" ──
+  //
+  // The gate above already means "not accepted"; re-narrowing it underneath to
+  // one exact string left capture RUNNING for any other value — a withdrawal, a
+  // cleared choice, a value added later. A consent check must never be narrower
+  // than the consent rule it implements.
+  it.each(["withdrawn", "unknown-future-value", ""])(
+    "opts out for a non-accepted consent value: %s",
+    async (value) => {
+      posthogMock.__loaded = true;
+      window.localStorage.setItem(CONSENT_KEY, value);
+
+      render(
+        <PostHogProviderWrapper>
+          <div>child</div>
+        </PostHogProviderWrapper>
+      );
+
+      await waitFor(() => expect(posthogMock.opt_out_capturing).toHaveBeenCalled());
+    }
+  );
+
+  // ── accepted -> declined -> accepted, the transition CodeRabbit asked for ──
+  it("re-enables capture when consent is granted again after a decline", async () => {
+    posthogMock.__loaded = true;
+    window.localStorage.setItem(CONSENT_KEY, "declined");
+
+    const { rerender } = render(
+      <PostHogProviderWrapper>
+        <div>child</div>
+      </PostHogProviderWrapper>
+    );
+    await waitFor(() => expect(posthogMock.opt_out_capturing).toHaveBeenCalled());
+
+    // Re-accept: the store is external, so change it and notify like the real
+    // consent banner does.
+    window.localStorage.setItem(CONSENT_KEY, "accepted");
+    window.dispatchEvent(new Event("job360:consent"));
+    rerender(
+      <PostHogProviderWrapper>
+        <div>child</div>
+      </PostHogProviderWrapper>
+    );
+
+    await waitFor(() => expect(posthogMock.opt_in_capturing).toHaveBeenCalled());
+    // ...and the opt-IN must be the LAST word, or the session stays silent.
+    expect(calls.lastIndexOf("opt_in")).toBeGreaterThan(calls.lastIndexOf("opt_out"));
   });
 });

--- a/frontend/src/components/providers/PostHogProviderWrapper.tsx
+++ b/frontend/src/components/providers/PostHogProviderWrapper.tsx
@@ -23,22 +23,73 @@ import { PostHogProvider } from "posthog-js/react";
 import { usePathname, useSearchParams } from "next/navigation";
 import { useEffect, useSyncExternalStore, Suspense } from "react";
 
+import type { ConsentValue } from "@/lib/consent";
 import { getConsent, subscribeConsent } from "@/lib/consent";
+
+// ── Init ─────────────────────────────────────────────────────────────────────
+
+/** Idempotent init. Returns true when posthog is loaded and may capture.
+ *
+ *  This lives OUTSIDE both components on purpose — see the ordering note on
+ *  PageViewTracker. Whichever effect runs first initialises; the other one
+ *  finds `__loaded` and does nothing.
+ */
+function ensurePostHogLoaded(): boolean {
+  const key = process.env.NEXT_PUBLIC_POSTHOG_KEY;
+  if (!key) return false;
+  if (posthog.__loaded) return true;
+
+  posthog.init(key, {
+    api_host:
+      process.env.NEXT_PUBLIC_POSTHOG_HOST ?? "https://eu.i.posthog.com",
+    // We fire $pageview manually so route-change events have the correct URL.
+    capture_pageview: false,
+    capture_pageleave: true,
+    // Only build profiles for identified users to stay GDPR-friendly.
+    person_profiles: "identified_only",
+    // Never record sessions: it would capture the user's CV, salary and
+    // application content — far beyond what they consented to (fable/05 C3).
+    disable_session_recording: true,
+  });
+  return true;
+}
 
 // ── Page-view tracker ────────────────────────────────────────────────────────
 // Separate component because useSearchParams requires a <Suspense> boundary in
 // Next.js App Router (it opts into dynamic rendering).
-
-function PageViewTracker() {
+//
+// WHY THIS EFFECT INITIALISES POSTHOG ITSELF — a real production outage of this
+// instrument (2026-08-10 → 2026-08-13: $pageleave arriving from /profile on four
+// consecutive days with ZERO $pageview; last $pageview of any kind
+// 2026-08-09T08:29:48Z).
+//
+// React runs CHILD effects before PARENT effects. PageViewTracker is a child of
+// PostHogProviderWrapper, so this effect fired BEFORE the parent's effect called
+// posthog.init() — and a capture before init is a silent no-op in posthog-js.
+// Its deps [pathname, searchParams] then never changed, so it never re-ran and
+// that page load emitted no pageview at all. Only a client-side route change
+// (effect re-runs, init already done) ever produced one — which is why the
+// numbers died the moment the one active person stopped navigating and just
+// opened /profile directly. $pageleave kept arriving because posthog-js emits
+// that one itself, after init.
+//
+// Doing init here, in the same effect and immediately before the capture,
+// removes the ordering assumption entirely instead of trying to satisfy it.
+// The consent check is also a REAL gate now: a declined visitor used to still
+// reach posthog.capture(), and only posthog-js's uninitialised-call guard kept
+// it silent.
+function PageViewTracker({ consent }: { consent: ConsentValue | null }) {
   const pathname = usePathname();
   const searchParams = useSearchParams();
 
   useEffect(() => {
+    if (consent !== "accepted") return;
+    if (!ensurePostHogLoaded()) return;
     const qs = searchParams.toString();
     const url =
       window.location.origin + (qs ? `${pathname}?${qs}` : pathname);
     posthog.capture("$pageview", { $current_url: url });
-  }, [pathname, searchParams]);
+  }, [consent, pathname, searchParams]);
 
   return null;
 }
@@ -58,36 +109,27 @@ export function PostHogProviderWrapper({
   const consent = useSyncExternalStore(subscribeConsent, getConsent, () => null);
 
   useEffect(() => {
-    const key = process.env.NEXT_PUBLIC_POSTHOG_KEY;
-    if (!key) return;
+    const alreadyLoaded = posthog.__loaded;
 
     if (consent !== "accepted") {
       // Declined (or undecided) after having loaded earlier in this session —
       // stop sending and drop the stored id.
-      if (posthog.__loaded && consent === "declined") {
+      if (alreadyLoaded && consent === "declined") {
         posthog.opt_out_capturing();
         posthog.reset();
       }
       return;
     }
 
-    if (posthog.__loaded) {
+    if (alreadyLoaded) {
       posthog.opt_in_capturing(); // re-accepted after a decline
       return;
     }
 
-    posthog.init(key, {
-      api_host:
-        process.env.NEXT_PUBLIC_POSTHOG_HOST ?? "https://eu.i.posthog.com",
-      // We fire $pageview manually so route-change events have the correct URL.
-      capture_pageview: false,
-      capture_pageleave: true,
-      // Only build profiles for identified users to stay GDPR-friendly.
-      person_profiles: "identified_only",
-      // Never record sessions: it would capture the user's CV, salary and
-      // application content — far beyond what they consented to (fable/05 C3).
-      disable_session_recording: true,
-    });
+    // Normally PageViewTracker's effect (a child, so it runs first) has already
+    // done this. Kept so the singleton still loads on a page that somehow has
+    // no tracker mounted.
+    ensurePostHogLoaded();
   }, [consent]);
 
   return (
@@ -95,7 +137,7 @@ export function PostHogProviderWrapper({
     <PostHogProvider client={posthog}>
       {/* Suspense required because PageViewTracker calls useSearchParams() */}
       <Suspense fallback={null}>
-        <PageViewTracker />
+        <PageViewTracker consent={consent} />
       </Suspense>
       {children}
     </PostHogProvider>

--- a/frontend/src/components/providers/PostHogProviderWrapper.tsx
+++ b/frontend/src/components/providers/PostHogProviderWrapper.tsx
@@ -112,11 +112,23 @@ export function PostHogProviderWrapper({
     const alreadyLoaded = posthog.__loaded;
 
     if (consent !== "accepted") {
-      // Declined (or undecided) after having loaded earlier in this session —
-      // stop sending and drop the stored id.
-      if (alreadyLoaded && consent === "declined") {
-        posthog.opt_out_capturing();
+      // Anything that is not "accepted" after having loaded earlier in this
+      // session — stop sending and drop the stored id.
+      //
+      // NOT `consent === "declined"`. Only one non-accepted value opted out, so
+      // any other — a withdrawal, a cleared choice, a value added later — left
+      // capture RUNNING while the app believed consent was absent. The gate
+      // above already says "not accepted"; re-narrowing it underneath is how a
+      // consent check ends up narrower than the consent rule.
+      //
+      // AND `reset()` COMES FIRST. `reset()` clears the SDK's consent state, so
+      // opting out and then resetting undoes the opt-out — with
+      // `opt_out_capturing_by_default: false` the SDK is free to capture again
+      // while the application still reads "declined". Order is the whole fix.
+      // (CodeRabbit, PR #387 — Major, and correct.)
+      if (alreadyLoaded) {
         posthog.reset();
+        posthog.opt_out_capturing();
       }
       return;
     }


### PR DESCRIPTION
## One shared failure shape

Correlating PostHog + Railway logs + prod Postgres turned up the same bug four times: **code that returns a success-looking value while measuring nothing.** Each fix has a test that was watched to fail first.

### 1. `$pageview` never fired on a first page load (frontend)

PostHog took `$pageleave` from `/profile` on **four consecutive days with ZERO `$pageview`**; last `$pageview` of any kind `2026-08-09T08:29:48Z`.

React runs child effects before parent effects, so `PageViewTracker` called `posthog.capture()` before `PostHogProviderWrapper` called `posthog.init()` — a no-op — and its deps never changed again, so a direct page load emitted nothing.

Init now happens in the same effect, immediately before the capture, so there is no ordering assumption left to break. The consent check is now a real gate instead of relying on posthog-js's uninitialised-call guard.

### 2. `search_run` could not describe a search (frontend)

The event carried only SDK defaults, and was captured only inside the `status === "completed"` branch — so a failed search, a 10-minute timeout, and the "Lost contact with the server" path all emitted **nothing**.

Now every terminal outcome reports: `outcome`, `duration_ms`, `total_found`, `new_jobs`, `sources_queried`.

### 3. `notification_tick` / `send_bundle` swallowed a dead query (backend)

A crashed `SELECT` returned the **identical dict** to "there is no work", with no log line, **288 times a day**. Both now log the exception and return `error: 1`, so idle and broken are distinguishable. Neither re-raises.

### 4. A failing source silently froze its listings as live (backend)

Read from prod: the **140 jobs** sitting in `staleness_state='active'` with `last_seen_at` 3–8 days old belong to exactly the three sources that raise every run — **workday 76, linkedin 54, adzuna 10**.

`_ghost_detection_pass` skips a failed fetch *on purpose* (a failed scrape is not evidence that jobs vanished) but did it with a bare `continue`, no log. Their `consecutive_misses` never reached 2 — which is also why `nightly_ghost_sweep` correctly reports `transitioned: 0`. **That sweep is not broken.**

The skip now logs the source, the reason, and how many live jobs stopped ageing.

## Deliberately not done here

Ageing those 140 frozen jobs out **changes what users see**, so it is left for the owner rather than bundled into an observability fix.

## Verification

`tests/test_silent_cron_failures.py` + `tests/test_ghost_sweep_skip_visibility.py` — **5/5 pass** locally. Frontend specs included for both PostHog fixes.

> This work was written 2026-08-13 and never had a PR opened; it was found sitting unmerged in a worktree. Cherry-picked cleanly onto current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LxteDWNFYg96HtwiNmLrtv


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Search activity now reports outcomes, duration, result counts, queried sources and search mode for improved monitoring.
  * Page-view tracking is more reliable and only activates after analytics consent is granted.
* **Bug Fixes**
  * Failed or incomplete source fetches now generate clear warnings, including affected active listings.
  * Background notification errors are identified separately from valid empty results.
* **Privacy**
  * Analytics remains disabled without consent, with opt-out and re-consent behaviour preserved.
* **Tests**
  * Added coverage for search reporting, consent handling and background failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->