### PR TITLE
docs: daily truth check

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,5 +1,5 @@
 # Job360 Architecture
-<!-- doc: LIVING | last-verified: 2026-08-21 by /sync -->
+<!-- doc: LIVING | last-verified: 2026-08-24 by /sync -->
 
 > **Current state lives in `docs/product/pillars/`** — three code-verified pillar docs (User, Search & Match Engine, Job Providers) plus a glossary and runbook are the *authoritative* architecture reference today. This file is preserved for historical continuity and gives a higher-level system overview; for any specific claim about the codebase, cross-check `docs/product/pillars/` first.
 
@@ -78,7 +78,7 @@ job360/
 │   │   │   ├── notifications/        # email / slack / discord / report_generator (legacy CLI summaries)
 │   │   │   └── profile/              # cv_parser, llm_provider, linkedin_parser, github_enricher, models, preferences, storage, keyword_generator
 │   │   ├── repositories/             # (post-Phase-4 rename from storage/)
-│   │   │   ├── database.py           # Postgres via psycopg3 (`pg.py` aiosqlite-shaped shim) + 25-migration forward-compat schema
+│   │   │   ├── database.py           # Postgres via psycopg3 (`pg.py` aiosqlite-shaped shim) + 31-migration forward-compat schema
 │   │   │   └── csv_export.py
 │   │   ├── sources/                  # (post-Phase-2 split into 6 category subfolders)
 │   │   │   ├── base.py               # BaseJobSource ABC: retry, rate limit, conditional fetch, _is_uk_or_remote
@@ -272,7 +272,7 @@ Note: as of 2026-04-09 (commit `3ba1342`) all default keyword lists in `keywords
 **Engine 4 — LLM judge detail:**
 - Service: `backend/src/services/llm_matcher.py`. `MatchVerdict{fit_score: int 0-100, verdict: str, reason: str}`.
 - `match_batch()` runs with `asyncio.Semaphore(3)`, skips jobs already holding a verdict, per-job errors swallowed.
-- Uses `llm_provider.llm_extract_validated` (Gemini→Groq→Cerebras chain). Test isolation via `llm_extract_validated_fn` kwarg.
+- Uses `llm_provider.llm_extract_validated` (OpenAI (PRIMARY) → Gemini → Groq → Cerebras chain — `llm_provider.py:329-334`). Test isolation via `llm_extract_validated_fn` kwarg.
 - Results stored on `user_feed` (per-user state; rules #10/#17 keep shared catalog tables untouched). Migration 0017 adds `llm_fit_score`, `llm_verdict`, `llm_reason`, `llm_matched_at`.
 - `_run_matcher_stage` in `src/main.py` invokes `match_batch` after the per-user feed write.
 - Feed read path: `SELECT ... ORDER BY COALESCE(llm_fit_score, score) DESC`.
@@ -511,7 +511,7 @@ PDF/DOCX -> extract_text() -> raw text
   |
   +-> _find_sections() -> {skills, experience, education, certifications, summary}
   |
-  +-> LLM extraction via llm_provider.py (Gemini/Groq/Cerebras with free-tier fallback)
+  +-> LLM extraction via llm_provider.py (OpenAI PRIMARY, then Gemini/Groq/Cerebras free-tier fallback)
   |     Returns: skills[], job_titles[], education[], certifications[], summary
   |     The regex KNOWN_SKILLS / KNOWN_TITLE_PATTERNS approach was removed in commit 804725c
 ```

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -51,7 +51,7 @@ job360/
 │   │   ├── core/                     # (post-Phase-4 rename from config/)
 │   │   │   ├── settings.py           # Env vars, RATE_LIMITS (41 entries), thresholds, feature flags
 │   │   │   ├── keywords.py           # LOCATIONS (25) + VISA_KEYWORDS (8); all other lists [] post-3ba1342
-│   │   │   ├── companies.py          # ATS company slugs (~264 across 11 platforms)
+│   │   │   ├── companies.py          # ATS company slugs (297 polled across 10 ATS sources; RIPPLING_COMPANIES has slugs but no source class)
 │   │   │   ├── skill_synonyms.py     # 493-entry alias dict (k8s↔kubernetes, ...)
 │   │   │   ├── fx.py                 # 18-currency → GBP rates
 │   │   │   └── tenancy.py            # DEFAULT_TENANT_ID UUID for CLI/legacy rows

--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ flowchart TD
 
     subgraph Sources["41 Job Sources (40 live instances)"]
         direction LR
-        KeyedAPIs["Keyed APIs (7)\nReed, Adzuna, JSearch, Jooble\nGoogle Jobs, Careerjet, Findwork"]
-        FreeJSON["Free JSON APIs (9)\nArbeitnow, RemoteOK, Jobicy, Himalayas\nRemotive, DevITjobs, Landing.jobs\nAIJobs.net, HN Jobs"]
-        ATSBoards["ATS Boards (11, ~264 slugs)\nGreenhouse, Lever, Workable, Ashby\nSmartRecruiters, Pinpoint, Recruitee\nWorkday, Personio, SuccessFactors\nRippling"]
-        RSSFeeds["RSS/XML Feeds (9)\njobs.ac.uk, NHS Jobs, NHS Jobs XML\nWorkAnywhere, WeWorkRemotely\nRealWorkFromAnywhere, BioSpace\nUniversity Jobs, Teaching Vacancies"]
+        KeyedAPIs["Keyed APIs (8)\nReed, Adzuna, JSearch, Jooble\nGoogle Jobs, Careerjet, Findwork\nGov Apprenticeships"]
+        FreeJSON["Free JSON APIs (8)\nArbeitnow, RemoteOK, Jobicy, Himalayas\nRemotive, DevITjobs, Landing.jobs\nHN Jobs"]
+        ATSBoards["ATS Boards (10, 297 slugs polled)\nGreenhouse, Lever, Workable, Ashby\nSmartRecruiters, Pinpoint, Recruitee\nWorkday, Personio, SuccessFactors"]
+        RSSFeeds["RSS/XML Feeds (5)\nNHS Jobs, WeWorkRemotely\nRealWorkFromAnywhere\nUniversity Jobs, Teaching Vacancies"]
         HTMLScrapers["HTML Scrapers (5)\nLinkedIn, Climatebase\n80000Hours, BCS Jobs, AIJobs AI"]
         OtherSources["Other (4 classes / 5 keys)\nIndeed+Glassdoor (JobSpySource)\nHackerNews, TheMuse, NoFluffJobs"]
     end
@@ -54,9 +54,9 @@ flowchart TD
 > The reconciliation: 40 *class files* on disk → 41 *registry keys* (`indeed`+`glassdoor` both map to `JobSpySource`) → 40 *live instances* per run. Test assertions pin all three (`test_cli.py` requires `len(SOURCE_REGISTRY) == 41`).
 
 - **8 keyed APIs**: Reed, Adzuna, JSearch, Jooble, Google Jobs (SerpApi), Careerjet, Findwork, Gov Apprenticeships (DfE) — skip gracefully if no API key set
