### PR TITLE
6/8 — Card truth: the Applied filter works, dead jobs are flagged, deadlines survive

### DIFF
--- a/backend/scripts/drill_wiring.py
+++ b/backend/scripts/drill_wiring.py
@@ -244,7 +244,72 @@ async def drill_instant(db: Any) -> list[str]:
     return failures
 
 
-DRILLS = {"chase": drill_chase, "instant": drill_instant}
+async def drill_pipeline_card(db: Any) -> list[str]:
+    """W-05/W-15/W-16 — the board must tell the truth about each application."""
+    print("\n=== DRILL: pipeline card truth (W-05, W-15, W-16) ===")
+    failures: list[str] = []
+    jdb = JobDatabase.from_connection("", db)
+    await _seed_user(db)
+    job_id = await _seed_job(db, "Backend Engineer", "Wise")
+    await db.execute(
+        "UPDATE jobs SET deadline = ? WHERE id = ?", ("2026-09-30", job_id)
+    )
+    await db.execute(
+        "INSERT INTO applications (user_id, job_id, stage, created_at, updated_at) "
+        "VALUES (?, ?, 'applied', ?, ?)",
+        (DRILL_USER, job_id, _iso(3), _iso(3)),
+    )
+    await db.execute(
+        "INSERT INTO tailored_documents (user_id, job_id, doc_kind, ai_draft, status, "
+        "created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (DRILL_USER, job_id, "cv", "draft", "kept", _iso(3), _iso(3)),
+    )
+    await db.commit()
+
+    rows = await jdb.get_applications(DRILL_USER)
+    summary = await jdb.get_tailored_summary_for_jobs(DRILL_USER, [job_id])
+    applied_ids = await jdb.get_applied_job_ids(DRILL_USER)
+    card = next((r for r in rows if r["job_id"] == job_id), None)
+    if card is None:
+        failures.append("pipeline: the application did not come back at all")
+        return failures
+
+    print(f"  card: {card['title']} at {card['company']}")
+    print(f"    deadline        : {card.get('deadline')}")
+    print(f"    staleness_state : {card.get('staleness_state')}")
+    print(f"    tailored        : {summary.get(job_id)}")
+    print(f"    in applied set  : {job_id in applied_ids}")
+
+    for label, ok in (
+        ("the closing date survived (W-16)", card.get("deadline") == "2026-09-30"),
+        ("a live job is not flagged expired (W-15)",
+         card.get("staleness_state") != "confirmed_expired"),
+        ("the CV shows on the card", summary.get(job_id, {}).get("cv") == "kept"),
+        ("the applied set drives the filter (W-05)", job_id in applied_ids),
+    ):
+        print(f"  [{'PASS' if ok else 'FAIL'}] {label}")
+        if not ok:
+            failures.append(f"pipeline: {label}")
+
+    # Now the job closes underneath the application.
+    await db.execute(
+        "UPDATE jobs SET staleness_state = 'confirmed_expired' WHERE id = ?", (job_id,)
+    )
+    await db.commit()
+    rows = await jdb.get_applications(DRILL_USER)
+    card = next(r for r in rows if r["job_id"] == job_id)
+    ok = card.get("staleness_state") == "confirmed_expired"
+    print(f"  [{'PASS' if ok else 'FAIL'}] the card notices the job closed (W-15)")
+    if not ok:
+        failures.append("pipeline: the card never learned the job closed")
+    return failures
+
+
+DRILLS = {
+    "chase": drill_chase,
+    "instant": drill_instant,
+    "pipeline": drill_pipeline_card,
+}
 
 
 async def main_async(which: str) -> int:

--- a/backend/src/api/models.py
+++ b/backend/src/api/models.py
@@ -101,6 +101,11 @@ class JobResponse(BaseModel):
     missing_required: list[str] = []
     transferable_skills: list[str] = []
     action: Optional[str] = None
