### PR TITLE
fix(arm): the pick job answered twice when there were no candidates

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -173,7 +173,26 @@ jobs:
             [ "$(echo "$meta" | jq -r .headRepositoryOwner.login)" = "${GH_REPO%%/*}" ] || continue
             keep="$keep $pr"
           done
-          json=$(echo $keep | tr ' ' '\n' | grep -E '^[0-9]+$' | jq -R . | jq -sc . || echo '[]')
+          # BUILT WITHOUT A PIPELINE, because the pipeline produced TWO answers.
+          # It was:
+          #     json=$(echo $keep | tr ' ' '\n' | grep -E '^[0-9]+$' \
+          #            | jq -R . | jq -sc . || echo '[]')
+          # With no candidates, `jq -sc` printed `[]` AND grep's exit 1 reached
+          # the `|| echo '[]'` through `pipefail` — so `$json` held two lines,
+          # `[]` and `[]`, and Actions refused the malformed output:
+          #     ##[error]Invalid format '[]'
+          # Measured on run 32876242568 and reproduced locally, where the empty
+          # case yields $'[]\r\n[]' ONLY with `set -o pipefail` on — which is
+          # why it looked correct in a shell and failed in CI.
+          #
+          # It fires on any `check_suite` for a branch with no open PR: a
+          # common, correct, nothing-to-do case. So the lane showed red runs
+          # while behaving perfectly, and a lane with red in it is a lane people
+          # stop reading — which is how a working guard becomes a dead one.
+          json="[]"
+          if [ -n "${keep// /}" ]; then
+            json=$(printf '%s\n' $keep | jq -R . | jq -sc .)
+          fi
           echo "prs=$json" >> "$GITHUB_OUTPUT"
           echo "candidates: ${keep:-none}" >> "$GITHUB_STEP_SUMMARY"
 


### PR DESCRIPTION
## The lane that decides what ships was showing red for doing its job right

Run [32876242568](https://github.com/Ranjith36963/job360/actions/runs/32876242568):

```
##[error]Invalid format '[]'
```

The candidate list was built as:

```bash
json=$(echo $keep | tr ' ' '\n' | grep -E '^[0-9]+$' | jq -R . | jq -sc . || echo '[]')
```

With no candidates, `jq -sc` prints `[]` — **and** grep's exit 1 reaches the `|| echo '[]'` through `pipefail`. Both fallbacks fire, `$json` holds two lines, and Actions refuses the malformed output.

## The reproduction is the interesting part

```
empty, no pipefail  ->  '[]'          looks fine
empty, pipefail on  ->  $'[]\r\n[]'   fails
```

It only misbehaves with `set -o pipefail`, which is the first line of the step in CI. That is why it read as correct and failed in practice.

## Why it matters even though it merged nothing wrong

It fires on any `check_suite` for a branch with **no open PR** — a common, correct, nothing-to-do case. Nothing was blocked and nothing was mis-merged.

That is worse rather than better. A guard whose failures are meaningless is a guard people stop reading, and this repo has written that lesson down more than once.

## The fix

No pipeline. `json="[]"` by default, replaced only when there is something to encode — one assignment, one value, no exit code doing double duty.

| candidates | result |
|---|---|
| `""` | `[]` |
| `" "` | `[]` |
| `" 388"` | `["388"]` |
| `" 388 390"` | `["388","390"]` |

Verified: `gate_wiring_check` 0 findings · `chain_check` 0 broken · `drill_registry --drill` 8/8 · `bash -n` on the extracted step · agent-gate PASS.

**This PR is `harness_owner`** — it edits the arm, so the cage will refuse to merge it itself. That one is yours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FEs1dix6f5imaMkuxuAAgd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed automated merge processing when no candidate pull requests are available.
  - Prevented duplicate empty results and malformed workflow output in this scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->