### PR TITLE
docs: daily truth check

### DIFF
--- a/.claude/skills/health/SKILL.md
+++ b/.claude/skills/health/SKILL.md
@@ -28,9 +28,15 @@ You are the Job360 health checker. You ignore the backlog and missions entirely 
 - RED: ranking ignores the judge, judged coverage 0 on a fresh feed, or any engine throwing.
 
 ### Pillar 3 — Delivery
-- Auth round-trip: register-or-login the test account, GET /api/auth/me. (The route is
-  `/api/auth/me` — `auth.py:39` `APIRouter(prefix="/auth")` + `auth.py:336` `@router.get("/me")`,
-  mounted under `/api`. There is no bare `/api/me`; it 404s.)
+- Auth round-trip: POST /api/auth/register (new account) **then always** POST /api/auth/login,
+  and only then GET /api/auth/me carrying the `job360_session` cookie.
+  - `/register` deliberately does **not** log you in — `backend/src/api/routes/auth.py:208-212`
+    ("NEITHER path sets one — the user signs in next"), and it returns `RegisterResponse()`
+    with no `_set_session_cookie`. The only cookie-setter on this flow is `/login`
+    (`auth.py:296`). Skipping the login step gets a 401 from `/me`, which reads as auth
+    broken on a perfectly healthy system.
+  - The route is `/api/auth/me` — `backend/src/api/routes/auth.py:39` `APIRouter(prefix="/auth")`
+    + `auth.py:336` `@router.get("/me")`, mounted under `/api`. There is no bare `/api/me`; it 404s.
 - Dashboard loads (browser flavor) with zero console errors; verdict badges render.
 - Pipeline/actions endpoints respond; notification rules endpoint responds.
 - GREEN: all respond 2xx, console clean. RED: any 5xx on the happy path or auth broken.

--- a/.claude/skills/health/SKILL.md
+++ b/.claude/skills/health/SKILL.md
@@ -28,7 +28,9 @@ You are the Job360 health checker. You ignore the backlog and missions entirely 
 - RED: ranking ignores the judge, judged coverage 0 on a fresh feed, or any engine throwing.
 
 ### Pillar 3 — Delivery
-- Auth round-trip: register-or-login the test account, GET /api/me.
+- Auth round-trip: register-or-login the test account, GET /api/auth/me. (The route is
+  `/api/auth/me` — `auth.py:39` `APIRouter(prefix="/auth")` + `auth.py:336` `@router.get("/me")`,
+  mounted under `/api`. There is no bare `/api/me`; it 404s.)
 - Dashboard loads (browser flavor) with zero console errors; verdict badges render.
 - Pipeline/actions endpoints respond; notification rules endpoint responds.
 - GREEN: all respond 2xx, console clean. RED: any 5xx on the happy path or auth broken.

--- a/.claude/skills/health/SKILL.md
+++ b/.claude/skills/health/SKILL.md
@@ -33,10 +33,10 @@ You are the Job360 health checker. You ignore the backlog and missions entirely 
   - `/register` deliberately does **not** log you in — `backend/src/api/routes/auth.py:208-212`
     ("NEITHER path sets one — the user signs in next"), and it returns `RegisterResponse()`
     with no `_set_session_cookie`. The only cookie-setter on this flow is `/login`
-    (`auth.py:296`). Skipping the login step gets a 401 from `/me`, which reads as auth
+    (`backend/src/api/routes/auth.py:296`). Skipping the login step gets a 401 from `/me`, which reads as auth
     broken on a perfectly healthy system.
   - The route is `/api/auth/me` — `backend/src/api/routes/auth.py:39` `APIRouter(prefix="/auth")`
-    + `auth.py:336` `@router.get("/me")`, mounted under `/api`. There is no bare `/api/me`; it 404s.
+    + `backend/src/api/routes/auth.py:336` `@router.get("/me")`, mounted under `/api`. There is no bare `/api/me`; it 404s.
 - Dashboard loads (browser flavor) with zero console errors; verdict badges render.
 - Pipeline/actions endpoints respond; notification rules endpoint responds.
 - GREEN: all respond 2xx, console clean. RED: any 5xx on the happy path or auth broken.

--- a/STORY.md
+++ b/STORY.md
@@ -137,7 +137,7 @@ message to anyone.**
 ### The evaluation exists, and it is the best work in this repo
 
 I claimed relevance had never been measured. False, twice over. `backend/scripts/accuracy_audit.py`
