### PR TITLE
docs: the copy my guard retirement missed

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -595,7 +595,7 @@ and must never be imported at module top level.
 
 > **The SQL below is SQLite-flavoured, and is never executed as written.** It is the legacy baseline `init_db()` hands to `executescript()`, which pushes every statement through `pg.translate()` first (`repositories/pg.py:670-674`) — `INTEGER PRIMARY KEY AUTOINCREMENT` becomes a Postgres identity column (`pg.py:193-195`), and `?` placeholders, `datetime('now')`, `INSERT OR IGNORE` and FK clauses are rewritten or stripped the same way. Read it as the *shape* of the baseline, not as DDL you could run against Postgres by hand.
 >
-> This section shows the baseline schema. The full schema is built by 31 forward-migrations (0000–0030). Key additions beyond the baseline below: `user_feed` gains `llm_fit_score/llm_verdict/llm_reason/llm_matched_at` (migration 0017) and `profile_version INTEGER` (migration 0018 — stamps the profile snapshot that produced each row's score); `users` gains `email_verified_at` (migration 0016); `password_resets` table (migration 0015); `email_verifications` table (migration 0016).
+> This section shows the baseline schema. The full schema is built by the forward migrations in `backend/migrations/` — see the code-facts table above for the current count and head. Key additions beyond the baseline below: `user_feed` gains `llm_fit_score/llm_verdict/llm_reason/llm_matched_at` (migration 0017) and `profile_version INTEGER` (migration 0018 — stamps the profile snapshot that produced each row's score); `users` gains `email_verified_at` (migration 0016); `password_resets` table (migration 0015); `email_verifications` table (migration 0016).
 
 ```sql
 CREATE TABLE IF NOT EXISTS jobs (


### PR DESCRIPTION
Retiring the `migrations-schema` guard assumed generation had replaced **every** copy of the fact. One survived:

> ARCHITECTURE.md:598 — "The full schema is built by 31 forward-migrations (0000–0030)."

Stale on both numbers (32 files, head 0031) — and in a phrasing the retired guard's patterns **did** match. So retiring a guard silently widened a blind spot, and only re-reading the doc found it.

**The rule that follows**, recorded because I will forget it: before retiring a guard, grep for every *phrasing* of the fact, not just the copies you deleted. A guard is safe to retire only when the fact has no hand-written home left anywhere.

Closed by **POINTER** per the contract — the sentence now points at the generated code-facts table instead of restating a number that drifts on the next migration.

Verified: gate PASS, no drift.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the database schema documentation to clarify that the complete schema is built through forward migrations.
  * Replaced the outdated fixed migration count with the current migration count and latest migration reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->