### PR TITLE
chore(doc-sync): lower the surface ceiling to 8,317 — track the floor

### DIFF
--- a/scripts/living_surface_ceiling.txt
+++ b/scripts/living_surface_ceiling.txt
@@ -10,5 +10,7 @@
 # in the commit what was added. A restatement of code is never a reason to
 # raise it: delete the restatement or point at the symbol instead.
 #
-# Set 2026-08-25 at the then-current main.
-8331
+# Set 2026-08-25 at the then-current main: 8331.
+# Lowered 2026-08-25 to 8317 after cycle 16 (#427) deleted 14 lines --
+# a ceiling left above the real number is slack the haystack grows into.
+8317


### PR DESCRIPTION
Cycle 16 deleted 14 lines (#427). A ceiling left above the real number is **slack the haystack grows back into** — the guard would pass while the surface regressed 14 lines, and it would measure nothing.

The ceiling has to follow the floor down after every shrink, or it is a cap and not a ratchet.

```
LIVING surface: 46 docs, 8,317 lines
No drift — every doc claim matches the code, all stamps fresh. OK
```

Gate PASS.