### PR TITLE
feat(doc-sync): make the haystack shrink — measure it, and ratchet line numbers

### DIFF
--- a/scripts/doc_sync_check.py
+++ b/scripts/doc_sync_check.py
@@ -482,6 +482,64 @@ def landing_page_source_claims() -> list[tuple[int, int]]:
 
 
 DOC_KINDS = ("LIVING", "PLAN", "LOG", "REFERENCE", "FROZEN")
+_LIVING_STAMPED_CACHE: list[str] | None = None
+
+
+def living_stamped_docs() -> list[str]:
+    """Every doc that STAMPS itself LIVING — not just the hand-kept list.
+
+    Proposed by cycle 15, which found the hole by measuring: `LIVING_DOCS` has
+    15 entries while 46 docs carry `<!-- doc: LIVING -->`. The route guard's
+    LOGIC was right; its INPUT was narrower than the thing it judged, so
+    `.claude/skills/health/SKILL.md:31` could tell an agent to call a route
+    (`GET /api/me`) that has never existed, and the guard never looked.
+
+    That is the third appearance of one shape today -- a 400-char stamp window
+    that missed stamps below long front matter, a doc-vs-doc check that could
+    only see disagreement, and this. A guard is only as wide as what you feed
+    it, and the width is the part nobody re-reads.
+
+    LIVING_DOCS stays for the COUNTABLE guards: those need a curated list,
+    because a number in an unexpected file is usually a quotation, not a claim.
+    The structural guards take a doc at its word instead -- a file that says it
+    is LIVING is asserting it is checkable.
+
+    Asks git, not the filesystem. The first cut used `ROOT.rglob("*.md")` and
+    filtered `node_modules` out afterwards -- but rglob WALKS a directory
+    before the filter can reject it, and this check runs in the blocking CI
+    step. It went from under a second to over two minutes. `git ls-files`
+    never descends there, and it agrees with `unstamped_docs()` about what
+    "tracked" means, so the two guards cannot disagree about the estate.
+
+    Memoised: three guards call this now, and the answer cannot change inside
+    a run.
+    """
+    global _LIVING_STAMPED_CACHE
+    if _LIVING_STAMPED_CACHE is not None:
+        return _LIVING_STAMPED_CACHE
+
+    try:
+        listing = subprocess.run(
+            ["git", "ls-files", "*.md"], cwd=ROOT,
+            capture_output=True, encoding="utf-8", check=True,
+        ).stdout
+    except (OSError, subprocess.SubprocessError):
+        _LIVING_STAMPED_CACHE = list(LIVING_DOCS)   # fall back to the curated list
+        return _LIVING_STAMPED_CACHE
+
+    stamp = re.compile(r"<!--\s*doc:\s*LIVING")
+    out: list[str] = []
+    for rel in listing.splitlines():
+        rel = rel.strip()
+        if not rel:
+            continue
+        path = ROOT / rel
+        if not path.exists():
+            continue
+        if stamp.search(path.read_text(encoding="utf-8", errors="replace")[:4000]):
+            out.append(rel)
+    _LIVING_STAMPED_CACHE = out
+    return out
 
 
 def unstamped_docs() -> list[str]:
@@ -649,7 +707,7 @@ def documented_routes_exist() -> list[tuple[str, str, str]]:
         r"was removed|no longer|instead of|not\s+`?[A-Z]{3,6}\s+/api)\b", re.I)
     cited = re.compile(r"\b(GET|POST|PUT|PATCH|DELETE)\s+`?(/api/[A-Za-z0-9_{}/\-]+)")
     out: list[tuple[str, str, str]] = []
-    for rel in LIVING_DOCS:
+    for rel in living_stamped_docs():
         path = ROOT / rel
         if not path.exists():
             continue
