### PR TITLE
docs: stop publishing an unverified collected-test count

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -74,11 +74,11 @@ job360/
 │   │   │   ├── vector_index.py       # ChromaDB wrapper (opt-in, lazy)
 │   │   │   ├── retrieval.py          # BM25 + RRF fusion + cross-encoder rerank (opt-in)
 │   │   │   ├── auth/                 # passwords (argon2id), sessions (HMAC cookies)
-│   │   │   ├── channels/             # crypto (Fernet), dispatcher (Apprise lazy)
-│   │   │   ├── notifications/        # email / slack / discord / report_generator (legacy CLI summaries)
+│   │   │   ├── channels/             # dispatcher (Apprise lazy), crypto (Fernet), email_url, ssrf_guard
+│   │   │   ├── notifications/        # defaults (signup rulebook seeder), report_generator
 │   │   │   └── profile/              # cv_parser, llm_provider, linkedin_parser, github_enricher, models, preferences, storage, keyword_generator
 │   │   ├── repositories/             # (post-Phase-4 rename from storage/)
-│   │   │   ├── database.py           # Postgres via psycopg3 (`pg.py` aiosqlite-shaped shim) + 25-migration forward-compat schema
+│   │   │   ├── database.py           # Postgres via psycopg3 (`pg.py` aiosqlite-shaped shim) + 31-migration forward-compat schema (0000 → 0030)
 │   │   │   └── csv_export.py
 │   │   ├── sources/                  # (post-Phase-2 split into 6 category subfolders)
 │   │   │   ├── base.py               # BaseJobSource ABC: retry, rate limit, conditional fetch, _is_uk_or_remote

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -94,7 +94,7 @@ job360/
 │   │       ├── logger.py             # Rotating file + console logging
 │   │       ├── rate_limiter.py       # Async semaphore + delay
 │   │       └── time_buckets.py
-│   └── tests/                        # 3,297 collected / 3,295 selected (2 `live` deselected) across 217 test_*.py files (defer to runtime count)
+│   └── tests/                        # across 218 `test_*.py` files (collected-test count: measure it, never quote it)
 ├── frontend/                         # Next.js 16 + React 19 + Tailwind 4 + shadcn
 │   ├── src/app/                      # App Router pages (server/client split; params is Promise<...> per Next.js 16)
 │   ├── src/components/{ui,jobs,profile,pipeline,layout}/

--- a/README.md
+++ b/README.md
@@ -121,9 +121,18 @@ flowchart TD
 - **Split requirements** — prod deps in `backend/pyproject.toml` `[project.dependencies]`, dev/test in the same file's `[project.optional-dependencies] dev` extra (`pip install -e ".[dev]"`). There is no `requirements*.txt` in the repo
 - **Hardened setup** — Python 3.9+ version check, idempotent installs, .env validation
 
-### Testing (3,297 collected, 3,295 selected offline, 2 live deselected — defer to the runtime collected count; run `pytest --collect-only -q | tail -1` for the live count)
+### Testing (218 `test_*.py` files; 2 `live` tests deselected offline)
 
-> Per-file counts below were measured with `cd backend && python -m pytest tests/<file>.py --collect-only -q -p no:randomly | tail -1`. `test_main.py` **is** in the canonical run — do not add `--ignore=tests/test_main.py` (root CLAUDE.md rule).
+> **The collected-test count is not written down anywhere on purpose.** Measure it:
+> `cd backend && python -m pytest --collect-only -q -p no:randomly | tail -1`.
+> `scripts/doc_sync_check.py` deliberately does not guard it (it needs Postgres, and
+> parametrization makes any cheap check flaky), so any total committed to a doc is
+> unguarded and silently rots — this table has carried a wrong one before.
+>
+> Per-file counts below are a **snapshot taken 2026-08-24**, not a live invariant; re-measure
+> with `python -m pytest tests/<file>.py --collect-only -q -p no:randomly | tail -1`.
+> `test_main.py` **is** in the canonical run — do not add `--ignore=tests/test_main.py`
+> (root CLAUDE.md rule).
 
 | Test file | Collected count | What it covers |
 |-----------|-------|----------------|
