### PR TITLE
docs: daily truth check — follow-up to #414

### DIFF
--- a/docs/product/pillars/02-search-and-match-engine.md
+++ b/docs/product/pillars/02-search-and-match-engine.md
@@ -294,13 +294,13 @@ Four layers run in sequence; each layer collapses near-duplicates into the highe
 
 ### Stage 5 — Enrich (opt-in, `ENGINE2_ENABLED` **or** `ENRICHMENT_ENABLED`)
 
-- Gate: **a budget, not a threshold** (`main.py:1137-1163`). Jobs must clear a low floor — `match_score >= ENRICHMENT_MIN_SCORE` (default **10**, `settings.py:152`) — and then the best `ENRICHMENT_MAX_JOBS` (default **20**) are sent to the LLM. `ENRICHMENT_THRESHOLD` is not read at this call site — it defaults to `ENRICHMENT_MIN_SCORE` when unset (`settings.py:155`) and survives only for old `.env` files. Why the change: the scorer's contract is 0–100, but the highest `match_score` measured across the whole 3,342-row prod feed on 2026-07-28 was **58**, so a threshold of 60 selected nothing and the stage had never run (`main.py:1138-1142` records the measurement). A budget makes no claim about the distribution, so it cannot go stale.
+- Gate: **a budget, not a threshold** (`main.py:1137-1163`). Jobs must clear a low floor — `match_score >= ENRICHMENT_MIN_SCORE` (default **10**, `settings.py:152`) — and then the best `ENRICHMENT_MAX_JOBS` (default **20**) are sent to the LLM. `ENRICHMENT_THRESHOLD` is not read at this call site — it defaults to `ENRICHMENT_MIN_SCORE` when unset (`settings.py:155`). It is **not** dead weight for old `.env` files, though: the ARQ worker's per-job enqueue path is still gated on it (`workers/tasks.py:237`), so setting it high stops worker-side fan-out while leaving this CLI selection untouched — see the env table at §5. Why the change: the scorer's contract is 0–100, but the highest `match_score` measured across the whole 3,342-row prod feed on 2026-07-28 was **58**, so a threshold of 60 selected nothing and the stage had never run (`main.py:1138-1142` records the measurement). A budget makes no claim about the distribution, so it cannot go stale.
 - `enrich_batch(jobs, semaphore_limit=10, skip_existing=True)` (`job_enrichment.py`) runs asyncio-parallel LLM calls capped at 10 concurrent.
 - Each call goes through `llm_extract_validated(prompt, JobEnrichment, max_retries=2)`:
   - **Provider chain** (`llm_provider.py:329-334`): **OpenAI (`gpt-4o-mini`, PRIMARY)** → Gemini (`gemini-3.7-flash`) → Groq (`llama-3.3-70b-versatile`) → Cerebras (`gpt-oss-120b`). Every model id is env-overridable.
   - **Self-correction loop**: on Pydantic `ValidationError`, the first 5 error messages are appended to the prompt and the call retries up to 2 more times.
   - If all providers fail or retries exhaust → `RuntimeError` (logged, no partial row written — atomicity over best-effort).
-- Output: a `JobEnrichment` row with **16 strict-typed fields** (see §3.2 below). The `job_enrichment` TABLE still has 18 enrichment columns — `employer_type` and `locations` were retired from the schema in 2026-08 but never dropped from the DB, so nothing writes them — `save_enrichment` excludes both from its column list (`job_enrichment.py:248-254`), and the read paths skip them too (`:329`, `:401`).
+- Output: a `JobEnrichment` row with **16 strict-typed fields** (see §3.2 below). The `job_enrichment` TABLE still has 18 enrichment columns — `employer_type` and `locations` were retired from the schema in 2026-08 but never dropped from the DB, so the application neither writes nor reads them — `save_enrichment` excludes both from its column list (`job_enrichment.py:248-254`) and the read paths skip them too (`:329`, `:401`). The columns are not empty, though: `0008_job_enrichment.up.sql:21,29` declares them `NOT NULL DEFAULT '[]'` / `'unknown'`, so every new row still gets those defaults from the database.
 - DB persistence: `INSERT OR REPLACE` into `job_enrichment` table (migration `0008`). **Shared catalog** — no `user_id` column, per CLAUDE.md rule #17 (the same enriched fields apply to every user; per-user scoring against the enrichment happens at read time).
 
 ### Stage 6 — Store + (opt-in) embed
