### PR TITLE
docs: daily truth check

### DIFF
--- a/.claude/skills/add-source/SKILL.md
+++ b/.claude/skills/add-source/SKILL.md
@@ -78,9 +78,9 @@ that is the **only** delivery path.
 
 ⚠️ **Older docs told you to implement a `NotificationChannel` ABC and register it
 in `get_all_channels()` in `src/services/notifications/base.py`. That module and
-both symbols no longer exist** (verified 2026-08-03 and re-verified 2026-08-11 —
-`src/services/notifications/` now holds only `__init__.py` and
-`report_generator.py`). An agent following the old instruction would be writing
+both symbols no longer exist** (verified 2026-08-03, re-verified 2026-08-24 —
+`src/services/notifications/` now holds `__init__.py`, `report_generator.py` and
+`defaults.py`, and no channel classes). An agent following the old instruction would be writing
 against a deleted API.
 
 Respect rules #23 and #24 while you are in there:

--- a/.claude/skills/verify-job360/CHECKLIST.md
+++ b/.claude/skills/verify-job360/CHECKLIST.md
@@ -22,7 +22,7 @@ not fired (needs external service or sample data) · `GATED` = needs infra not p
 ---
 
 ## A. Landing & entry
-- [ ] 1. Landing `/` renders — hero, stats card, CTAs. **The card should read 41 sources** (41 registry keys; 40 live instances). ⚠️ As of 2026-08-24 the frontend still hardcodes **47** in four places — `src/app/page.tsx:287`, `src/components/layout/Footer.tsx:49`, `src/app/layout.tsx:37,40,47` (the last two feed the OG/Twitter cards). Until that is fixed this box FAILS; do not "correct" it to 47 to make it pass.
+- [ ] 1. Landing `/` renders — hero, stats card, CTAs. **The card should read 41 sources** (41 registry keys; 40 live instances). The hardcoded **47** that made this box fail through 2026-08-24 is gone: every rendered count — hero, stats card, footer strapline, and the OG/Twitter card metadata — now reads `SOURCE_COUNT` from `frontend/src/lib/catalog.ts` (`page.tsx`, `layout.tsx`, `Footer.tsx`). If the number on screen disagrees with `SOURCE_REGISTRY`, the bug is in that one constant, and `scripts/doc_sync_check.py` (guard `landing-source-count`) should already be red.
 - [ ] 2. Every nav + footer link and the Get-started / Login buttons navigate correctly
 
 ## B. Auth (full lifecycle)

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -546,8 +546,9 @@ new sources `about_me_llm` (weight 2.0) and `github_llm` (1.5) feed
 > ⚠️ **REMOVED — do not write against it.** The `NotificationChannel` ABC
 > (`src/services/notifications/base.py`), its auto-discovery helpers
 > (`get_all_channels()` / `get_configured_channels()`) and the per-channel classes
-> (`EmailChannel` / `SlackChannel` / `DiscordChannel`) no longer exist. The only modules
-> left under `src/services/notifications/` are `__init__.py` and `report_generator.py`.
+> (`EmailChannel` / `SlackChannel` / `DiscordChannel`) no longer exist. What is left
+> under `src/services/notifications/` is `__init__.py`, `report_generator.py` and
+> `defaults.py` (signup rulebook seeder) — no channel classes, no discovery.
 > Verified 2026-08-19 — `grep -rn "class NotificationChannel\|def get_all_channels" backend/src/`
 > returns nothing.
 

--- a/README.md
+++ b/README.md
@@ -286,8 +286,9 @@ timezone-aware quiet hours, and digest mode.
 > ⚠️ **The `NotificationChannel` ABC is GONE — do not write against it.** It used to live at
 > `backend/src/services/notifications/base.py`. That file, the auto-discovery helpers
 > (`get_all_channels()` / `get_configured_channels()`) and the per-channel classes were all
-> REMOVED. The only modules left under `backend/src/services/notifications/` are
-> `__init__.py` and `report_generator.py`.
+> REMOVED. What is left under `backend/src/services/notifications/` is `__init__.py`,
+> `report_generator.py` and `defaults.py` (the signup rulebook seeder + the one source of
+> truth for `NOTIFY_SCORE_THRESHOLD`) — no channel classes, no discovery.
 
 Channels are **per-user rows in the database**, not env-var-configured classes. The
 dispatcher's public surface:
@@ -399,7 +400,7 @@ job360/
 │       │   └── other/       (4 classes / 5 keys)
 │       ├── workers/             # ARQ tasks + WorkerSettings
 │       └── utils/
-├── backend/tests/               # ~1,409 collected offline (2 live deselected) across 60+ files (defer to runtime count)
+├── backend/tests/               # 3,297 collected / 3,295 selected (2 live deselected) across 217 test_*.py files (defer to runtime count)
 ├── frontend/                    # Next.js 16 + React 19 + Tailwind 4 + shadcn 4
 │   └── src/
 │       ├── app/                 # App Router pages