@@ -147,7 +156,7 @@ flowchart TD
 | `test_cron.py` | 5 | cron_setup.sh validation |
 | `test_setup.py` | 4 | setup.sh validation |
 | `test_csv_export.py` | 4 | CSV export format |
-| (the other ~197 `test_*.py` files) | balance of 3,297 | auth, feed, prefilter, channels, scheduler, circuit_breaker, enrichment, embeddings, retrieval, IDOR, account-mgmt, application history, llm_matcher, uk_gate, visa_signal, shelf registry, harness guards |
+| (the other 198 `test_*.py` files) | measure it | auth, feed, prefilter, channels, scheduler, circuit_breaker, enrichment, embeddings, retrieval, IDOR, account-mgmt, application history, llm_matcher, uk_gate, visa_signal, shelf registry, harness guards |
 
 ## Quick Start
 
@@ -384,8 +393,8 @@ job360/
 │       │   ├── circuit_breaker.py
 │       │   ├── feed.py
 │       │   ├── auth/
-│       │   ├── channels/        # Apprise dispatcher
-│       │   ├── notifications/   # email, slack, discord, report_generator
+│       │   ├── channels/        # dispatcher (Apprise), crypto, email_url, ssrf_guard
+│       │   ├── notifications/   # defaults (signup rulebook seeder), report_generator
 │       │   └── profile/         # cv_parser, llm_provider, linkedin_parser, github_enricher, models, preferences, storage, keyword_generator
 │       ├── repositories/        # (renamed from storage/)
 │       │   ├── database.py
@@ -400,7 +409,7 @@ job360/
 │       │   └── other/       (4 classes / 5 keys)
 │       ├── workers/             # ARQ tasks + WorkerSettings
 │       └── utils/
-├── backend/tests/               # 3,297 collected / 3,295 selected (2 live deselected) across 217 test_*.py files (defer to runtime count)
+├── backend/tests/               # 218 test_*.py files (collected-test count: measure it, never quote it)
 ├── frontend/                    # Next.js 16 + React 19 + Tailwind 4 + shadcn 4
 │   └── src/
 │       ├── app/                 # App Router pages