-plus ten sibling scripts, and **six documented iterations** in `docs/engine_eval_audit_log.md`:
+plus ten sibling scripts, and **six documented iterations** in `harness/eval/engine_eval_audit_log.md`:
 
 - 100 gold-graded jobs, blind, shuffled, scores hidden from the grader
 - 16 engine combinations, bootstrap 95% CIs, paired significance tests

--- a/docs/harness/maintenance/DOC-MAINTENANCE.md
+++ b/docs/harness/maintenance/DOC-MAINTENANCE.md
@@ -115,7 +115,9 @@ report, but never edits them — memory hygiene is the session's own job.
 
 ## 6. Outputs this framework maintains
 
-- `docs/harness/maintenance/DOC-HEALTH.md` — scorecard from each Tier-3 audit:
+- `docs/harness/maintenance/DOC-HEALTH.md` — **written by the first Tier-3 audit; absent
+  until one runs**, so an unresolved link here is expected, not rot. This is the
+  destination `.claude/skills/doc-audit/SKILL.md:89` writes to. Scorecard from each audit:
   docs checked, drifts fixed, plans archived, gaps parked, modules undocumented.
 - `docs/harness/maintenance/PARKED.md` — the "code is behind the doc" list: intentions
   found in docs that are not yet implemented, each with source doc + date.

--- a/docs/harness/maintenance/DOC-MAINTENANCE.md
+++ b/docs/harness/maintenance/DOC-MAINTENANCE.md
@@ -115,7 +115,7 @@ report, but never edits them — memory hygiene is the session's own job.
 
 ## 6. Outputs this framework maintains
 
-- `docs/maintenance/DOC-HEALTH.md` — scorecard from each Tier-3 audit:
+- `docs/harness/maintenance/DOC-HEALTH.md` — scorecard from each Tier-3 audit:
   docs checked, drifts fixed, plans archived, gaps parked, modules undocumented.
 - `docs/harness/maintenance/PARKED.md` — the "code is behind the doc" list: intentions
   found in docs that are not yet implemented, each with source doc + date.

--- a/docs/product/DEPLOY.md
+++ b/docs/product/DEPLOY.md
@@ -32,10 +32,12 @@ The manual `railway up` recipe further down still works, but it is the fallback 
 
 ## 🟢 What's already done (no action needed)
 - Backend + frontend **Dockerfiles**, **`docker-compose.prod.yml`** (5 services) — validated.
-- App runs on **Postgres** (1608 tests green).
+- App runs on **Postgres**. (Test count deliberately not quoted here — measure it:
+  `cd backend && python -m pytest --collect-only -q -p no:randomly | tail -1`. The
+  merge-gate floor lives in one place, `CONTRIBUTING.md`, and only there.)
 - **`/health`, `/livez`, `/readyz`** + **env validation at boot** (fail-fast on missing prod secrets).
 - **DB backup script** (`backend/scripts/backup_db.py`).
-- All prod env values staged in the local `.env` (LLM keys, `SESSION_SECRET`, `CHANNEL_ENCRYPTION_KEY`, `SENTRY_DSN`, `POSTHOG_KEY`).
+- All prod env values staged in the local `.env` (LLM keys, `SESSION_SECRET`, `CHANNEL_ENCRYPTION_KEY`, `SENTRY_DSN`, `NEXT_PUBLIC_POSTHOG_KEY`).
 
 ## First-time provisioning (HISTORICAL — already done 2026-07-02)
 

--- a/docs/product/DEPLOY.md
+++ b/docs/product/DEPLOY.md
@@ -33,7 +33,7 @@ The manual `railway up` recipe further down still works, but it is the fallback 
 ## 🟢 What's already done (no action needed)
 - Backend + frontend **Dockerfiles**, **`docker-compose.prod.yml`** (5 services) — validated.
 - App runs on **Postgres**. (Test count deliberately not quoted here — measure it:
-  `cd backend && python -m pytest --collect-only -q -p no:randomly | tail -1`. The
+  `cd backend && python -m pytest --collect-only -q | tail -1`. The
   merge-gate floor lives in one place, `CONTRIBUTING.md`, and only there.)
 - **`/health`, `/livez`, `/readyz`** + **env validation at boot** (fail-fast on missing prod secrets).
 - **DB backup script** (`backend/scripts/backup_db.py`).