+    # W-05 — derived from the ``applications`` table, NOT from ``user_actions``.
+    # Kept separate from ``action`` on purpose: a job can be both liked AND applied
+    # to, and ``user_actions`` holds one value per (user, job), so folding "applied"
+    # into ``action`` would erase the like.
+    applied: bool = False
     bucket: str = ""
     # Step-1 B6 — date-model fields (Pillar 3 Batch 1). Persisted on the
     # `jobs` table; `posted_at` is None when no trustworthy source field
@@ -397,6 +402,18 @@ class PipelineApplication(BaseModel):
     notes: str = ""
     title: str = ""
     company: str = ""
+    # W-15 — has this job since closed? Only ``confirmed_expired`` counts: that
+    # comes from a direct URL check, while possibly_stale/likely_stale are guesses
+    # from absence (ghost_detection.py:31). Telling someone to stop chasing a live
+    # job is worse than saying nothing.
+    expired: bool = False
+    # W-16 — the closing date was on the job card and vanished the moment the job
+    # became an application. None means no deadline was ever known.
+    deadline: Optional[str] = None
+    # {doc_kind: status}, e.g. {"cv": "kept"}. From ``get_tailored_summary_for_jobs``,
+    # which was written for this board and then never called — leaving the CV/Letter
+    # button unable to say whether a document already exists. Empty = nothing tailored.
+    tailored: dict[str, str] = {}
 
 
 class PipelineListResponse(BaseModel):

--- a/backend/src/api/routes/jobs.py
+++ b/backend/src/api/routes/jobs.py
@@ -121,7 +121,9 @@ def _compute_bucket(date_found: str) -> str:
         return "7d"
 
 
-def _row_to_job_response(row: dict[str, Any], action: str | None = None) -> JobResponse:
+def _row_to_job_response(
+    row: dict[str, Any], action: str | None = None, *, applied: bool = False
+) -> JobResponse:
     """Build a `JobResponse` from a single LEFT-JOIN row.
 
     Step-1 B6: ``row`` may carry both ``jobs.*`` columns and ``enr_*``-prefixed
@@ -192,6 +194,9 @@ def _row_to_job_response(row: dict[str, Any], action: str | None = None) -> JobR
         semantic=row.get("semantic", 0) or 0,
         penalty=row.get("penalty", 0) or 0,
         action=action,
+        # Separate from `action` on purpose — a job can be liked AND applied to,
+        # and `user_actions` holds only one value per (user, job) (W-05).
+        applied=applied,
         bucket=_compute_bucket(row.get("date_found", "")),
         # Date-model fields (jobs table columns; Pillar 3 Batch 1).
         posted_at=row.get("posted_at"),
@@ -651,16 +656,31 @@ async def list_jobs(
     if user is not None:
         action_rows = await db.get_actions(user.id)
         action_map: dict[int, str] = {row["job_id"]: row["action"] for row in action_rows}
+        # W-05 — "applied" lives in `applications`, written by the Apply button.
+        # `user_actions` never receives it, which is why ?action=applied returned an
+        # empty list for everyone, forever. Read the truth instead of writing a
+        # duplicate: `user_actions` is one row per (user, job), so an 'applied' write
+        # there would erase a 'liked'.
+        applied_ids = await db.get_applied_job_ids(user.id)
     else:
         action_map = {}
+        applied_ids = set()
 
     if action is not None:
-        all_rows = [r for r in all_rows if action_map.get(r["id"]) == action]
+        if action == "applied":
+            all_rows = [r for r in all_rows if r["id"] in applied_ids]
+        else:
+            all_rows = [r for r in all_rows if action_map.get(r["id"]) == action]
 
     total = len(all_rows)
     page = all_rows[offset : offset + limit]
 
-    jobs = [_row_to_job_response(row, action_map.get(row["id"])) for row in page]
+    jobs = [
+        _row_to_job_response(
+            row, action_map.get(row["id"]), applied=row["id"] in applied_ids
+        )
+        for row in page
+    ]
 
     filters_applied: dict[str, Any] = {}
     if hours is not None:

--- a/backend/src/api/routes/pipeline.py
+++ b/backend/src/api/routes/pipeline.py
@@ -36,7 +36,9 @@ router = APIRouter(tags=["pipeline"])
 _VALID_STAGES = {"applied", "outreach", "interview", "offer", "rejected", "ghosted"}
 
 
-def _to_pipeline_application(row: dict[str, Any]) -> PipelineApplication:
+def _to_pipeline_application(
+    row: dict[str, Any], tailored: dict[str, str] | None = None
+) -> PipelineApplication:
     return PipelineApplication(
         job_id=row["job_id"],
         stage=row["stage"],
@@ -45,6 +47,12 @@ def _to_pipeline_application(row: dict[str, Any]) -> PipelineApplication:
         notes=row.get("notes", ""),
         title=row.get("title", ""),
         company=row.get("company", ""),
+        # ONLY confirmed_expired. `possibly_stale` / `likely_stale` are inferred
+        # from absence, and telling someone their live application is dead is a
+        # worse error than staying quiet (ghost_detection.py:31).
+        expired=row.get("staleness_state") == "confirmed_expired",
+        deadline=row.get("deadline"),
+        tailored=tailored or {},
     )
 
 
@@ -56,7 +64,18 @@ async def list_pipeline(
 ) -> PipelineListResponse:
     """List caller's tracked job applications, optionally filtered by stage."""
     rows = await db.get_applications(user.id, stage)