@@ -424,7 +433,7 @@ python -m pytest backend/tests/test_scorer.py -v
 python -m pytest backend/tests/ -v -s
 ```
 
-The full suite passes (3,297 collected / 3,295 selected, 2 live deselected — defer to the runtime count). Every source is tested with mocked HTTP responses (aioresponses). No network access required. 3 tests skip on Windows (bash-only tests for `setup.sh` and `cron_setup.sh`).
+The suite runs against a real Postgres and 2 `live`-marked tests are deselected offline. **Measure the collected count, never quote one** — `cd backend && python -m pytest --collect-only -q -p no:randomly | tail -1`; `scripts/doc_sync_check.py` deliberately does not guard it (needs Postgres, and parametrization makes any cheap check flaky), so any number written here is unguarded and rots. Every source is tested with mocked HTTP responses (aioresponses). No network access required. 3 tests skip on Windows (bash-only tests for `setup.sh` and `cron_setup.sh`).
 
 ## Output
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -44,8 +44,8 @@
 > delivery to live Slack/Telegram/Gmail (needs provider credentials).
 
 **Last updated:** 2026-08-24 (doc truth check; the phase narratives below are older — see `docs/harness/IMPLEMENTATION_LOG.md` for the current history)
-**Total tests:** defer to the runtime collected count (3,297 collected / 3,295 selected, 2 live deselected; 0 failing, 3 skipped on Windows)
-**Source files:** 40 source files in `backend/src/sources/` (excluding `__init__.py` and `base.py`) split into 6 category subfolders | **Test files:** 217 `test_*.py` modules
+**Total tests:** measure it, never quote it — `cd backend && python -m pytest --collect-only -q -p no:randomly | tail -1` (2 `live` tests deselected offline; 3 skip on Windows)
+**Source files:** 40 source files in `backend/src/sources/` (excluding `__init__.py` and `base.py`) split into 6 category subfolders | **Test files:** 218 `test_*.py` modules
 **Job sources:** 41 entries in `SOURCE_REGISTRY`; 40 live instances since `indeed` + `glassdoor` share `JobSpySource`; gov_apprenticeships restored 2026-06-16 on DfE Display Advert API v2 (M6 2026-06 dropped jobtensor, comeet, aijobs_global; the 2026-08-10 rotation dropped 6 more dead upstreams — aijobs, rippling, biospace, jobs_ac_uk, workanywhere, nhs_jobs_xml). See CLAUDE.md rule #13 for the five load-bearing surfaces that move together on a registry change.
 **Latest merged head:** `225040e` on `origin/main` — docs audit + cleanup (2026-06-21); all worktree/feature branches merged and deleted.
 **Sentinel:** `.claude/step-3-verified.txt` → `337fbda19b5ae30d55dba061bc6658a49bcd208d` (post-reviewer-fix SHA).
@@ -202,7 +202,7 @@ Engine #4 runs after per-user feed write (`_run_matcher_stage`). Results stored 
 - Email, Slack, Discord, Telegram, webhook — all via the Apprise dispatcher, per-user channels (Batch 2). The old built-in channel classes are REMOVED.
 - CLI commands: run, view, api, status, sources, setup-profile
 - Next.js frontend (at `frontend/`) + FastAPI backend (at `backend/src/api/`) deliver the interactive UI
-- Tests: defer to the runtime collected count (3,297 collected / 3,295 selected, 2 live deselected); 3 skip on Windows (bash-only `setup.sh` / `cron_setup.sh` tests), 0 failing
+- Tests: 218 `test_*.py` modules; measure the collected count, never quote it (2 `live` deselected offline); 3 skip on Windows (bash-only `setup.sh` / `cron_setup.sh` tests)
 
 ---
 
@@ -246,8 +246,8 @@ Engine #4 runs after per-user feed write (`_run_matcher_stage`). Results stored 
 > per-file counts roughly a third of the real ones. Two copies of a number is one copy too
 > many — README's is the measured one.
 
-**Current green baseline:** 3,297 collected / 3,295 selected (2 `live` deselected), 0 failing,
-3 skipped on Windows. Measure it, never quote it:
+**Current green baseline:** 218 `test_*.py` modules, 2 `live` tests deselected offline, 3 skipped
+on Windows. The collected count is deliberately not recorded here — measure it, never quote it:
 `cd backend && python -m pytest --collect-only -q -p no:randomly | tail -1`.
 
 Broad coverage beyond the top-20 files: migrations, auth, feed, prefilter, channels, crypto,

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -32,7 +32,7 @@ CLAUDE.md rule #29).
 
 ```bash
 # Canonical pre-commit test run — defer to the runtime collected count, not a doc figure
-python -m pytest -q -p no:randomly   # ~3,295 selected of 3,297 collected (2 `live` deselected) — test_main.py included
+python -m pytest -q -p no:randomly   # 2 `live` deselected; test_main.py included. Measure the count, never quote it.
 
 python -m pytest tests/test_scorer.py::test_name -v   # single test
 python -m ruff check .                                # lint (CI gate)

