### PR TITLE
fix(doc-sync): count LOCATIONS from the code — five docs agreed on a wrong number

### DIFF
--- a/scripts/doc_sync_check.py
+++ b/scripts/doc_sync_check.py
@@ -242,6 +242,40 @@ def migration_head() -> int:
     return max(_migration_pairs())
 
 
+def locations_count() -> int:
+    """Entries in LOCATIONS (backend/src/core/keywords.py). AST-strict.
+
+    Added 2026-08-25, and the reason matters more than the number. This repo
+    already had a `disagree:LOCATIONS` guard, and it was GREEN: it asks "do two
+    docs agree?", and five LIVING docs agreed perfectly -- on 25, when the list
+    holds 26. Cycle 14 caught it by counting the source.
+
+    Consensus is not verification. A doc-vs-doc check can only ever find
+    disagreement, never a shared falsehood, and shared falsehoods are exactly
+    what documentation drifts toward, because docs get copied from each other.
+    So this one counts the CODE, and the disagreement guard stays as the
+    cheaper net for facts no extractor owns.
+
+    The 26 includes "Remote" and "Hybrid", which `_location_score` skips when
+    matching (skill_matcher.py:277-278) -- they are workplace modes living in a
+    place list. Counted anyway: this guard reports what the list HOLDS, and a
+    doc wanting to say "24 places" should say so in those words.
+    """
+    tree = ast.parse((ROOT / "backend/src/core/keywords.py").read_text(encoding="utf-8"))
+    for node in tree.body:
+        targets: list[ast.expr] = []
+        if isinstance(node, ast.Assign):
+            targets = list(node.targets)
+        elif isinstance(node, ast.AnnAssign) and node.value is not None:
+            targets = [node.target]
+        for t in targets:
+            if getattr(t, "id", None) == "LOCATIONS":
+                if not isinstance(node.value, ast.List):
+                    raise RuntimeError("LOCATIONS is not a plain list literal")
+                return len(node.value.elts)
+    raise RuntimeError("LOCATIONS list literal not found in backend/src/core/keywords.py")
+
+
 def rate_limit_count() -> int:
     """Entries in RATE_LIMITS. Same AST-strict style as registry_counts().
 
@@ -1169,6 +1203,17 @@ def build_checks() -> tuple[list[tuple[str, int, str]], list[tuple[str, str, str
         # Second promotion batch, 2026-08-24, all found by the nightly routine
         # in the pillar docs and glossary -- the densest concentration of
         # countable facts in the repo, and until today none of them watched.
+        # Counted from the CODE, deliberately alongside the doc-vs-doc
+        # `disagree:LOCATIONS` net. That net was green while five LIVING docs
+        # agreed on 25 and the list held 26 -- agreement is not truth.
+        # UPPERCASE only, and that is the whole rule. A looser second pattern
+        # allowing the lowercase word fired on "top 8 titles x top 2 locations"
+        # (ARCHITECTURE.md:474, 01-user-pillar.md:286) -- a search-query fan-out
+        # that has nothing to do with the constant. Same lesson as the SOURCE
+        # guard, opposite direction: there, case-insensitivity hid a real lie;
+        # here, it invented two.
+        ("locations", locations_count(), r"`?LOCATIONS`?\s*\((\d+)\)"),
+        ("locations", locations_count(), r"(\d+)\s+entries in `?LOCATIONS`?\b"),
         ("rate-limits", rate_limit_count(), r"`?RATE_LIMITS`?[^.\n]{0,40}?\((\d+) entries"),
         ("rate-limits", rate_limit_count(), r"`?RATE_LIMITS`? dict in `?settings\.py`? \((\d+) entries"),
         ("subclasses", source_subclass_count(), r"checking all (\d+) subclasses"),

--- a/scripts/doc_sync_mutation_test.py
+++ b/scripts/doc_sync_mutation_test.py
@@ -164,6 +164,17 @@ CASES: list[tuple[str, str, str, str]] = [
     # claim, which is why thirteen cycles could never reach zero.
     ("STATUS.md",
      r"<!-- doc: (LIVING)", "<!-- doc: BOGUS", "unstamped-doc"),
+    # Ninth batch, 2026-08-25, and the most instructive promotion so far.
+    # `disagree:LOCATIONS` above was GREEN while FIVE living docs said 25 and
+    # the list held 26 -- because it asks "do two docs agree?", and they all
+    # agreed. Consensus is not verification: a doc-vs-doc check can only find
+    # disagreement, never a shared falsehood, and shared falsehoods are what
+    # docs drift toward because docs are copied from each other. The new guard
+    # counts the SOURCE. Both are kept: one is cheap and needs no extractor,
+    # the other is true.
+    ("ARCHITECTURE.md",
+     r"`LOCATIONS` \((\d+)\) \+ `VISA_KEYWORDS`", "`LOCATIONS` (999) + `VISA_KEYWORDS`",
+     "locations"),
 ]
 
 

--- a/scripts/doc_sync_mutation_test.py
+++ b/scripts/doc_sync_mutation_test.py
@@ -172,8 +172,15 @@ CASES: list[tuple[str, str, str, str]] = [
     # docs drift toward because docs are copied from each other. The new guard
     # counts the SOURCE. Both are kept: one is cheap and needs no extractor,
     # the other is true.
+    #
+    # Anchored on the BACKTICKED prose form at ARCHITECTURE.md:10, not the
+    # tree-diagram line at :53. The first draft targeted the tree line, whose
+    # `LOCATIONS (26) + VISA_KEYWORDS (8)` carries no backticks, and the drill
+    # said "guard watches nothing" instead of passing quietly -- the third time
+    # a drill has caught its own target being rewritten by someone else's fix.
     ("ARCHITECTURE.md",
-     r"`LOCATIONS` \((\d+)\) \+ `VISA_KEYWORDS`", "`LOCATIONS` (999) + `VISA_KEYWORDS`",
+     r"Only `LOCATIONS` \((\d+)\) and `VISA_KEYWORDS`",
+     "Only `LOCATIONS` (999) and `VISA_KEYWORDS`",
      "locations"),
 ]
 


### PR DESCRIPTION
## Consensus is not verification

Cycle 14 found `LOCATIONS` documented as **25** in five LIVING docs. The list holds **26** (`backend/src/core/keywords.py:28-55`). #421 fixed the prose.

The part worth keeping is *why no guard caught it*. A guard for this already existed, and it was **green**:

```
PASS  disagree:LOCATIONS   went RED when ARCHITECTURE.md lied
```

`disagree:LOCATIONS` asks **"do two docs agree?"** — and all five agreed. Perfectly. On a false number.

A doc-vs-doc check can only ever find *disagreement*, never a shared falsehood. And a shared falsehood is exactly what documentation drifts toward, because docs get copied from **each other** rather than from the source. The check was working as designed; the design had a blind spot the size of "everyone is wrong in the same direction."

## The fix

`locations_count()` counts the **source** via AST — same strict style as `registry_counts()` / `rate_limit_count()`: if `LOCATIONS` stops being a plain list literal it raises rather than guessing.

**Both guards stay.** The doc-vs-doc net is cheap and needs no extractor, so it covers facts nothing can count. This one is true. They answer different questions and neither replaces the other.

## The pattern is UPPERCASE-only, and that is load-bearing

A looser second pattern allowing the lowercase word fired on:

```
ARCHITECTURE.md:474        +-- search_queries: top 8 titles x top 2 locations
01-user-pillar.md:286      - **Search queries**: top 8 titles × 2 locations, capped at 16
```

A search-query fan-out with nothing to do with the constant. Removed — a guard that cries wolf gets ignored, which kills the loop.

This is the exact mirror of the `SOURCE_COUNT` guard, where **case-insensitivity was what hid a real lie** (`"ource" not in line` skipped the uppercase constant, so setting it to 99 left the report green). Same letter-case question, opposite correct answer, because one guard reads prose and the other reads a constant.

## On the 26

26 = 24 UK place/country names + `Remote` + `Hybrid`. `_location_score` skips the latter two when matching (`skill_matcher.py:277-278`), so only 24 can score the full 10.

This guard reports what the list **holds**. A doc wanting to say "24 places" should say that in those words — and after #421, they do. I checked cycle 14's arithmetic before trusting it; it was right.

## The drill re-anchor

The first anchor targeted the tree-diagram line at `ARCHITECTURE.md:53`, whose `LOCATIONS (26) + VISA_KEYWORDS (8)` carries no backticks. #421 rewrote both lines while this was being written, so the drill reported **"guard watches nothing"** rather than passing quietly.

That is the drill working. A mutation test that cannot find its target has two options: call the guard unproven, or silently succeed. Silently succeeding is how a guard rots — green forever while watching a string nobody writes any more. Third time this design has caught its own target being rewritten by someone else's fix (`suite-baseline` after #393, `stale-phrase` after #396).

## Verified

- `doc_sync_check.py` → **no drift** (green against #421's corrected docs — the loop closed: scout found it, docs fixed, guard now holds it without an LLM)
- `doc_sync_mutation_test.py` → **All 25 guards proven able to go RED**
- `agent-gate.sh` → PASS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Improved checks that keep documented location counts aligned with the application’s available locations.
  - Documentation validation now reports missing or incorrectly structured location data.

- **Tests**
  - Added mutation coverage to verify that incorrect location counts are detected automatically.
  - Strengthened safeguards against documentation drifting out of sync with the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->