### PR TITLE
4/8 — The instant email finally says what the dashboard says, and links back to us

### DIFF
--- a/backend/src/services/delivery/email_body.py
+++ b/backend/src/services/delivery/email_body.py
@@ -46,25 +46,69 @@ def render_digest_subject(*, shown: int, considered: int) -> str:
     return f"Job360 — {_plural(shown, 'job')} worth a look"
 
 
-def _render_card(card: DecisionCard, index: int) -> str:
-    """One job, as a small block. Numbered so a reply can name it later."""
-    lines = [f"{index}. {card.title} — {card.company}"]
+def _card_lines(card: DecisionCard, *, indent: str) -> list[str]:
+    """What one job SAYS — the single definition both send modes render from.
+
+    Split out of ``_render_card`` for wiring.md W-17: the instant path used to
+    hand-roll its own body (``"Job360 match: {title}\\n{apply_url}"``), so the
+    default notify mode shipped no score, no verdict, no reason and a link
+    straight to the employer, while the digest said all four. Two users on
+    different settings received different products.
+
+    Everything after the heading line is indented by ``indent`` so the digest can
+    keep its numbered layout while a single-job email reads flat.
+    """
+    lines: list[str] = []
 
     where = " · ".join(p for p in (card.location, card.salary) if p)
     if where:
-        lines.append(f"   {where}")
+        lines.append(f"{indent}{where}")
 
     if card.is_judged:
         # The score AND the words that justify it, never the number alone.
-        lines.append(f"   Fit {card.primary_score}/100 ({card.verdict})")
+        lines.append(f"{indent}Fit {card.primary_score}/100 ({card.verdict})")
         if card.reason:
-            lines.append(f"   Why: {card.reason}")
+            lines.append(f"{indent}Why: {card.reason}")
     else:
         # Honest about which engine spoke. No invented reason.
-        lines.append(f"   Keyword match {card.primary_score}/100 — not yet reviewed")
+        lines.append(f"{indent}Keyword match {card.primary_score}/100 — not yet reviewed")
 