--- a/backend/README.md
+++ b/backend/README.md
@@ -83,7 +83,7 @@ python -m pytest -q -p no:randomly
 ```
 
 Invariant: full suite passes, 0 failing. (Live count is **3,297 collected / 3,295 selected**
-(2 `live` deselected) across **217** `test_*.py` files — run
+(2 `live` deselected) across **218** `test_*.py` files — run
 `python -m pytest --collect-only -q -p no:randomly | tail -1` for the exact
 number, and defer to it rather than to any figure written down here.) The
 `-p no:randomly` flag keeps the default order deterministic (pytest-randomly is

--- a/backend/README.md
+++ b/backend/README.md
@@ -82,10 +82,12 @@ Must pass from `backend/`:
 python -m pytest -q -p no:randomly
 ```
 
-Invariant: full suite passes, 0 failing. (Live count is **3,297 collected / 3,295 selected**
-(2 `live` deselected) across **218** `test_*.py` files — run
-`python -m pytest --collect-only -q -p no:randomly | tail -1` for the exact
-number, and defer to it rather than to any figure written down here.) The
+Invariant: full suite passes, 0 failing, across **218** `test_*.py` files (2 `live`
+deselected offline). The collected count is deliberately not written down — run
+`python -m pytest --collect-only -q -p no:randomly | tail -1` for it. Any total
+committed to a doc is unguarded (`scripts/doc_sync_check.py` declines to check it
+on purpose: it needs Postgres, and parametrization makes a cheap check flaky) and
+rots silently — this line carried a stale one. The
 `-p no:randomly` flag keeps the default order deterministic (pytest-randomly is
 installed but opt-in).
 

--- a/docs/product/pillars/01-user-pillar.md
+++ b/docs/product/pillars/01-user-pillar.md
@@ -336,8 +336,8 @@ Only the survivors get the full `JobScorer` treatment (Pillar 2).
   - `telegram` → `tgram://bot_token/chat_id`
   - `webhook` → `json://host/path`
 - **`backend/src/services/channels/crypto.py`** — `encrypt(plaintext) → bytes` / `decrypt(ciphertext) → str`. Fails closed if `CHANNEL_ENCRYPTION_KEY` is unset.