--- a/docs/product/MONETIZATION_GAPS.md
+++ b/docs/product/MONETIZATION_GAPS.md
@@ -22,7 +22,7 @@
 |---|---|---|
 | Product (features) | ~90% | engine + API + UI + auth + profiles + 4 scoring engines + control surface; 1,571 tests green |
 | Launch readiness (ship it live) | ~30% | no CI gate, no Dockerfile/deploy, no prod Redis+ARQ, no SES |
-| **Money layer (charge for it)** | **~5%** | **no Stripe, no billing, no plans, no pricing page, no analytics** |
+| **Money layer (charge for it)** | **~5%** | **no Stripe, no billing, no plans, no pricing page**, ~~no analytics~~ (analytics shipped since — see Tier 3) |
 
 **What already exists (the hard part is done):** the working product (CV → scored jobs → pipeline → notifications), auth/sessions, profiles, `/privacy` + `/terms` pages, GDPR account-delete (password-gated).
 

--- a/docs/product/MONETIZATION_GAPS.md
+++ b/docs/product/MONETIZATION_GAPS.md
@@ -18,6 +18,12 @@
 
 ## Where we are (code-verified 2026-06-22)
 
+> **The date above applies to the unannotated cells only.** Percentages and evidence
+> here are the 2026-06-22 reading and have NOT been re-verified since. Where a later
+> check found a cell stale it is ~~struck through~~ with its own date inline — those
+> annotations are 2026-08-25. Do not refresh the heading to today: that would claim a
+> re-audit of the percentages that nobody has done.
+
 | Dimension | % | Evidence |
 |---|---|---|
 | Product (features) | ~90% | engine + API + UI + auth + profiles + 4 scoring engines + control surface; ~~1,571 tests green~~ (that count was the 2026-06-22 reading and is long stale — measure it, never quote it: `cd backend && python -m pytest --collect-only -q \| tail -1`; the merge-gate floor lives only in `CONTRIBUTING.md`) |

--- a/docs/product/MONETIZATION_GAPS.md
+++ b/docs/product/MONETIZATION_GAPS.md
@@ -50,7 +50,7 @@
 
 | Missing | Why |
 |---|---|
-| ~~**Analytics + funnel**~~ **PARTLY SHIPPED** | PostHog **is** wired and consent-gated (`posthog-js` in `frontend/package.json:38`, mounted at `frontend/src/app/layout.tsx:66`, init at `PostHogProviderWrapper.tsx:61-80`), and the signup→activation funnel is instrumented: `signup_completed`, `cv_uploaded`, `extraction_completed`, `search_run`, `job_viewed`, `application_created`, `$pageview`. What REMAINS is the **paid → churn** half, which needs the Stripe work in Tier 1 — there is no revenue event to track yet. |
+| ~~**Analytics + funnel**~~ **PARTLY SHIPPED** | PostHog **is** wired and consent-gated (`posthog-js` in `frontend/package.json:38`, mounted at `frontend/src/app/layout.tsx:66`, init at `frontend/src/components/providers/PostHogProviderWrapper.tsx:61-80`), and the signup→activation funnel is instrumented: `signup_completed`, `cv_uploaded`, `extraction_completed`, `search_run`, `job_viewed`, `application_created`, `$pageview`. What REMAINS is the **paid → churn** half, which needs the Stripe work in Tier 1 — there is no revenue event to track yet. |
 | **Onboarding** | Get users to the "wow" (CV → first great matches) fast = activation = conversion. |
 | **Subscription management UI** | Upgrade / downgrade / cancel / invoices / billing history. |
 | **Lifecycle emails + support** | Welcome, trial-ending, payment-failed, receipts; a contact/support channel. |

--- a/docs/product/MONETIZATION_GAPS.md
+++ b/docs/product/MONETIZATION_GAPS.md
@@ -20,7 +20,7 @@
 
 | Dimension | % | Evidence |
 |---|---|---|
-| Product (features) | ~90% | engine + API + UI + auth + profiles + 4 scoring engines + control surface; 1,571 tests green |
+| Product (features) | ~90% | engine + API + UI + auth + profiles + 4 scoring engines + control surface; ~~1,571 tests green~~ (that count was the 2026-06-22 reading and is long stale — measure it, never quote it: `cd backend && python -m pytest --collect-only -q \| tail -1`; the merge-gate floor lives only in `CONTRIBUTING.md`) |
 | Launch readiness (ship it live) | ~30% | no CI gate, no Dockerfile/deploy, no prod Redis+ARQ, no SES |
 | **Money layer (charge for it)** | **~5%** | **no Stripe, no billing, no plans, no pricing page**, ~~no analytics~~ (analytics shipped since — see Tier 3) |
 