-- **9 free JSON APIs** (`category="free_json"`): Arbeitnow, RemoteOK, Jobicy, Himalayas, Remotive, DevITjobs, Landing.jobs, AIJobs.net, HN Jobs — no auth required; Teaching Vacancies *(Batch 3)* is in `apis_free/` but runs on the 15-min RSS scheduler tier (`category="rss"`) not the free_json tier
-- **11 ATS boards** over ~264 company slugs: Greenhouse, Lever, Workable, Ashby, SmartRecruiters, Pinpoint, Recruitee, Workday, Personio, SuccessFactors, Rippling *(Batch 3)* — see `backend/src/core/companies.py` for the per-platform slug lists
-- **9 RSS/XML feeds** (`category="rss"`): jobs.ac.uk, NHS Jobs (keyword search), NHS Jobs XML *(Batch 3, full vacancy feed with conditional fetch pilot)*, WorkAnywhere, WeWorkRemotely, RealWorkFromAnywhere, BioSpace, University Jobs, plus Teaching Vacancies *(lives in `apis_free/` but runs on the 15-min RSS tier)*
+- **8 free JSON APIs** (`category="free_json"`): Arbeitnow, RemoteOK, Jobicy, Himalayas, Remotive, DevITjobs, Landing.jobs, HN Jobs — no auth required; Teaching Vacancies *(Batch 3)* is a 9th file in `apis_free/` but runs on the 15-min RSS scheduler tier (`category="rss"`) not the free_json tier, so it is counted under RSS/XML below
+- **10 ATS boards** polling 297 company slugs: Greenhouse, Lever, Workable, Ashby, SmartRecruiters, Pinpoint, Recruitee, Workday, Personio, SuccessFactors — see `backend/src/core/companies.py`, which holds **302** slugs across 11 platform lists; `RIPPLING_COMPANIES` (5) has had no source class since the 2026-08-10 rotation, so 10 boards poll the other 297
+- **5 RSS/XML feeds** (`category="rss"`): NHS Jobs (keyword search), WeWorkRemotely, RealWorkFromAnywhere, University Jobs, plus Teaching Vacancies *(lives in `apis_free/` but runs on the 15-min RSS tier)*
 - **5 HTML scrapers**: LinkedIn (guest API), Climatebase, 80000Hours, BCS Jobs, AIJobs AI
 - **4 other**: Indeed/Glassdoor (via optional `python-jobspy`), HackerNews (Algolia), TheMuse, NoFluffJobs
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ flowchart TD
 
 ### Frontend (Next.js + FastAPI)
 - Next.js 16 + React 19 + Tailwind 4 + shadcn at `frontend/`
-- Talks to FastAPI (`backend/src/api/`) over HTTP — 25 routes (health, jobs, actions, profile, search, pipeline)
+- Talks to FastAPI (`backend/src/api/`) over HTTP — 13 route modules, 72 endpoints (health, jobs, actions, profile, search, pipeline, tailor, channels, notifications, runs)
 - Job list with filters, score radar, time buckets
 - Profile setup: CV upload, LinkedIn profile PDF import, GitHub username, preferences form
 - Application pipeline Kanban board
@@ -376,7 +376,7 @@ job360/
 │       ├── core/                # (renamed from config/)
 │       │   ├── settings.py      # Env vars, RATE_LIMITS, feature flags (ENRICHMENT/SEMANTIC/MATCHER)
 │       │   ├── keywords.py      # LOCATIONS (25) + VISA_KEYWORDS (8); all other lists [] since 3ba1342
-│       │   ├── companies.py     # ATS company slugs (~264 across 11 platforms)
+│       │   ├── companies.py     # ATS company slugs (297 polled across 10 ATS sources; RIPPLING_COMPANIES has slugs but no source class)
 │       │   ├── skill_synonyms.py
 │       │   ├── fx.py
 │       │   └── tenancy.py

--- a/README.md
+++ b/README.md
@@ -345,18 +345,18 @@ Full slug lists are in `backend/src/core/companies.py`. Batch 3 expanded slugs s
 
 | Platform | Slugs | Notes |
 |----------|-------|-------|
-| Greenhouse | 80 | 25 original + 55 Batch 3 additions |
-| Lever | 35 | 12 original + 23 Batch 3 additions |
-| Workable | 25 | 8 original + 17 Batch 3 additions |
-| Ashby | 25 | 9 original + 16 Batch 3 additions |
-| SmartRecruiters | 15 | 6 original + 9 Batch 3 additions |
-| Pinpoint | 15 | 8 original + 7 Batch 3 additions |
-| Recruitee | 20 | 8 original + 12 Batch 3 additions |
-| Workday | 20 | 15 original + 5 Batch 3 additions (dict format: tenant/wd/site) |
-| Personio | 18 | 10 original + 8 Batch 3 additions |
+| Greenhouse | 82 | |
+| Lever | 35 | |
+| Workable | 21 | |
+| Ashby | 25 | |
+| SmartRecruiters | 15 | |
+| Pinpoint | 39 | |
+| Recruitee | 31 | |
+| Workday | 20 | dict format: tenant/wd/site |
+| Personio | 26 | |
 | SuccessFactors | 3 | BAE Systems, QinetiQ, Thales UK (sitemap format; MBDA removed: DNS failure) |
-| Rippling | 5 | Added Batch 3 |
-| **Total** | **~264** | |
+| Rippling | 5 | **not polled** — no source class since the 2026-08-10 rotation |
+| **Total** | **(302 slugs across 11 platforms)** | `RIPPLING_COMPANIES` has no source class, so 10 ATS boards poll 297 company slugs |
 
 ## Project Structure
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Job360
-<!-- doc: LIVING | last-verified: 2026-08-21 by /sync -->
+<!-- doc: LIVING | last-verified: 2026-08-24 by /sync -->
 
 Automated UK job search system supporting **any professional domain**. Aggregates jobs from **40 source instances** (41 keys in `SOURCE_REGISTRY`; `indeed`/`glassdoor` share `JobSpySource`), scores them 0–100 against your profile (CV, LinkedIn, GitHub, and manual preferences), deduplicates via a four-layer cascade, and delivers results via CLI, email/Slack/Discord/Telegram/webhook (per-user via Apprise), CSV, Rich terminal table, and a Next.js dashboard backed by FastAPI.
 
@@ -328,7 +328,7 @@ What `keywords.py` still contains (domain-agnostic, applies to any profession):
 - **25 UK locations** + Remote/Hybrid (the `LOCATIONS` list)
 - **8 visa/sponsorship keywords** (the `VISA_KEYWORDS` list: "visa sponsorship", "tier 2", "skilled worker visa", etc.)
 
-**LLM-only CV parsing** is at `backend/src/services/profile/llm_provider.py` (multi-provider: Gemini→Groq→Cerebras free-tier fallback chain). The earlier 391-entry `KNOWN_SKILLS` regex set and all keyword defaults were removed in commits `804725c` and `3ba1342`.
+**LLM-only CV parsing** is at `backend/src/services/profile/llm_provider.py` (multi-provider: **OpenAI (PRIMARY, `gpt-4o-mini`)** → Gemini → Groq → Cerebras fallback chain — `llm_provider.py:329-334`). The earlier 391-entry `KNOWN_SKILLS` regex set and all keyword defaults were removed in commits `804725c` and `3ba1342`.
 
 ### ATS Companies (`backend/src/core/companies.py`)
 
@@ -393,11 +393,11 @@ job360/
 │       ├── sources/             # 40 source files in 6 category subfolders; 41 SOURCE_REGISTRY keys
 │       │   ├── base.py
 │       │   ├── apis_keyed/  (8)
-│       │   ├── apis_free/   (9 free_json + 2 rss-tier)
-│       │   ├── ats/         (12)
-│       │   ├── feeds/       (8)
-│       │   ├── scrapers/    (7)
-│       │   └── other/       (4 classes / 5 keys)
+│       │   ├── apis_free/   (9)   # 8 free_json + 1 rss (teaching_vacancies)
+│       │   ├── ats/         (10)
+│       │   ├── feeds/       (4)   # all rss-tier
+│       │   ├── scrapers/    (5)
+│       │   └── other/       (4 classes / 5 keys)   # indeed+glassdoor share JobSpySource
 │       ├── workers/             # ARQ tasks + WorkerSettings
 │       └── utils/
 ├── backend/tests/               # 3,297 collected / 3,295 selected (2 live deselected) across 218 test_*.py files (defer to runtime count)

--- a/docs/product/pillars/02-search-and-match-engine.md
+++ b/docs/product/pillars/02-search-and-match-engine.md
@@ -670,9 +670,9 @@ backend/
 │   │   ├── scheduler.py                       — TieredScheduler + TIER_INTERVALS_SECONDS
 │   │   ├── circuit_breaker.py                 — 5-fail/300s state machine + BreakerRegistry
 │   │   ├── conditional_cache.py               — 256-entry FIFO for ETag/Last-Modified