-    return PipelineListResponse(applications=[_to_pipeline_application(r) for r in rows])
+    # ONE extra query for the whole board, not one per card. This is the call
+    # `get_tailored_summary_for_jobs` was written for and never got — its docstring
+    # says "for the Kanban attach" and it had zero callers, so the CV/Letter button
+    # could never say whether a document already existed.
+    summary = await db.get_tailored_summary_for_jobs(
+        user.id, [int(r["job_id"]) for r in rows]
+    )
+    return PipelineListResponse(
+        applications=[
+            _to_pipeline_application(r, summary.get(int(r["job_id"]), {})) for r in rows
+        ]
+    )
 
 
 @router.get("/pipeline/counts")

--- a/backend/src/repositories/database.py
+++ b/backend/src/repositories/database.py
@@ -1299,7 +1299,7 @@ class JobDatabase:
         if stage:
             cursor = await self._db.execute(
                 """SELECT a.job_id, a.stage, a.created_at, a.updated_at, a.notes,
-                          j.title, j.company
+                          j.title, j.company, j.staleness_state, j.deadline
                    FROM applications a LEFT JOIN jobs j ON a.job_id = j.id
                    WHERE a.user_id = ? AND a.stage = ?
                    ORDER BY a.updated_at DESC""",
@@ -1308,7 +1308,7 @@ class JobDatabase:
         else:
             cursor = await self._db.execute(
                 """SELECT a.job_id, a.stage, a.created_at, a.updated_at, a.notes,
-                          j.title, j.company
+                          j.title, j.company, j.staleness_state, j.deadline
                    FROM applications a LEFT JOIN jobs j ON a.job_id = j.id
                    WHERE a.user_id = ?
                    ORDER BY a.updated_at DESC""",
@@ -1323,9 +1323,32 @@ class JobDatabase:
                 "notes": r[4] or "",
                 "title": r[5] or "",
                 "company": r[6] or "",
+                # W-15: staleness was checked ONCE, when the row was created, and
+                # never again — so a card kept looking live for a job that closed
+                # months ago. W-16: the deadline was on the job card right up until
+                # the moment it became an application, then vanished.
+                "staleness_state": r[7],
+                "deadline": r[8],
             }
             for r in await cursor.fetchall()
         ]
