### PR TITLE
fix(doc-sync): a guard is only as wide as what you feed it

### DIFF
--- a/docs/product/MONETIZATION_GAPS.md
+++ b/docs/product/MONETIZATION_GAPS.md
@@ -20,7 +20,7 @@
 
 | Dimension | % | Evidence |
 |---|---|---|
-| Product (features) | ~90% | engine + API + UI + auth + profiles + 4 scoring engines + control surface; 1,571 tests green |
+| Product (features) | ~90% | engine + API + UI + auth + profiles + 4 scoring engines + control surface; test suite green — measure the count with `python -m pytest --collect-only -q | tail -1`, never quote it |
 | Launch readiness (ship it live) | ~30% | no CI gate, no Dockerfile/deploy, no prod Redis+ARQ, no SES |
 | **Money layer (charge for it)** | **~5%** | **no Stripe, no billing, no plans, no pricing page, no analytics** |
 

--- a/scripts/doc_sync_check.py
+++ b/scripts/doc_sync_check.py
@@ -482,6 +482,64 @@ def landing_page_source_claims() -> list[tuple[int, int]]:
 
 
 DOC_KINDS = ("LIVING", "PLAN", "LOG", "REFERENCE", "FROZEN")
+_LIVING_STAMPED_CACHE: list[str] | None = None
+
+
+def living_stamped_docs() -> list[str]:
+    """Every doc that STAMPS itself LIVING — not just the hand-kept list.
+
+    Proposed by cycle 15, which found the hole by measuring: `LIVING_DOCS` has
+    15 entries while 46 docs carry `<!-- doc: LIVING -->`. The route guard's
+    LOGIC was right; its INPUT was narrower than the thing it judged, so
+    `.claude/skills/health/SKILL.md:31` could tell an agent to call a route
+    (`GET /api/me`) that has never existed, and the guard never looked.
+
+    That is the third appearance of one shape today -- a 400-char stamp window
+    that missed stamps below long front matter, a doc-vs-doc check that could
+    only see disagreement, and this. A guard is only as wide as what you feed
+    it, and the width is the part nobody re-reads.
+
+    LIVING_DOCS stays for the COUNTABLE guards: those need a curated list,
+    because a number in an unexpected file is usually a quotation, not a claim.
+    The structural guards take a doc at its word instead -- a file that says it
+    is LIVING is asserting it is checkable.
+
+    Asks git, not the filesystem. The first cut used `ROOT.rglob("*.md")` and
+    filtered `node_modules` out afterwards -- but rglob WALKS a directory
+    before the filter can reject it, and this check runs in the blocking CI
+    step. It went from under a second to over two minutes. `git ls-files`
+    never descends there, and it agrees with `unstamped_docs()` about what
+    "tracked" means, so the two guards cannot disagree about the estate.
+
+    Memoised: three guards call this now, and the answer cannot change inside
+    a run.
+    """
+    global _LIVING_STAMPED_CACHE
+    if _LIVING_STAMPED_CACHE is not None:
+        return _LIVING_STAMPED_CACHE
+
+    try:
+        listing = subprocess.run(
+            ["git", "ls-files", "*.md"], cwd=ROOT,
+            capture_output=True, encoding="utf-8", check=True,
+        ).stdout
+    except (OSError, subprocess.SubprocessError):
+        _LIVING_STAMPED_CACHE = list(LIVING_DOCS)   # fall back to the curated list
+        return _LIVING_STAMPED_CACHE
+
+    stamp = re.compile(r"<!--\s*doc:\s*LIVING")
+    out: list[str] = []
+    for rel in listing.splitlines():
+        rel = rel.strip()
+        if not rel:
+            continue
+        path = ROOT / rel
+        if not path.exists():
+            continue
+        if stamp.search(path.read_text(encoding="utf-8", errors="replace")[:4000]):
+            out.append(rel)
+    _LIVING_STAMPED_CACHE = out
+    return out
 
 
 def unstamped_docs() -> list[str]:
@@ -611,7 +669,7 @@ def documented_routes_exist() -> list[tuple[str, str, str]]:
         r"was removed|no longer|instead of|not\s+`?[A-Z]{3,6}\s+/api)\b", re.I)
     cited = re.compile(r"\b(GET|POST|PUT|PATCH|DELETE)\s+`?(/api/[A-Za-z0-9_{}/\-]+)")
     out: list[tuple[str, str, str]] = []
-    for rel in LIVING_DOCS:
+    for rel in living_stamped_docs():
         path = ROOT / rel
         if not path.exists():
             continue
@@ -765,9 +823,13 @@ def collected_baseline_claims() -> list[tuple[str, str, int]]:
     Consistency is checkable without a database. One baseline, stated the same
     everywhere, or red.
     """
-    pat = re.compile(r"([\d,]{3,})\s+collected")
+    # "N collected" was the only phrasing watched, and DEPLOY.md:35 wrote
+    # "1608 tests green" -- a test count in a doc that had never been read
+    # against the others, missing this guard twice over: wrong words AND
+    # outside the list it swept. Cycle 15 found it. Both holes closed here.
+    pat = re.compile(r"([\d,]{3,})\s+(?:collected|tests?\s+(?:green|passing))")
     out: list[tuple[str, str, int]] = []
-    for rel in LIVING_DOCS:
+    for rel in living_stamped_docs():
         path = ROOT / rel
         if not path.exists():
             continue


### PR DESCRIPTION
Cycle 15 measured the hole: `LIVING_DOCS` has **15** entries while **46** docs carry a `<!-- doc: LIVING -->` stamp. `documented_routes_exist()` and `collected_baseline_claims()` were both correct and both blind — their **input** was narrower than the estate they judged.

That is the third appearance of one shape today:

| Guard | Logic | Width |
|---|---|---|
| stamp presence | fine | 400-char window missed stamps below long front matter |
| `disagree:LOCATIONS` | fine | could only see disagreement, never five docs agreeing on a false number |
| routes / suite-baseline | fine | swept 15 files out of 46 |

The logic gets reviewed. The width never does.

## What changed

Both structural guards now sweep `living_stamped_docs()` — every file that says of itself that it is LIVING, and is therefore claiming to be checkable.

`LIVING_DOCS` stays for the **countable** guards: a number in an unexpected file is usually a quotation, not a claim. `constant_disagreements()` stays on the curated list for the same reason.

The suite-baseline regex also only ever watched `N collected`, so `DEPLOY.md:35`'s "1608 tests green" missed it **twice over** — wrong words *and* outside the swept set. Widened to accept `tests green` / `tests passing`.

## It earned immediately

Together the two widenings caught `MONETIZATION_GAPS.md:23` ("1,571 tests green") — which **cycle 15 itself did not find**. Neither widening alone would have seen it. Replaced with the measure-it command rather than a fresh unverifiable number.

## Performance, learned the hard way

The first cut used `ROOT.rglob("*.md")` and filtered `node_modules` out afterwards. **rglob walks a directory before the filter can reject it**, and this runs in the *blocking* CI step — it went from under a second to over two minutes.

It asks `git ls-files` now, which never descends there and agrees with `unstamped_docs()` about what "tracked" means, so the two guards cannot disagree about the estate. Memoised; three guards call it.

## Verified

- `doc_sync_check.py` → the only remaining rows are the two #423 fixes
- `doc_sync_mutation_test.py` → **All 25 guards proven able to go RED**
- `agent-gate.sh` → PASS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated product-readiness guidance to reference the current collected test count rather than a fixed figure.
  * Improved documentation checks to keep living documentation and test-status statements aligned with the latest project state.

* **Bug Fixes**
  * Documentation validation now recognises additional wording for successful test results, reducing false warnings during checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->