-│   │   └── profile/llm_provider.py            — Gemini/Groq/Cerebras chain + llm_extract_validated
+│   │   └── profile/llm_provider.py            — OpenAI (PRIMARY) → Gemini → Groq → Cerebras chain + llm_extract_validated
 │   ├── workers/tasks.py                       — score_and_ingest (per-user worker path)
-│   ├── repositories/database.py               — JobDatabase + 14-migration forward-compat schema
+│   ├── repositories/database.py               — JobDatabase + 31-migration forward-compat schema
 │   └── api/routes/jobs.py                     — exposes match_score + 9-field breakdown to API
 └── migrations/
     ├── 0008_job_enrichment.up.sql             — shared-catalog enrichment table

--- a/scripts/doc_sync_check.py
+++ b/scripts/doc_sync_check.py
@@ -131,16 +131,80 @@ def registry_counts() -> tuple[int, int]:
     raise RuntimeError("SOURCE_REGISTRY dict literal not found at top level of backend/src/main.py")
 
 
+def registry_keys() -> list[str]:
+    """The SOURCE_REGISTRY keys — the names `_build_sources()` actually polls.
+
+    Same AST-strict parse as registry_counts(); split out so active_ats_inventory()
+    can ask "is this platform registered?" instead of trusting a filename.
+    """
+    tree = ast.parse((ROOT / "backend/src/main.py").read_text(encoding="utf-8"))
+    for node in tree.body:
+        targets: list[ast.expr] = []
+        if isinstance(node, ast.Assign):
+            targets = list(node.targets)
+        elif isinstance(node, ast.AnnAssign) and node.value is not None:
+            targets = [node.target]
+        for t in targets:
+            if getattr(t, "id", None) == "SOURCE_REGISTRY":
+                if not isinstance(node.value, ast.Dict):
+                    raise RuntimeError("SOURCE_REGISTRY is not a plain dict literal")
+                return [
+                    k.value for k in node.value.keys
+                    if isinstance(k, ast.Constant) and isinstance(k.value, str)
+                ]
+    raise RuntimeError("SOURCE_REGISTRY dict literal not found in backend/src/main.py")
+
+
+def _migration_pairs() -> dict[int, str]:
+    """{NNNN: stem} for migrations the RUNNER will actually apply.
+
+    Mirrors ``migrations/runner.py::_discover_pairs``, which includes a stem only
+    when BOTH ``.up.sql`` and ``.down.sql`` exist. CodeRabbit, on PR #394: the
+    two guards below used to glob the filesystem independently -- ``*.sql`` for
+    the head, ``*.up.sql`` for the count -- so a lone ``0031_x.up.sql`` with no
+    matching down-file would push both numbers to a schema state the runner
+    silently ignores. A guard that validates a migration the app will never
+    apply is measuring the directory, not the database.
+
+    One inventory now feeds both, and the pairing rule is the runner's own.
+    """
+    d = ROOT / "backend/migrations"
+    seen: dict[int, str] = {}
+    for u in sorted(d.glob("*.up.sql")):
+        stem = u.name[: -len(".up.sql")]
+        m = re.match(r"(\d{4})_.+$", stem)
+        if not m:
+            raise RuntimeError(
+                f"migration {u.name} does not match NNNN_<name>.up.sql — "
+                "a file the runner cannot order is not a migration"
+            )
+        if not (d / f"{stem}.down.sql").exists():
+            raise RuntimeError(
+                f"migration {u.name} has no matching {stem}.down.sql — "
+                "the runner skips unpaired migrations, so this one never applies"
+            )
+        num = int(m.group(1))
+        if num in seen:
+            raise RuntimeError(
+                f"duplicate migration prefix {m.group(1)}: {seen[num]} and {stem}"
+            )
+        seen[num] = stem
+    if not seen:
+        raise RuntimeError("no paired NNNN_*.up.sql/.down.sql migrations found")
+    head = max(seen)
+    missing = sorted(set(range(head + 1)) - set(seen))
+    if missing:
+        raise RuntimeError(
+            "migration sequence has gaps at "
+            + ", ".join(f"{n:04d}" for n in missing)
+            + f" (head is {head:04d}) — the schema cannot be rebuilt from 0000"
+        )
+    return seen
+
+
 def migration_head() -> int:
-    """Highest NNNN prefix among backend/migrations/*.sql filenames."""
-    nums = []
-    for p in (ROOT / "backend/migrations").glob("*.sql"):
-        m = re.match(r"(\d{4})_", p.name)
-        if m:
-            nums.append(int(m.group(1)))
-    if not nums:
-        raise RuntimeError("no NNNN_*.sql migrations found")
-    return max(nums)
+    """Highest NNNN the runner will apply (paired migrations only)."""
+    return max(_migration_pairs())
 
 
 def rate_limit_count() -> int:
@@ -244,17 +308,32 @@ def active_ats_inventory() -> tuple[int, int]:
     rotation that retires another platform would leave "297" stale and green.
 
     Added 2026-08-24 at CodeRabbit's request on PR #394. Derived, not typed: a
-    platform counts as active when a source class in `sources/ats/` exists for
-    it, so retiring one moves both numbers automatically.
+    platform counts as active when it is actually POLLED, so retiring one moves
+    both numbers automatically.
+
+    Second CodeRabbit round: "polled" is read from SOURCE_REGISTRY, not from the
+    files in `sources/ats/`. The first draft scanned module filenames, so a
+    module left on disk after being dropped from the registry kept inflating
+    both totals while the pipeline never called it — the mirror image of the
+    Rippling case this function exists for (slugs with no class, versus a class
+    with no registration). The registry is what `_build_sources()` iterates, so
+    it is the only list that answers "does this platform get polled?".
     """
     per_platform = ats_platform_slugs()
+    registered = {k.replace("_", "") for k in registry_keys()}
     ats_dir = ROOT / "backend/src/sources/ats"
+    # A platform is active only if BOTH a module exists AND the registry names
+    # it. Either alone is a half-truth: an unregistered module is dead code, and
+    # a registry key with no module would have failed at import long before here.
     modules = {
-        p.stem.replace("_", "").upper()
+        p.stem.replace("_", "")
         for p in ats_dir.glob("*.py")
         if p.name != "__init__.py"
     } if ats_dir.is_dir() else set()
-    active = {k: v for k, v in per_platform.items() if k.replace("_", "") in modules}
+    active = {
+        k: v for k, v in per_platform.items()
+        if k.replace("_", "").lower() in (modules & registered)
+    }
     return len(active), sum(active.values())
 
 
@@ -408,32 +487,13 @@ def migration_file_count() -> int:
     run is required to be contiguous ``0000..head`` with no duplicates; a
     malformed or gapped set raises (exit 2), which is this file's contract:
     fail LOUD, never silently green.
+
+    Second CodeRabbit round: it now shares ``_migration_pairs()`` with
+    ``migration_head()``, so both read the RUNNER's definition of a migration
+    (an ``.up.sql`` with a matching ``.down.sql``) rather than each globbing the
+    directory its own way.
     """
-    seen: dict[int, str] = {}
-    for p in sorted((ROOT / "backend/migrations").glob("*.up.sql")):
-        m = re.match(r"(\d{4})_.+\.up\.sql$", p.name)
-        if not m:
-            raise RuntimeError(
-                f"migration {p.name} does not match NNNN_<name>.up.sql — "
-                "a file the runner cannot order is not a migration"
-            )
-        num = int(m.group(1))
-        if num in seen:
-            raise RuntimeError(
-                f"duplicate migration prefix {m.group(1)}: {seen[num]} and {p.name}"
-            )
-        seen[num] = p.name
-    if not seen:
-        raise RuntimeError("no NNNN_*.up.sql forward migrations found")
-    head = max(seen)
-    missing = sorted(set(range(head + 1)) - set(seen))
-    if missing:
-        raise RuntimeError(
-            "migration sequence has gaps at "
-            + ", ".join(f"{n:04d}" for n in missing)
-            + f" (head is {head:04d}) — the schema cannot be rebuilt from 0000"
-        )
-    return len(seen)
+    return len(_migration_pairs())
 
 
 # The source subfolders that MUST exist. Named explicitly rather than