-    lines.append(f"   {card.url}")
-    return "\n".join(lines)
+    # ALWAYS our own page, never the employer's apply_url (W-18). The click has
+    # to be able to come back: attribution, the staleness guard and the
+    # "this one closed" message all live on that page.
+    lines.append(f"{indent}{card.url}")
+    return lines
+
+
+def _render_card(card: DecisionCard, index: int) -> str:
+    """One job, as a small block. Numbered so a reply can name it later."""
+    return "\n".join(
+        [f"{index}. {card.title} — {card.company}", *_card_lines(card, indent="   ")]
+    )
+
+
+def render_instant_subject(card: DecisionCard) -> str:
+    """Subject for a single-job instant alert.
+
+    Leads with the role, because that is what makes someone open it. The score
+    rides along only when the job was actually judged — putting a keyword number
+    in the subject would dress a guess up as an assessment.
+    """
+    head = f"{card.title} at {card.company}"
+    if card.is_judged:
+        return f"Job360 — {head} ({card.primary_score}/100)"
+    return f"Job360 — {head}"
+
+
+def render_instant_text(card: DecisionCard) -> str:
+    """Body for a single-job instant alert — same facts as the digest states.
+
+    Rendered from :func:`_card_lines`, so instant and digest cannot drift apart:
+    change what a job says in one place and both modes follow.
+    """
+    return "\n".join(
+        [f"{card.title} — {card.company}", *_card_lines(card, indent=""), ""]
+    )
 
 
 def render_digest_text(

--- a/backend/src/workers/tasks.py
+++ b/backend/src/workers/tasks.py
@@ -350,14 +350,40 @@ async def send_notification(
     db: pg.Connection = ctx["db"]
     db.row_factory = pg.Row
 
-    # Fetch job context for the notification body
-    cur = await db.execute("SELECT title, company, apply_url FROM jobs WHERE id = ?", (job_id,))
+    # W-17/W-18 — the SAME join send_bundle uses (tasks.py, the digest path), for
+    # one job. The old query read three columns off the shared catalog
+    # (`title, company, apply_url`) and hand-rolled the body, which meant the
+    # DEFAULT notify mode structurally could not say what the dashboard says: no
+    # score, no verdict, no reason, no salary, and a link straight to the
+    # employer so the click could never come back.
+    #
+    # INNER on user_feed, deliberately, and for the reason the digest already
+    # states: a job with no feed row for this user is one we can neither score
+    # nor explain, so we do not send it. An unexplainable alert is precisely the
+    # spam this product exists not to be.
+    cur = await db.execute(
+        "SELECT j.id AS job_id, j.title, j.company, j.location, "
+        "       e.salary AS enr_salary, "
+        "       f.score, f.llm_fit_score, f.llm_verdict, f.llm_reason "
+        "FROM jobs j "
+        "JOIN user_feed f ON f.job_id = j.id AND f.user_id = ? "
+        "LEFT JOIN job_enrichment e ON e.job_id = j.id "
+        "WHERE j.id = ?",
+        (user_id, job_id),
+    )
     job_row = await cur.fetchone()
     if job_row is None:
         return {"sent": 0, "queued": 0, "failed": 0}
 
-    title = f"{job_row['title']} @ {job_row['company']}"
-    body = f"Job360 match: {job_row['title']}\n{job_row['apply_url']}"
+    from src.services.delivery.decision_card import build_decision_card  # noqa: PLC0415
+    from src.services.delivery.email_body import (  # noqa: PLC0415
+        render_instant_subject,
+        render_instant_text,
+    )
+
+    card = build_decision_card(dict(job_row), site_base_url=SITE_BASE_URL)
+    title = render_instant_subject(card)
+    body = render_instant_text(card)
 
     # Test hook: ctx['dispatcher'] short-circuits the real Apprise path.
     # In production, we import lazily to dodge Apprise's ~30MB dep chain
@@ -372,9 +398,15 @@ async def send_notification(
     # job_id, `dispatcher._queue_digest` returns immediately without writing a
     # row -- so a `daily` rule produced NO digest AND no send, while the code
     # below still counted it. (CodeRabbit, PR #352.)
+    # `match_score` feeds dispatch()'s score-threshold gate. It used to read
+    # `job_row.get("match_score")` from a SELECT that never fetched that column,
+    # so it was ALWAYS None and the gate could never gate anything. The card's
+    # primary_score is the right value anyway: it is the number the user is
+    # actually ranked by (the judge's fit score when judged, the keyword score
+    # otherwise) — the same one their threshold setting is expressed against.
     results = await dispatcher_fn(
         db, user_id=user_id, title=title, body=body,
-        job_id=job_id, match_score=job_row.get("match_score"),
+        job_id=job_id, match_score=card.primary_score,
     )
 
     sent = 0

--- a/backend/tests/test_instant_notification_content.py
+++ b/backend/tests/test_instant_notification_content.py
@@ -1,0 +1,279 @@
+"""W-17 / W-18 — the instant email must say what the dashboard says, and link to us.
+
+Instant is the DEFAULT notify mode, and it was the worst message the product could
+produce: `SELECT title, company, apply_url` and a body of
+``f"Job360 match: {title}\\n{apply_url}"``. Two separate failures in one line:
+
+  W-17  No score, no verdict, no reason, no salary — everything that answers "why am
+        I being told about this?" The digest path already had all of it via
+        build_decision_card. Two users on different settings received different
+        products, and the default one was the poor one.
+
+  W-18  The link went STRAIGHT TO THE EMPLOYER. The digest links to
+        job360.uk/jobs/{id}. So in the default mode the click could never come back —
+        no attribution, no staleness guard, no "this one closed" page.
+
+A third bug falls out of the same query: `job_row.get("match_score")` was passed to
+dispatch() as the score-threshold gate input, but the SELECT never fetched that column,
+so it was ALWAYS None and the gate never actually gated anything.
+
+The anti-drift test is the important one here. Both modes must be rendered from ONE
+definition (build_decision_card), so a future edit cannot make them disagree again.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import pytest
+
+from src.repositories import pg
+from src.workers import tasks as worker_tasks
+
+USER = "instant-user"
+EMPLOYER_URL = "https://boards.example.com/apply/platform-engineer"
+# The REAL configured value, not a hardcoded guess: this worktree's backend/.env
+# sets SITE_BASE_URL=http://localhost:3000, and the anti-drift test below must
+# compare the instant body against the same base the code actually used.
+from src.core.settings import SITE_BASE_URL as SITE  # noqa: E402
+
+
+def iso(days_ago: float = 0) -> str:
+    return (datetime.now(timezone.utc) - timedelta(days=days_ago)).isoformat()
+
+
+class Recorder:
+    """Stands in for dispatcher.dispatch at the Apprise boundary."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    async def __call__(self, db: Any, **kw: Any) -> list[Any]:
+        self.calls.append(kw)
+        return [type("R", (), {"ok": True, "queued_digest": False, "skipped": False,
+                               "channel_type": "email", "channel_id": 1, "error": None})()]
+
+
+@pytest.fixture
+async def db(tmp_path):
+    async with pg.connect(str(tmp_path / "instant.db")) as conn:
+        await conn.executescript(
+            """
+            CREATE TABLE jobs (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                title TEXT NOT NULL,
+                company TEXT NOT NULL,
+                location TEXT DEFAULT '',
+                apply_url TEXT DEFAULT '',
+                match_score INTEGER DEFAULT 0
+            );
+            CREATE TABLE user_feed (
+                user_id TEXT NOT NULL,
+                job_id INTEGER NOT NULL,
+                score INTEGER DEFAULT 0,
+                llm_fit_score INTEGER,
+                llm_verdict TEXT,
+                llm_reason TEXT,
+                notified_at TEXT,
+                UNIQUE(user_id, job_id)
+            );
+            CREATE TABLE job_enrichment (
+                job_id INTEGER PRIMARY KEY,
+                salary TEXT
+            );
+            CREATE TABLE notification_ledger (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id TEXT NOT NULL,
+                job_id INTEGER NOT NULL,
+                channel TEXT NOT NULL,
+                status TEXT NOT NULL,
+                sent_at TEXT,
+                error_message TEXT,
+                retry_count INTEGER NOT NULL DEFAULT 0,
+                created_at TEXT NOT NULL DEFAULT '2026-01-01',
+                UNIQUE(user_id, job_id, channel)
+            );
+            """
+        )
+        await conn.commit()
+        yield conn
+
+
+async def seed(
+    conn,
+    *,
+    judged: bool = True,
+    salary: str | None = '{"currency": "GBP", "min": 70000, "max": 85000, "frequency": "yearly"}',
+    location: str = "London, UK",
+    feed_row: bool = True,
+    score: int = 61,
+) -> int:
+    cur = await conn.execute(
+        "INSERT INTO jobs (title, company, location, apply_url, match_score) "
+        "VALUES (?, ?, ?, ?, ?)",
+        ("Platform Engineer", "Meta", location, EMPLOYER_URL, score),
+    )
+    job_id = cur.lastrowid
+    if feed_row:
+        await conn.execute(
+            "INSERT INTO user_feed (user_id, job_id, score, llm_fit_score, llm_verdict, llm_reason) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (
+                USER,
+                job_id,
+                score,
+                82 if judged else None,
+                "strong fit" if judged else None,
+                "Your Kubernetes and Terraform work maps directly to their platform team."
+                if judged
+                else None,
+            ),
+        )
+    if salary is not None:
+        await conn.execute(
+            "INSERT INTO job_enrichment (job_id, salary) VALUES (?, ?)", (job_id, salary)
+        )
+    await conn.commit()
+    return job_id
+
+
+async def send(conn, job_id: int, rec: Recorder) -> dict[str, int]:
+    return await worker_tasks.send_notification(
+        {"db": conn, "dispatcher": rec}, USER, job_id
+    )
+
+
+# ── W-17: the email must say WHY ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_instant_body_carries_the_score_the_verdict_and_the_reason(db):
+    job_id = await seed(db)
+    rec = Recorder()
+
+    await send(db, job_id, rec)
+
+    assert rec.calls, "no message was dispatched at all"
+    body = rec.calls[0]["body"]
+    assert "82" in body, f"the fit score is missing:\n{body}"
+    assert "strong fit" in body, f"the verdict is missing:\n{body}"
+    assert "Kubernetes" in body, f"the reason is missing:\n{body}"
+
+
+@pytest.mark.asyncio
+async def test_instant_body_carries_salary_and_location(db):
+    job_id = await seed(db)
+    rec = Recorder()
+
+    await send(db, job_id, rec)
+
+    body = rec.calls[0]["body"]
+    assert "London" in body, f"location missing:\n{body}"
+    # The dashboard's own words — "£70k–£85k", not "£70,000". Parity of WORDING is
+    # the point of the shared card: a different format is a visible difference to
+    # the only person who matters.
+    assert "70k" in body, f"salary missing, or worded differently to the dashboard:\n{body}"
+
+
+@pytest.mark.asyncio
+async def test_an_unjudged_job_says_not_reviewed_rather_than_inventing_a_verdict(db):
+    """Rule #29's spirit: say what we know, never manufacture what we don't."""
+    job_id = await seed(db, judged=False)
+    rec = Recorder()
+
+    await send(db, job_id, rec)
+
+    body = rec.calls[0]["body"]
+    assert "not yet reviewed" in body.lower(), f"unjudged job did not say so:\n{body}"
+    assert "strong fit" not in body.lower()
+
+
+# ── W-18: the click must be able to come back ────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_instant_body_links_to_job360_not_straight_to_the_employer(db):
+    """THE W-18 assertion. The digest already does this; instant did not."""
+    job_id = await seed(db)
+    rec = Recorder()
+
+    await send(db, job_id, rec)
+
+    body = rec.calls[0]["body"]
+    assert f"/jobs/{job_id}" in body, f"no Job360 job link in the body:\n{body}"
+    assert EMPLOYER_URL not in body, (
+        "the raw employer apply_url is still in the instant email — the click "
+        f"cannot come back:\n{body}"
+    )
+
+
+# ── the two modes must not drift apart again ─────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_instant_and_digest_describe_one_job_identically(db):
+    """Both modes must render from ONE definition, so they cannot disagree.
+
+    This is the guard that outlives the fix: if someone later hand-rolls the
+    instant body again, the score/verdict/reason/link will drift and this fails.
+    """
+    from src.services.delivery.decision_card import build_decision_card
+    from src.services.delivery.email_body import render_digest_text
+
+    job_id = await seed(db)
+    rec = Recorder()
+    await send(db, job_id, rec)
+    instant_body = rec.calls[0]["body"]
+
+    cur = await db.execute(
+        "SELECT j.id AS job_id, j.title, j.company, j.location, e.salary AS enr_salary, "
+        "       f.score, f.llm_fit_score, f.llm_verdict, f.llm_reason "
+        "FROM jobs j JOIN user_feed f ON f.job_id = j.id AND f.user_id = ? "
+        "LEFT JOIN job_enrichment e ON e.job_id = j.id WHERE j.id = ?",
+        (USER, job_id),
+    )
+    db.row_factory = pg.Row
+    row = dict(await cur.fetchone())
+    card = build_decision_card(row, site_base_url=SITE)
+    digest_body = render_digest_text([card], considered=1, dropped_reasons=[])
+
+    for fact in (str(card.primary_score), card.verdict or "", card.url):
+        assert fact in instant_body, f"instant is missing {fact!r} that the digest states"
+        assert fact in digest_body, f"digest is missing {fact!r} (test setup wrong)"
+
+
+# ── the gate that never gated ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_the_real_match_score_reaches_the_dispatcher(db):
+    """`job_row.get("match_score")` was always None — the SELECT never fetched it.
+
+    So dispatch()'s score-threshold gate (dispatcher.py Gate 2) received None for
+    every instant notification and could never gate anything.
+    """
+    job_id = await seed(db, score=61)
+    rec = Recorder()
+
+    await send(db, job_id, rec)
+
+    passed = rec.calls[0].get("match_score")
+    assert passed is not None, "match_score is still None — the threshold gate is dead"
+    assert passed == 82, f"expected the judged fit score the user is ranked by, got {passed}"
+
+
+@pytest.mark.asyncio
+async def test_a_job_we_cannot_explain_is_not_sent(db):
+    """No user_feed row → we cannot score or explain it, so we do not send it.
+
+    Same rule the digest already states for its INNER join. Consistency matters
+    more than reach: an unexplainable alert is exactly the spam we are avoiding.
+    """
+    job_id = await seed(db, feed_row=False)
+    rec = Recorder()
+
+    result = await send(db, job_id, rec)
+
+    assert rec.calls == [], "sent a job we have no feed row for"
+    assert result.get("sent", 0) == 0

--- a/backend/tests/test_worker_send_notification.py
+++ b/backend/tests/test_worker_send_notification.py
@@ -92,6 +92,16 @@ async def db_ctx():
             ("AI Engineer", "Acme", "https://acme.test/a", now,
              "acme", "ai engineer", now),
         )
+        # W-17/W-18: send_notification now reads the SAME user_feed join the
+        # digest uses, so it can state the score and the reason instead of
+        # shipping a bare link. Production always has this row — both enqueue
+        # sites are feed-driven (main.py:509 enqueues *for feed rows*;
+        # tasks.py:229 fires straight after upsert_feed_row) — so seeding it
+        # here makes the fixture match reality rather than weakening the code.
+        await db.execute(
+            "INSERT INTO user_feed (user_id, job_id, score, bucket) VALUES (?, ?, ?, ?)",
+            ("alice", 1, 77, "good"),
+        )
         await db.commit()
     conn = await pg.connect(path)
     conn.row_factory = pg.Row

--- a/wiring.md
+++ b/wiring.md
@@ -43,7 +43,7 @@ Work top to bottom. Each block is independently shippable.
 |---|---|---|---|---|
 | 1 | **The door** | W-01, W-03 | ✅ **rungs 1-4 verified** (browser evidence in `test-artifacts/rung4/`) · rung 5 = merge, owner's call | Own email dead-ended at our own front door; new users hit a wall on minute one. |
 | 2 | **Close the loop** | W-19, W-20 | ✅ **rungs 1-4 verified** (cron driven against real migrated Postgres) · rung 5 = merge, owner's call | One cron + one template turns the filing cabinet into a loop. Biggest value, cheapest fix. |
-| 3 | **Fix the default email** | W-17, W-18 | ready | The default mode sends the worst message the system can make, and links away from us. One change closes both. |
+| 3 | **Fix the default email** | W-17, W-18 | ✅ **rungs 1-4 verified** (real body read off real Postgres) · rung 5 = merge, owner's call | The default mode sends the worst message the system can make, and links away from us. One change closes both. |
 | 4 | **Don't lose the CV he sent** | W-08, W-10 | ready | Data is being destroyed today. Every day we wait, more is gone. |
 | 5 | **Pipeline card truth** | W-05, W-15, W-16 (deadline half) | tests already written | Cards lie about dead jobs, drop deadlines, and the Applied filter always returns zero. |
 | 6 | **Close the silent holes** | W-06, W-12, W-28, W-29 | ready | One-liners: an untracked exit, a stale-doc warning, a feed that shows old scores as fresh. |
@@ -287,7 +287,7 @@ reminder is impossible.
 quiet hours, digest, retries, a notifications history page. Nothing pipeline-shaped ever
 enters it.
 
-### [ ] W-17 — The instant email strips the score, the reason, and the salary
+### [x] W-17 — The instant email strips the score, the reason, and the salary  ✅ RUNGS 1-4 VERIFIED
 **Severity:** breaks the loop — **instant is the DEFAULT mode**
 **What happens:** the digest joins `user_feed` + `job_enrichment` and calls
 `build_decision_card`. The instant path runs `SELECT title, company, apply_url` and builds
@@ -297,7 +297,7 @@ default one is the poor one.
 **Side effect:** `job_row.get("match_score")` passed to `dispatch()` is therefore **always `None`** — it is used only as a threshold gate (`dispatcher.py:330`), never in the text.
 **Smallest fix:** make `send_notification` reuse the digest's join + `build_decision_card`.
 
-### [ ] W-18 — The instant email links **straight to the employer**, not to us
+### [x] W-18 — The instant email links **straight to the employer**, not to us  ✅ RUNGS 1-4 VERIFIED
 **Severity:** breaks the loop — **your explicit requirement, and this is the hard blocker on it**
 **What happens:** the digest link is `job360.uk/jobs/{id}` — correct, the click *can* come
 back. The instant email sends the **raw employer `apply_url`**. In the default mode the
@@ -305,6 +305,27 @@ click physically cannot return. Your two notification modes ship opposite design
 **Proof exists:** `services/delivery/decision_card.py:205` → `f"{site_base_url.rstrip('/')}/jobs/{job_id}"` (good) vs `workers/tasks.py:360` → `body = f"Job360 match: {title}\n{apply_url}"` (raw employer link). Also `services/notifications/report_generator.py:87` → `[Apply]({apply_url})`, same raw link.
 *(Verified by hand, not just by agent — this corrects an earlier report that said all email links point at our own page.)*
 **Smallest fix:** same fix as W-17. One change closes both.
+
+**Fixed together (one change closed both), 2026-08-25.** `send_notification` now runs
+the SAME `user_feed` + `job_enrichment` join `send_bundle` uses and renders through
+`build_decision_card`, so the two modes cannot drift apart again — `_card_lines()` in
+`email_body.py` is the single definition of what a job says.
+
+Before: `Job360 match: {title}` + the raw employer `apply_url`.
+After: subject `Job360 — Staff Site Reliability Engineer at Monzo (88/100)`; body with
+location, `£95k–£115k`, `Fit 88/100 (strong fit)`, the reason, and a `/jobs/{id}` link.
+
+**A third bug fell out of the same query:** `job_row.get("match_score")` fed dispatch's
+score-threshold gate from a SELECT that never fetched that column, so it was ALWAYS
+`None` and the gate could never gate anything. Now passes the card's `primary_score` —
+the number the user is actually ranked by.
+
+**Deliberate behaviour change:** the join is INNER on `user_feed`, so a job with no feed
+row is not sent. Same rule the digest already states — we cannot score or explain it, and
+an unexplainable alert is the spam this product exists not to be. Verified safe: both
+enqueue sites are feed-driven (`main.py:509` enqueues *for feed rows*; `tasks.py:229`
+fires straight after `upsert_feed_row`), so production always has the row. Four existing
+tests encoded the old contract and were updated to seed a feed row, not the code weakened.
 
 ### [ ] W-19 — Nothing ever notices "no reply"
 **Severity:** breaks the loop — **THE ONE BREAK**


### PR DESCRIPTION
Stacked on #449.

**This one changes the email every user receives. Read it before merging.**

Instant is the **default** notify mode, and it was the worst message the product could produce. One line did two kinds of damage:

```python
body = f"Job360 match: {title}\n{apply_url}"
```

## W-17 — no score, no verdict, no reason, no salary

Everything that answers *"why am I being told about this?"* was missing — while the **digest path already had all of it** via `build_decision_card`. Two users on different settings received different products, and the default one was the poor one.

## W-18 — the link went straight to the employer

The digest links to `/jobs/{id}`. So in the default mode **the click could never come back**: no attribution, no staleness guard, no page that can still say "this one closed".

## The fix

`send_notification` now runs the **same** `user_feed` + `job_enrichment` join `send_bundle` uses, for one job, and renders through `build_decision_card`. `_card_lines()` is extracted as the **single definition of what a job says**, so the two modes cannot drift apart again — and there is a test that fails if they ever do.

**Before:** `Job360 match: Staff Site Reliability Engineer` + a raw employer link.
**After:** subject `Job360 — Staff Site Reliability Engineer at Monzo (88/100)`, body with London, £95k–£115k, `Fit 88/100 (strong fit)`, the reason, and `/jobs/7`.

## A third bug fell out of the same query

`match_score` — the input to dispatch's score-threshold gate — was read from a `SELECT` that **never fetched that column**. It was always `None`, so that gate has never gated anything for instant notifications. It now passes the score the user is actually ranked by.

## One deliberate behaviour change, checked before making it

The join is **INNER** on `user_feed`, so a job with no feed row is not sent — the rule the digest already states: we can neither score nor explain such a job, and an unexplainable alert is exactly the spam this product exists not to be.

Verified safe first: both enqueue sites are feed-driven (`main.py:509` enqueues *for feed rows*; `tasks.py:229` fires straight after `upsert_feed_row`), so production always has the row. Four existing tests encoded the old contract and were **updated to seed a feed row, rather than weakening the code to suit them**.

## Verified

7 tests **watched fail first** — the failure line was literally `assert '82' in 'Job360 match: Platform Engineer\nhttps://boards.example.com/...'`, both bugs visible at once. 136 passed across the notification, dispatcher, decision-card, digest-body and worker suites. Driven against real migrated Postgres with the actual subject and body printed and checked, 9/9.

**Bound:** no real email left the building — the Apprise boundary is stubbed. Deliverability is unproven and needs production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpxEMPz2ZWG9Qed5BsFHvg
