### PR TITLE
fix(doc-sync): repoint a drill whose target another PR removed

### DIFF
--- a/scripts/doc_sync_mutation_test.py
+++ b/scripts/doc_sync_mutation_test.py
@@ -114,7 +114,13 @@ CASES: list[tuple[str, str, str, str]] = [
     # database -- five dead COMMANDS, not stale prose. The four SQLite entries
     # in FORBIDDEN_PHRASES all pin sentences; none matched a shell command.
     ("docs/product/pillars/runbook.md",
-     r"(railway) run -s Postgres psql", "sqlite3 data/jobs.db run -s Postgres psql",
+     # Anchored on `psql ` rather than the longer `railway run -s Postgres psql`
+     # form this drill originally targeted. #396 rewrote the runbook to use bare
+     # SQL blocks with a connect line, so the longer string vanished and the
+     # drill reported "guard watches nothing" -- correctly. Second time a drill
+     # has caught its own target being removed by someone else's fix (the first
+     # was suite-baseline after #393). That is the drill working, not failing.
+     r"(psql) postgresql://", "sqlite3 data/jobs.db postgresql://",
      "stale-phrase"),
     # Fifth batch, 2026-08-24. Two "N-thing schema" style guards promoted by the
     # nightly routine after ARCHITECTURE.md carried "25-migration forward-compat


### PR DESCRIPTION
The `stale-phrase` drill anchored on `railway run -s Postgres psql` in `runbook.md`. #396 rewrote that file to use bare SQL blocks with a connect line, so the string vanished and the drill reported:

```
stale-phrase: no claim matching /(railway) run -s Postgres psql/ in
docs/product/pillars/runbook.md — guard watches nothing
```

**Second time a drill has caught its own target being deleted by someone else's fix** — `suite-baseline` did the same after #393 removed the collected-test count.

Both times the drill *said so* instead of passing quietly, which is the entire reason it exists: **a guard whose target was deleted is indistinguishable from a guard that passes.** Without the drill, two of the 21 guards would now be silently watching nothing.

Re-anchored on `psql postgresql://`, the connect string the rewritten runbook uses in two places.

```
All 21 guards proven able to go RED.
[gate] PASS
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6DsQH5EUxJc3Vnqz9YHgQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated runbook mutation coverage to validate the current database connection command format.
  * Improved test feedback when expected mutation targets are missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->