--- a/docs/product/MONETIZATION_GAPS.md
+++ b/docs/product/MONETIZATION_GAPS.md
@@ -50,7 +50,7 @@
 
 | Missing | Why |
 |---|---|
-| **Analytics + funnel** | No signup → activation → paid → churn tracking (no PostHog/GA). Can't optimize money you can't measure. |
+| ~~**Analytics + funnel**~~ **PARTLY SHIPPED** | PostHog **is** wired and consent-gated (`posthog-js` in `frontend/package.json:38`, mounted at `frontend/src/app/layout.tsx:66`, init at `PostHogProviderWrapper.tsx:61-80`), and the signup→activation funnel is instrumented: `signup_completed`, `cv_uploaded`, `extraction_completed`, `search_run`, `job_viewed`, `application_created`, `$pageview`. What REMAINS is the **paid → churn** half, which needs the Stripe work in Tier 1 — there is no revenue event to track yet. |
 | **Onboarding** | Get users to the "wow" (CV → first great matches) fast = activation = conversion. |
 | **Subscription management UI** | Upgrade / downgrade / cancel / invoices / billing history. |
 | **Lifecycle emails + support** | Welcome, trial-ending, payment-failed, receipts; a contact/support channel. |

--- a/docs/product/RUNBOOK-backups.md
+++ b/docs/product/RUNBOOK-backups.md
@@ -64,5 +64,5 @@ rm -f "job360-${TS}.sql.gz.gpg"
 - **Restore into a fresh DB first**, verify, then repoint the app — never blind-restore over live prod.
 - The dump is `--no-owner --no-privileges`, so it restores cleanly into a DB with a different role/owner than prod.
 - The pg client must be **≥ the prod server major version** (prod Postgres is 18.x — use psql 18).
-- **Retention is ~30 newest** (nightly ⇒ ~30 days). If you need older, it's already gone — there is no long-term archive. (Gap flagged in `docs/fable/04`: consider a second region + a monthly cold copy.)
+- **Retention is ~30 newest** (nightly ⇒ ~30 days). If you need older, it's already gone — there is no long-term archive. (Gap flagged in `docs/harness/fable/04-OPS-AND-RELIABILITY.md`: consider a second region + a monthly cold copy.)
 - **Do a restore drill quarterly** into a scratch DB so this procedure stays true and you stay practiced.

--- a/docs/product/troubleshooting.md
+++ b/docs/product/troubleshooting.md
@@ -47,7 +47,11 @@ one test writes to schema A while another reads schema B.
 # From the repo root. `make redis-up` starts the redis service ONLY
 # (Makefile:238 → `docker compose ... up -d redis`), so it does NOT fix this
 # symptom — postgres is a separate service in docker-compose.dev.yml:37.
-docker compose -f docker-compose.dev.yml up -d      # both: postgres + redis
+# `--wait` is load-bearing: plain `up -d` returns as soon as the container is
+# RUNNING, so pytest can start before postgres accepts connections and you get
+# this exact symptom back. `--wait` blocks on the pg_isready healthcheck at
+# docker-compose.dev.yml:50-54.
+docker compose -f docker-compose.dev.yml up -d --wait   # both: postgres + redis
 cd backend && python -m pytest -q -p no:randomly
 ```
 
@@ -220,9 +224,9 @@ python -m migrations.runner up
 > worked and changes nothing about 0010.
 
 > ⚠️ **`down` takes NO migration stem.** It reverts the *last applied* migration and
-> nothing else — `runner.py:281-297` reads `applied[-1]` and runs that stem's
+> nothing else — `backend/migrations/runner.py:281-297` reads `applied[-1]` and runs that stem's
 > `.down.sql`. The second positional argument is the **db_path**, not a selector
-> (`runner.py:395,399`: usage is `[up|down|status] [db_path]`, defaulting to
+> (`backend/migrations/runner.py:395,399`: usage is `[up|down|status] [db_path]`, defaulting to
 > `data/jobs.db`). So `python -m migrations.runner down 0010` does **not** target
 > migration 0010 — it swallows `0010` as a connection path and still reverts
 > whatever is at the head. Against a head of `0030` that reverts `0030`.

--- a/docs/product/troubleshooting.md
+++ b/docs/product/troubleshooting.md
@@ -196,12 +196,28 @@ cd backend && python -m pytest tests\ -v
 
 ```bash
 cd backend