@@ -423,7 +424,7 @@ python -m pytest backend/tests/test_scorer.py -v
 python -m pytest backend/tests/ -v -s
 ```
 
-The full suite passes (~1,409 collected offline, 2 live deselected — defer to the runtime count). Every source is tested with mocked HTTP responses (aioresponses). No network access required. 3 tests skip on Windows (bash-only tests for setup.sh and cron_run.sh).
+The full suite passes (3,297 collected / 3,295 selected, 2 live deselected — defer to the runtime count). Every source is tested with mocked HTTP responses (aioresponses). No network access required. 3 tests skip on Windows (bash-only tests for `setup.sh` and `cron_setup.sh`).
 
 ## Output
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -44,8 +44,8 @@
 > delivery to live Slack/Telegram/Gmail (needs provider credentials).
 
 **Last updated:** 2026-08-24 (doc truth check; the phase narratives below are older — see `docs/harness/IMPLEMENTATION_LOG.md` for the current history)
-**Total tests:** defer to the runtime collected count (~1,409 collected offline, 2 live deselected; 0 failing, 3 skipped on Windows)
-**Source files:** 40 source files in `backend/src/sources/` (excluding `__init__.py` and `base.py`) split into 6 category subfolders | **Test files:** 60+ test modules
+**Total tests:** defer to the runtime collected count (3,297 collected / 3,295 selected, 2 live deselected; 0 failing, 3 skipped on Windows)
+**Source files:** 40 source files in `backend/src/sources/` (excluding `__init__.py` and `base.py`) split into 6 category subfolders | **Test files:** 217 `test_*.py` modules
 **Job sources:** 41 entries in `SOURCE_REGISTRY`; 40 live instances since `indeed` + `glassdoor` share `JobSpySource`; gov_apprenticeships restored 2026-06-16 on DfE Display Advert API v2 (M6 2026-06 dropped jobtensor, comeet, aijobs_global; the 2026-08-10 rotation dropped 6 more dead upstreams — aijobs, rippling, biospace, jobs_ac_uk, workanywhere, nhs_jobs_xml). See CLAUDE.md rule #13 for the five load-bearing surfaces that move together on a registry change.
 **Latest merged head:** `225040e` on `origin/main` — docs audit + cleanup (2026-06-21); all worktree/feature branches merged and deleted.
 **Sentinel:** `.claude/step-3-verified.txt` → `337fbda19b5ae30d55dba061bc6658a49bcd208d` (post-reviewer-fix SHA).
@@ -202,7 +202,7 @@ Engine #4 runs after per-user feed write (`_run_matcher_stage`). Results stored 
 - Email, Slack, Discord, Telegram, webhook — all via the Apprise dispatcher, per-user channels (Batch 2). The old built-in channel classes are REMOVED.
 - CLI commands: run, view, api, status, sources, setup-profile
 - Next.js frontend (at `frontend/`) + FastAPI backend (at `backend/src/api/`) deliver the interactive UI
-- Tests: defer to the runtime collected count (~1,409 collected offline, 2 live deselected); 3 skip on Windows (bash-only `setup.sh` / `cron_run.sh` tests), 0 failing
+- Tests: defer to the runtime collected count (3,297 collected / 3,295 selected, 2 live deselected); 3 skip on Windows (bash-only `setup.sh` / `cron_setup.sh` tests), 0 failing
 
 ---
 
@@ -225,7 +225,7 @@ Engine #4 runs after per-user feed write (`_run_matcher_stage`). Results stored 
 
 | Issue | Severity | Notes |
 |-------|----------|-------|
-| 3 tests skip on Windows | Low | bash-only tests for `setup.sh` and `cron_run.sh` — pass on Linux/Mac |
+| 3 tests skip on Windows | Low | bash-only tests for `setup.sh` and `cron_setup.sh` — pass on Linux/Mac |
 | ~~`test_main.py` still hits live Indeed~~ RESOLVED (M8 batch) | — | JobSpy stubbed via autouse fixture; `load_profile` patched. Runs offline in ~8 s (14 tests). Now part of canonical suite — `--ignore` removed from Makefile, agent-gate.sh, and CLAUDE.md. |
 | Layer-4 embedding repost dedup not activated | Medium | Scaffolded in `backend/src/services/deduplicator.py` but gated behind `SEMANTIC_ENABLED`; ChromaDB-backed layer is opt-in and not yet wired into the default pipeline path. |
 | ~~Batch 2.7 hybrid mode flag not wired to HTTP routes~~ RESOLVED 2026-06-10 | — | `GET /api/jobs?mode=hybrid` consults the retrieval stack and the dashboard requests it by default (a19db65); the LLM judge re-ranks on top via `COALESCE(llm_fit_score, score)`. |
@@ -239,30 +239,23 @@ Engine #4 runs after per-user feed write (`_run_matcher_stage`). Results stored 
 
 ## Test Coverage by Module
 
-| Test file | Module tested | Tests |
-|-----------|--------------|-------|
-| `test_sources.py` | All 41 registry entries (40 source classes) | 55+ |
-| `test_profile.py` | `backend/src/services/profile/*`, `JobScorer` | 55 |
-| `test_linkedin_github.py` | LinkedIn parser, GitHub enricher | 54 |
-| `test_scorer.py` | `skill_matcher.py` scoring | 53 |
-| `test_time_buckets.py` | `time_buckets.py` | 33 |
-| `test_models.py` | `models.py` Job dataclass | 21 |
-| `test_notifications.py` | Slack + Discord + Email channels | 19 |
-| `test_deduplicator.py` | `deduplicator.py` | 13 |
-| `test_main.py` | `main.py` orchestrator + error paths | 14 |
-| `test_cli.py` | `cli.py` commands + SOURCE_REGISTRY | 11 |
-| `test_database.py` | Postgres database + migration + source history | 9 |
-| `test_api.py` | FastAPI endpoints (health, jobs, actions, profile, search, pipeline) | 9 |
-| `test_llm_provider.py` | Multi-provider LLM client for CV parsing | 8 |
-| `test_notification_base.py` | Channel base + discovery | 7 |
-| `test_reports.py` | Report generation | 6 |
-| `test_setup.py` | setup.sh + requirements | 6 |
-| `test_rate_limiter.py` | `rate_limiter.py` | 5 |
-| `test_cron.py` | cron_run.sh | 5 |
-| `test_cli_view.py` | `cli_view.py` | 5 |
-| `test_csv_export.py` | CSV export | 4 |
-| (Plus Pillar-2/-3 + Step-0/1/1.5/2/3 additions) | migrations, auth, feed, prefilter, channels, crypto, dispatcher (rule consultation + timezone-aware quiet hours), scheduler, circuit_breaker, conditional_cache, embeddings, retrieval, enrichment, dedup layers, Pillar-2 scoring dims, score-dim columns, multi-dim scoring, hybrid retrieval, IDOR, account-mgmt, ghost-sweep, application history, notification rules, ledger filters, dim-score round-trips | +~744 |
-| **Total (current green baseline)** | | defer to runtime count (~1,409 collected offline, 2 live deselected) / 0 failing / 3 skipped on Windows |
+> **The per-file table lives in `README.md` ("Testing") and nowhere else.** It used to be
+> duplicated here, and the copy rotted: it still listed `test_notifications.py` and
+> `test_notification_base.py` (both deleted with the `NotificationChannel` ABC), named
+> `cron_run.sh` for what `test_cron.py` actually exercises (`cron_setup.sh`), and carried
+> per-file counts roughly a third of the real ones. Two copies of a number is one copy too
+> many — README's is the measured one.
+
+**Current green baseline:** 3,297 collected / 3,295 selected (2 `live` deselected), 0 failing,
+3 skipped on Windows. Measure it, never quote it:
+`cd backend && python -m pytest --collect-only -q -p no:randomly | tail -1`.
+
+Broad coverage beyond the top-20 files: migrations, auth, feed, prefilter, channels, crypto,
+dispatcher (rule consultation + timezone-aware quiet hours), scheduler, circuit_breaker,
+conditional_cache, embeddings, retrieval, enrichment, dedup layers, Pillar-2 scoring dims,
+score-dim columns, multi-dim scoring, hybrid retrieval, IDOR, account-mgmt, ghost-sweep,
+application history, notification rules + tick + bundling, ledger filters, dim-score
+round-trips, harness guards.
 
 ### Not covered or lightly covered
 

--- a/docs/product/pillars/01-user-pillar.md
+++ b/docs/product/pillars/01-user-pillar.md
@@ -106,8 +106,8 @@ On the channels page:
 
 Then a rule:
 
-- `POST /api/settings/notification-rules {channel:"email", score_threshold:80, notify_mode:"instant", quiet_hours_start:"22:00", quiet_hours_end:"07:00"}`
-- UPSERT by `UNIQUE(user_id, channel)`. Stored in `notification_rules`.
+- `PUT /api/settings/notification-rule {score_threshold:80, notify_mode:"instant", quiet_hours_start:"22:00", quiet_hours_end:"07:00"}`
+- UPSERT by `UNIQUE(user_id)`. Stored in `notification_rules`. **One rulebook per user, not one per channel** (CLAUDE.md rule #23) — the rule governs every channel Alice has connected, so there is no `channel` field in the body.
 
 ### T+2h — A fresh job posts, Alice gets notified
 
@@ -119,7 +119,7 @@ Worker fetches a new job, scores it 87 for Alice. `score_and_ingest`:
 `send_notification` worker task:
 
 1. Loads Alice's enabled channels → finds the email channel.
-2. Consults `notification_rules` for `(alice.id, 'email')`: enabled, threshold ≤ 87 ✓.
+2. Consults Alice's single `notification_rules` row (looked up by `user_id` alone): enabled, threshold ≤ 87 ✓.
 3. Current time in Alice's `users.timezone` → outside quiet hours (22:00–07:00) ✓.
 4. Idempotency check on `notification_ledger UNIQUE(user_id, job_id, channel)` — no row → proceed.
 5. `crypto.decrypt()` the channel credential.
@@ -336,25 +336,30 @@ Only the survivors get the full `JobScorer` treatment (Pillar 2).
   - `telegram` → `tgram://bot_token/chat_id`
   - `webhook` → `json://host/path`
 - **`backend/src/services/channels/crypto.py`** — `encrypt(plaintext) → bytes` / `decrypt(ciphertext) → str`. Fails closed if `CHANNEL_ENCRYPTION_KEY` is unset.
-- **`backend/src/services/channels/dispatcher.py`** — thin wrapper around Apprise. Imports `apprise` *lazily inside the function* (CLAUDE.md rule #11 — Apprise pulls ~30 MB of deps; library code must not pay that cost on import). Tests monkeypatch `apprise.Apprise`. The dispatcher runs each notification through four gates before sending: (1) `enabled=0` skip, (2) `match_score < score_threshold` skip, (3) `notify_mode='digest'` route to the digest queue, (4) inside quiet-hours window (evaluated with stdlib `zoneinfo` against `users.timezone`) route to digest or drop.
-- **Dual systems coexist.** The pre-Batch-2 single-tenant notification code in `src/services/notifications/{email_notify,slack_notify,discord_notify}.py` is still active — it reads env vars (`SMTP_EMAIL`, `SLACK_WEBHOOK_URL`, `DISCORD_WEBHOOK_URL`) and is used by the **CLI batch run** at end-of-run to send a single per-source summary. The new per-user `src/services/channels/dispatcher.py` is only invoked by ARQ worker tasks under an authenticated `user_id`. They never collide because they read different config surfaces.
+- **`backend/src/services/channels/dispatcher.py`** — thin wrapper around Apprise. Imports `apprise` *lazily inside the function* (CLAUDE.md rule #11 — Apprise pulls ~30 MB of deps; library code must not pay that cost on import). Tests monkeypatch `apprise.Apprise`. The dispatcher runs each notification through gates before sending: (1) `enabled=0` skip, (2) `match_score < score_threshold` skip, (3+4) `notify_mode` is a **bundling** mode (`daily` / `every_n_hours`) **or** the moment falls inside the quiet-hours window (evaluated with stdlib `zoneinfo` against `users.timezone`) → queue for the digest instead of sending now (`dispatcher.py:317`). `force=True` bypasses gate 3+4 and is how `send_bundle` delivers already-queued rows.
+- **There is only ONE delivery path.** The pre-Batch-2 single-tenant notification code (`src/services/notifications/{base,email_notify,slack_notify,discord_notify}.py`, env-var webhooks) was **deleted** — see the removal note in `ARCHITECTURE.md` / `README.md`. Everything user-facing goes through the per-user `src/services/channels/dispatcher.py`, invoked by ARQ worker tasks under an authenticated `user_id`. The CLI batch run no longer sends its own summary: it writes a markdown report via `services/notifications/report_generator.generate_markdown_report` (`main.py:49`) and enqueues the ordinary per-user `send_notification` task for above-threshold feed rows (`main.py:481` `_enqueue_notifications`).
 - **API** — `backend/src/api/routes/channels.py`:
   - `GET /api/settings/channels` — list caller's channels
   - `POST /api/settings/channels` — create (encrypts credential server-side)
   - `DELETE /api/settings/channels/{id}` — delete (two-layer ownership check: SELECT in route + dispatcher re-checks `user_id`)
   - `POST /api/settings/channels/{id}/test` — send a "test" message, return ok/error
 
-### 4.5 Notification rules — `backend/migrations/0012_notification_rules.up.sql`
+### 4.5 Notification rules — `backend/migrations/0020_notification_rule_single.up.sql`
+
+Migration `0012` created this table **per channel**. Migration `0020` collapsed it to **one row per user** — the `channel` column and `digest_send_time` are gone, and `notify_mode` gained two bundling modes:
 
 ```sql
-notification_rules(id, user_id FK, channel, score_threshold=60, notify_mode='instant'|'digest',
-                   quiet_hours_start, quiet_hours_end, digest_send_time='08:00', enabled)
-UNIQUE(user_id, channel)
+notification_rules(id, user_id FK, score_threshold=60,
+                   notify_mode='instant'|'daily'|'every_n_hours',
+                   interval_hours=6, daily_send_time='08:00',
+                   quiet_hours_start, quiet_hours_end, last_sent_at, enabled)
+UNIQUE(user_id)
 ```
 
-Lets the user say *"email me only for score ≥ 75; Slack for everything but only between 09:00 and 18:00; Discord as a daily 08:00 digest."* The `users.timezone` column (added in the same migration, default `'UTC'`) is what quiet-hours and digest times are evaluated against.
+One rulebook governs **all** of a user's channels at once (CLAUDE.md rule #23), so the user says *"notify me for score ≥ 75, bundled daily at 08:00, nothing between 22:00 and 07:00"* — not one policy per channel. The `users.timezone` column (added by `0012`, default `'UTC'`) is what quiet hours and `daily_send_time` are evaluated against.
 
-- API: `backend/src/api/routes/notification_rules.py` — `GET`, `POST` (upsert by user+channel), `PATCH`, `DELETE`. Every endpoint filters by `user_id = current_user.id`.
+- API: `backend/src/api/routes/notification_rules.py` — exactly two endpoints, `GET /api/settings/notification-rule` (returns `null` when unset) and `PUT /api/settings/notification-rule` (upsert, merging unsupplied fields). Both gate on `Depends(require_user)` and key off `user.id`; neither accepts a `user_id` from the request (rule #12).
+- A rulebook is **seeded at signup** (`services/notifications/defaults.py`, master switch `NOTIFY_SEED_DEFAULTS`) — before that, nothing in the product ever created a row, so no user could be alerted at all.
 
 ### 4.6 Notification ledger — `backend/migrations/0004_notification_ledger.up.sql`
 
@@ -369,7 +374,7 @@ This is the **idempotency table**: the UNIQUE constraint *guarantees* a (user, j
 
 ### 4.7 Digest queue — `backend/migrations/0013_user_notification_digests.up.sql`
 
-When `notify_mode='digest'`, individual job matches are queued in `user_notification_digests` rather than sent immediately. A scheduled worker drains the queue at `digest_send_time` in the user's timezone, batches all queued items into one message, and writes the result to the ledger.
+When `notify_mode` is a bundling mode (`daily` / `every_n_hours`) — or when an `instant` match lands inside quiet hours — the match is queued in `user_notification_digests` rather than sent immediately. The `notification_tick` ARQ cron runs **every 5 minutes** (`workers/settings.py:233`), asks `_bundle_due()` per enabled rule (using `daily_send_time` / `interval_hours` in the user's timezone), and enqueues `send_bundle` when due. `send_bundle` batches the queued rows into one Apprise call per channel with `force=True`, marks them `sent`, and writes the ledger — flipping a channel's ledger row to `dlq` after `MAX_BUNDLE_RETRIES` failures. `notification_tick` also flushes an `instant` user's queue once quiet hours end, which nothing else would drain.
 
 ### 4.8 Worker layer — `backend/src/workers/tasks.py`
 
@@ -377,7 +382,8 @@ Pure async functions (no `arq` import at module top level, per CLAUDE.md rule #1
 
 - `score_and_ingest(ctx, job_id, users_override=None)` — Pillar 2's `JobScorer` runs here; on success it `upsert_feed_row()`s into every user whose profile matches, then enqueues `send_notification` for any feed row above each user's threshold. The `users_override` kwarg lets the test suite scope to a single user without seeding others.
 - `send_notification(ctx, user_id, job_id, urgency='instant')` — dispatches to all of the user's enabled channels via `dispatcher.dispatch()`; one ledger row written per channel.
-- `send_daily_digest(ctx, user_id, channel)` — drains queued rows from `user_notification_digests`, batches into one Apprise call, marks rows `sent=1`.
+- `send_bundle(ctx, user_id)` (`tasks.py:971`) — drains queued rows from `user_notification_digests` across **all** the user's channels, batches into one Apprise call per channel, marks rows `sent`. There is no `send_daily_digest`; the per-channel task of that name was removed with the one-rule-per-user collapse.
+- `notification_tick(ctx)` (`tasks.py:1243`) — the 5-minute cron that decides which users are due and enqueues `send_bundle`.
 - `nightly_ghost_sweep(ctx)` — re-evaluates every non-expired job via `evaluate_job_state()`; transitions confirmed-dead postings to `staleness_state='confirmed_expired'` and `cascade_stale()`s them across every user's feed.
 - `enrich_job_task(ctx, job_id)` — idempotent LLM enrichment (skips if a `job_enrichment` row exists). One enrichment per job, not per user — shared catalog (CLAUDE.md rule #10 / #17).
 - `idempotency_key(user_id, job_id, channel)` — deterministic SHA1 ledger key.
@@ -557,12 +563,12 @@ Legend: ✅ done & wired · 🟡 partial · ❌ planned but not built · ⚠️ 
 | `user_channels` table + Fernet crypto | ✅ | migration `0005`, `crypto.py` |
 | 5 channel types (email/slack/discord/telegram/webhook) via Apprise | ✅ | `dispatcher.py`, lazy import |
 | Channel CRUD + test-send endpoint | ✅ | `routes/channels.py`, two-layer ownership check |
-| `notification_rules` per channel (threshold, mode, quiet hours, digest time) | ✅ | migration `0012` |
-| Notification rule CRUD endpoints | ✅ | `routes/notification_rules.py` |
+| `notification_rules` — ONE row per user (threshold, mode, quiet hours, daily send time, interval) | ✅ | migration `0012`, collapsed to `UNIQUE(user_id)` by `0020` |
+| Notification rule endpoints (`GET` / `PUT` on `/api/settings/notification-rule`) | ✅ | `routes/notification_rules.py` |
 | `notification_ledger` idempotency table | ✅ | migration `0004` — `UNIQUE(user_id, job_id, channel)` |
 | Ledger pagination + filters + per-channel stats | ✅ | `routes/notifications.py` |
 | Digest queue (`user_notification_digests`) | ✅ | migration `0013` |
-| ARQ + Redis worker for production | 🟡 | `tasks.py` are async-pure; worker config (`workers/settings.py`) is wired but production deployment is install-dependent |
+| ARQ + Redis worker for production | ✅ | `tasks.py` are async-pure; `workers/settings.py` is wired and `backend/railway.worker.json` deploys it as its own Railway service (`arq src.workers.settings.WorkerSettings`) |
 | Per-user timezone | ✅ | `users.timezone` column added in `0012`, default `'UTC'` |
 | Notification dry-run / preview before save | ❌ | only post-save `/test` endpoint exists |
 | Push notifications (FCM/APN) | ❌ | not in the channel list |
@@ -579,7 +585,7 @@ Legend: ✅ done & wired · 🟡 partial · ❌ planned but not built · ⚠️ 
 | Profile editor (CV, LinkedIn, GitHub, prefs, version history) | ✅ | `app/profile/page.tsx` |
 | Pipeline Kanban with drag-and-drop | ✅ | `KanbanBoard` |
 | Channel management UI | ✅ | `listChannels` / `createChannel` / `testChannel` wired |
-| Notification rules UI | ✅ | `notification_rules.ts` API client functions exist |
+| Notification rules UI | ✅ | `getNotificationRule` / `saveNotificationRule` in `frontend/src/lib/api.ts` (there is no separate `notification_rules.ts`) |
 | Notification ledger UI page | ✅ | API ready (`getNotificationLedger`) — frontend route is wired (Step 2 S4) |
 | Theme toggle (dark/light) | ✅ | in `Navbar.tsx` |
 | Mobile responsive | ✅ | Tailwind v4 + mobile Navbar menu |
@@ -600,9 +606,10 @@ backend/
 │   ├── 0005_user_channels.up.sql              — Fernet-encrypted channels
 │   ├── 0006_user_profiles.up.sql              — multi-tenant profile storage
 │   ├── 0007_user_profile_versions.up.sql      — 10-version history
-│   ├── 0012_notification_rules.up.sql         — per-channel preferences + users.timezone
+│   ├── 0012_notification_rules.up.sql         — notification preferences + users.timezone
 │   ├── 0013_user_notification_digests.up.sql  — digest queue
-│   └── 0014_application_history.up.sql        — pipeline stage history + interview dates
+│   ├── 0014_application_history.up.sql        — pipeline stage history + interview dates
+│   └── 0020_notification_rule_single.up.sql   — collapse to ONE rule row per user
 ├── src/
 │   ├── api/
 │   │   ├── auth_deps.py                       — require_user / optional_user / CurrentUser
@@ -614,7 +621,7 @@ backend/
 │   │       ├── actions.py                     — like / apply / not_interested
 │   │       ├── pipeline.py                    — 5-stage Kanban API
 │   │       ├── channels.py                    — channel CRUD + test
-│   │       ├── notification_rules.py          — per-channel rule CRUD
+│   │       ├── notification_rules.py          — single per-user rule (GET / PUT)
 │   │       └── notifications.py               — ledger pagination + stats
 │   ├── core/
 │   │   └── tenancy.py                         — DEFAULT_TENANT_ID
@@ -630,14 +637,14 @@ backend/
 │   │   └── profile/
 │   │       ├── models.py                      — CVData / UserPreferences / UserProfile / SearchConfig
 │   │       ├── cv_parser.py                   — pdfplumber/python-docx → LLM
-│   │       ├── llm_provider.py                — Gemini/Groq/Cerebras
+│   │       ├── llm_provider.py                — OpenAI (PRIMARY) → Gemini → Groq → Cerebras
 │   │       ├── linkedin_parser.py             — LinkedIn PDF parsing
 │   │       ├── github_enricher.py             — GitHub API + temporal weighting
 │   │       ├── preferences.py                 — form validation + merging
-│   │       ├── storage.py                     — SQLite + legacy JSON hydration
+│   │       ├── storage.py                     — Postgres (sync `pgsync`) + legacy JSON hydration
 │   │       └── keyword_generator.py           — profile → SearchConfig
 │   └── workers/
-│       └── tasks.py                           — score_and_ingest, mark_ledger_sent/failed
+│       └── tasks.py                           — score_and_ingest, send_notification, notification_tick, send_bundle, mark_ledger_sent/failed
 └── tests/                                     — auth (4 files), profile (3 files), feed/channels/notifications (8+ files)
 frontend/
 ├── src/

--- a/docs/product/pillars/03-job-providers.md
+++ b/docs/product/pillars/03-job-providers.md
@@ -616,4 +616,4 @@ backend/tests/
 
 ---
 
-*Source roster (post-2026-08-10 rotation): 40 classes / 41 registry keys / 40 instances. Backend test baseline ~1,409 collected (2 live deselected — defer to runtime count).*
+*Source roster (post-2026-08-10 rotation): 40 classes / 41 registry keys / 40 instances. Backend test baseline 3,297 collected / 3,295 selected (2 live deselected — defer to runtime count).*


### PR DESCRIPTION
Scout pass over the drift the two scripts cannot see. Markdown only — no code touched.

**Guards, before and after this change:**

```
python scripts/doc_sync_check.py          -> "No drift ... OK"  (exit 0)
python scripts/doc_sync_mutation_test.py  -> "All 15 guards proven able to go RED"
```

Nothing here duplicates them. Every claim was re-verified against the code at the cited line before it was written down.

---

## Fixes — `file:line — doc said X, code says Y`

### 1. Pillar 1 documents the notification schema that migration `0020` deleted

Root `CLAUDE.md` calls `docs/product/pillars/` the authoritative code-verified reference, and rules #23/#24 state the current model plainly. `01-user-pillar.md` still described the **pre-`0020`** model as current, in nine places. This is the one that would actually break someone: an agent wiring a notification feature from this doc writes against a table shape that has not existed since `0020_notification_rule_single.up.sql`.

- `docs/product/pillars/01-user-pillar.md:109` — doc said `POST /api/settings/notification-rules {channel:"email", ...}`; code says `PUT /api/settings/notification-rule` (singular) with no `channel` in the body — `backend/src/api/routes/notification_rules.py:63`.
- `01-user-pillar.md:110` — doc said `UPSERT by UNIQUE(user_id, channel)`; code says `UNIQUE(user_id)` — `backend/migrations/0020_notification_rule_single.up.sql:37`.
- `01-user-pillar.md:122` — doc said the worker consults the rule for `(alice.id, 'email')`; code has no `channel` column and looks up by user alone — `db.get_user_notification_rule(user.id)`.
- `01-user-pillar.md:339` — doc said dispatcher gate (3) is `notify_mode='digest'`; code says `if not force and (notify_mode in ("daily", "every_n_hours") or in_quiet)` — `backend/src/services/channels/dispatcher.py:317`.
- `01-user-pillar.md:340` — doc said "**Dual systems coexist**", the env-var modules `notifications/{email_notify,slack_notify,discord_notify}.py` are "still active" and used by the CLI batch run; code says those files do not exist. The CLI run writes a markdown report (`main.py:49`) and enqueues the ordinary per-user `send_notification` (`main.py:481`).
- `01-user-pillar.md:349-357` — doc's SQL block carried `channel`, `notify_mode='instant'|'digest'`, `digest_send_time`, `UNIQUE(user_id, channel)`, and an API of `GET`/`POST`/`PATCH`/`DELETE`; code says migration `0020`'s shape (`interval_hours`, `daily_send_time`, `last_sent_at`) and exactly two endpoints.
- `01-user-pillar.md:372` — doc said the queue drains at `digest_send_time`; code says `notification_tick` runs **every 5 minutes** (`workers/settings.py:233`) and enqueues `send_bundle`.
- `01-user-pillar.md:378` — doc named `send_daily_digest(ctx, user_id, channel)`; **no such function**. It is `send_bundle(ctx, user_id)` — `backend/src/workers/tasks.py:971`.
- `01-user-pillar.md:560, 582, 603, 617` — status table and directory tree repeated "per channel" and named `notification_rules.ts`, which does not exist (the client functions are `getNotificationRule` / `saveNotificationRule` in `frontend/src/lib/api.ts:542,551`).

Same doc, three smaller ones found alongside:

- `01-user-pillar.md:566` — doc said the ARQ worker's "production deployment is install-dependent" (🟡); code says `backend/railway.worker.json` deploys it as its own service (`arq src.workers.settings.WorkerSettings`).
- `01-user-pillar.md:635` — doc said `llm_provider.py — Gemini/Groq/Cerebras`; code puts **OpenAI first and primary** — `llm_provider.py:330`.
- `01-user-pillar.md:636` — doc said `storage.py — SQLite`; the DB is Postgres. (`FORBIDDEN_PHRASES` only bans the exact string "async SQLite", so this spelling walked past it — see the promotion section.)

### 2. The `notifications/` module inventory is one file out of date, in three copies

`defaults.py` landed with the signup-seeding fix and is cited by `ARCHITECTURE.md` as the one source of truth for `NOTIFY_SCORE_THRESHOLD` — while three docs went on saying the directory holds only two files. The load-bearing half of the warning (the `NotificationChannel` ABC and `get_all_channels` are gone) is still true and is kept.

- `README.md:290`, `ARCHITECTURE.md:550`, `.claude/skills/add-source/SKILL.md:82` — doc said "only ... `__init__.py` and `report_generator.py`"; `ls backend/src/services/notifications/` says `__init__.py`, `defaults.py`, `report_generator.py`.

### 3. A checklist that instructs a verifier to fail a box the code already fixed

- `.claude/skills/verify-job360/CHECKLIST.md:25` — doc said the frontend "still hardcodes **47** in four places" at `page.tsx:287` / `Footer.tsx:49` / `layout.tsx:37,40,47`, and that **the box FAILS** until fixed. Code says every rendered count reads `SOURCE_COUNT = 41` from `frontend/src/lib/catalog.ts:28` — fixed in #382, hours after that checklist line was written. All three cited line numbers are also wrong now. A checklist that demands a failure for a fixed bug is how a checklist stops being read.

### 4. Two stale test-suite baselines, in one repo, on one page

`README.md` contradicted **itself**: `:124` said 3,297 collected across 217 files, `:402` said "~1,409 across 60+ files".

- `README.md:402`, `README.md:426`, `STATUS.md:47`, `STATUS.md:205`, `STATUS.md:265`, `docs/product/pillars/03-job-providers.md:619` — doc said `~1,409 collected`; the measured baseline the other six docs carry is `3,297 collected / 3,295 selected across 217 test_*.py files`.
- `STATUS.md:250` — doc listed `test_notifications.py`; the file does not exist.
- `STATUS.md:257` — doc listed `test_notification_base.py` ("Channel base + discovery"); the file does not exist — it went with the ABC removal that `README`/`ARCHITECTURE` already document.
- `STATUS.md:205, 228` — doc named `cron_run.sh`; the script is `cron_setup.sh` (`backend/tests/test_cron.py:13`).

`STATUS.md`'s duplicate per-file table is replaced by a pointer at `README.md`'s measured one. It was a second copy of numbers that were roughly a third of the real ones (`test_sources.py` "55+" against 110 test functions), and two copies of a number is one copy too many.

**Verification caveat, stated plainly:** this container has no `pytest` and no Postgres on 5433, so I could not run a collection. What I *could* measure from the filesystem is `217` `test_*.py` files and `2,729` raw `def test_` before any parametrization — which is enough to prove `~1,409` false, and consistent with the `3,297` the six other docs recorded on 2026-08-24. `doc_sync_check.py`'s `test-files` guard confirms the 217.

---

## Promote to the guard

Three of these were countable, so the script should own them and I should never re-find them.

**(a) One collected-test baseline, repo-wide.** The `~1,409` / `3,297` split is the exact failure `CLAUDE.md` warns about ("three docs once disagreed by 400–800 tests"). The collected count itself can't be guarded — it needs Postgres, and `doc_sync_check.py` says so on purpose — but *self-consistency* can, with no DB and no runtime:

```python
def collected_baseline_claims() -> list[tuple[str, int, int]]:
    """(doc:line, collected, selected) for every stated suite baseline.

    NOT a check against a live collection — that needs Postgres. This checks the
    docs against EACH OTHER: one baseline, stated identically everywhere, or red.
    README.md contradicted itself on one page for weeks (3,297 at :124, ~1,409 at
    :402) and every existing guard stayed green, because none of them asks
    "do two docs disagree?"
    """
    pat = re.compile(r"([\d,]{3,})\s+collected(?:\s*/\s*([\d,]{3,})\s+selected)?")
    ...
