### PR TITLE
docs: daily truth check

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -329,19 +329,20 @@ RemotiveSource, DevITJobsSource, LandingJobsSource, AIJobsSource,
 HNJobsSource
 ```
 
-**ATS Boards** (11 — iterate company slugs from companies.py):
+**ATS Boards** (10 — iterate company slugs from companies.py):
 ```
-GreenhouseSource(session, companies, search_config)   # 25 companies
-LeverSource(session, companies, search_config)         # 12 companies
-WorkableSource(session, companies, search_config)      # 8 companies
-AshbySource(session, companies, search_config)         # 9 companies
-SmartRecruitersSource(session, companies, search_config) # 6 companies
-PinpointSource(session, companies, search_config)      # 8 companies
-RecruiteeSource(session, companies, search_config)     # 8 companies
-WorkdaySource(session, companies, search_config)       # 15 companies (dict format)
-PersonioSource(session, companies, search_config)      # 10 companies
+GreenhouseSource(session, companies, search_config)   # 82 companies
+LeverSource(session, companies, search_config)         # 35 companies
+WorkableSource(session, companies, search_config)      # 21 companies
+AshbySource(session, companies, search_config)         # 25 companies
+SmartRecruitersSource(session, companies, search_config) # 15 companies
+PinpointSource(session, companies, search_config)      # 39 companies
+RecruiteeSource(session, companies, search_config)     # 31 companies
+WorkdaySource(session, companies, search_config)       # 20 companies (dict format)
+PersonioSource(session, companies, search_config)      # 26 companies
 SuccessFactorsSource(session, companies, search_config) # 3 companies (sitemap format)
-RipplingSource(session, companies, search_config)       # added Batch 3
+# RipplingSource retired in the 2026-08-10 rotation — RIPPLING_COMPANIES (5)
+# remains in companies.py but no source class builds it, so 10 boards poll 297.
 ```
 
 **RSS/XML Feeds** (9 — parse with xml.etree.ElementTree):

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -329,7 +329,8 @@ RemotiveSource, DevITJobsSource, LandingJobsSource, AIJobsSource,
 HNJobsSource
 ```
 
