### PR TITLE
feat(doc-sync): the haystack may not grow — a ratchet on the LIVING surface

### DIFF
--- a/scripts/doc_sync_check.py
+++ b/scripts/doc_sync_check.py
@@ -486,6 +486,49 @@ _LIVING_STAMPED_CACHE: list[str] | None = None
 
 
 LINE_CITATION_BASELINE = ROOT / "scripts" / "line_citation_baseline.txt"
+SURFACE_CEILING = ROOT / "scripts" / "living_surface_ceiling.txt"
+
+
+def surface_regression() -> list[str]:
+    """The LIVING surface may not GROW. A ratchet on the haystack itself.
+
+    Added 2026-08-25, after cycle 16 became the first run in sixteen to shrink
+    the surface (8,331 -> 8,317). Until then "delete, do not reword" lived only
+    in the routine's prompt, and a prompt is a request, not an enforcement --
+    the next writer, human or model, adds a paragraph and the haystack grows
+    back without anyone noticing.
+
+    The ceiling is the honest number to guard because it is the one that cannot
+    be gamed by the scout: findings-per-night falls if the scout gets lazy, but
+    lines only fall if prose is actually removed.
+
+    Deliberately NOT a hard cap on new prose. A doc explaining WHY -- the
+    product rules, the reasoning code cannot hold -- is the content worth
+    having, and this guard would block it. So the ceiling is raised by editing
+    the file, in a commit that has to say what was added and why. The cost is
+    one deliberate line; the benefit is that growth is never accidental.
+    """
+    docs, lines = living_surface()
+    if not docs or not SURFACE_CEILING.exists():
+        return []
+    for row in SURFACE_CEILING.read_text(encoding="utf-8").splitlines():
+        row = row.strip()
+        if not row or row.startswith("#"):
+            continue
+        try:
+            ceiling = int(row.replace(",", ""))
+        except ValueError:
+            continue
+        if lines > ceiling:
+            return [
+                f"LIVING surface grew to {lines:,} lines, ceiling is {ceiling:,}. "
+                f"Close findings by DELETING prose or pointing at a symbol, not by "
+                f"rewording. If the new lines are genuinely WHY (not a restatement "
+                f"of code), raise the ceiling in scripts/living_surface_ceiling.txt "
+                f"and say what you added."
+            ]
+        return []
+    return []
 
 
 def living_surface() -> tuple[int, int]:
@@ -1572,6 +1615,12 @@ def main() -> int:
             "a doc that never declares LIVING/PLAN/LOG/REFERENCE/FROZEN "
             "gets re-litigated every cycle and never converges",
         ))
+
+    # The haystack itself may not grow. "Delete, do not reword" was only a line
+    # in the routine's prompt until now, and a prompt is a request.
+    for row in surface_regression():
+        drift.append(("scripts/living_surface_ceiling.txt", "1", "surface-ratchet",
+                      f"{living_surface()[1]:,} lines", row))
 
     # New raw line numbers in LIVING prose are refused (ratchet, may only fall).
     for row in line_citation_regressions():

--- a/scripts/doc_sync_mutation_test.py
+++ b/scripts/doc_sync_mutation_test.py
@@ -277,6 +277,29 @@ def structural_drills() -> list[str]:
                     real_status.write_bytes(before)
                     dsc.ROOT = fake
 