```

Wire it as a drift row when the claimed values are not all equal, listing every `file:line` and its number side by side. Cheap, offline, deterministic, and it fails the moment someone updates four docs out of six.

**(b) Widen `FORBIDDEN_PHRASES` beyond the exact string "async SQLite".** `01-user-pillar.md:636` described profile storage as `SQLite` and no guard saw it, because the entry pins one two-word phrase. Suggested addition, worded to survive the legitimate uses:

```python
("SQLite table", "the DB is Postgres via psycopg3 since 2026-07-02 (pg.py shim)"),
("SQLite database", "same — pg.py is an aiosqlite-SHAPED driver, not SQLite"),
```

Deliberately *not* a bare `"SQLite"`: `pg.py` is honestly described as an aiosqlite-shaped shim and the migrations legitimately discuss SQLite DDL limits, so a bare match would be a permanent false alarm — and a permanent alarm is how a loop dies.

**(c) A test file named in a doc must exist.** `STATUS.md` cited `test_notifications.py` and `test_notification_base.py` long after both were deleted. `dead_path_claims()` cannot see them: it only matches `backend/src/...` / `frontend/src/...` / `docs/...` prefixes, and these were bare filenames in a table. Extend the pattern to bare `` `test_*.py` `` tokens and resolve them against `backend/tests/`:

```python
# Bare `test_foo.py` in a table cell is still a factual claim that a test exists.
pat_test = re.compile(r"`(test_[a-z0-9_]+\.py)`")
```

This is the cheapest of the three and catches a whole class: a deleted test file keeps being cited as coverage, which reads as "this is tested" when nothing tests it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RWNxoLnJ1vGz7QC5V3Qc5a)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated notification-system documentation to describe the current per-user notification model, shared bundling and quiet-hour settings, and worker scheduling.
  - Clarified the OpenAI-first language-model fallback order and Postgres storage references.
  - Refreshed project structure, source-count verification, testing totals, test-file counts, and Windows test-skip guidance.
  - Replaced duplicated coverage details with instructions for obtaining current runtime measurements.
  - Updated verification checklists and architecture references to reflect the latest implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->