-python -m migrations.runner status        # lists applied + pending
-# `down` reverts ONLY the most recently applied migration — one step, no argument.
-# To get back to 0010 you must step down repeatedly, checking `status` each time.
+python -m migrations.runner status        # lists applied + pending — read this FIRST
+```
+
+`down` pops exactly one migration off the HEAD, so what to do next depends on where
+the stem you want sits:
+
+```bash
+# CASE A — the stem you want re-run IS the head (status lists it last).
+# `down` reverts it, `up` re-applies it. This pair only does what you want here.
 python -m migrations.runner down
 python -m migrations.runner up
+
+# CASE B — the stem is BURIED (e.g. you want 0010 and head is 0030).
+# There is no way to reach it without reverting 0030…0011 first, one `down` at a
+# time, re-reading `status` between each. That is ~20 destructive down-migrations
+# against real data. In dev, rebuilding the database is almost always the right
+# call instead; in prod, do neither without a backup (docs/product/RUNBOOK-backups.md).
 ```
+
+> ⚠️ Running `down` then `up` while the stem you care about is buried undoes and
+> immediately re-applies the HEAD migration and nothing else — it looks like it
+> worked and changes nothing about 0010.
 
 > ⚠️ **`down` takes NO migration stem.** It reverts the *last applied* migration and
 > nothing else — `runner.py:281-297` reads `applied[-1]` and runs that stem's

--- a/docs/product/troubleshooting.md
+++ b/docs/product/troubleshooting.md
@@ -69,7 +69,8 @@ isolation, and the symptom looks like unrelated tests failing.
 ## 3. CV parse fails / LLM provider unreachable
 
 **Symptom:** `setup-profile --cv ...` errors with `LLMKeyMissing`, `LLMRateLimited` or
-`LLMAllProvidersFailed` — all subclasses of `LLMError` (`llm_provider.py:48,53,62,71`;
+`LLMAllProvidersFailed` — all subclasses of `LLMError`
+(`backend/src/services/profile/llm_provider.py:48,53,62,71`;
 there is no `LLMProviderError`) — or hangs with no output.
 
 **Cause:** No LLM API key set, or the first provider in the fallback chain is rate-limited.
@@ -82,7 +83,7 @@ GROQ_API_KEY=...
 CEREBRAS_API_KEY=...
 ```
 
-Fallback chain (`src/services/profile/llm_provider.py:329-334`): **OpenAI (PRIMARY)** → Gemini → Groq → Cerebras. If every configured provider fails, `llm_extract` raises `LLMRateLimited` (retry later) or `LLMAllProvidersFailed`; with no key at all it raises `LLMKeyMissing`. Callers must NOT persist an empty result on `LLMRateLimited`.
+Fallback chain (`backend/src/services/profile/llm_provider.py:329-334`): **OpenAI (PRIMARY)** → Gemini → Groq → Cerebras. If every configured provider fails, `llm_extract` raises `LLMRateLimited` (retry later) or `LLMAllProvidersFailed`; with no key at all it raises `LLMKeyMissing`. Callers must NOT persist an empty result on `LLMRateLimited`.
 
 Debug with:
 

--- a/docs/product/troubleshooting.md
+++ b/docs/product/troubleshooting.md
@@ -219,17 +219,14 @@ python -m migrations.runner up
 # call instead; in prod, do neither without a backup (docs/product/RUNBOOK-backups.md).
 ```
 
-> ⚠️ Running `down` then `up` while the stem you care about is buried undoes and
-> immediately re-applies the HEAD migration and nothing else — it looks like it
-> worked and changes nothing about 0010.
-
 > ⚠️ **`down` takes NO migration stem.** It reverts the *last applied* migration and
-> nothing else — `backend/migrations/runner.py:281-297` reads `applied[-1]` and runs that stem's
-> `.down.sql`. The second positional argument is the **db_path**, not a selector
-> (`backend/migrations/runner.py:395,399`: usage is `[up|down|status] [db_path]`, defaulting to
-> `data/jobs.db`). So `python -m migrations.runner down 0010` does **not** target
-> migration 0010 — it swallows `0010` as a connection path and still reverts
-> whatever is at the head. Against a head of `0030` that reverts `0030`.
+> nothing else — `backend/migrations/runner.py:281-297` reads `applied[-1]` and runs
+> that stem's `.down.sql`. The second positional argument is the **db_path**, not a
+> selector (`backend/migrations/runner.py:395,399`: usage is `[up|down|status] [db_path]`,
+> defaulting to `data/jobs.db`). So `python -m migrations.runner down 0010` does **not**
+> target migration 0010 — it swallows `0010` as a connection path and still reverts
+> whatever is at the head. Against a head of `0030` that reverts `0030`, and following
+> it with `up` re-applies `0030`: it looks like it worked and changes nothing about 0010.
 
 Migrations are forward-only by default, and `down` is one step at a time — there is
 no `down <stem>` and no `down --all`.

--- a/docs/product/troubleshooting.md
+++ b/docs/product/troubleshooting.md
@@ -44,7 +44,10 @@ one test writes to schema A while another reads schema B.
 **Fix:**
 
 ```bash
