### PR TITLE
fix(doc-sync): a guard that asks whether two docs disagree with EACH OTHER

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -94,7 +94,7 @@ job360/
 │   │       ├── logger.py             # Rotating file + console logging
 │   │       ├── rate_limiter.py       # Async semaphore + delay
 │   │       └── time_buckets.py
-│   └── tests/                        # 3,297 collected / 3,295 selected (2 `live` deselected) across 217 test_*.py files (defer to runtime count)
+│   └── tests/                        # 3,297 collected / 3,295 selected (2 `live` deselected) across 218 test_*.py files (defer to runtime count)
 ├── frontend/                         # Next.js 16 + React 19 + Tailwind 4 + shadcn
 │   ├── src/app/                      # App Router pages (server/client split; params is Promise<...> per Next.js 16)
 │   ├── src/components/{ui,jobs,profile,pipeline,layout}/

--- a/README.md
+++ b/README.md
@@ -400,7 +400,7 @@ job360/
 │       │   └── other/       (4 classes / 5 keys)
 │       ├── workers/             # ARQ tasks + WorkerSettings
 │       └── utils/
-├── backend/tests/               # 3,297 collected / 3,295 selected (2 live deselected) across 217 test_*.py files (defer to runtime count)
+├── backend/tests/               # 3,297 collected / 3,295 selected (2 live deselected) across 218 test_*.py files (defer to runtime count)
 ├── frontend/                    # Next.js 16 + React 19 + Tailwind 4 + shadcn 4
 │   └── src/
 │       ├── app/                 # App Router pages