-**ATS Boards** (10 — iterate company slugs from companies.py):
+**ATS Boards** (10 — iterate company configurations from companies.py; plain
+string slugs except Workday and SuccessFactors, whose entries are dicts):
 ```
 GreenhouseSource(session, companies, search_config)   # 82 companies
 LeverSource(session, companies, search_config)         # 35 companies

--- a/STATUS.md
+++ b/STATUS.md
@@ -212,9 +212,9 @@ Engine #4 runs after per-user feed write (`_run_matcher_stage`). Results stored 
 |------------------|------|-------|
 | **HTML scrapers** (5) | High | LinkedIn, Climatebase, 80000Hours, BCS Jobs, AIJobs AI all use regex parsing on HTML. Any layout change breaks them silently (returns 0 jobs, no error). |
 | **python-jobspy** (Indeed/Glassdoor) | Medium | Not in backend/pyproject.toml. Optional dependency. If Indeed/Glassdoor change their site, python-jobspy breaks. |
-| **Workday ATS** | Medium | Complex dict-format config (tenant/wd/site). Workday API endpoints change occasionally. 15 companies = 15 potential breakpoints. |
+| **Workday ATS** | Medium | Complex dict-format config (tenant/wd/site). Workday API endpoints change occasionally. 20 companies = 20 potential breakpoints. |
 | **SuccessFactors** | Medium | Parses sitemap.xml files. Only 3 companies. MBDA already removed (DNS failure). |
-| **Personio** | Medium | Uses XML job feed API. 10 companies. Personio may restrict access. |
+| **Personio** | Medium | Uses XML job feed API. 26 companies. Personio may restrict access. |
 | **LinkedIn guest API** | High | Unofficial, can break or get rate-limited at any time. |
 | **HackerNews sources** | Low | Algolia API is stable, but "Who is Hiring" thread format could change. |
 | **CV parser** | Medium | Regex-based section detection. Works for ~80% of CVs. Non-standard formats may miss skills. |

--- a/docs/product/pillars/02-search-and-match-engine.md
+++ b/docs/product/pillars/02-search-and-match-engine.md
@@ -87,7 +87,7 @@ UserPreferences(
 
 ### Stage 1 — Fetch
 
-`TieredScheduler.tick()` saw `greenhouse.category="ats"` (60s tier) was due. Breaker `CLOSED` → dispatched. `GreenhouseSource.fetch_jobs()` iterated 80 company slugs, found this one among ~500 results, returned the `Job` above. `breaker.record_success()`.
+`TieredScheduler.tick()` saw `greenhouse.category="ats"` (60s tier) was due. Breaker `CLOSED` → dispatched. `GreenhouseSource.fetch_jobs()` iterated 82 company slugs, found this one among ~500 results, returned the `Job` above. `breaker.record_success()`.
 
 ### Stage 2 — Prefilter (3 gates)
 

--- a/docs/product/pillars/02-search-and-match-engine.md
+++ b/docs/product/pillars/02-search-and-match-engine.md
@@ -87,7 +87,7 @@ UserPreferences(
 
 ### Stage 1 — Fetch
 
-`TieredScheduler.tick()` saw `greenhouse.category="ats"` (60s tier) was due. Breaker `CLOSED` → dispatched. `GreenhouseSource.fetch_jobs()` iterated 82 company slugs, found this one among ~500 results, returned the `Job` above. `breaker.record_success()`.
+`TieredScheduler.tick()` saw `greenhouse.category="ats"` (60s tier) was due. Breaker `CLOSED` → dispatched. `GreenhouseSource.fetch_jobs()` iterated 82 company slugs, found this one among the results, returned the `Job` above. `breaker.record_success()`.
 
 ### Stage 2 — Prefilter (3 gates)
 

--- a/docs/product/pillars/03-job-providers.md
+++ b/docs/product/pillars/03-job-providers.md
@@ -71,7 +71,7 @@ async def fetch_jobs(self) -> list[Job]:
 
 Each `_get_json(url)` call goes through `_request()`:
 
-1. `await self._rate_limiter.acquire()` — at most 2 concurrent requests across all 80 companies; 1.5 s minimum delay between acquisitions.
+1. `await self._rate_limiter.acquire()` — at most 2 concurrent requests across all 82 companies; 1.5 s minimum delay between acquisitions.
 2. `aiohttp.GET(url, timeout=30)`.
 3. Response handling:
    - `200` → `response.json()`, return.
@@ -120,7 +120,7 @@ Two things the `Job.__post_init__` does automatically:
 
 ### T+0 — Return + scheduler post-processing
 
-`await GreenhouseSource.fetch_jobs()` returns a `list[Job]` of ~500 entries across 80 companies.
+`await GreenhouseSource.fetch_jobs()` returns a `list[Job]` of ~500 entries across 82 companies.
 
 Back in `TieredScheduler.tick()`:
 

--- a/docs/product/pillars/03-job-providers.md
+++ b/docs/product/pillars/03-job-providers.md
@@ -58,7 +58,7 @@ In `BaseJobSource.__init__`:
 ```python
 async def fetch_jobs(self) -> list[Job]:
     jobs = []
-    for slug in GREENHOUSE_COMPANIES:        # ~80 slugs
+    for slug in GREENHOUSE_COMPANIES:        # 82 slugs
         url = f"https://boards-api.greenhouse.io/v1/boards/{slug}/jobs"
         data = await self._get_json(url)     # all retry/rate-limit machinery
         if not data:

--- a/docs/product/pillars/03-job-providers.md
+++ b/docs/product/pillars/03-job-providers.md
@@ -105,6 +105,15 @@ For one healthy company (say `acme-corp`), this returns ~6 postings in JSON like
 For each upstream posting, the source builds a canonical `Job`:
 
 ```python
+# The date contract, established BEFORE the Job is built (greenhouse.py:64-68).
+# posted_at comes from `first_published`, NOT `updated_at` — the latter tracks
+# edits (a salary tweak) and would bump a stale posting back into the "just
+# posted" bucket. normalize_posted_at() returns the confidence alongside it, so
+# an unparseable value is reported low rather than fabricated as "high".
+raw_updated_at = posting.get("updated_at")          # audit only, never recency
+raw_published = posting.get("first_published")
+posted_at, confidence = normalize_posted_at(raw_published)
+
 job = Job(
     title=posting["title"],
     company="acme-corp",  # or via COMPANY_NAME_OVERRIDES → "Acme Corp"
@@ -113,13 +122,9 @@ job = Job(
     location=posting.get("location", {}).get("name", ""),
     description=_strip_html(posting["content"]),  # raw HTML → text
     date_found=now_iso(),
-    # posted_at comes from `first_published`, NOT `updated_at` — the latter
-    # tracks edits (a salary tweak) and would bump a stale posting back into
-    # the "just posted" bucket. normalize_posted_at() decides the confidence,
-    # so an unparseable value is reported low rather than fabricated.
-    posted_at=posted_at,                           # normalize_posted_at(first_published)[0]
-    date_confidence=confidence,                    # ...[1] — derived, never hardcoded
-    date_posted_raw=raw_updated_at,                # updated_at kept for audit
+    posted_at=posted_at,
+    date_confidence=confidence,                    # derived, never hardcoded
+    date_posted_raw=raw_updated_at,
 )
 ```
 

--- a/docs/product/pillars/03-job-providers.md
+++ b/docs/product/pillars/03-job-providers.md
@@ -120,7 +120,10 @@ Two things the `Job.__post_init__` does automatically:
 
 ### T+0 — Return + scheduler post-processing
 
-`await GreenhouseSource.fetch_jobs()` returns a `list[Job]` of ~500 entries across 82 companies.
+`await GreenhouseSource.fetch_jobs()` returns a `list[Job]` gathered across 82 companies.
+Volume is an upstream fact, not a constant, so it is quoted only as a dated measurement:
+**996 greenhouse rows in prod** as of 2026-08-05 (`backend/src/sources/ats/greenhouse.py:34`),
+and `first_published` verified across **928 live jobs** (`greenhouse.py:57-58`).
 
 Back in `TieredScheduler.tick()`:
 

--- a/docs/product/pillars/03-job-providers.md
+++ b/docs/product/pillars/03-job-providers.md
@@ -90,6 +90,7 @@ For one healthy company (say `acme-corp`), this returns ~6 postings in JSON like
      "location": {"name": "London, UK"},
      "absolute_url": "https://boards.greenhouse.io/acme-corp/jobs/12345",
      "content": "&lt;p&gt;We're hiring...&lt;/p&gt;",
+     "first_published": "2026-05-20T11:30:00Z",
      "updated_at": "2026-05-28T09:00:00Z"},
     ...
   ]
@@ -109,8 +110,13 @@ job = Job(
     location=posting.get("location", {}).get("name", ""),
     description=_strip_html(posting["content"]),  # raw HTML → text
     date_found=now_iso(),
-    posted_at=posting.get("updated_at"),           # high-confidence date
-    date_confidence="high",
+    # posted_at comes from `first_published`, NOT `updated_at` — the latter
+    # tracks edits (a salary tweak) and would bump a stale posting back into
+    # the "just posted" bucket. normalize_posted_at() decides the confidence,
+    # so an unparseable value is reported low rather than fabricated.
+    posted_at=posted_at,                           # normalize_posted_at(first_published)[0]
+    date_confidence=confidence,                    # ...[1] — derived, never hardcoded
+    date_posted_raw=raw_updated_at,                # updated_at kept for audit
 )
 ```
 

--- a/docs/product/pillars/03-job-providers.md
+++ b/docs/product/pillars/03-job-providers.md
@@ -58,8 +58,11 @@ In `BaseJobSource.__init__`:
 ```python
 async def fetch_jobs(self) -> list[Job]:
     jobs = []