-- **`backend/src/services/channels/dispatcher.py`** — thin wrapper around Apprise. Imports `apprise` *lazily inside the function* (CLAUDE.md rule #11 — Apprise pulls ~30 MB of deps; library code must not pay that cost on import). Tests monkeypatch `apprise.Apprise`. The dispatcher runs each notification through gates before sending: (1) `enabled=0` skip, (2) `match_score < score_threshold` skip, (3+4) `notify_mode` is a **bundling** mode (`daily` / `every_n_hours`) **or** the moment falls inside the quiet-hours window (evaluated with stdlib `zoneinfo` against `users.timezone`) → queue for the digest instead of sending now (`dispatcher.py:317`). `force=True` bypasses gate 3+4 and is how `send_bundle` delivers already-queued rows.
-- **There is only ONE delivery path.** The pre-Batch-2 single-tenant notification code (`src/services/notifications/{base,email_notify,slack_notify,discord_notify}.py`, env-var webhooks) was **deleted** — see the removal note in `ARCHITECTURE.md` / `README.md`. Everything user-facing goes through the per-user `src/services/channels/dispatcher.py`, invoked by ARQ worker tasks under an authenticated `user_id`. The CLI batch run no longer sends its own summary: it writes a markdown report via `services/notifications/report_generator.generate_markdown_report` (`main.py:49`) and enqueues the ordinary per-user `send_notification` task for above-threshold feed rows (`main.py:481` `_enqueue_notifications`).
+- **`backend/src/services/channels/dispatcher.py`** — thin wrapper around Apprise. Imports `apprise` *lazily inside the function* (CLAUDE.md rule #11 — Apprise pulls ~30 MB of deps; library code must not pay that cost on import). Tests monkeypatch `apprise.Apprise`. The dispatcher runs each notification through gates before sending: (1) `enabled=0` skip, (2) `match_score < score_threshold` skip, (3+4) `notify_mode` is a **bundling** mode (`daily` / `every_n_hours`) **or** the moment falls inside the quiet-hours window (evaluated with stdlib `zoneinfo` against `users.timezone`) → queue for the digest instead of sending now (`backend/src/services/channels/dispatcher.py:317`). `force=True` bypasses gate 3+4 and is how `send_bundle` delivers already-queued rows.
+- **There is only ONE delivery path.** The pre-Batch-2 single-tenant notification code (`backend/src/services/notifications/{base,email_notify,slack_notify,discord_notify}.py`, env-var webhooks) was **deleted** — see the removal note in `ARCHITECTURE.md` / `README.md`. Everything user-facing goes through the per-user `backend/src/services/channels/dispatcher.py`, invoked by ARQ worker tasks under an authenticated `user_id`. The CLI batch run no longer sends its own summary: it writes a markdown report via `generate_markdown_report()` from `backend/src/services/notifications/report_generator.py` (`backend/src/main.py:49`) and enqueues the ordinary per-user `send_notification` task for above-threshold feed rows (`backend/src/main.py:481` `_enqueue_notifications`).
 - **API** — `backend/src/api/routes/channels.py`:
   - `GET /api/settings/channels` — list caller's channels
   - `POST /api/settings/channels` — create (encrypts credential server-side)
@@ -675,9 +675,9 @@ For completeness — these belong in the other two pillars and you won't find th
 
 ---
 
-*Last updated 2026-08-24. Backend suite: 3,297 collected / 3,295 selected across 217 test files — measure it, never quote it
-collected, 2 deselected (measured `python -m pytest --collect-only -q`, this session —
-per root `CLAUDE.md`: "never quote a test count from a doc, measure it"). Pass/fail count
-NOT verified this session (no local Postgres reachable — the suite needs `docker-compose.dev.yml`
-up on port 5433); do not carry the old "600p/0f/3s" figure forward, it predates this update by
-~2.5 months and was already off by roughly 5x collected-test count alone.*
+*Last updated 2026-08-24. Backend suite: 218 `test_*.py` files (filesystem count, verified).
+The collected-test count and the pass/fail count were **NOT** verified in this session — no
+local Postgres was reachable (the suite needs `docker-compose.dev.yml` up on port 5433) — so
+neither is recorded here. Measure them, never quote them:
+`cd backend && python -m pytest --collect-only -q -p no:randomly | tail -1`. Do not carry the
+old "600p/0f/3s" figure forward either; it predates this update by ~2.5 months.*

--- a/docs/product/pillars/03-job-providers.md
+++ b/docs/product/pillars/03-job-providers.md
@@ -616,4 +616,4 @@ backend/tests/
 
 ---
 
-*Source roster (post-2026-08-10 rotation): 40 classes / 41 registry keys / 40 instances. Backend test baseline 3,297 collected / 3,295 selected (2 live deselected — defer to runtime count).*
+*Source roster (post-2026-08-10 rotation): 40 classes / 41 registry keys / 40 instances. Backend tests: 218 `test_*.py` files; measure the collected count, never quote it (2 `live` deselected offline).*


### PR DESCRIPTION
Follow-up to #391, which was merged before its review landed. CodeRabbit posted four findings on it at 15:29; the merge was at 15:36. Three were right. This is those fixes, plus two further review rounds on this PR, plus two the guard caught.

Markdown only — no code touched.

```
python scripts/doc_sync_check.py          -> "No drift ... OK"  (exit 0)
python scripts/doc_sync_mutation_test.py  -> "All 15 guards proven able to go RED"
```

---

## 1. The collected-test count was never measured

#391 asserted **"3,297 collected / 3,295 selected, 0 failing"** as a *measured current baseline* in six places. It was not measured. Neither `pytest` nor Docker is available in the routine's container, and `01-user-pillar.md`'s own footer said so in the same paragraph that quoted the number — the text contradicted itself on one line:

> *Backend suite: 3,297 collected / 3,295 selected ... Pass/fail count NOT verified this session (no local Postgres reachable)*

Worse, this number **cannot** be guarded, by deliberate design — `scripts/doc_sync_check.py:16-19`:

> *Deliberately NOT checked: the collected-test count (needs Postgres, and parametrization makes any cheap def-count tolerance flaky — a false-alarming check trains people to ignore the loop).*

So a total committed to a doc is unguarded by construction and rots silently. That is precisely the fact this routine keeps re-finding: #391's own body documents `README.md` contradicting *itself* on one page (`3,297` at `:124`, `~1,409` at `:402`).

The fix is not a better number — it is **no number**. Each site now carries the measurement command instead:

`cd backend && python -m pytest --collect-only -q -p no:randomly | tail -1`

Removed from: `README.md` (×4), `STATUS.md` (×3), `ARCHITECTURE.md:97`, `docs/product/pillars/01-user-pillar.md:678`, `docs/product/pillars/03-job-providers.md:619`, and — after review — `backend/README.md:85` and `backend/CLAUDE.md:35`.

What stays is the **`test_*.py` file count** — filesystem-only, verified here, and genuinely guarded by `doc_sync_check.py`'s `test-files` check. The README per-file table is kept but relabelled a **dated snapshot** rather than a live invariant, since its 20 per-file counts are the same class of unverifiable claim.

**`CONTRIBUTING.md:81,86,88` is now the only place the number survives, deliberately.** It is the merge-gate ratchet floor (`>= 3,297 collected ... as of 2026-08-24`) — a policy threshold, not a claim about current state. Raising or lowering a merge gate is the owner's call, not a docs fix. Only a real collection run can settle whether it is still right.

## 2. Two load-bearing trees listed three deleted modules

`ls backend/src/services/notifications/` → `__init__.py`, `defaults.py`, `report_generator.py`. The `email`/`slack`/`discord` modules went with the `NotificationChannel` ABC.

- `README.md:388` — tree said `notifications/   # email, slack, discord, report_generator`. This sat **99 lines below** the prose #391 had already corrected, in the same file.
- `ARCHITECTURE.md:78` — **the same stale tree**, caught on review after I fixed only the README copy. Worse: it also read `(legacy CLI summaries)`, repeating the "dual systems coexist" claim #391 disproved. There is no legacy CLI summary path — the CLI run writes a markdown report via `generate_markdown_report()` (`backend/src/main.py:49`) and enqueues the ordinary per-user `send_notification` (`backend/src/main.py:481`).

Both now read `defaults (signup rulebook seeder), report_generator`. `channels/` is spelled out in both while there — each listed only `crypto` + `dispatcher`, missing `email_url.py` and `ssrf_guard.py`.

## 3. Ambiguous basename citations

- `docs/product/pillars/01-user-pillar.md:339-340` — cited `main.py:49`, `main.py:481`, `dispatcher.py:317` as bare basenames. `backend/main.py` exists and is **30 lines**, so `main.py:481` resolves to nothing.

All three pointed at the right code, verified before editing — only the paths were qualified:

| citation | line reads |
|---|---|
| `backend/src/main.py:49` | `from src.services.notifications.report_generator import generate_markdown_report` |
| `backend/src/main.py:481` | `async def _enqueue_notifications(` |
| `backend/src/services/channels/dispatcher.py:317` | `if not force and (notify_mode in ("daily", "every_n_hours") or in_quiet):` |

## 4. Two countable facts, both caught here rather than by a human

- **Test-file count 217 → 218.** Caught by `doc_sync_check.py` on rebase, not by me: `test_conflict_marker_guard.py` landed on `main` via #390. Updated in all seven docs, plus the derived `(the other ~197 files)` → `198` in README's table.
- **`ARCHITECTURE.md:81` said `25-migration forward-compat schema`.** There are **31**, `0000` → `0030` (`ls backend/migrations/*.up.sql | wc -l`). Found while verifying an adjacent line.

---

## Not fixed, with the reason

**(i) OG/Twitter test assertions** (`.claude/skills/verify-job360/CHECKLIST.md:25`, from #391). The checklist sentence claims *the code reads `SOURCE_COUNT`*, which is true and verified — `layout.tsx:40,43,50` (description, `openGraph`, `twitter`), `page.tsx:30,68,146,164,290`, `Footer.tsx:52` all interpolate it. It does not claim the test asserts metadata, so there is no false statement to fix. The suggested remedy is a **code** change, and this routine may only edit `*.md`. The underlying observation is fair — the guard would not catch metadata hardcoded to the *current* value — but that is benign today and goes red the moment the registry moves. A latent gap, not drift.

**(ii) Deleting `2 live deselected`.** Declined; see [the thread](https://github.com/Ranjith36963/job360/pull/393#discussion_r3845142264). This is not the class of claim the rule targets. The collected count needs Postgres and moves with parametrization; this one is filesystem-checkable in a single grep:

```
backend/tests/test_live_pipeline.py:33:pytestmark = pytest.mark.live   # module-level, 2 unparametrized tests
backend/pyproject.toml:166:addopts = "-p no:randomly -m 'not live'"
```

It is correct today, so removing it would delete a true and cheaply-verifiable fact — the opposite of this PR's purpose. It belongs in the guard instead, as **(d)** below. Overrule me if you'd rather the docs carry no test numbers at all; that is a policy call, not a correctness fix.

---

## Promote to the guard

`doc_sync_check.py` caught **two regressions I introduced** while making these edits — a removed `test-files` phrasing, and a symbol path that `dead_path_claims()` read as a file — plus the 217 → 218 move. That is the guard working, and it argues for feeding it more:

**(a) Self-consistency for the collected-test baseline.** The live count can't be guarded, but *agreement between docs* can, with no DB and no runtime. #391's body records `README.md` disagreeing with itself by ~1,900 tests while every guard stayed green — because none of them asks "do two docs disagree?"

```python
def collected_baseline_claims() -> list[tuple[str, int, int]]:
    """(doc:line, collected, selected) for every stated suite baseline.

    NOT a check against a live collection -- that needs Postgres. This checks the
    docs against EACH OTHER: one baseline, stated identically everywhere, or red.
    """
    pat = re.compile(r"([\d,]{3,})\s+collected(?:\s*/\s*([\d,]{3,})\s+selected)?")
```

**(b) A test file named in a doc must exist.** `dead_path_claims()` only matches `backend/src/...` / `frontend/src/...` / `docs/...` prefixes, so bare `` `test_foo.py` `` tokens in a table walk past it — which is how `STATUS.md` cited `test_notifications.py` and `test_notification_base.py` long after both were deleted. A deleted test cited as coverage reads as "this is tested" when nothing tests it.

```python
pat_test = re.compile(r"`(test_[a-z0-9_]+\.py)`")   # resolve against backend/tests/
```

**(c) The migration COUNT, not just the head.** `doc_sync_check.py` already computes `migration_head()` and guards the `0000 → NNNN` phrasing, but nothing guards how many migrations there are — which is how `ARCHITECTURE.md` sat on `25` while the tree held `31`. One line, reusing the existing glob:

```python
("migration-count", len(list((ROOT / "backend/migrations").glob("*.up.sql"))),
 r"(\d+)-migration forward-compat schema"),
```

**(d) The `live`-deselected count.** Filesystem-only and cheap — the exact opposite of the collected count, which is why it should be *held* rather than deleted (see **(ii)** above).

```python
def live_deselected_count() -> int:
    """Tests deselected by the default `-m 'not live'` addopts.

    Module-level `pytestmark = pytest.mark.live` today; a per-function marker
    or a parametrize in that module must move this number.
    """
```

paired with `("live-deselected", live_deselected_count(), r"(\d+) `?live`? (?:tests? )?deselected")`.