--- a/scripts/doc_sync_check.py
+++ b/scripts/doc_sync_check.py
@@ -131,28 +131,43 @@ def registry_counts() -> tuple[int, int]:
     raise RuntimeError("SOURCE_REGISTRY dict literal not found at top level of backend/src/main.py")
 
 
-def registry_keys() -> list[str]:
-    """The SOURCE_REGISTRY keys — the names `_build_sources()` actually polls.
+def built_source_classes() -> set[str]:
+    """Class names `_build_sources()` actually INSTANTIATES.
 
-    Same AST-strict parse as registry_counts(); split out so active_ats_inventory()
-    can ask "is this platform registered?" instead of trusting a filename.
+    CodeRabbit, third round on PR #394, correcting a false claim this file made
+    in its previous revision. `_build_sources()` does NOT iterate
+    SOURCE_REGISTRY -- it hand-writes `all_sources = [ReedSource(...), ...]`
+    (`backend/src/main.py:251-303`). The registry is a SEPARATE surface, used by
+    the CLI `--source` choices and `GET /api/sources`.
+
+    That gap is the whole point of CLAUDE.md rules #8/#13: registry and
+    `_build_sources()` are two of the five surfaces that must move together
+    precisely BECAUSE nothing makes them move together automatically. A source
+    can sit in the registry, have a module on disk, and still never be polled.
+
+    So "is this platform polled?" has exactly one honest answer: is its class in
+    this list. Reading the registry instead was a guard pointed at the wrong
+    authority -- the same mistake, one layer up, as reading the directory.
     """
     tree = ast.parse((ROOT / "backend/src/main.py").read_text(encoding="utf-8"))
-    for node in tree.body:
-        targets: list[ast.expr] = []
-        if isinstance(node, ast.Assign):
-            targets = list(node.targets)
-        elif isinstance(node, ast.AnnAssign) and node.value is not None:
-            targets = [node.target]
-        for t in targets:
-            if getattr(t, "id", None) == "SOURCE_REGISTRY":
-                if not isinstance(node.value, ast.Dict):
-                    raise RuntimeError("SOURCE_REGISTRY is not a plain dict literal")
-                return [
-                    k.value for k in node.value.keys
-                    if isinstance(k, ast.Constant) and isinstance(k.value, str)
-                ]
-    raise RuntimeError("SOURCE_REGISTRY dict literal not found in backend/src/main.py")
+    for node in ast.walk(tree):
+        if not (isinstance(node, ast.FunctionDef) and node.name == "_build_sources"):
+            continue
+        for st in ast.walk(node):
+            if not isinstance(st, ast.Assign):
+                continue
+            if not any(getattr(x, "id", None) == "all_sources" for x in st.targets):
+                continue
+            if not isinstance(st.value, ast.List):
+                raise RuntimeError("_build_sources: all_sources is not a list literal")
+            names = {
+                e.func.id for e in st.value.elts
+                if isinstance(e, ast.Call) and isinstance(e.func, ast.Name)
+            }
+            if not names:
+                raise RuntimeError("_build_sources: all_sources instantiates nothing")
+            return names
+    raise RuntimeError("all_sources list not found in _build_sources() in backend/src/main.py")
 
 
 def _migration_pairs() -> dict[int, str]:
@@ -311,28 +326,28 @@ def active_ats_inventory() -> tuple[int, int]:
     platform counts as active when it is actually POLLED, so retiring one moves
     both numbers automatically.
 
-    Second CodeRabbit round: "polled" is read from SOURCE_REGISTRY, not from the
-    files in `sources/ats/`. The first draft scanned module filenames, so a
-    module left on disk after being dropped from the registry kept inflating
-    both totals while the pipeline never called it — the mirror image of the
-    Rippling case this function exists for (slugs with no class, versus a class
-    with no registration). The registry is what `_build_sources()` iterates, so
-    it is the only list that answers "does this platform get polled?".
+    "Polled" is read from the classes `_build_sources()` INSTANTIATES, and it
+    took two corrections to get there. Draft 1 scanned module filenames in
+    `sources/ats/`, so a module left on disk counted forever. Draft 2 switched
+    to SOURCE_REGISTRY on the belief that `_build_sources()` iterates it -- it
+    does not (CodeRabbit, third round): the registry is a separate surface for
+    the CLI and `GET /api/sources`, while `_build_sources()` hand-writes its own
+    `all_sources` list. A source can be in the registry, have a module on disk,
+    and still never be fetched.
+
+    Both drafts made the same mistake at different depths: guarding a proxy for
+    the behaviour instead of the behaviour. `built_source_classes()` is the list
+    the pipeline actually constructs, so it is the only one that answers
+    "does this platform get polled?".
     """
     per_platform = ats_platform_slugs()
-    registered = {k.replace("_", "") for k in registry_keys()}
-    ats_dir = ROOT / "backend/src/sources/ats"
-    # A platform is active only if BOTH a module exists AND the registry names
-    # it. Either alone is a half-truth: an unregistered module is dead code, and
-    # a registry key with no module would have failed at import long before here.
-    modules = {
-        p.stem.replace("_", "")
-        for p in ats_dir.glob("*.py")
-        if p.name != "__init__.py"
-    } if ats_dir.is_dir() else set()
+    # GREENHOUSE -> greenhousesource; a platform is active when some class the
+    # pipeline builds starts with its name. RIPPLING_COMPANIES has no
+    # RipplingSource, which is exactly why 302 configured and 297 polled differ.
+    built = {c.lower().replace("_", "") for c in built_source_classes()}
     active = {
         k: v for k, v in per_platform.items()
-        if k.replace("_", "").lower() in (modules & registered)
+        if any(c.startswith(k.lower().replace("_", "")) for c in built)
     }
     return len(active), sum(active.values())
 

--- a/scripts/doc_sync_check.py
+++ b/scripts/doc_sync_check.py
@@ -336,37 +336,85 @@ def test_file_count() -> int:
 
 
 def migration_file_count() -> int:
-    """Number of forward-migration files (NNNN_*.up.sql).
+    """Number of forward-migration files, as a VALIDATED ``0000..head`` sequence.
 
-    Distinct from ``migration_head()``: head is the highest NNNN, count is
-    how many actually exist. Both must exist (no gap in the sequence) for the
-    schema story a doc tells to be true, but only file count matches the
-    ``N-migration forward-compat schema`` prose docs write.
+    Distinct from ``migration_head()``: head is the highest NNNN, this is how
+    many actually exist. Promoted 2026-08-24 by the nightly routine, which found
+    ARCHITECTURE.md saying ``25-migration forward-compat schema`` and the
+    search-and-match-engine pillar saying ``14-migration`` while 31 forward
+    migrations existed. Six doc bumps (0025→0030) landed with the
+    migration-head guard staying green, because that guard only watches
+    ``0000 → NNNN`` phrasing, not the total.
 