+
+    async def get_applied_job_ids(self, user_id: str) -> set[int]:
+        """Job ids this user has an application for — the ONE truth for "applied".
+
+        W-05: the job list's ``?action=applied`` filter read ``user_actions``, which
+        the Apply button never writes, so it always returned an empty list. It reads
+        this instead.
+
+        Deliberately NOT solved by writing 'applied' into ``user_actions``: that table
+        is one row per (user, job) with ``ON CONFLICT DO UPDATE`` (see
+        :meth:`insert_action`), so an applied write would silently ERASE a 'liked' and
+        the heart would vanish from the card. Two facts, two homes.
+        """
+        cursor = await self._db.execute(
+            "SELECT job_id FROM applications WHERE user_id = ?", (user_id,)
+        )
+        return {int(r[0]) for r in await cursor.fetchall()}
 
     async def get_application_counts(self, user_id: str) -> dict[str, int]:
         cursor = await self._db.execute(

--- a/backend/tests/test_pipeline_wiring.py
+++ b/backend/tests/test_pipeline_wiring.py
@@ -70,6 +70,21 @@ async def _insert_job_row(
     return cur.lastrowid  # type: ignore[return-value]
 
 
+async def _add_to_feed(db: JobDatabase, user_id: str, job_id: int, score: int = 80) -> None:
+    """Put the job in this user's feed.
+
+    NOT optional decoration: for a logged-in caller `GET /api/jobs` reads
+    `get_user_feed_jobs` (routes/jobs.py:564), not the shared catalog. A job with no
+    feed row is invisible to the list no matter what else is true of it — which is
+    also a real bound on the Applied filter, not just a test detail.
+    """
+    await db._conn.execute(
+        "INSERT INTO user_feed (user_id, job_id, score, bucket) VALUES (?, ?, ?, ?)",
+        (user_id, job_id, score, "good"),
+    )
+    await db._conn.commit()
+
+
 async def _expire_job(db: JobDatabase, job_id: int) -> None:
     """Flip a live job to confirmed_expired, the way the ghost detector does."""
     await db._conn.execute(
@@ -105,6 +120,9 @@ async def test_applied_filter_finds_jobs_added_to_the_pipeline(authenticated_asy
     db = await api_deps.get_db()
     applied_id = await _insert_job_row(db, title="Applied Role", company="AppliedCo")
     other_id = await _insert_job_row(db, title="Untouched Role", company="OtherCo")
+    uid = authenticated_async_context.fixture_user_id
+    await _add_to_feed(db, uid, applied_id)
+    await _add_to_feed(db, uid, other_id)
 
     async with authenticated_async_context() as client:
         resp = await client.post(f"/api/pipeline/{applied_id}")
@@ -124,6 +142,9 @@ async def test_applied_flag_is_true_on_the_job_row(authenticated_async_context):
     db = await api_deps.get_db()
     applied_id = await _insert_job_row(db, title="Flagged Role", company="FlagCo")
     other_id = await _insert_job_row(db, title="Unflagged Role", company="PlainCo")
+    uid = authenticated_async_context.fixture_user_id
+    await _add_to_feed(db, uid, applied_id)
+    await _add_to_feed(db, uid, other_id)
 
     async with authenticated_async_context() as client:
         await client.post(f"/api/pipeline/{applied_id}")
@@ -146,6 +167,7 @@ async def test_applying_never_erases_a_like(authenticated_async_context):
     """
     db = await api_deps.get_db()
     job_id = await _insert_job_row(db, title="Liked And Applied", company="BothCo")
+    await _add_to_feed(db, authenticated_async_context.fixture_user_id, job_id)
 
     async with authenticated_async_context() as client:
         resp = await client.post(f"/api/jobs/{job_id}/action", json={"action": "liked"})
@@ -168,6 +190,9 @@ async def test_liked_filter_still_reads_user_actions(authenticated_async_context
     db = await api_deps.get_db()
     liked_id = await _insert_job_row(db, title="Liked Only", company="HeartCo")
     pipelined_id = await _insert_job_row(db, title="Pipelined Only", company="TrackCo")
+    uid = authenticated_async_context.fixture_user_id
+    await _add_to_feed(db, uid, liked_id)
+    await _add_to_feed(db, uid, pipelined_id)
 
     async with authenticated_async_context() as client:
         await client.post(f"/api/jobs/{liked_id}/action", json={"action": "liked"})
@@ -227,6 +252,50 @@ async def test_pipeline_card_of_a_live_job_is_not_expired(authenticated_async_co
         card = next(a for a in resp.json()["applications"] if a["job_id"] == job_id)
 
     assert card["expired"] is False
+
+
+# ── wire 2b: the closing date survives becoming an application (W-16) ────────
+
+
+@pytest.mark.asyncio
+async def test_the_closing_date_survives_becoming_an_application(
+    authenticated_async_context,
+):
+    """Before applying the card says "Apply by 30 June". After, it said nothing.
+
+    The date was never lost from the database — the pipeline query simply did not
+    select it and the response model had nowhere to put it. So a deadline you could
+    still act on became invisible the moment you started acting on it.
+    """
+    db = await api_deps.get_db()
+    job_id = await _insert_job_row(db, title="Closing Role", company="DeadlineCo")
+    await db._conn.execute(
+        "UPDATE jobs SET deadline = ? WHERE id = ?", ("2026-09-30", job_id)
+    )
+    await db._conn.commit()
+
+    async with authenticated_async_context() as client:
+        await client.post(f"/api/pipeline/{job_id}")
+        resp = await client.get("/api/pipeline")
+        card = next(a for a in resp.json()["applications"] if a["job_id"] == job_id)
+
+    assert card["deadline"] == "2026-09-30", "the closing date vanished on applying"
+
+
+@pytest.mark.asyncio
+async def test_a_job_with_no_deadline_reports_none_rather_than_a_guess(
+    authenticated_async_context,
+):
+    """Most ads state no closing date. None must mean "unknown", never a made-up one."""
+    db = await api_deps.get_db()
+    job_id = await _insert_job_row(db, title="Open Ended Role", company="NoDateCo")
+
+    async with authenticated_async_context() as client:
+        await client.post(f"/api/pipeline/{job_id}")
+        resp = await client.get("/api/pipeline")
+        card = next(a for a in resp.json()["applications"] if a["job_id"] == job_id)
+
+    assert card["deadline"] is None
 
 
 # ── wire 3: the Kanban card knows which documents exist ──────────────────────

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -565,6 +565,11 @@
             ],
             "title": "Action"
           },
+          "applied": {
+            "default": false,
+            "title": "Applied",
+            "type": "boolean"
+          },
           "apply_url": {
             "title": "Apply Url",
             "type": "string"
@@ -1487,6 +1492,22 @@
             "title": "Created At",
             "type": "string"
           },
+          "deadline": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Deadline"
+          },
+          "expired": {
+            "default": false,
+            "title": "Expired",
+            "type": "boolean"
+          },
           "job_id": {
             "title": "Job Id",
             "type": "integer"
@@ -1499,6 +1520,14 @@
           "stage": {
             "title": "Stage",
             "type": "string"
+          },
+          "tailored": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "default": {},
+            "title": "Tailored",
+            "type": "object"
           },
           "title": {
             "default": "",

--- a/frontend/src/lib/api-types.ts
+++ b/frontend/src/lib/api-types.ts
@@ -1676,6 +1676,11 @@ export interface components {
         JobResponse: {
             /** Action */
             action?: string | null;
+            /**
+             * Applied
+             * @default false
+             */
+            applied: boolean;
             /** Apply Url */
             apply_url: string;
             /**
@@ -2033,6 +2038,13 @@ export interface components {
             company: string;
             /** Created At */
             created_at: string;
+            /** Deadline */
+            deadline?: string | null;
+            /**
+             * Expired
+             * @default false
+             */
+            expired: boolean;
             /** Job Id */
             job_id: number;
             /**
@@ -2042,6 +2054,13 @@ export interface components {
             notes: string;
             /** Stage */
             stage: string;
+            /**
+             * Tailored
+             * @default {}
+             */
+            tailored: {
+                [key: string]: string;
+            };
             /**
              * Title
              * @default

--- a/wiring.md
+++ b/wiring.md
@@ -45,7 +45,7 @@ Work top to bottom. Each block is independently shippable.
 | 2 | **Close the loop** | W-19, W-20 | ✅ **rungs 1-4 verified** (cron driven against real migrated Postgres) · rung 5 = merge, owner's call | One cron + one template turns the filing cabinet into a loop. Biggest value, cheapest fix. |
 | 3 | **Fix the default email** | W-17, W-18 | ✅ **rungs 1-4 verified** (real body read off real Postgres) · rung 5 = merge, owner's call | The default mode sends the worst message the system can make, and links away from us. One change closes both. |
 | 4 | **Don't lose the CV he sent** | W-08, W-10 | ✅ **rungs 1-4 verified** (tailor→apply→regenerate walked on real Postgres) · rung 5 = merge, owner's call | Data is being destroyed today. Every day we wait, more is gone. |
-| 5 | **Pipeline card truth** | W-05, W-15, W-16 (deadline half) | tests already written | Cards lie about dead jobs, drop deadlines, and the Applied filter always returns zero. |
+| 5 | **Pipeline card truth** | W-05, W-15, W-16 (deadline half) | ✅ **rungs 1-4 verified** (board read off real Postgres) · rung 5 = merge, owner's call | Cards lie about dead jobs, drop deadlines, and the Applied filter always returns zero. |
 | 6 | **Close the silent holes** | W-06, W-12, W-28, W-29 | ready | One-liners: an untracked exit, a stale-doc warning, a feed that shows old scores as fresh. |
 | 7 | **Launch gates** | W-23, W-27 | ready | No unsubscribe = cannot email the public. No analytics = the launch teaches nothing. |
 | 8 | **Delete sweep** | D-01…D-05 | ready | Deleting dead code is a real fix. Fan out — 5 unrelated files. |
@@ -168,7 +168,7 @@ Same row. There is no button anywhere to say "I actually submitted it".
 **Proof missing:** `git grep -n "confirm.*submit|mark.*submitted|confirmed_applied"` → one unrelated hit (the magic-link confirm page).
 **Smallest fix:** decide D-A first. Then at most a "submitted?" tick on the pipeline card.
 
-### [ ] W-05 — Two different truths for "applied"
+### [x] W-05 — Two different truths for "applied"  ✅ RUNGS 1-4 VERIFIED
 **Severity:** degrades — **resolved by D-05, see delete list**
 **What happens:** `applications` (written by Apply) and `user_actions` (read by the job
 list's "My Actions → Applied" filter) never speak. So that filter **always returns zero**.
@@ -291,14 +291,14 @@ There is no rule anywhere that says "21 days of silence = ghosted".
 **Proof exists:** all 5 `ghosted` hits in the codebase are: `pipeline.py:29-36` (a comment saying it's deliberately user-confirmed), `pipeline/page.tsx:154-162` (`handleMarkGhosted`, the only writer), `KanbanBoard.tsx:121,142` (column definitions).
 **Proof missing:** none of those 5 is a cron, worker, or scheduled writer.
 
-### [ ] W-15 — A pipeline card never learns its job died
+### [x] W-15 — A pipeline card never learns its job died  ✅ RUNGS 1-4 VERIFIED
 **Severity:** degrades
 **What happens:** staleness is checked **once**, at the moment the row is created. Never
 again. The card looks alive forever.
 **Proof exists:** `pipeline.py:108` is the only check. The 3 write statements to `applications` (`database.py:1103, 1130, 1802`) never touch `staleness_state`.
 **Smallest fix:** select `j.staleness_state` in `get_applications`; flag `expired` on the card. *(Tests written.)*
 
-### [ ] W-16 — Deadlines vanish, interview dates were never captured
+### [~] W-16 — Deadlines vanish, interview dates were never captured  ✅ DEADLINE HALF VERIFIED · interview half still blocked on D-D
 **Severity:** degrades — **DECISION REQUIRED (D-D)**
 **What happens:** before applying, the card shows "Apply by 30 June". The second it becomes
 an application, the date is gone — the pipeline query never selects it and the model has no
@@ -316,6 +316,32 @@ reminder is impossible.
 **This is the heart of the problem.** The plumbing is genuinely good — dispatcher, ledger,
 quiet hours, digest, retries, a notifications history page. Nothing pipeline-shaped ever
 enters it.
+
+**PR 5 landed the deadline half, 2026-08-25.** `get_applications` now selects
+`j.staleness_state` and `j.deadline`; `PipelineApplication` carries `expired`,
+`deadline` and `tailored`. The interview half is untouched and still waits on D-D —
+`interview_dates` remains a dead column, and wiring it is a product decision.
+
+`expired` is true ONLY for `confirmed_expired`. `possibly_stale`/`likely_stale` are
+inferred from absence, and telling someone to stop chasing a live job is a worse error
+than staying quiet.
+
+W-05 is fixed by DERIVING, not duplicating: `get_applied_job_ids` reads the
+`applications` table. Writing 'applied' into `user_actions` would have erased the user's
+'liked', since that table holds one value per (user, job). So `applied` is its own field
+on `JobResponse`, separate from `action`.
+
+The dead `get_tailored_summary_for_jobs` is now called — once per board, not per card.
+
+**A real constraint found while testing:** for a logged-in caller `GET /api/jobs` reads
+`get_user_feed_jobs` (routes/jobs.py:564), NOT the shared catalog. A job with no
+`user_feed` row is invisible to the list — so the Applied filter cannot show an
+application whose feed row has been purged. A genuine bound on the feature, not a test
+detail.
+
+**D-F is still open** — whether the Applied filter should exist at all, given the
+pipeline page already lists applications. Making it work is the reversible choice;
+deleting it later is easy, and meanwhile it is no longer a broken feature.
 
 ### [x] W-17 — The instant email strips the score, the reason, and the salary  ✅ RUNGS 1-4 VERIFIED
 **Severity:** breaks the loop — **instant is the DEFAULT mode**


### PR DESCRIPTION
Stacked on #451.

Three things the pipeline board was telling users that were not true.

## W-05 — the "Applied" filter returned an empty list for every user, always

The job list's "My Actions → Applied" filter read `user_actions`. The Apply button writes `applications`. So it returned **zero results for everyone, forever**, while looking like a working feature.

Fixed by **deriving, not duplicating**. The obvious fix — write `'applied'` into `user_actions` — would have been wrong: that table is one row per (user, job) with `ON CONFLICT DO UPDATE`, so it would **silently erase a `liked`** and the heart would vanish from the card. Two facts, two homes — so `applied` is its own field, and a job can honestly be both.

## W-15 — a card never learned its job had closed

Staleness was checked **once**, when the row was created, and never again. A card kept looking live for a job that closed months ago.

`expired` is true **only** for `confirmed_expired`, which comes from a direct URL check. `possibly_stale`/`likely_stale` are inferred from absence, and telling someone to stop chasing a live job is a worse error than staying quiet.

## W-16 (deadline half) — "Apply by 30 June" vanished the moment you applied

The date was never lost from the database; the pipeline query simply did not select it and the model had nowhere to put it.

**The interview half is deliberately untouched** — `interview_dates` stays a dead column here. (The owner has since decided to build it; that is follow-up work, not this PR.)

## Also wires a function written for this exact board and never called

`get_tailored_summary_for_jobs` — its docstring says *"for the Kanban attach"* and it had **zero callers**, leaving the CV/Letter button unable to say whether a document already existed. Called once per board, not once per card.

## A real constraint found while testing, not a test detail

For a logged-in caller `GET /api/jobs` reads `get_user_feed_jobs` (`routes/jobs.py:564`), **not** the shared catalog. A job with no `user_feed` row is invisible to the list no matter what else is true of it — so the Applied filter cannot show an application whose feed row has been purged. Written into `wiring.md` as a bound on the feature.

This surfaced because a **control** test — the `liked` filter, which should already have passed — was failing. Eight failures looked like "the feature isn't built yet"; the ninth meant something completely different.

## Verified

9 tests **watched fail first**, plus 2 more for the deadline half that were **mutation-tested** because they went green on the first run — forcing `deadline=None` killed exactly 1 and left the other 10 green. 115 passed across pipeline, API, IDOR, chase and document suites. `api-types` regenerated. A drill fires the whole board against real Postgres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpxEMPz2ZWG9Qed5BsFHvg