+            # 1d. The SURFACE ratchet must refuse prose GROWTH. This is the one
+            #     guard that enforces the deletion contract itself: without it,
+            #     "delete, do not reword" is a request in a prompt, and the next
+            #     writer grows the haystack back without anyone noticing.
+            real_status = real_root / "STATUS.md"
+            if real_status.exists() and (real_root / "scripts" / "living_surface_ceiling.txt").exists():
+                before = real_status.read_bytes()
+                try:
+                    dsc.ROOT = real_root
+                    dsc._LIVING_STAMPED_CACHE = None
+                    pad = "\n" + "\n".join(f"padding {i}" for i in range(40)) + "\n"
+                    real_status.write_bytes(before + pad.encode("utf-8"))
+                    if not dsc.surface_regression():
+                        failures.append(
+                            "surface-ratchet: 40 added lines of LIVING prose went "
+                            "unreported — the haystack can grow back and the "
+                            "deletion contract is unenforced"
+                        )
+                finally:
+                    real_status.write_bytes(before)
+                    dsc._LIVING_STAMPED_CACHE = None
+                    dsc.ROOT = fake
+
             # 2. A gapped migration sequence must RAISE, not count quietly.
             migs = fake / "backend" / "migrations"
             migs.mkdir(parents=True)
@@ -367,7 +390,7 @@ def structural_drills() -> list[str]:
     if not failures:
         print("PASS  structural      missing subfolder (count + emitted guard), "
               "gapped/malformed/duplicate migrations, unwatched pillar doc, "
-              "control byte in a guard, line-citation ratchet")
+              "control byte in a guard, line-citation ratchet, surface ratchet")
     return failures
 
 

--- a/scripts/living_surface_ceiling.txt
+++ b/scripts/living_surface_ceiling.txt
@@ -1,0 +1,14 @@
+# Maximum lines of LIVING prose. A RATCHET: it may only come DOWN.
+#
+# Every line in a LIVING doc is a claim that must match the code, so every
+# line is a thing that can become false. Fifteen nightly runs found real
+# drift and none found zero, because this number never moved. Cycle 16 was
+# the first to shrink it (8,331 -> 8,317) under the deletion contract.
+#
+# Lower it when prose is removed. Raise it ONLY for content that is
+# genuinely WHY -- a product rule, a reason the code cannot hold -- and say
+# in the commit what was added. A restatement of code is never a reason to
+# raise it: delete the restatement or point at the symbol instead.
+#
+# Set 2026-08-25 at the then-current main.
+8331


### PR DESCRIPTION
feat(doc-sync): the haystack may not grow — a ratchet on the LIVING surface

Cycle 16 was the first run in sixteen to SHRINK the surface: 8,331 -> 8,317
lines, on a net-negative PR (+15 -29), every finding closed by DELETE, POINTER
or TEST and not one by rewording. The contract works.

Until now it was only a paragraph in the routine's prompt, and a prompt is a
request. The next writer — human or model — adds a paragraph, the haystack
grows back, and nobody notices because no single commit looks wrong. Nobody
ever DECIDES to grow it; it happens one paragraph at a time. So the ceiling is
now enforced by the same CI step that enforces everything else.

Why the surface is the honest number to guard: findings-per-night can fall
because the scout got lazy, or got a smaller model, or ran out of turns. Lines
only fall when prose is actually removed. It is the one metric the scout
cannot flatter.

Deliberately NOT a hard cap on new writing. A doc explaining WHY — a product
rule, the reasoning code cannot hold — is the content worth having, and a blunt
cap would block exactly the prose worth adding. Raising the ceiling is allowed;
it costs one deliberate edit to scripts/living_surface_ceiling.txt in a commit
that has to say what was added. Growth stays possible, and stops being
accidental.

Proven RED by appending 40 lines to STATUS.md. The drill mutates the REAL tree
rather than a throwaway root (the guard reads a committed baseline, so a fake
root has nothing to compare against) and restores byte-for-byte in a finally —
verified after an external kill mid-run left STATUS.md untouched.

Verified: gate PASS, all guards proven able to go RED, tree clean.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01D6DsQH5EUxJc3Vnqz9YHgQ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a check that detects when the measured LIVING documentation exceeds its approved line-count ceiling.
  * Added a documented ceiling and reporting for surface-area growth.

* **Tests**
  * Expanded structural validation to verify that documentation growth is detected and that temporary test changes are safely restored.
  * Updated success reporting to include the new surface-growth check.

* **Documentation**
  * Recorded the current documentation baseline, ceiling, and rules for future ceiling changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->