### PR TITLE
docs: daily truth check

### DIFF
--- a/docs/product/pillars/03-job-providers.md
+++ b/docs/product/pillars/03-job-providers.md
@@ -487,11 +487,11 @@ There are **no** separate `test_ats*.py` / `test_feed*.py` files — all source 
 
 ## Environment variables — every var the Providers pillar reads
 
-Almost all are the keyed-source API credentials. The other **33** registry keys need no env at all — 41 keys minus the 8 keyed sources (README's "API Key Setup" states the same split).
+Almost all are the keyed-source API credentials. The other **33** registry keys have no **required** environment variables — 41 keys minus the 8 keyed sources (README's "API Key Setup" states the same split). "Required" is the operative word: `EightyKHoursSource` is not a keyed source, yet the row below lets you override the public Algolia keys it ships with.
 
 | Var | Required by | Default | What changes when you flip it |
 | --- | --- | --- | --- |
-| `REED_API_KEY` | `ReedSource` | (unset) | Reed `return []` silently when unset; logged at INFO |
+| `REED_API_KEY` | `ReedSource` | (unset) | Reed returns `[]` when unset, logging `Reed: no API key, skipping` at **`WARNING`** (`reed.py:45`) — not silent, and not INFO |
 | `ADZUNA_APP_ID` + `ADZUNA_APP_KEY` | `AdzunaSource` | (unset) | Both must be set; either unset → return [] |
 | `JSEARCH_API_KEY` | `JSearchSource` | (unset) | RapidAPI key |
 | `JOOBLE_API_KEY` | `JoobleSource` | (unset) | |

--- a/docs/product/pillars/03-job-providers.md
+++ b/docs/product/pillars/03-job-providers.md
@@ -326,7 +326,7 @@ This tuple is the DB's UNIQUE constraint and the deduplicator's Layer-1 key. **C
 
 ### 4.1 Keyed APIs — `apis_keyed/` (8)
 
-Pattern: accept `api_key` in `__init__`, return `[]` early with an info log if the key is empty (so the source skips gracefully on free installs).
+Pattern: accept `api_key` in `__init__`, return `[]` early if the key is empty (so the source skips gracefully on free installs). The log line is `WARNING` in seven of the eight — `gov_apprenticeships.py:62` is the only `INFO`.
 
 | Source | Upstream | Env var |
 | --- | --- | --- |
@@ -487,7 +487,7 @@ There are **no** separate `test_ats*.py` / `test_feed*.py` files — all source 
 
 ## Environment variables — every var the Providers pillar reads
 
-Almost all are the keyed-source API credentials. The 43 free sources need no env at all.
+Almost all are the keyed-source API credentials. The other **33** registry keys need no env at all — 41 keys minus the 8 keyed sources (README's "API Key Setup" states the same split).
 
 | Var | Required by | Default | What changes when you flip it |
 | --- | --- | --- | --- |


### PR DESCRIPTION
Follow-up to #405. That PR merged while its last commit was still in flight, so two verified fixes never landed. Both are re-applied here on top of the merged result — and neither was introduced by #405; both predate it.

New branch rather than a push to the old one: a merged PR cannot carry follow-up work. Restarted from `origin/main` (`d6b0c7d`), so this sits on top of both #405 and #406.

## The two fixes

| Where | Doc said | Code says |
|---|---|---|
| `docs/product/pillars/03-job-providers.md:490` | "The **43** free sources need no env at all" | **33** — 41 registry keys minus 8 keyed sources |
| `docs/product/pillars/03-job-providers.md:329` | missing key logs "an **info** log" | **`WARNING`** in seven of eight; `gov_apprenticeships.py:62` is the only `INFO` |

**43 matches nothing in the tree.** Not the registry (41), not the source files on disk (40), not the instances built per run (40). `README.md`'s "API Key Setup" section already states the 33/8 split, so the two docs were contradicting each other as well as the code.

The `:329` line is the second copy of the log-level claim; #405 corrected the one at `:505` and missed this one.

## Promote to the guard

The count is the point. It is **derivable** — `registry − keyed` — so it moves on its own every time the roster does, and typing it by hand is exactly what let it sit wrong behind a green check. Add to `scripts/doc_sync_check.py`:

```python
def keyed_source_count() -> int:
    """Sources that take an api_key — the complement of the 'free' count docs quote.

    03-job-providers.md said "the 43 free sources need no env at all" against a
    real 33. The number is DERIVED (registry - keyed), so it moves on its own
    every time the roster does; typing it is what let it rot.
    """
    d = ROOT / "backend/src/sources/apis_keyed"
    return len([p for p in d.glob("*.py") if p.name != "__init__.py"])
```

…then in `build_checks()`, beside the other registry patterns:

```python
("free-sources", registry - keyed_source_count(), r"(\d+) free sources"),
("free-sources", registry - keyed_source_count(), r"other \*\*(\d+)\*\* registry keys"),
("keyed-sources", keyed_source_count(), r"`?apis_keyed/`?\s*\((\d+)\)"),
```

The first pattern is what would have caught this one; the second guards the replacement wording this PR introduces, so the new phrasing is watched from the day it lands rather than becoming the next unguarded claim. The third pins the `apis_keyed/ (8)` heading that the same section carries.

This is the third promotion candidate the routine has produced. The other two — a doc-cited-test-file check and an env-var readability check, both with drills — are written out in #405's body and are still unimplemented.

## Already resolved, by someone else

#405 reported that `scripts/doc_sync_mutation_test.py` was RED on `main` and said the fix was a `.py` change this routine may not make. **#406 fixed it** — the stale-phrase drill is re-anchored on `psql postgresql://`. Measured on this branch:

```
$ python scripts/doc_sync_mutation_test.py
All 21 guards proven able to go RED.
```

## Verification

```
$ python scripts/doc_sync_check.py
No drift — every doc claim matches the code, all stamps fresh. OK

$ python scripts/doc_sync_mutation_test.py
All 21 guards proven able to go RED.
```

Counts re-measured on this branch, not quoted from a doc:

```
$ find backend/src/sources -type f -name '*.py' ! -name '__init__.py' ! -name 'base.py' | wc -l
40
$ find backend/src/sources/apis_keyed -maxdepth 1 -type f -name '*.py' ! -name '__init__.py' | wc -l
8
```

One file, two lines, docs only. No code touched, no doc deleted or renamed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018RkkvYXg79CmjhDtpfehvp

---
_Generated by [Claude Code](https://claude.ai/code/session_018RkkvYXg79CmjhDtpfehvp)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified that missing credentials produce `WARNING` logs for seven of the eight keyed API sources.
  - Documented the exception: `gov_apprenticeships` reports missing credentials at `INFO` level.
  - Corrected the documented count of registry keys without required environment variables from 43 to 33.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->