-    Promoted 2026-08-24 by the nightly routine. ARCHITECTURE.md said
-    ``25-migration forward-compat schema`` and the search-and-match-engine
-    pillar said ``14-migration`` while 31 forward migrations existed. Six
-    doc bumps (0025→0030) landed with the migration-head guard staying
-    green, because that guard only watches ``0000 → NNNN`` phrasing —
-    not the total. Countable fact, cheap to hold here.
+    CodeRabbit, on the PR that added this: the first draft globbed every
+    ``*.up.sql`` and merely DOCUMENTED the ``NNNN_`` shape. Deleting
+    ``0020_....up.sql`` and adding ``notes.up.sql`` left both the count and the
+    head unchanged, so a schema with a hole in it stayed green -- a count that
+    does not measure the thing that breaks. The prefixes are now parsed and the
+    run is required to be contiguous ``0000..head`` with no duplicates; a
+    malformed or gapped set raises (exit 2), which is this file's contract:
+    fail LOUD, never silently green.
     """
-    return len(list((ROOT / "backend/migrations").glob("*.up.sql")))
+    seen: dict[int, str] = {}
+    for p in sorted((ROOT / "backend/migrations").glob("*.up.sql")):
+        m = re.match(r"(\d{4})_.+\.up\.sql$", p.name)
+        if not m:
+            raise RuntimeError(
+                f"migration {p.name} does not match NNNN_<name>.up.sql — "
+                "a file the runner cannot order is not a migration"
+            )
+        num = int(m.group(1))
+        if num in seen:
+            raise RuntimeError(
+                f"duplicate migration prefix {m.group(1)}: {seen[num]} and {p.name}"
+            )
+        seen[num] = p.name
+    if not seen:
+        raise RuntimeError("no NNNN_*.up.sql forward migrations found")
+    head = max(seen)
+    missing = sorted(set(range(head + 1)) - set(seen))
+    if missing:
+        raise RuntimeError(
+            "migration sequence has gaps at "
+            + ", ".join(f"{n:04d}" for n in missing)
+            + f" (head is {head:04d}) — the schema cannot be rebuilt from 0000"
+        )
+    return len(seen)
+
+
+# The source subfolders that MUST exist. Named explicitly rather than
+# discovered, so a deleted or renamed folder is drift instead of a guard that
+# quietly stops existing -- see source_subfolder_counts().
+EXPECTED_SOURCE_SUBFOLDERS = (
+    "apis_keyed", "apis_free", "ats", "feeds", "other", "scrapers",
+)
 
 
 def source_subfolder_counts() -> dict[str, int]:
     """{'apis_keyed': N, 'apis_free': N, 'ats': N, 'feeds': N, 'other': N, 'scrapers': N}
 
     File count per source subfolder, excluding ``__init__.py`` and ``base.py``.
-    Docs everywhere use a tree-diagram of ``apis_keyed/ (8)  apis_free/ (9) ...`` —
-    the numbers rot every rotation, and until today no guard watched them.
+    Docs everywhere use a tree diagram of ``apis_keyed/ (8)  apis_free/ (9) ...``
+    — the numbers rot every rotation, and until today no guard watched them.
 
     Promoted 2026-08-24 by the nightly routine. README.md said ``ats/ (12)``
     against 10, ``feeds/ (8)`` against 4, ``scrapers/ (7)`` against 5.