-make redis-up            # from the repo root; brings up the dev containers
+# From the repo root. `make redis-up` starts the redis service ONLY
+# (Makefile:238 → `docker compose ... up -d redis`), so it does NOT fix this
+# symptom — postgres is a separate service in docker-compose.dev.yml:37.
+docker compose -f docker-compose.dev.yml up -d      # both: postgres + redis
 cd backend && python -m pytest -q -p no:randomly
 ```
 
@@ -61,7 +64,9 @@ isolation, and the symptom looks like unrelated tests failing.
 
 ## 3. CV parse fails / LLM provider unreachable
 
-**Symptom:** `setup-profile --cv ...` errors with `LLMProviderError` or hangs with no output.
+**Symptom:** `setup-profile --cv ...` errors with `LLMKeyMissing`, `LLMRateLimited` or
+`LLMAllProvidersFailed` — all subclasses of `LLMError` (`llm_provider.py:48,53,62,71`;
+there is no `LLMProviderError`) — or hangs with no output.
 
 **Cause:** No LLM API key set, or the first provider in the fallback chain is rate-limited.
 
@@ -192,12 +197,22 @@ cd backend && python -m pytest tests\ -v
 ```bash
 cd backend
 python -m migrations.runner status        # lists applied + pending
-# If you need to re-apply 0010:
-python -m migrations.runner down 0010
+# `down` reverts ONLY the most recently applied migration — one step, no argument.
+# To get back to 0010 you must step down repeatedly, checking `status` each time.
+python -m migrations.runner down
 python -m migrations.runner up
 ```
 
-Migrations are forward-only by default. `down` is available per-stem and must be explicit — there is no `down --all`.
+> ⚠️ **`down` takes NO migration stem.** It reverts the *last applied* migration and
+> nothing else — `runner.py:281-297` reads `applied[-1]` and runs that stem's
+> `.down.sql`. The second positional argument is the **db_path**, not a selector
+> (`runner.py:395,399`: usage is `[up|down|status] [db_path]`, defaulting to
+> `data/jobs.db`). So `python -m migrations.runner down 0010` does **not** target
+> migration 0010 — it swallows `0010` as a connection path and still reverts
+> whatever is at the head. Against a head of `0030` that reverts `0030`.
+
+Migrations are forward-only by default, and `down` is one step at a time — there is
+no `down <stem>` and no `down --all`.
 
 ---
 

--- a/docs/product/troubleshooting.md
+++ b/docs/product/troubleshooting.md
@@ -75,12 +75,14 @@ there is no `LLMProviderError`) — or hangs with no output.
 
 **Cause:** No LLM API key set, or the first provider in the fallback chain is rate-limited.
 
-**Fix:** At least ONE of these must be set in `.env`:
+**Fix:** At least ONE of these four must be set in `.env` — the same four
+`LLM_KEY_VARS` names the key probe reads (`backend/src/services/profile/llm_provider.py:231-236`):
 
 ```
