### PR TITLE
docs: the runbook queries a user_profile_versions column that does not exist

### DIFF
--- a/docs/product/pillars/runbook.md
+++ b/docs/product/pillars/runbook.md
@@ -172,10 +172,17 @@ FROM sessions WHERE id = '<session_id_before_the_dot>';
 
 Table `user_profiles` (current tip) + `user_profile_versions` (last-10 history).
 
+There is **no `version` column** — the row's `id` *is* the version. `current_profile_version_id()`
+is literally `SELECT MAX(id) FROM user_profile_versions WHERE user_id = ?`
+(`backend/src/services/profile/storage.py:260-271`), and that id is what `user_feed.profile_version`
+stores. Columns are `id, user_id, created_at, source_action, cv_data, preferences`
+(`backend/migrations/0007_user_profile_versions.up.sql:17-25`) plus `snapshot_id`
+(migration `0030`).
+
 ```sql
-SELECT user_id, version, source_action, created_at
+SELECT id AS version, user_id, source_action, created_at
 FROM user_profile_versions WHERE user_id = '<uuid>'
-ORDER BY version DESC;
+ORDER BY id DESC;
 ```
 
 ### Dump a user's current profile


### PR DESCRIPTION
Found while verifying that #398 actually landed on `main`. I grepped the merged runbook for `ORDER BY version` — the defect #398 fixed on `_schema_migrations` — and got a hit on a **different** query, four sections away, that I had never looked at:

```sql
SELECT user_id, version, source_action, created_at
FROM user_profile_versions WHERE user_id = '<uuid>'
ORDER BY version DESC;
```

`user_profile_versions` has **no `version` column**, and never has. The statement fails twice over — once in the SELECT list, once in `ORDER BY`.

## Evidence

Columns are `id, user_id, created_at, source_action, cv_data, preferences` (`backend/migrations/0007_user_profile_versions.up.sql:17-25`), plus `snapshot_id` from migration `0030` — which is the *only* ALTER against this table in the entire migration set:

```
$ grep -rn 'user_profile_versions' backend/migrations/*.sql | grep -i 'alter\|add column'
migrations/0030_profile_snapshot_id.up.sql:28:ALTER TABLE user_profile_versions ADD COLUMN IF NOT EXISTS snapshot_id TEXT;
migrations/0030_profile_snapshot_id.down.sql:5:ALTER TABLE user_profile_versions DROP COLUMN IF EXISTS snapshot_id;
```

**The row's `id` *is* the version.** `current_profile_version_id()` is literally `SELECT MAX(id) FROM user_profile_versions WHERE user_id = ?` (`backend/src/services/profile/storage.py:260-271`), and its docstring says so: *"Return the highest `id` from `user_profile_versions`"*. That id is what `user_feed.profile_version` stores, and what the version-conditional freeze in `upsert_feed_row` compares.

Fixed to `SELECT id AS version … ORDER BY id DESC`, with the real column list stated inline so the next reader doesn't have to go find it.

## Why this survived #396 and #398

Same defect class as the `_schema_migrations ORDER BY version` bug, in the same file, four sections apart. I fixed the one CodeRabbit pointed at and never asked whether the file had others.

**A reviewer finding is a sample, not an inventory.** That's the lesson worth keeping from this one.

## So I swept the class instead of fixing one line

Rather than patch and move on, I checked **every column referenced in every ` ```sql ` block** in the runbook against the real schema — reconstructed from the full migration set plus the base DDL and `_add_missing_columns` lists in `database.py`. 16 tables. This was the only genuine miss.

One further hit was a **false positive from my own checker**, verified and dismissed rather than "fixed": `applications.user_id` looked absent because migration `0002` adds it via a table **rebuild** (`applications_new` + rename) rather than an `ALTER`, so a literal table-name match never sees it. The column is real — `0002_multi_tenant.up.sql:44` declares it, `:61` indexes it. The runbook query was correct as written.

## Note on the `LIVING_DOCS` item

Already closed by #397, and better than I proposed — it guards `docs/product/pillars/` as a *folder* via `pillars_fully_watched()` rather than file-by-file, so a new doc dropped in there can't sit unwatched. `runbook.md` and `README.md` are both in `LIVING_DOCS` now. Nothing further needed from me there.

Still open and still yours: the `pipefail` bug at `.github/workflows/auto-merge.yml:176`, with a verified one-line patch in [my comment on #396](https://github.com/Ranjith36963/job360/pull/396#issuecomment-5399322810).

Verified: `python scripts/doc_sync_check.py` reports no drift on this branch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WSLp7uxJpgGN7izme1jhyz)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the profile-version inspection guidance to use the current version identifier.
  * Corrected result ordering to reflect the latest schema.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->