-    Countable, on-tree, and the same shape as ATS platform slugs -- exactly
-    the class of number this file is meant to own.
+
+    CodeRabbit, on the PR that added this: the first draft DISCOVERED the
+    folders by iterating the directory, so deleting ``ats/`` deleted the
+    ``subfolder-ats`` guard along with it and left ``ats/ (10)`` green forever
+    — a check that cannot be made to go red on demand. The expected set is now
+    named as a constant and a missing folder yields a count of 0, which the
+    docs' non-zero claim then contradicts loudly. A NEW folder is still
+    discovered (and, having no doc claim, trips the "claim not found in any
+    doc" alarm), so the set can grow without editing this file.
     """
     out: dict[str, int] = {}
     base = ROOT / "backend/src/sources"
+    # A missing folder scores 0 rather than vanishing: the guard must survive
+    # the deletion of the thing it guards.
+    for name in EXPECTED_SOURCE_SUBFOLDERS:
+        out[name] = 0
     if not base.is_dir():
         return out
     for d in base.iterdir():

--- a/scripts/doc_sync_check.py
+++ b/scripts/doc_sync_check.py
@@ -335,6 +335,48 @@ def test_file_count() -> int:
     return len(list((ROOT / "backend/tests").glob("test_*.py")))
 
 
+def migration_file_count() -> int:
+    """Number of forward-migration files (NNNN_*.up.sql).
+
+    Distinct from ``migration_head()``: head is the highest NNNN, count is
+    how many actually exist. Both must exist (no gap in the sequence) for the
+    schema story a doc tells to be true, but only file count matches the
+    ``N-migration forward-compat schema`` prose docs write.
+
+    Promoted 2026-08-24 by the nightly routine. ARCHITECTURE.md said
+    ``25-migration forward-compat schema`` and the search-and-match-engine
+    pillar said ``14-migration`` while 31 forward migrations existed. Six
+    doc bumps (0025→0030) landed with the migration-head guard staying
+    green, because that guard only watches ``0000 → NNNN`` phrasing —
+    not the total. Countable fact, cheap to hold here.
+    """
+    return len(list((ROOT / "backend/migrations").glob("*.up.sql")))
+
+
+def source_subfolder_counts() -> dict[str, int]:
+    """{'apis_keyed': N, 'apis_free': N, 'ats': N, 'feeds': N, 'other': N, 'scrapers': N}
+
+    File count per source subfolder, excluding ``__init__.py`` and ``base.py``.
+    Docs everywhere use a tree-diagram of ``apis_keyed/ (8)  apis_free/ (9) ...`` —
+    the numbers rot every rotation, and until today no guard watched them.
+
+    Promoted 2026-08-24 by the nightly routine. README.md said ``ats/ (12)``
+    against 10, ``feeds/ (8)`` against 4, ``scrapers/ (7)`` against 5.
+    Countable, on-tree, and the same shape as ATS platform slugs -- exactly
+    the class of number this file is meant to own.
+    """
+    out: dict[str, int] = {}
+    base = ROOT / "backend/src/sources"
+    if not base.is_dir():
+        return out
+    for d in base.iterdir():
+        if d.is_dir() and d.name != "__pycache__":
+            out[d.name] = len([
+                p for p in d.glob("*.py") if p.name not in {"__init__.py", "base.py"}
+            ])
+    return out
+
+
 def frontend_versions() -> tuple[str, str]:
     """(next, react) exact versions from frontend/package.json.
 
@@ -605,7 +647,26 @@ def build_checks() -> tuple[list[tuple[str, int, str]], list[tuple[str, str, str
         # decision notes that are correct at the time of writing. Guarding it
         # fires on every honest citation, and a permanent false alarm is how a
         # loop dies. The prose form above covers the claim that matters.
+        #
+        # Fourth batch, 2026-08-24 -- promoted from the nightly routine after
+        # ARCHITECTURE.md read "25-migration forward-compat schema" and the
+        # search-and-match-engine pillar read "14-migration" against 31 actual
+        # forward migrations. The existing `migration-head` guard watches only
+        # "0000 → NNNN" phrasing, so both stale numbers slid past for weeks.
+        ("migrations-schema", migration_file_count(),
+         r"(\d+)-migration forward-compat schema"),
     ]
+
+    # Per-subfolder source counts. Docs everywhere use a tree diagram
+    # `apis_keyed/ (8)  ats/ (10) ...` and the numbers rot every rotation;
+    # until today no guard watched them and README.md carried three drifted
+    # values (ats/12, feeds/8, scrapers/7) against real 10/4/5.
+    for _name, _count in source_subfolder_counts().items():
+        checks.append((
+            f"subfolder-{_name}",
+            _count,
+            rf"\b{re.escape(_name)}/\s*\((\d+)\)",
+        ))
 
     # String-valued facts. Kept separate because the numeric loop below does
     # int(m.group(1)); a version like "16.3.0" is not an int and must be

--- a/scripts/doc_sync_check.py
+++ b/scripts/doc_sync_check.py
@@ -204,6 +204,60 @@ def ats_slug_count() -> tuple[int, int]:
     return total, lists
 
 
+def ats_platform_slugs() -> dict[str, int]:
+    """{'GREENHOUSE': 82, 'LEVER': 35, ...} — slugs per *_COMPANIES list.
+
+    ats_slug_count() returns only the TOTAL, which is why README's per-platform
+    breakdown table rotted invisibly: the total guard was satisfied by the
+    glossary's one-line claim while the table beneath it disagreed on six of
+    eleven rows (Greenhouse 80/82, Workable 25/21, Pinpoint 15/39,
+    Recruitee 20/31, Personio 18/26, total ~264/302).
+
+    Promoted 2026-08-24 after CodeRabbit flagged the stale total. The rows are
+    worse than the total: someone reading "Pinpoint 15" plans against a quarter
+    of the real board list.
+    """
+    tree = ast.parse((ROOT / "backend/src/core/companies.py").read_text(encoding="utf-8"))
+    out: dict[str, int] = {}
+    for node in tree.body:
+        targets: list[ast.expr] = []
+        if isinstance(node, ast.Assign):
+            targets = list(node.targets)
+        elif isinstance(node, ast.AnnAssign) and node.value is not None:
+            targets = [node.target]
+        for t in targets:
+            name = getattr(t, "id", None)
+            if name and name.endswith("_COMPANIES") and isinstance(node.value, (ast.List, ast.Tuple)):
+                out[name[: -len("_COMPANIES")]] = len(node.value.elts)
+    if not out:
+        raise RuntimeError("no *_COMPANIES list literals found in backend/src/core/companies.py")
+    return out
+
+
+def active_ats_inventory() -> tuple[int, int]:
+    """(ATS source classes, slugs those classes actually poll).
+
+    CONFIGURED is not ACTIVE, and the gap is load-bearing: companies.py holds
+    302 slugs across 11 platform lists, but `RIPPLING_COMPANIES` has had no
+    source class since the 2026-08-10 rotation, so 10 boards poll 297. Docs
+    state BOTH numbers, and only the configured one was ever guarded — a
+    rotation that retires another platform would leave "297" stale and green.
+
+    Added 2026-08-24 at CodeRabbit's request on PR #394. Derived, not typed: a
+    platform counts as active when a source class in `sources/ats/` exists for
+    it, so retiring one moves both numbers automatically.
+    """
+    per_platform = ats_platform_slugs()
+    ats_dir = ROOT / "backend/src/sources/ats"
+    modules = {
+        p.stem.replace("_", "").upper()
+        for p in ats_dir.glob("*.py")
+        if p.name != "__init__.py"
+    } if ats_dir.is_dir() else set()
+    active = {k: v for k, v in per_platform.items() if k.replace("_", "") in modules}
+    return len(active), sum(active.values())
+
+
 def dataclass_field_count(rel: str, cls: str) -> int:
     """Annotated fields on a dataclass. Used for Job and JobEnrichment.
 
@@ -638,6 +692,7 @@ def build_checks() -> tuple[list[tuple[str, int, str]], list[tuple[str, str, str
         "backend/src/services/job_enrichment_schema.py", "JobEnrichment"
     )
     enr_enums = enrichment_enum_count()
+    active_boards, active_slugs = active_ats_inventory()
 
     # (fact-name, actual-value, regex-with-one-capture-group). Patterns are
     # deliberately SPECIFIC phrases so unrelated numbers never false-match.
@@ -703,7 +758,39 @@ def build_checks() -> tuple[list[tuple[str, int, str]], list[tuple[str, str, str
         # "0000 → NNNN" phrasing, so both stale numbers slid past for weeks.
         ("migrations-schema", migration_file_count(),
          r"(\d+)-migration forward-compat schema"),
+        # Sixth batch, 2026-08-24, at CodeRabbit's request on PR #394.
+        # CONFIGURED (302 slugs / 11 lists) was guarded; ACTIVE (10 boards
+        # polling 297) was not, though the docs state both. A rotation that
+        # retires another platform would leave "297" stale and green.
+        ("ats-boards-active", active_boards, r"\*\*(\d+) ATS boards\*\* polling"),
+        ("ats-boards-active", active_boards, r"ATS Boards \((\d+), \d+ slugs polled\)"),
+        ("ats-boards-active", active_boards, r"so (\d+) ATS boards poll"),
+        ("ats-slugs-active", active_slugs, r"polling (\d+) company slugs"),
+        ("ats-slugs-active", active_slugs, r"ATS Boards \(\d+, (\d+) slugs polled\)"),
+        ("ats-slugs-active", active_slugs, r"ATS boards poll (\d+) company slugs"),
     ]
+
+    # Per-platform ATS slug counts. The TOTAL was guarded; the breakdown table
+    # under it was not, and six of its eleven rows were stale (Greenhouse
+    # 80/82, Workable 25/21, Pinpoint 15/39, Recruitee 20/31, Personio 18/26).
+    # A reader planning against "Pinpoint 15" is off by a factor of two and a
+    # half. Matches the README table row `| Pinpoint | 39 | ... |`.
+    #
+    # The negative lookahead is load-bearing, not tidiness. 03-job-providers.md
+    # has a RATE-LIMIT table whose rows are `| personio | 1 | 3.0 | XML feed |`
+    # — same shape, different meaning — and the matcher below runs IGNORECASE,
+    # so the first draft read that "1" as a slug count and reported personio as
+    # 1-vs-26 drift on a doc that was perfectly correct. Requiring the third
+    # column NOT to open with a decimal separates the two tables: slug rows
+    # carry prose notes or nothing, rate rows carry a delay like `3.0`.
+    # A permanent false alarm is how a loop dies (see the module docstring).
+    for _plat, _n in ats_platform_slugs().items():
+        _label = re.escape(_plat.title().replace("_", ""))
+        checks.append((
+            f"ats-slugs-{_plat.lower()}",
+            _n,
+            rf"^\|\s*{_label}\s*\|\s*(\d+)\s*\|(?!\s*\d+\.\d)",
+        ))
 
     # Per-subfolder source counts. Docs everywhere use a tree diagram
     # `apis_keyed/ (8)  ats/ (10) ...` and the numbers rot every rotation;

--- a/scripts/doc_sync_check.py
+++ b/scripts/doc_sync_check.py
@@ -758,6 +758,17 @@ def build_checks() -> tuple[list[tuple[str, int, str]], list[tuple[str, str, str
         # "0000 → NNNN" phrasing, so both stale numbers slid past for weeks.
         ("migrations-schema", migration_file_count(),
          r"(\d+)-migration forward-compat schema"),
+        # The same COUNT, stated two other ways in the directory trees. Found by
+        # CodeRabbit on PR #394: both lines end "(0000 → 0030)", so
+        # `migration-head` matched them and they LOOKED guarded -- but that guard
+        # reads the HEAD, not the count beside it. Adding migration 0031 would
+        # correctly force the head to 0031 while "31 forward/reverse SQL
+        # migrations" quietly stayed 31. A guard on the same line is not a guard
+        # on the same fact.
+        ("migrations-schema", migration_file_count(),
+         r"(\d+) forward/reverse SQL migrations"),
+        ("migrations-schema", migration_file_count(),
+         r"(\d+) forward\+reverse SQL migration pairs"),
         # Sixth batch, 2026-08-24, at CodeRabbit's request on PR #394.
         # CONFIGURED (302 slugs / 11 lists) was guarded; ACTIVE (10 boards
         # polling 297) was not, though the docs state both. A rotation that

--- a/scripts/doc_sync_check.py
+++ b/scripts/doc_sync_check.py
@@ -779,6 +779,19 @@ def build_checks() -> tuple[list[tuple[str, int, str]], list[tuple[str, str, str
         ("ats-slugs-active", active_slugs, r"polling (\d+) company slugs"),
         ("ats-slugs-active", active_slugs, r"ATS Boards \(\d+, (\d+) slugs polled\)"),
         ("ats-slugs-active", active_slugs, r"ATS boards poll (\d+) company slugs"),
+        # A THIRD wording of the same two numbers, added to the companies.py
+        # tree comment in ARCHITECTURE.md:54 / README.md:379 while this PR was
+        # open: "297 polled across 10 ATS sources". Found by CodeRabbit.
+        #
+        # This is the failure mode the "claim not found in any doc" alarm cannot
+        # catch, and the reason it cannot is worth stating: that alarm is keyed
+        # on the FACT NAME, not the site. Both facts already had other matching
+        # claims elsewhere, so matches_per_fact stayed non-zero and the checker
+        # reported a clean run while two fresh, unwatched copies of the same
+        # numbers sat in the two most-read files in the repo. Every new phrasing
+        # of a guarded fact needs its own pattern.
+        ("ats-boards-active", active_boards, r"\d+ polled across (\d+) ATS sources"),
+        ("ats-slugs-active", active_slugs, r"(\d+) polled across \d+ ATS sources"),
     ]
 
     # Per-platform ATS slug counts. The TOTAL was guarded; the breakdown table

--- a/scripts/doc_sync_mutation_test.py
+++ b/scripts/doc_sync_mutation_test.py
@@ -99,6 +99,84 @@ CASES: list[tuple[str, str, str, str]] = [
 ]
 
 
+def structural_drills() -> list[str]:
+    """Drills for failure paths a TEXT mutation cannot express.
+
+    The CASES above all work by planting a lie in a file and re-running the
+    checker. Two failure modes cannot be reached that way, and CodeRabbit
+    caught both on the PR that added the migration/subfolder guards:
+
+    1. Deleting a source subfolder used to delete its own guard. The checker
+       discovered folders by iterating the directory, so removing ``ats/``
+       removed ``subfolder-ats`` too and left a stale ``ats/ (10)`` green
+       forever. There is no text to mutate here -- the bug is an ABSENT check.
+    2. The migration guard counted every ``*.up.sql`` while documenting the
+       ``NNNN_`` shape, so a gapped or malformed sequence (delete 0020, add
+       ``notes.up.sql``) kept both count and head unchanged and stayed green.
+
+    Both are checked against a THROWAWAY root, never the real tree: renaming a
+    live source package to prove a point is how a drill becomes an outage.
+    """
+    import tempfile  # noqa: PLC0415 — only this drill needs it
+
+    sys.path.insert(0, str(ROOT / "scripts"))
+    import doc_sync_check as dsc  # noqa: PLC0415
+
+    failures: list[str] = []
+    real_root = dsc.ROOT
+
+    with tempfile.TemporaryDirectory() as tmp:
+        fake = Path(tmp)
+        try:
+            dsc.ROOT = fake
+
+            # 1. Every expected subfolder must still yield a guard (count 0)
+            #    when backend/src/sources/ is not there at all.
+            counts = dsc.source_subfolder_counts()
+            for name in dsc.EXPECTED_SOURCE_SUBFOLDERS:
+                if name not in counts:
+                    failures.append(
+                        f"subfolder-{name}: guard VANISHES when the folder is missing "
+                        "— a deleted folder would silently retire its own check"
+                    )
+                elif counts[name] != 0:
+                    failures.append(
+                        f"subfolder-{name}: missing folder scored {counts[name]}, expected 0"
+                    )
+
+            # 2. A gapped migration sequence must RAISE, not count quietly.
+            migs = fake / "backend" / "migrations"
+            migs.mkdir(parents=True)
+            for n in (0, 1, 3):  # deliberate hole at 0002
+                (migs / f"{n:04d}_drill.up.sql").write_text("-- drill\n", encoding="utf-8")
+            try:
+                got = dsc.migration_file_count()
+                failures.append(
+                    f"migrations-schema: a sequence with a hole at 0002 returned {got} "
+                    "instead of raising — a schema that cannot rebuild from 0000 stayed green"
+                )
+            except RuntimeError:
+                pass
+
+            # 3. A file the runner cannot order must RAISE too.
+            (migs / f"{2:04d}_drill.up.sql").write_text("-- drill\n", encoding="utf-8")
+            (migs / "notes.up.sql").write_text("-- not a migration\n", encoding="utf-8")
+            try:
+                got = dsc.migration_file_count()
+                failures.append(
+                    f"migrations-schema: a malformed 'notes.up.sql' counted as a migration "
+                    f"(returned {got}) instead of raising"
+                )
+            except RuntimeError:
+                pass
+        finally:
+            dsc.ROOT = real_root
+
+    if not failures:
+        print("PASS  structural      missing subfolder + gapped/malformed migrations all caught")
+    return failures
+
+
 def unwatched_claims() -> list[str]:
     """Find docs that state a guarded fact but are NOT in LIVING_DOCS.
 
@@ -185,6 +263,10 @@ def main() -> int:
                 failures.append(f"{fact}: stayed GREEN on a broken {rel} — the guard is blind")
         finally:
             path.write_bytes(original)
+
+    # Failure paths no text mutation can express: an ABSENT check (deleted
+    # source folder) and a structurally broken migration run.
+    failures.extend(structural_drills())
 
     # Second half of the drill: docs that make a guarded claim while sitting
     # outside LIVING_DOCS. Planting a lie proves the LISTED docs are scanned;

--- a/scripts/doc_sync_mutation_test.py
+++ b/scripts/doc_sync_mutation_test.py
@@ -82,7 +82,18 @@ CASES: list[tuple[str, str, str, str]] = [
     # (3,297 collected at :124, ~1,409 at :402) while every check stayed green.
     # Breaking ONE doc's number is therefore a real mutation: it creates the
     # disagreement.
-    ("ARCHITECTURE.md",
+    # Points at CONTRIBUTING.md, not ARCHITECTURE.md, and the move is the
+    # lesson. #393 deleted the collected count from every doc that stated it as
+    # fact -- correctly: a number no guard can check against the code rots
+    # silently, so the fix is NO number, not a better one. That left this drill
+    # mutating a claim that no longer existed, and the drill SAID SO rather
+    # than passing quietly.
+    #
+    # CONTRIBUTING.md keeps it twice on purpose, as the merge-gate ratchet
+    # floor -- a policy threshold, not a claim about current state. Two sites
+    # is exactly what this guard needs: it fires on DISAGREEMENT, so mutating
+    # one of the pair is the only mutation that can make it red.
+    ("CONTRIBUTING.md",
      r"([\d,]{3,}) collected", "9,999 collected", "suite-baseline"),
     ("backend/CLAUDE.md",
      r"(SQLite|Postgres) via psycopg3", "SQLite table via psycopg3", "stale-phrase"),

--- a/scripts/doc_sync_mutation_test.py
+++ b/scripts/doc_sync_mutation_test.py
@@ -180,11 +180,49 @@ def structural_drills() -> list[str]:
                 )
             except RuntimeError:
                 pass
+
+            # 4. TWO files claiming the same prefix must RAISE. CodeRabbit, on
+            #    PR #394: cases 2 and 3 leave the duplicate-prefix branch
+            #    unexercised, so deleting it would not fail this drill. A
+            #    contiguous 0000..0002 run with 0002 claimed twice is the
+            #    smallest fixture that isolates it from the gap and malformed
+            #    checks above.
+            (migs / "notes.up.sql").unlink()
+            (migs / "0002_duplicate.up.sql").write_text("-- drill\n", encoding="utf-8")
+            try:
+                got = dsc.migration_file_count()
+                failures.append(
+                    f"migrations-schema: two files claiming prefix 0002 returned {got} "
+                    "instead of raising — duplicate-prefix detection is dead code"
+                )
+            except RuntimeError:
+                pass
         finally:
             dsc.ROOT = real_root
 
+    # 5. The GENERATED guard, not just the count behind it. CodeRabbit, on
+    #    PR #394: drill 1 proves source_subfolder_counts() keeps a zero entry,
+    #    but a regression that filtered zero-count folders out of
+    #    build_checks() would still pass it -- the count survives while the
+    #    check it feeds disappears. Force ats to 0 and require the emitted
+    #    check list to still carry `subfolder-ats`. Runs against the REAL root
+    #    (build_checks parses main.py, settings.py, companies.py...), with only
+    #    the counts function swapped.
+    real_counts = dsc.source_subfolder_counts
+    try:
+        dsc.source_subfolder_counts = lambda: {**real_counts(), "ats": 0}  # noqa: E731
+        emitted = {name for name, _, _ in dsc.build_checks()[0]}
+        if "subfolder-ats" not in emitted:
+            failures.append(
+                "subfolder-ats: build_checks() DROPS the guard when the folder counts 0 "
+                "— the count survives but the check it feeds does not"
+            )
+    finally:
+        dsc.source_subfolder_counts = real_counts
+
     if not failures:
-        print("PASS  structural      missing subfolder + gapped/malformed migrations all caught")
+        print("PASS  structural      missing subfolder (count + emitted guard), "
+              "gapped/malformed/duplicate migrations")
     return failures
 
 

--- a/scripts/doc_sync_mutation_test.py
+++ b/scripts/doc_sync_mutation_test.py
@@ -86,6 +86,16 @@ CASES: list[tuple[str, str, str, str]] = [
      r"([\d,]{3,}) collected", "9,999 collected", "suite-baseline"),
     ("backend/CLAUDE.md",
      r"(SQLite|Postgres) via psycopg3", "SQLite table via psycopg3", "stale-phrase"),
+    # Fifth batch, 2026-08-24. Two "N-thing schema" style guards promoted by the
+    # nightly routine after ARCHITECTURE.md carried "25-migration forward-compat
+    # schema" (real 31) and README.md's source-tree said `ats/ (12)` (real 10).
+    # The migration-head guard could not see either — it watches "0000 → NNNN"
+    # phrasing only — and no per-subfolder count was ever guarded.
+    ("ARCHITECTURE.md",
+     r"(\d+)-migration forward-compat schema",
+     "999-migration forward-compat schema", "migrations-schema"),
+    ("ARCHITECTURE.md",
+     r"\bats/\s*\((\d+)\)", "ats/ (999)", "subfolder-ats"),
 ]
 
 


### PR DESCRIPTION
Countable and behavioural drift across the LIVING docs, plus guards so the countable half is held for free. Two review rounds each found something bigger than the round before: **README was advertising six retired job sources as live**, and **the ATS slug table was stale in six of eleven rows**.

## Fixes on the LIVING docs

Each line: `file:line — doc said X, code says Y`.

**Retired sources listed as live** (`9f0c71e`). The mermaid diagram and source bullets described the pre-2026-08-10 roster while `README.md:249` in the same file says those sources were dropped — the file contradicted itself. Verified by reading the `category` attribute off every source class: `keyed_api` 8, `free_json` 8, `ats` 10, `rss` 5, `scrapers` 5, `other` 4 (40 classes / 41 registry keys).

- `Keyed APIs (7)` → **8** (Gov Apprenticeships was missing entirely)
- `Free JSON APIs (9)` incl. AIJobs.net → **8** (AIJobs.net retired)
- `ATS Boards (11, ~264 slugs)` incl. Rippling → **10 boards polling 297 slugs**
- `RSS/XML Feeds (9)` incl. jobs.ac.uk, NHS Jobs XML, WorkAnywhere, BioSpace → **5**

**ATS slug table** (`ed1f1e9`). The total was the least of it — the per-platform breakdown was wrong on six rows: Greenhouse 80→**82**, Workable 25→**21**, Pinpoint 15→**39**, Recruitee 20→**31**, Personio 18→**26**, total ~264→**302**. Rippling is now marked *not polled*: it has slugs but no source class, which is exactly why 302 configured and 297 polled differ.

**Counts and chains** (`dc46379`)

- `ARCHITECTURE.md:81` — `25-migration forward-compat schema` → 31
- `docs/product/pillars/02-search-and-match-engine.md:675` — `14-migration ...` → 31
- `README.md` source tree — `ats/(12)`→10, `feeds/(8)`→4, `scrapers/(7)`→5
- Four sites described the LLM chain as `Gemini→Groq→Cerebras`; code leads with OpenAI (`gpt-4o-mini`) as PRIMARY (`llm_provider.py:329-334`)

> On `apis_free`: the folder guard says `(9)` and the source bullet says 8 free JSON APIs. Both are right — Teaching Vacancies is a 9th *file* in `apis_free/` but an rss-tier *source*. Both docs now say so explicitly.

## Promote to the guard

- **`migrations-schema`** — parses migration prefixes and requires a contiguous `0000..head` run with no duplicates or malformed names; any violation raises (exit 2). Three phrasings guarded, including two the `migration-head` guard *appeared* to cover: both end `(0000 → 0030)`, so it matched the line but read the head, not the count beside it.
- **`subfolder-NAME`** — one guard per subfolder under `backend/src/sources/`. The expected set is a named constant, so a deleted folder scores 0 rather than retiring its own check.
- **`ats-boards-active` / `ats-slugs-active`** — derived by intersecting the `*_COMPANIES` lists with the classes actually in `sources/ats/`, yielding `(10, 297)`. Retiring a platform moves both numbers without editing the checker. Three phrasings guarded.
- **`ats-slugs-<platform>`** — one per `*_COMPANIES` list, matching the README table row, so the breakdown can't rot behind a green total again.

## Two traps worth recording

**A guard on the same line is not a guard on the same fact.** Twice in this PR a number looked covered because *something* matched its line — `migration-head` on `(0000 → 0030)`, and the active-ATS facts matching other wordings elsewhere. The "claim not found in any doc" alarm is keyed on the fact *name*, not the site, so `matches_per_fact` stayed non-zero and the checker reported clean while unguarded copies sat in the two most-read files. Every new phrasing needs its own pattern.

**A guard that fires on correct docs is worse than no guard.** The first per-platform pattern matched `03-job-providers.md`'s *rate-limit* table (`| personio | 1 | 3.0 |`) under `IGNORECASE` and reported drift against a perfectly correct doc. It now requires the third column not to open with a decimal.

## Not promoted (deliberate)

The LLM-chain drift is prose, not a number. A guard flagging any provider list missing OpenAI would fire on every dated citation in `docs/harness/` and the evaluation reports — the same reason this checker already refuses to guard `SOURCE_INSTANCE_COUNT`.

## Known, not fixed here

Two docstrings in `backend/src/**` still describe the old chain — `llm_provider.py:1` says *"Gemini → Groq → Cerebras fallback. Zero cost."*, wrong twice over now that OpenAI leads and `gpt-4o-mini` is paid; `llm_matcher.py:5` likewise. Out of scope for a `*.md`-only routine, and touching `backend/` trips the commit gate, whose `scripts/agent-gate.sh` currently fails to parse under bash 5.2 (line 61, `|| true` on a heredoc line inside a command substitution) — byte-identical on `main`, so that breakage predates this branch. Flagged separately.

## Conflict with main, and a drill that was already red

- **`ARCHITECTURE.md:81`** — main fixed the same drift concurrently while this PR was open; its wording carries `(0000 → 0030)` and was adopted verbatim.
- **`suite-baseline` drill** — **already red on `origin/main`** before this branch existed (verified in a clean worktree). #393 correctly retired the collected-test count from the docs but left the drill mutating text that no longer exists. Repointed at `CONTRIBUTING.md`, which keeps the count twice on purpose as the merge-gate ratchet floor.

## Verified on the current head

```
$ python scripts/doc_sync_check.py
Code facts: SOURCE_REGISTRY entries = 41, unique source classes = 40, migration head = 0030
No drift — every doc claim matches the code, all stamps fresh. OK

$ python scripts/doc_sync_mutation_test.py
All 19 guards proven able to go RED.
PASS structural  missing subfolder (count + emitted guard), gapped/malformed/duplicate migrations
```

Every new guard was proven to go red on demand, not assumed: `pinpoint 999`, `99 ATS boards`, `polling 999`, `99 ATS sources`, `999 polled`, `99/98 migrations`. The structural drills were each confirmed to **fail against the pre-fix code** — 8 findings for the subfolder/migration regressions, and one each for the `build_checks()` filter and duplicate-prefix deletions.

Title kept as `docs: daily truth check` per the routine's convention, against CodeRabbit's title-check suggestion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architecture, product, and README documentation with current verification dates and system inventories.
  * Clarified available data sources, ATS coverage, frontend routes, endpoints, and CV-processing provider priorities.

* **Tests**
  * Expanded documentation consistency checks for migrations, ATS coverage, source folders, and catalogue counts.
  * Added validation scenarios for malformed migrations, missing folders, duplicate prefixes, and zero-count sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->