-    for slug in GREENHOUSE_COMPANIES:        # 82 slugs
-        url = f"https://boards-api.greenhouse.io/v1/boards/{slug}/jobs"
+    for slug in self._companies:             # GREENHOUSE_COMPANIES by default — 82 slugs
+        # `?content=true` is LOAD-BEARING, not decoration: without it the board
+        # list endpoint returns no `content` field at all, which is why 996 prod
+        # rows carried an empty description until 2026-08-05 (greenhouse.py:31-36).
+        url = f"https://boards-api.greenhouse.io/v1/boards/{slug}/jobs?content=true"
         data = await self._get_json(url)     # all retry/rate-limit machinery
         if not data:
             continue

--- a/docs/product/pillars/glossary.md
+++ b/docs/product/pillars/glossary.md
@@ -237,7 +237,7 @@ Polling-cadence bucket for sources. Today: `ats`=60s, `reed`=5min, `workday`=15m
 
 ### Worker (ARQ tasks)
 
-The background process that runs `score_and_ingest`, `send_notification`, `send_daily_digest`, `nightly_ghost_sweep`, `enrich_job_task`. Tests call these as pure async functions; production runs them under ARQ + Redis.
+The background process that runs `score_and_ingest`, `send_notification`, `send_bundle`, `notification_tick`, `nightly_ghost_sweep`, `enrich_job_task`. Tests call these as pure async functions; production runs them under ARQ + Redis.
 **Code:** `backend/src/workers/tasks.py` · **Pillars 1 + 2**
 
 ---


### PR DESCRIPTION
Scout pass over `main`. Both guard scripts are green, so nothing here duplicates them — these are the drifts a regex can't see: behavioural claims, dead names, and counts sitting in prose and fenced code blocks the guard's table patterns don't reach. Every fact was verified against **code**, cited `file:line`, and re-read before writing.

**The scope grew during review, and the character of it changed.** It started as stale counts. It ended up finding that a load-bearing pillar doc was teaching a *known regression*. Those are the two most important fixes here and they are last in the list.

## Fixes — `file:line — doc said X, code says Y`

**Stale counts and dead names** (the original pass)

- **ARCHITECTURE.md:332-345** — said **"ATS Boards (11)"** and listed `RipplingSource` as active, with counts `25/12/8/9/6/8/8/15/10/3`. Code has **10** ATS classes: `_build_sources()` (`backend/src/main.py:261-303`) builds no `RipplingSource` — retired in the 2026-08-10 rotation (`main.py:160-163` names it and the reason). `RIPPLING_COMPANIES` (5) remains in `companies.py` with nothing building it, which is the "302 configured / 297 polled" split the README already documents. Real counts: Greenhouse **82**, Lever **35**, Workable **21**, Ashby **25**, SmartRecruiters **15**, Pinpoint **39**, Recruitee **31**, Workday **20**, Personio **26**, SuccessFactors 3. Heading also corrected from "company slugs" to "company configurations" — `WORKDAY_COMPANIES` and `SUCCESSFACTORS_COMPANIES` hold dicts, not strings (AST: elem type `Dict`; the other 8 `Constant`).
- **glossary.md:240** — named `send_daily_digest` as a running ARQ task. It no longer exists; `01-user-pillar.md:385` already says so. Real tasks: `send_bundle` (`workers/tasks.py:971`) + `notification_tick` (`:1243`).
- **STATUS.md:215,217** — Workday *"15 companies"* → **20**; Personio *"10"* → **26**.
- **03-job-providers.md:61,74,123 / 02-search-and-match-engine.md:90** — Greenhouse *"~80 slugs/companies"* → **82**.
- **03-job-providers.md:123 / 02-search-and-match-engine.md:90** — an invented `~500` posting total, roughly half of every checked-in measurement: **996 prod rows** (`greenhouse.py:34`, 2026-08-05) and **928 live jobs** (`greenhouse.py:57-58`). Replaced with both, dated and cited, plus a note that volume is an upstream fact rather than a constant. Deliberately *not* collapsed into one number — 996 is accumulated prod rows, 928 is a live fetch across 3 boards, and averaging them would invent a third figure nobody measured. Dropped entirely from the 02 walkthrough, where it does no work.