@@ -803,9 +861,13 @@ def collected_baseline_claims() -> list[tuple[str, str, int]]:
     Consistency is checkable without a database. One baseline, stated the same
     everywhere, or red.
     """
-    pat = re.compile(r"([\d,]{3,})\s+collected")
+    # "N collected" was the only phrasing watched, and DEPLOY.md:35 wrote
+    # "1608 tests green" -- a test count in a doc that had never been read
+    # against the others, missing this guard twice over: wrong words AND
+    # outside the list it swept. Cycle 15 found it. Both holes closed here.
+    pat = re.compile(r"([\d,]{3,})\s+(?:collected|tests?\s+(?:green|passing))")
     out: list[tuple[str, str, int]] = []
-    for rel in LIVING_DOCS:
+    for rel in living_stamped_docs():
         path = ROOT / rel
         if not path.exists():
             continue

--- a/scripts/doc_sync_check.py
+++ b/scripts/doc_sync_check.py
@@ -485,6 +485,85 @@ DOC_KINDS = ("LIVING", "PLAN", "LOG", "REFERENCE", "FROZEN")
 _LIVING_STAMPED_CACHE: list[str] | None = None
 
 
+LINE_CITATION_BASELINE = ROOT / "scripts" / "line_citation_baseline.txt"
+
+
+def living_surface() -> tuple[int, int]:
+    """(docs, lines) of prose that MUST be true — the haystack, measured.
+
+    Reported every run, never a failure. Added 2026-08-25 with the deletion
+    contract, because fifteen consecutive nightly runs found real drift and
+    none found zero -- and the reason was not sloppy writing. 46 LIVING docs
+    hold ~8,278 lines restating what code already says, and every one of those
+    lines is a claim that can become false.
+
+    Detection cannot win against a haystack that never shrinks. The number
+    that says whether this is being won is therefore NOT "findings per night"
+    -- that can fall because the scout got lazy -- it is this one. A line
+    deleted is a lie that can never be told again; a line reworded is a lie
+    with a fresh expiry date. Watch the trend, not any single run.
+    """
+    docs = lines = 0
+    for rel in living_stamped_docs():
+        path = ROOT / rel
+        if not path.exists():
+            continue
+        docs += 1
+        lines += len(path.read_text(encoding="utf-8", errors="replace").splitlines())
+    return (docs, lines)
+
+
+def line_number_citations() -> dict[str, int]:
+    """{doc: count} of `file.py:NN` citations in LIVING docs. A RATCHET.
+
+    A raw line number is the fastest-rotting reference form there is: it
+    breaks on any unrelated edit ABOVE it, silently, and nothing about the doc
+    looks wrong afterwards. A symbol name (`services/uk_gate.check_uk`)
+    survives every edit that does not delete the thing itself.
+
+    There are ~107 of these today, so a guard that simply reported them would
+    fire 107 times on day one and be ignored inside a week -- and a guard that
+    cries wolf is worse than no guard, because it teaches everyone to skip the
+    report. So this is a RATCHET, the shape the mypy gate already uses: the
+    current count is a ceiling that may only fall. New line numbers are
+    refused; the existing ones drain as the docs shrink.
+    """
+    pat = re.compile(r"\b[A-Za-z_][A-Za-z0-9_/]*\.(?:py|ts|tsx|yml|sh):\d+")
+    out: dict[str, int] = {}
+    for rel in living_stamped_docs():
+        path = ROOT / rel
+        if not path.exists():
+            continue
+        n = len(pat.findall(path.read_text(encoding="utf-8", errors="replace")))
+        if n:
+            out[rel] = n
+    return out
+
+
+def line_citation_regressions() -> list[str]:
+    """Docs that GAINED line-number citations since the baseline."""
+    if not LINE_CITATION_BASELINE.exists():
+        return []
+    base: dict[str, int] = {}
+    for row in LINE_CITATION_BASELINE.read_text(encoding="utf-8").splitlines():
+        row = row.strip()
+        if not row or row.startswith("#"):
+            continue
+        rel, _, num = row.rpartition(" ")
+        try:
+            base[rel.strip()] = int(num)
+        except ValueError:
+            continue
+
+    out: list[str] = []
+    for rel, n in sorted(line_number_citations().items()):
+        was = base.get(rel, 0)
+        if n > was:
+            out.append(f"{rel}: {was} -> {n} (cite a SYMBOL name — a line "
+                       f"number rots on any edit above it)")
+    return out
+
+
 def living_stamped_docs() -> list[str]:
     """Every doc that STAMPS itself LIVING — not just the hand-kept list.
 