-GEMINI_API_KEY=...
-GROQ_API_KEY=...
-CEREBRAS_API_KEY=...
+OPENAI_API_KEY=...      # PRIMARY — heads the chain; set this one if you have it
+GEMINI_API_KEY=...      # free tier
+GROQ_API_KEY=...        # free tier
+CEREBRAS_API_KEY=...    # free tier
 ```
 
 Fallback chain (`backend/src/services/profile/llm_provider.py:329-334`): **OpenAI (PRIMARY)** → Gemini → Groq → Cerebras. If every configured provider fails, `llm_extract` raises `LLMRateLimited` (retry later) or `LLMAllProvidersFailed`; with no key at all it raises `LLMKeyMissing`. Callers must NOT persist an empty result on `LLMRateLimited`.


### PR DESCRIPTION
Scout pass over the 46 `<!-- doc: LIVING -->` docs. Both guards were green before and after (`scripts/doc_sync_check.py` → "No drift"; `scripts/doc_sync_mutation_test.py` → "All 24 guards proven able to go RED"), so nothing here duplicates them. Every claim was verified by opening the cited line in the code, never another doc.

## Fixes — `file:line — doc said X, code says Y`

**`docs/product/troubleshooting.md:196,200`** — doc said `python -m migrations.runner down 0010` re-applies migration 0010, and that "`down` is available per-stem". Code says `down` takes **no stem**: `backend/migrations/runner.py:281` is `async def down(db_path, ...)`, `:286` "Reverse the most recently applied migration", `:295-297` reads `applied[-1]` and runs that stem's `.down.sql`. `runner.py:395` prints usage `[up|down|status] [db_path]` and `:399` assigns `db_path = sys.argv[2]` — so `0010` is swallowed as a **connection path**, not a selector. Against a head of `0030` the documented command reverts `0030`. This is the worst kind of doc lie: a destructive command that runs successfully and does something else.

**`docs/product/troubleshooting.md:47`** — doc said the fix for *"Postgres connection / schema errors in tests"* is `make redis-up  # brings up the dev containers`. Code says `Makefile:238` runs `docker compose -f docker-compose.dev.yml up -d redis` — the **redis service only**. `docker-compose.dev.yml:37` declares `postgres` as a separate service that target never starts, so the very next line's `pytest` fails identically. (`backend/README.md:118` already describes this target honestly as "start Redis".)

**`docs/product/troubleshooting.md:64`** — doc said the symptom is `LLMProviderError`. Code says that name exists nowhere in the repo; the classes are `LLMError` / `LLMKeyMissing` / `LLMRateLimited` / `LLMAllProvidersFailed` (`backend/src/services/profile/llm_provider.py:48,53,62,71`) — which the same section's body already names correctly.

**`.claude/skills/health/SKILL.md:31`** — doc said the Pillar-3 auth round-trip is `GET /api/me`. Code says the route is `/api/auth/me` (`backend/src/api/routes/auth.py:39` `APIRouter(prefix="/auth")` + `:336` `@router.get("/me")`, mounted under `/api`); there is no bare `/api/me`. Every other LIVING doc says `/api/auth/me`. This one is an **instruction an agent executes nightly** — it would 404 and report Pillar 3 RED on a healthy system.

**`docs/product/DEPLOY.md:35`** — doc said "App runs on **Postgres** (1608 tests green)", undated, in a "What's already done" list. `CONTRIBUTING.md:83` states the guarded baseline as **3,297 collected / 3,295 selected as of 2026-08-24**, and `README.md:126`, `backend/README.md:86`, `STATUS.md:208`, `ARCHITECTURE.md:98` and `docs/product/pillars/03-job-providers.md:636` all say *measure it, never quote it*. Replaced with the measure-it command rather than another unverifiable number — this session has no Docker, so the suite could not be collected here.

**`docs/product/DEPLOY.md:38`** — doc said `POSTHOG_KEY`. Code says that name is read nowhere; it is `NEXT_PUBLIC_POSTHOG_KEY` (`frontend/src/components/providers/PostHogProviderWrapper.tsx:61`, `frontend/Dockerfile:16,20`).

**`docs/product/MONETIZATION_GAPS.md:64`** — doc listed as a Tier-3 gap: "No signup → activation → paid → churn tracking (**no PostHog**/GA)". Code says PostHog ships: `posthog-js` at `frontend/package.json:38`, mounted at `frontend/src/app/layout.tsx:66`, consent-gated init at `PostHogProviderWrapper.tsx:61-80` — and the signup→activation funnel is instrumented end to end (`signup_completed` `register/page.tsx:60`; `cv_uploaded` + `extraction_completed` `profile/page.tsx:199-200`; `search_run` `dashboard/page.tsx:409`; `job_viewed` `JobDetailClient.tsx:168`; `application_created` `ApplyButton.tsx:39`, `JobCard.tsx:135`; `$pageview` `PostHogProviderWrapper.tsx:40`). Struck through and narrowed to the half that is genuinely missing — **paid → churn**, which needs the Tier-1 Stripe work. This doc's own 2026-08-24 correction note names this exact failure: *"Listing shipped infrastructure as a gap is the expensive kind of stale: a reader goes and builds it twice."*