@@ -466,7 +466,7 @@ Either name opens this surface — every E2 call site reads `ENGINE2_ENABLED or 
 
 When on:
 - Stage 5 runs (see §2).
-- `JobScorer` gains a populated `enrichment_lookup`, so the Batch 2.9 dimension scorers have real data instead of their neutral halves.
+- `JobScorer` gets an `enrichment_lookup` that *can* carry rows, so the Batch 2.9 dimension scorers see real data for any job enrichment has reached. The flag opens the path; it does not guarantee rows — `_build_enrichment_lookup` returns `{}` when the table is empty or absent (`job_enrichment.py:313-328`), which is what happens with a zero `ENRICHMENT_MAX_JOBS` budget, no job above the floor, or every provider failing (the four preconditions in §6). Each unreached job falls back to the same neutral halves as the flag-off case below.
 - Dedup tie-breaker uses the `+5` enrichment bonus.
 
 When off:


### PR DESCRIPTION
Follow-up to #414, which merged at `7b22f28` while CodeRabbit's second review round was still in flight. Those three findings never made it in, so they land here as a fresh PR on top of the merged `main` (`0610995`). Nothing is stacked on the merged history.

All three were verified against code before acting; none was taken on the reviewer's word.

## Fixes — `file:line` · doc said X · code says Y

**1. `02-search-and-match-engine.md:303` — "so nothing writes them" is true of the application and false of the row.**

`save_enrichment` really does omit `employer_type` and `locations` (`job_enrichment.py:248-254`) and the read paths skip them (`:329`, `:401`) — that part of #414's sentence stands. But `0008_job_enrichment.up.sql:21,29` declares both `NOT NULL DEFAULT '[]'` / `'unknown'`, so **every new row still carries those defaults**, written by Postgres rather than by us. "Nothing writes them" invites a reader to expect NULL or empty and be surprised by `'unknown'` in a `SELECT`. Now states both halves.

**2. `02-search-and-match-engine.md:469` — "`JobScorer` gains a populated `enrichment_lookup`" promises something the flag cannot deliver.**

`_build_enrichment_lookup` returns `{}` when the table is empty or absent — its own docstring says so (`job_enrichment.py:313-328`: *"Returns an empty dict when the table is empty or absent — callers should treat `{}` as 'no enrichment available, fall back to legacy 4-component scoring' per CLAUDE.md rule #19"*). A zero `ENRICHMENT_MAX_JOBS` budget, no job above the floor, or an all-providers failure each produce exactly that with the flag **on**. The flag opens the path; it does not guarantee rows, and unreached jobs fall back to the same neutral halves the "When off" bullet directly below already documents. This is rule #29 territory — the line as written is the "empty means zero" reading that rule exists to kill, which is also what #413 fixed six lines away at `:471`.

Not my line originally — it is pre-existing text that neither #413 nor #414 touched.

**3. `02-search-and-match-engine.md:297` — "survives only for old `.env` files" contradicts `:525` in the same file.**

`:525` (from #409, refined in #414) says the worker's per-job enqueue path reads `ENRICHMENT_THRESHOLD` (`workers/tasks.py:237`). `:297` still said it survives only for old `.env` files. #409's commit message explicitly called out that "'not the gate' was too broad" — it corrected the env table and left this sentence, so the file gave two different answers depending on which section you landed in. Exactly the self-contradiction class the doc-sync guards were extended to catch, and one no guard can see because neither side is a number.

## A false-positive class in the new `constant_disagreements` guard

Worth recording, because it cost a red run here and will recur.

My first draft of finding 2 wrote the failure mode as `` `ENRICHMENT_MAX_JOBS=0` ``. `doc_sync_check.py` went **RED**:

```
| 02-search-and-match-engine.md | 469 | disagree:ENRICHMENT_MAX_JOBS | 0 | 20 at ...:165 |
```

The guard (`constant_disagreements`, added in #412) cannot distinguish **"set `X=0` to disable it"** — a failure-mode description — from **"`X` is 0"**, a claim about the constant's value. `=` is one of its binding tokens, so any doc that documents disabling a numeric setting by naming the value trips it.

I reworded to "a zero `ENRICHMENT_MAX_JOBS` budget" and the check went green, so **this PR needs no guard change**. But the pattern is worth knowing about before someone hits it and assumes their doc is wrong. If it recurs, the narrow fix is a negative lookbehind for an imperative context — `set`, `setting`, `with` — mirroring how `HISTORICAL` already exempts retired values:

```python
DISABLING = re.compile(r"\b(set(ting)?|with|use|using|pass(ing)?)\b[^.]{0,20}$", re.IGNORECASE)
# ... alongside the existing HISTORICAL check:
if DISABLING.search(line[max(0, m.start() - 30):m.start()]):
    continue
```

That is a proposal, not a change in this PR — the guard's own docstring warns that a permanent false alarm is how a loop dies, and widening its exemptions deserves its own review rather than riding along on a docs fix.

Note `:545` documents the same zero-budget precondition with the `=0` spelling and is **not** flagged, because the guard reports only the minority value across all LIVING docs and `20` currently wins. That makes the behaviour bistable: the same sentence is legal or illegal depending on how many other docs happen to state the default. Another reason the exemption belongs in the guard rather than in every author's head.

## Verification

```
python scripts/doc_sync_check.py               # No drift — OK (exit 0)
python scripts/doc_sync_check.py --budget-only # CLAUDE.md within size budget
python scripts/doc_sync_mutation_test.py       # All 22 guards proven able to go RED
```

One file, +3/−3, markdown only. Branch cut fresh from `origin/main` at `0610995`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013jzeFAen5L3PWx5yoGk5mQ

---
_Generated by [Claude Code](https://claude.ai/code/session_013jzeFAen5L3PWx5yoGk5mQ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how enrichment thresholds and job limits affect processing.
  * Documented that legacy employer type and location fields continue to receive default values.
  * Explained that enrichment lookups may return no results, with unreached jobs receiving neutral scoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->