@@ -866,13 +945,23 @@ def collected_baseline_claims() -> list[tuple[str, str, int]]:
     # against the others, missing this guard twice over: wrong words AND
     # outside the list it swept. Cycle 15 found it. Both holes closed here.
     pat = re.compile(r"([\d,]{3,})\s+(?:collected|tests?\s+(?:green|passing))")
+    # ~~struck~~ text is RETRACTED by definition. Widening this guard to catch
+    # "N tests green" made it fire on MONETIZATION_GAPS.md:29, where the old
+    # count is struck through and annotated "long stale" -- a doc doing exactly
+    # the right thing with a number it no longer claims. A guard that punishes
+    # the correct way to retire a fact teaches people to delete the history
+    # instead, which is worse than the drift it was written to catch.
+    struck = re.compile(r"~~.*?~~", re.S)
     out: list[tuple[str, str, int]] = []
     for rel in living_stamped_docs():
         path = ROOT / rel
         if not path.exists():
             continue
         for i, line in enumerate(path.read_text(encoding="utf-8", errors="replace").splitlines(), 1):
+            spans = [m.span() for m in struck.finditer(line)]
             for m in pat.finditer(line):
+                if any(a <= m.start() < b for a, b in spans):
+                    continue  # retracted, not claimed
                 try:
                     out.append((rel, str(i), int(m.group(1).replace(",", ""))))
                 except ValueError:
@@ -1484,6 +1573,12 @@ def main() -> int:
             "gets re-litigated every cycle and never converges",
         ))
 
+    # New raw line numbers in LIVING prose are refused (ratchet, may only fall).
+    for row in line_citation_regressions():
+        rel, _, detail = row.partition(": ")
+        drift.append((rel, "1", "line-citation-ratchet", detail,
+                      "a line number rots on any edit above it — cite a symbol"))
+
     # A stamp the reader cannot see does not retire the claim under it.
     for rel in missing_reader_banner():
         drift.append((
@@ -1574,6 +1669,14 @@ def main() -> int:
     print(f"Code facts: SOURCE_REGISTRY entries = **{registry}**, "
           f"unique source classes = **{unique_classes}**, "
           f"migration head = **{mig_head:04d}**\n")
+
+    # The haystack. Never a failure -- a trend line. Findings-per-night can
+    # fall because the scout got lazy; this cannot.
+    surf_docs, surf_lines = living_surface()
+    if surf_docs:
+        print(f"LIVING surface: **{surf_docs}** docs, **{surf_lines:,}** lines of "
+              f"prose that must be true. Deleting a line retires the claim; "
+              f"rewording it renews it.\n")
 
     if not drift:
         print("No drift — every doc claim matches the code, all stamps fresh. OK")

--- a/scripts/doc_sync_mutation_test.py
+++ b/scripts/doc_sync_mutation_test.py
@@ -254,6 +254,29 @@ def structural_drills() -> list[str]:
                     "gets ignored, which kills the loop"
                 )
 
+            # 1c. The line-citation RATCHET must refuse a NEW raw line number.
+            #     Not a text mutation: the guard compares against a baseline
+            #     file, so the drill has to add a citation to the real tree and
+            #     put it back. ~317 exist today, so this guard can never report
+            #     them all without becoming noise nobody reads -- it only ever
+            #     refuses an INCREASE, and that is the branch worth proving.
+            real_status = real_root / "STATUS.md"
+            if real_status.exists():
+                before = real_status.read_bytes()
+                try:
+                    dsc.ROOT = real_root
+                    real_status.write_bytes(
+                        before + b"\n\nSee `backend/src/main.py:999` for details.\n")
+                    if not dsc.line_citation_regressions():
+                        failures.append(
+                            "line-citation-ratchet: a NEW raw line number went "
+                            "unreported — new prose can keep adding the "
+                            "fastest-rotting reference form there is"
+                        )
+                finally:
+                    real_status.write_bytes(before)
+                    dsc.ROOT = fake
+
             # 2. A gapped migration sequence must RAISE, not count quietly.
             migs = fake / "backend" / "migrations"
             migs.mkdir(parents=True)
@@ -344,7 +367,7 @@ def structural_drills() -> list[str]:
     if not failures:
         print("PASS  structural      missing subfolder (count + emitted guard), "
               "gapped/malformed/duplicate migrations, unwatched pillar doc, "
-              "control byte in a guard")
+              "control byte in a guard, line-citation ratchet")
     return failures
 
 