**Behavioural drift — the doc taught the wrong thing**

- **03-job-providers.md:93,112** — the walkthrough built `posted_at=posting.get("updated_at")` with `date_confidence="high"` hardcoded. Against `greenhouse.py:66-79`, all of that is wrong: `posted_at` comes from **`first_published`** via `normalize_posted_at()`; `date_confidence` is **returned** by that function, never hardcoded (hardcoding it is the fabrication `:62-63` exists to prevent); and `date_posted_raw=raw_updated_at` was missing — `updated_at` is kept for **audit**, not recency. The source's own comment (`:57-61`) explains why using `updated_at` is harmful: it tracks edits, so a salary tweak bumps a stale posting back into the "just posted" bucket. The sample payload was also missing `first_published` entirely. **An agent following this walkthrough would have implemented the wrong recency behaviour.**
- **03-job-providers.md:62** — the fetch URL omitted **`?content=true`**. That parameter is the whole point: without it the board list endpoint returns no `content` field at all, which is why 996 prod rows had empty descriptions until the 2026-08-05 fix (`greenhouse.py:31-36`). So the sample taught the regression *and* contradicted itself eleven lines later, where `:111` does `description=_strip_html(posting["content"])` — impossible against the URL shown. Now carries a comment saying it is load-bearing, so it doesn't get "tidied" away again. Also `GREENHOUSE_COMPANIES` → `self._companies`, what the loop actually iterates (`greenhouse.py:30`).

## Promote to the guard

`ats_platform_slugs()` already computes the per-platform counts, but the `ats-slugs-<plat>` check only matches the **README markdown-table row** (`^\|\s*Greenhouse\s*\|\s*(\d+)`). It cannot see the same numbers in a fenced code block — which is why nine of them rotted in ARCHITECTURE.md and a tenth in a Python sample while the table stayed guarded. CodeRabbit independently reached the same conclusion and recorded it as a repo learning. Proposed addition inside the existing loop:

```python
# ALSO guard the fenced-code-block form ARCHITECTURE.md uses:
#   GreenhouseSource(session, ...)   # 82 companies
checks.append((
    f"ats-slugs-block-{_plat.lower()}",
    _n,
    rf"{re.escape(_plat.title().replace('_',''))}Source\b[^\n#]*#\s*(\d+)\s+compan",
))
```

Not proposed: a `send_daily_digest` forbidden-phrase guard (`01-user-pillar.md` legitimately writes the name to say it's gone — a permanent false alarm is how a loop dies), and nothing for the behavioural fixes, which are prose and not mechanically checkable.

## Separately: `doc_sync_mutation_test.py` is RED on `main`

Pre-existing, not caused by this PR, and **not fixable by this routine** (a `.py` change; the nightly pass may only edit `*.md`). Full detail and a proposed one-line patch in [this comment](https://github.com/Ranjith36963/job360/pull/400#issuecomment-5399872656). Short version: #398 legitimately rewrote a `runbook.md` command into `railway run -s Postgres sh -c 'psql …'`, breaking the mutation fixture's anchor. The `sqlite3` guard still works; what's lost is the *proof it can go red*, which is that file's entire purpose.

## Verification

`doc_sync_check.py` green after every commit. `doc_sync_mutation_test.py` unchanged from `main` (see above). Docs-only, `*.md` only, no code touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated ATS coverage information to reflect 10 active boards and 297 companies.
  - Revised source-risk figures for Workday and Personio.
  - Updated the search-and-match example to cover 82 company slugs.
  - Expanded the Greenhouse walkthrough with job-description content, publication dates and revised production figures.
  - Updated background-task terminology in the glossary, including bundled notifications and notification checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->