--- a/scripts/doc_sync_check.py
+++ b/scripts/doc_sync_check.py
@@ -75,6 +75,17 @@ LIVING_DOCS = [
 # Prose lies that numbers can't catch. Each = (forbidden phrase, why).
 FORBIDDEN_PHRASES = [
     ("async SQLite", "the DB is Postgres via psycopg3 since 2026-07-02 (pg.py shim)"),
+    # Added 2026-08-24 by the nightly routine. 01-user-pillar.md described
+    # profile storage as "SQLite" and walked straight past this list, because
+    # the single entry above pins one exact two-word phrase.
+    #
+    # Deliberately NOT a bare "SQLite": pg.py is honestly documented as an
+    # aiosqlite-SHAPED driver, and the migrations legitimately discuss SQLite
+    # DDL limits. A bare match would fire on both forever, and a permanent
+    # false alarm is how a loop dies.
+    ("SQLite table", "the DB is Postgres via psycopg3 — pg.py is aiosqlite-SHAPED, not SQLite"),
+    ("SQLite database", "the DB is Postgres via psycopg3 — pg.py is aiosqlite-SHAPED, not SQLite"),
+    ("stored in SQLite", "the DB is Postgres via psycopg3 since 2026-07-02 (pg.py shim)"),
 ]
 
 # Header spec (DOC-MAINTENANCE.md): one HTML comment near the top of a doc,
@@ -265,6 +276,41 @@ def landing_page_source_claims() -> list[tuple[int, int]]:
                 claimed = m.group(1) or m.group(2)
                 if claimed:
                     out.append((i, int(claimed)))
+    return out
+
+
+def collected_baseline_claims() -> list[tuple[str, str, int]]:
+    """(doc, line, collected-count) for every stated test-suite baseline.
+
+    NOT a check against a live collection. Collecting the suite imports conftest,
+    which wants a Postgres on 5433, and this runs in a blocking CI step that must
+    stay fast and offline — test_file_count() exists for what the filesystem can
+    answer.
+
+    This asks a different question, and the only one every other guard here is
+    structurally unable to ask: DO TWO DOCS DISAGREE WITH EACH OTHER?
+
+    Every guard above compares a doc to the code. None of them notices when six
+    docs say 3,297 and two say ~1,409 — which is exactly what happened, with
+    README.md contradicting ITSELF on one page (3,297 at :124, ~1,409 at :402)
+    while every check stayed green. Root CLAUDE.md already warns about this
+    exact failure: "three docs once disagreed by 400-800 tests".
+
+    Consistency is checkable without a database. One baseline, stated the same
+    everywhere, or red.
+    """
+    pat = re.compile(r"([\d,]{3,})\s+collected")
+    out: list[tuple[str, str, int]] = []
+    for rel in LIVING_DOCS:
+        path = ROOT / rel
+        if not path.exists():
+            continue
+        for i, line in enumerate(path.read_text(encoding="utf-8", errors="replace").splitlines(), 1):
+            for m in pat.finditer(line):
+                try:
+                    out.append((rel, str(i), int(m.group(1).replace(",", ""))))
+                except ValueError:
+                    continue
     return out
 
 
@@ -627,6 +673,20 @@ def main() -> int:
             drift.append((rel, "-", "doc-type", "no doc-type header", "needs <!-- doc: LIVING ... -->"))
         elif type_tag.group(1) != "LIVING":
             drift.append((rel, "-", "doc-type", f"tagged {type_tag.group(1)}", "this file is a LIVING doc"))
+
+    # Do the docs agree with EACH OTHER about the suite baseline? Every other
+    # guard compares a doc to the code; none can see six docs saying 3,297 while
+    # two say ~1,409, or README.md contradicting itself on one page.
+    baselines = collected_baseline_claims()
+    distinct = {n for _, _, n in baselines}
+    if len(distinct) > 1:
+        agreed = max(distinct)  # the freshest measurement wins the comparison
+        for rel, line_no, claimed in baselines:
+            if claimed != agreed:
+                drift.append((
+                    rel, line_no, "suite-baseline", f"{claimed:,} collected",
+                    f"{agreed:,} collected — docs must agree with each other",
+                ))
 
     # The landing page is a claim to USERS, and it drifted the same way a doc
     # does — it advertised 47 sources against a registry of 41 for a week.

--- a/scripts/doc_sync_mutation_test.py
+++ b/scripts/doc_sync_mutation_test.py
@@ -73,6 +73,19 @@ CASES: list[tuple[str, str, str, str]] = [
     # that. One capital letter, one blind guard.
     ("frontend/src/lib/catalog.ts",
      r"SOURCE_COUNT = (\d+)", "SOURCE_COUNT = 999", "landing-source-count"),
+    # Fourth batch, 2026-08-24, from the nightly routine.
+    #
+    # suite-baseline is the odd one out and the point of it: every other guard
+    # asks "does this doc match the code?". This one asks "do two docs disagree
+    # with EACH OTHER?" -- the question none of the others can ask, and the one
+    # that would have caught README.md contradicting itself on a single page
+    # (3,297 collected at :124, ~1,409 at :402) while every check stayed green.
+    # Breaking ONE doc's number is therefore a real mutation: it creates the
+    # disagreement.
+    ("ARCHITECTURE.md",
+     r"([\d,]{3,}) collected", "9,999 collected", "suite-baseline"),
+    ("backend/CLAUDE.md",
+     r"(SQLite|Postgres) via psycopg3", "SQLite table via psycopg3", "stale-phrase"),
 ]
 
 


### PR DESCRIPTION
Fourth promotion round, from the nightly routine's cycle-3 proposal.

## The question no existing guard could ask

Every check in this file compares **a doc to the code**. Not one can see six docs saying 3,297 while two say ~1,409 — because the code side of that comparison does not exist offline: collecting the suite needs a Postgres on 5433, and this runs in a *blocking* CI step that must stay fast.

So `README.md` contradicted **itself on a single page** — 3,297 collected at `:124`, ~1,409 at `:402` — and every guard stayed green. Root `CLAUDE.md` already warns about exactly this (*"three docs once disagreed by 400–800 tests"*). Nothing enforced it.

**Consistency needs no database.** `collected_baseline_claims()` gathers every stated baseline across `LIVING_DOCS` and reports drift when they are not all equal, naming each `file:line` and its number side by side.

Verified: it independently reproduced the **exact six locations** the routine found by reading — `README.md:402,426`, `STATUS.md:47,205,265`, `03-job-providers.md:619`.

## FORBIDDEN_PHRASES widened

`01-user-pillar.md` described profile storage as "SQLite" and walked past the phrase list, because the single entry pins the exact two-word string `"async SQLite"`. Added `"SQLite table"`, `"SQLite database"`, `"stored in SQLite"`.

**Deliberately not a bare `"SQLite"`:** `pg.py` is honestly documented as an aiosqlite-*shaped* driver and the migrations legitimately discuss SQLite DDL limits. A bare match fires on both forever — the same reason `SOURCE_INSTANCE_COUNT` was dropped from the pattern list two commits ago.

## Second live catch today

`test-files` 217 → 218. PR #390 added `test_conflict_marker_guard.py`; `README.md:403` and `ARCHITECTURE.md:97` went stale the moment it merged, and the guard reported it on the next run.

Countable facts rot within **hours** of a merge. A nightly LLM pass finds that tomorrow; the script finds it on the next push.

## Verified

```
No drift — every doc claim matches the code, all stamps fresh. OK
All 17 guards proven able to go RED.
[gate] PASS
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6DsQH5EUxJc3Vnqz9YHgQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated project documentation to accurately reflect the current number of backend test files.
  - Improved consistency of test-suite baseline information across architecture and project documentation.
  - Clarified guidance by removing or flagging outdated SQLite terminology.

- **Quality Improvements**
  - Enhanced documentation checks to detect conflicting test-count claims and stale database references.
  - Added coverage to ensure documentation drift is identified when these details change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->