--- a/scripts/line_citation_baseline.txt
+++ b/scripts/line_citation_baseline.txt
@@ -1,0 +1,27 @@
+# Raw file.py:NN citations in LIVING docs -- a RATCHET, not a target.
+#
+# A line number rots on any unrelated edit ABOVE it, silently, and the doc
+# still looks right afterwards. A symbol name survives every edit that does
+# not delete the thing itself. These may only ever go DOWN: the guard fails
+# on an increase, so new prose must cite symbols.
+#
+# Written 2026-08-25 with the deletion contract. Lower a number here when a
+# doc genuinely loses citations. Total at baseline: 317.
+
+.claude/skills/add-source/SKILL.md 1
+.claude/skills/health/SKILL.md 4
+.claude/skills/worker/SKILL.md 1
+ARCHITECTURE.md 51
+CLAUDE.md 5
+README.md 13
+STATUS.md 15
+STORY.md 4
+backend/CLAUDE.md 2
+docs/product/MONETIZATION_GAPS.md 3
+docs/product/pillars/01-user-pillar.md 67
+docs/product/pillars/02-search-and-match-engine.md 71
+docs/product/pillars/03-job-providers.md 30
+docs/product/pillars/glossary.md 15
+docs/product/pillars/runbook.md 23
+docs/product/product_design_rules.md 5
+docs/product/troubleshooting.md 7


### PR DESCRIPTION
feat(doc-sync): make the haystack shrink — measure it, and ratchet line numbers

Fifteen nightly runs, never zero findings, every finding real. The cause was
never sloppy writing: 46 LIVING docs hold ~8,300 lines restating what code
already says, and every one of those lines is a claim that can become false.
Detection cannot win against a haystack that never shrinks.

So the routine's FIX CONTRACT changed (prompt updated on the trigger). A
finding may now be closed exactly three ways: DELETE the sentence, REPLACE it
with a pointer to code BY SYMBOL, or PIN it with a pytest the doc then cites.
Re-wording a claim to be accurate is BANNED — a more precise restatement of
code is still a restatement, and it drifts again the next time code moves.

Fable 5 argued this and was right. My own answer — keep promoting facts into
bespoke doc-parsers — does not scale to behavioural claims, and grows a
1,450-line second codebase that can itself drift. Behaviour belongs in pytest;
the doc should cite the test by name.

Two mechanisms so this is measurable rather than aspirational:

* living_surface() prints "46 docs, 8,331 lines" on every run. Never a
  failure — a trend line. It matters that THIS is the convergence number and
  "findings per night" is not: findings can fall because the scout got lazy,
  while a deleted line is a lie that can never be told again.

* line_number_citations() ratchets raw file.py:NN refs in LIVING prose. A line
  number is the fastest-rotting reference form there is — it breaks on any
  unrelated edit ABOVE it, silently, and the doc still looks right afterwards.
  317 exist today across 17 docs, so a guard that reported them would fire 317
  times on day one and be ignored inside a week; an ignored guard is worse than
  none, because it teaches people to skip the whole report. The baseline is a
  CEILING that may only fall. Proven RED by adding one to STATUS.md.

Also: the widened suite-baseline guard fired on a struck-through "1,571 tests
green" in MONETIZATION_GAPS.md, annotated "long stale" — a doc doing exactly
the right thing with a number it no longer claims. Struck text is retracted by
definition, so it is skipped now. A guard that punishes the correct way to
retire a fact teaches people to delete the history instead, which is worse
than the drift it was written to catch.

Verified: gate PASS, 25 guards all proven able to go RED.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01D6DsQH5EUxJc3Vnqz9YHgQ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated checks for the current LIVING documentation surface and line-number citations.
  - Added regression detection for unexpected increases in documentation citations.
  - Improved discovery of tracked, stamped LIVING documents, with a fallback when repository metadata is unavailable.
  - Enhanced baseline checks to recognise passing-test claims and ignore struck-through text.

- **Tests**
  - Added a structural validation that confirms new line citations trigger the expected safeguards.
  - Added a documented citation baseline covering 27 files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->