**Three paths that moved** — `docs/harness/maintenance/DOC-MAINTENANCE.md:118` said `docs/maintenance/DOC-HEALTH.md` while the very next bullet and the skill that writes the file (`.claude/skills/doc-audit/SKILL.md:89`) both say `docs/harness/maintenance/`; `STORY.md:140` said `docs/engine_eval_audit_log.md`, the file is at `harness/eval/engine_eval_audit_log.md`; `docs/product/RUNBOOK-backups.md:67` said `docs/fable/04`, the file is `docs/harness/fable/04-OPS-AND-RELIABILITY.md`. These are backticked paths, not markdown links, so the existing link sweep cannot see them.

## Promote to the guard

Two of the eight are countable and should stop being an LLM's nightly job.

**1. Sweep routes across every LIVING-*stamped* doc, not the `LIVING_DOCS` list.** `documented_routes_exist()` (`scripts/doc_sync_check.py:540`) is already correct — it assembles the path from all three places and handles negations. Its only blind spot is its input: it iterates `LIVING_DOCS` (15 files) while **46** docs carry a `<!-- doc: LIVING -->` stamp. I ran its exact logic over all 46 and it returned precisely one hit, the `/api/me` above — so widening it costs nothing and would have owned this finding for free.

```python
def _living_stamped_docs() -> list[str]:
    """Every doc that STAMPS itself LIVING — not just the hand-maintained list.

    LIVING_DOCS is what the countable guards watch; the stamp is what a doc
    CLAIMS about itself. A doc that says "I am LIVING" is asserting it is
    checkable, so the cheap structural guards should take it at its word.
    """
    out = []
    for p in sorted(ROOT.rglob("*.md")):
        if "node_modules" in p.parts or ".git" in p.parts:
            continue
        head = p.read_text(encoding="utf-8", errors="replace")[:4000]
        if re.search(r"<!--\s*doc:\s*LIVING", head):
            out.append(str(p.relative_to(ROOT)).replace("\\", "/"))
    return out
```

Then in `documented_routes_exist()` swap `for rel in LIVING_DOCS:` → `for rel in _living_stamped_docs():`. Mutation drill: flip `GET /api/auth/me` to `GET /api/me` in `.claude/skills/health/SKILL.md` and assert RED.

**2. Make the suite-baseline guard see phrasings other than "N collected", and sweep the stamped set too.** `collected_baseline_claims()` (`:714`) exists precisely to catch two docs disagreeing about the test count — the exact bug in `DEPLOY.md:35`. It missed twice over: its regex is `([\d,]{3,})\s+collected` and DEPLOY.md wrote "1608 tests green", and DEPLOY.md is outside `LIVING_DOCS`. Widen to `([\d,]{3,})\s+(?:collected|tests?\s+(?:green|passing))` and iterate `_living_stamped_docs()`. That turns "one baseline, stated the same everywhere, or red" into something actually enforced across the estate. Mutation drill: write "2000 tests green" into a second stamped doc and assert RED on the disagreement.

Both are pure-filesystem checks — no Postgres, no network — so they stay safe in the blocking CI step.

## Verification

- `python scripts/doc_sync_check.py` → **"No drift — every doc claim matches the code, all stamps fresh. OK"** (exit 0), before and after.
- `python scripts/doc_sync_mutation_test.py` → **"All 24 guards proven able to go RED"**, before and after.
- All 308 `file.py:NN` citations across the 46 stamped docs were extracted and each cited line re-read: no missing files, no out-of-range lines, no line that had drifted off its claim.
- Docs only — no code touched, nothing deleted or renamed. `PLAN`/`LOG`/`REFERENCE`/`FROZEN` docs were not read for drift and not edited; every file with a stamp was checked, and none was unstamped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NLhyUGTbp2esc6C9rLHFky


---
_Generated by [Claude Code](https://claude.ai/code/session_01NLhyUGTbp2esc6C9rLHFky)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated authentication guidance to cover registration, login, session cookies, and the correct `/api/auth/me` endpoint.
  - Corrected evaluation, maintenance, backup, and deployment documentation references.
  - Replaced outdated test-count guidance with instructions to check the current total and merge-gate requirement.
  - Updated local analytics configuration and clarified implemented PostHog tracking and remaining coverage gaps.
  - Improved troubleshooting for PostgreSQL and Redis setup, LLM errors, API keys, provider configuration, and migration rollbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->