### PR TITLE
8/8 — Launch gates: unsubscribe, analytics, and the first deletions

### DIFF
--- a/backend/scripts/drill_wiring.py
+++ b/backend/scripts/drill_wiring.py
@@ -305,10 +305,64 @@ async def drill_pipeline_card(db: Any) -> list[str]:
     return failures
 
 
+async def drill_unsubscribe(db: Any) -> list[str]:
+    """W-23 — the exit in every email must actually work."""
+    print("\n=== DRILL: unsubscribe (W-23) ===")
+    failures: list[str] = []
+    from src.services.notifications.unsubscribe import (
+        unsubscribe_line,
+        verify_token,
+    )
+
+    await _seed_user(db)
+    await db.execute(
+        "INSERT INTO notification_rules (user_id, enabled) VALUES (?, 1)", (DRILL_USER,)
+    )
+    await db.commit()
+
+    line = unsubscribe_line(SITE_BASE_URL, DRILL_USER)
+    print("  the line that goes in every email:")
+    print("   ", line)
+    token = line.rsplit("token=", 1)[1]
+
+    jdb = JobDatabase.from_connection("", db)
+    await jdb.set_notifications_enabled(verify_token(token) or "", enabled=False)
+    cur = await db.execute(
+        "SELECT enabled FROM notification_rules WHERE user_id = ?", (DRILL_USER,)
+    )
+    row = await cur.fetchone()
+    enabled_after = row[0] if row else None
+    print(f"  notification_rules.enabled after unsubscribing: {enabled_after}")
+
+    for label, ok in (
+        ("the emitted token verifies to the right user", verify_token(token) == DRILL_USER),
+        ("a forged token is refused", verify_token(f"{DRILL_USER}.{'0' * 32}") is None),
+        ("another user cannot be silenced with this token",
+         verify_token(f"someone-else.{token.rsplit('.', 1)[1]}") is None),
+        ("notifications are actually off", enabled_after in (0, False)),
+    ):
+        print(f"  [{'PASS' if ok else 'FAIL'}] {label}")
+        if not ok:
+            failures.append(f"unsubscribe: {label}")
+
+    # Turning it back on must restore, not recreate.
+    await jdb.set_notifications_enabled(DRILL_USER, enabled=True)
+    cur = await db.execute(
+        "SELECT enabled FROM notification_rules WHERE user_id = ?", (DRILL_USER,)
+    )
+    back = (await cur.fetchone())[0]
+    ok = back in (1, True)
+    print(f"  [{'PASS' if ok else 'FAIL'}] the user can turn them back on")
+    if not ok:
+        failures.append("unsubscribe: could not re-enable")
+    return failures
+
+
 DRILLS = {
     "chase": drill_chase,
     "instant": drill_instant,
     "pipeline": drill_pipeline_card,
+    "unsubscribe": drill_unsubscribe,
 }
 
 

--- a/backend/src/api/routes/notifications.py
+++ b/backend/src/api/routes/notifications.py
@@ -18,12 +18,14 @@ from __future__ import annotations
 
 from typing import Optional
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
 
 from src.api.auth_deps import CurrentUser, require_user
 from src.api.dependencies import get_request_db
 from src.api.models import NotificationLedgerEntry, NotificationLedgerListResponse
 from src.repositories.database import JobDatabase
+from src.services.notifications.unsubscribe import verify_token
 
 router = APIRouter(tags=["notifications"])
 
@@ -88,3 +90,40 @@ async def notification_stats(
     Always 200 — empty dict when no ledger rows exist yet.
     """
     return await db.get_notification_ledger_stats(user_id=user.id)
+
+class UnsubscribeRequest(BaseModel):
+    token: str
+
+
+@router.post("/notifications/unsubscribe")
+async def unsubscribe(
+    body: UnsubscribeRequest,
+    db: JobDatabase = Depends(get_request_db),  # noqa: B008 — FastAPI DI idiom
+) -> dict[str, bool]:
+    """Turn ALL notifications off for the user a signed token names (W-23).
+
+    NO SESSION REQUIRED, on purpose. Someone who wants the emails to stop is often
+    exactly the person who will not log in to make it happen — and a recipient who
+    cannot find the exit presses "spam" instead, which is the worst signal a sending
+    domain can collect. The token IS the authorisation.
+
+    Safe to expose unauthenticated because of what it can do: the ONLY outcome is
+    silence. It cannot read anything, cannot change an address, and cannot be used to
+    reach an account. A leaked token buys an attacker the ability to stop someone's
+    email, which the owner reverses by logging in and switching it back on.
+
+    POST, never GET. Email clients and security scanners prefetch links, and a
+    state-changing GET would unsubscribe people who never clicked — the same trap the
+    magic-link landing page already solves with a confirm button. The emailed URL
+    points at a frontend page; that page POSTs here when the human presses the button.
+
+    Idempotent: unsubscribing twice is a success, not an error. A retry, a double-click
+    or a second visit to an old email must not produce a scary failure page.
+    """
+    user_id = verify_token(body.token)
+    if user_id is None:
+        # One message for forged AND malformed. Distinguishing them would let
+        # someone probe which user ids exist.
+        raise HTTPException(status_code=400, detail="This unsubscribe link is not valid.")
+    await db.set_notifications_enabled(user_id, enabled=False)
+    return {"unsubscribed": True}

--- a/backend/src/repositories/database.py
+++ b/backend/src/repositories/database.py
@@ -1333,6 +1333,23 @@ class JobDatabase:
             for r in await cursor.fetchall()
         ]
 
+    async def set_notifications_enabled(self, user_id: str, *, enabled: bool) -> None:
+        """Flip the caller's ONE notification_rules row on or off (W-23).
+
+        Rule #23: exactly one row per user governs every channel, so unsubscribing is
+        a single flag rather than a sweep over channels. Deliberately does NOT delete
+        anything — the user's channels, quiet hours and mode survive, so switching
+        back on restores exactly what they had rather than an empty default.
+
+        Silent when no rule row exists: a user with nothing configured is already as
+        unsubscribed as it is possible to be, and that is a success, not an error.
+        """
+        await self._db.execute(
+            "UPDATE notification_rules SET enabled = ? WHERE user_id = ?",
+            (1 if enabled else 0, user_id),
+        )
+        await self._db.commit()
+
     async def get_applied_job_ids(self, user_id: str) -> set[int]:
         """Job ids this user has an application for — the ONE truth for "applied".
 

--- a/backend/src/services/delivery/email_body.py
+++ b/backend/src/services/delivery/email_body.py
@@ -100,15 +100,20 @@ def render_instant_subject(card: DecisionCard) -> str:
     return f"Job360 — {head}"
 
 
-def render_instant_text(card: DecisionCard) -> str:
+def render_instant_text(card: DecisionCard, unsubscribe: str | None = None) -> str:
     """Body for a single-job instant alert — same facts as the digest states.
 
     Rendered from :func:`_card_lines`, so instant and digest cannot drift apart:
     change what a job says in one place and both modes follow.
+
+    ``unsubscribe`` is the one-line exit (W-23). Optional so a caller that has no
+    user context still renders a valid body, but every real send passes it: an email
+    with no way out gets marked as spam instead.
     """
-    return "\n".join(
-        [f"{card.title} — {card.company}", *_card_lines(card, indent=""), ""]
-    )
+    lines = [f"{card.title} — {card.company}", *_card_lines(card, indent=""), ""]
+    if unsubscribe:
+        lines.extend(["—", unsubscribe])
+    return "\n".join(lines)
 
 
 def render_digest_text(
@@ -116,6 +121,7 @@ def render_digest_text(
     *,
     considered: int,
     dropped_reasons: Sequence[str],
+    unsubscribe: str | None = None,
 ) -> str:
     """Render the whole email body.
 
@@ -152,5 +158,13 @@ def render_digest_text(
     else:
         out.append("")
         out.append("We would rather send you nothing than send you noise.")
+
+    # W-23 — every outbound email carries its own exit. A recipient who cannot find
+    # one presses "spam" instead, and that costs the sending domain far more than
+    # the unsubscribe ever would.
+    if unsubscribe:
+        out.append("")
+        out.append("—")
+        out.append(unsubscribe)
 
     return "\n".join(out).rstrip() + "\n"

--- a/backend/src/services/notifications/unsubscribe.py
+++ b/backend/src/services/notifications/unsubscribe.py
@@ -1,0 +1,76 @@
+"""One-click unsubscribe tokens (wiring.md W-23).
+
+The digest had no unsubscribe link at all. The only way to stop the emails was to log
+in and delete the channel — which is a deliverability problem before it is a legal one:
+a recipient who cannot find an unsubscribe link presses "spam" instead, and that is the
+single worst signal a sending domain can collect.
+
+DESIGN — stateless, derived, no table:
+
+    token = "{user_id}.{hmac_sha256(secret, user_id)[:32]}"
+
+* No storage, so no migration, no cleanup job, and no row that can drift out of sync
+  with the account it refers to.
+* Not guessable: forging one requires SESSION_SECRET.
+* Not an account takeover if leaked. The token authorises exactly ONE irreversible-in-
+  the-safe-direction action — turning notifications OFF. The worst a leaked token buys
+  an attacker is silence, and the user can turn them back on by logging in.
+* Revocable in bulk by rotating SESSION_SECRET, same as sessions.
+
+Deliberately NOT time-limited. An unsubscribe link must work in a year-old email — a
+recipient discovering an ancient email and being told "this link has expired, please log
+in" is exactly the dead end this exists to remove.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import os
+
+# 128 bits of the digest. Enough that forging is infeasible, short enough that the
+# whole link stays readable in a plain-text email.
+_SIG_LENGTH = 32
+
+
+def _secret() -> bytes:
+    """The signing key. Falls back to a constant ONLY when unset (dev/test).
+
+    A missing SESSION_SECRET already breaks sessions long before it reaches here, so
+    this fallback is never the thing standing between a real deployment and safety —
+    it just keeps the module importable in a bare test environment.
+    """
+    return (os.environ.get("SESSION_SECRET") or "job360-dev-unsubscribe").encode()
+
+
+def make_token(user_id: str) -> str:
+    """Build the unsubscribe token for ``user_id``."""
+    sig = hmac.new(_secret(), user_id.encode(), hashlib.sha256).hexdigest()[:_SIG_LENGTH]
+    return f"{user_id}.{sig}"
+
+
+def verify_token(token: str | None) -> str | None:
+    """Return the user id a token authorises, or None if it is not ours.
+
+    Uses ``compare_digest`` so a wrong signature cannot be discovered one character at
+    a time by timing the response.
+    """
+    if not token or "." not in token:
+        return None
+    user_id, _, sig = token.rpartition(".")
+    if not user_id or not sig:
+        return None
+    expected = hmac.new(_secret(), user_id.encode(), hashlib.sha256).hexdigest()[:_SIG_LENGTH]
+    if not hmac.compare_digest(sig, expected):
+        return None
+    return user_id
+
+
+def unsubscribe_line(site_base_url: str, user_id: str) -> str:
+    """The line appended to every outbound digest.
+
+    Says what it does in plain words. "Manage" or "preferences" hides the action the
+    recipient is looking for, and a recipient who cannot find it presses spam.
+    """
+    base = site_base_url.rstrip("/")
+    return f"Stop these emails: {base}/unsubscribe?token={make_token(user_id)}"

--- a/backend/src/workers/tasks.py
+++ b/backend/src/workers/tasks.py
@@ -383,7 +383,9 @@ async def send_notification(
 
     card = build_decision_card(dict(job_row), site_base_url=SITE_BASE_URL)
     title = render_instant_subject(card)
-    body = render_instant_text(card)
+    from src.services.notifications.unsubscribe import unsubscribe_line  # noqa: PLC0415
+
+    body = render_instant_text(card, unsubscribe_line(SITE_BASE_URL, user_id))
 
     # Test hook: ctx['dispatcher'] short-circuits the real Apprise path.
     # In production, we import lazily to dodge Apprise's ~30MB dep chain
@@ -1129,8 +1131,17 @@ async def send_bundle(ctx: dict[str, Any], user_id: str) -> dict[str, int]:
         ["no longer in your feed"] if considered > jobs_count else []
     )
     digest_title = render_digest_subject(shown=jobs_count, considered=considered)
+    from src.services.notifications.unsubscribe import unsubscribe_line  # noqa: PLC0415
+
     digest_body = render_digest_text(
-        cards, considered=considered, dropped_reasons=dropped_reasons
+        cards,
+        considered=considered,
+        dropped_reasons=dropped_reasons,
+        # W-23 — the exit rides in the body itself. Apprise's mailto transport
+        # carries no custom headers, so a List-Unsubscribe header is not
+        # available on this path; an in-body link is what actually reaches
+        # the recipient.
+        unsubscribe=unsubscribe_line(SITE_BASE_URL, user_id),
     )
 
     dispatcher_fn = ctx.get("dispatcher")

--- a/backend/tests/test_unsubscribe.py
+++ b/backend/tests/test_unsubscribe.py
@@ -1,0 +1,82 @@
+"""W-23 — one-click unsubscribe.
+
+The digest had no unsubscribe link at all; the only exit was to log in and delete the
+channel. That is a deliverability problem before it is a legal one: a recipient who
+cannot find the link presses "spam" instead, and that is the worst signal a sending
+domain can collect.
+
+The tests that matter are the forgery ones. A token that turns notifications off for
+whoever holds it must not be guessable, and must not be accepted in a mangled form —
+email clients wrap, truncate and re-case URLs, and "close enough" must fail closed.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.services.notifications.unsubscribe import (
+    make_token,
+    unsubscribe_line,
+    verify_token,
+)
+
+USER = "11111111-2222-3333-4444-555555555555"
+
+
+def test_a_token_round_trips_to_its_own_user() -> None:
+    assert verify_token(make_token(USER)) == USER
+
+
+def test_each_user_gets_a_different_token() -> None:
+    other = "99999999-8888-7777-6666-555555555555"
+    assert make_token(USER) != make_token(other)
+    assert verify_token(make_token(other)) == other
+
+
+@pytest.mark.parametrize(
+    ("bad", "why"),
+    [
+        ("", "empty"),
+        (None, "absent"),
+        ("no-dot-at-all", "not a token shape"),
+        (f"{USER}.", "signature stripped"),
+        (f".{'a' * 32}", "user id stripped"),
+        (f"{USER}.{'a' * 32}", "forged signature"),
+        (f"{USER}.{'A' * 32}", "forged, upper case"),
+        ("other-user." + make_token(USER).split(".")[1], "someone else's signature reused"),
+    ],
+)
+def test_a_token_that_is_not_ours_is_refused(bad, why: str) -> None:
+    assert verify_token(bad) is None, f"accepted a bad token ({why})"
+
+
+def test_swapping_the_user_id_invalidates_the_signature() -> None:
+    """The signature must be OVER the user id, not merely next to it.
+
+    A token that authorises "turn notifications off" would otherwise let anyone
+    silence any account by editing the id in the URL.
+    """
+    victim = "victim-user-id"
+    forged = f"{victim}.{make_token(USER).split('.')[1]}"
+    assert verify_token(forged) is None
+
+
+def test_a_truncated_token_is_refused() -> None:
+    """Email clients wrap and truncate long URLs. Close enough must fail closed."""
+    token = make_token(USER)
+    assert verify_token(token[:-1]) is None
+    assert verify_token(token[:-8]) is None
+
+
+def test_the_line_says_plainly_what_it_does() -> None:
+    """"Manage preferences" hides the action; a recipient who cannot find the exit
+    presses spam instead."""
+    line = unsubscribe_line("https://job360.uk", USER)
+    assert "Stop these emails" in line
+    assert "https://job360.uk/unsubscribe?token=" in line
+    assert verify_token(line.rsplit("token=", 1)[1]) == USER
+
+
+def test_the_line_survives_a_base_url_with_a_trailing_slash() -> None:
+    line = unsubscribe_line("https://job360.uk/", USER)
+    assert "job360.uk//unsubscribe" not in line

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -2514,6 +2514,19 @@
         "title": "TimelineEntry",
         "type": "object"
       },
+      "UnsubscribeRequest": {
+        "properties": {
+          "token": {
+            "title": "Token",
+            "type": "string"
+          }
+        },
+        "required": [
+          "token"
+        ],
+        "title": "UnsubscribeRequest",
+        "type": "object"
+      },
       "UserResponse": {
         "properties": {
           "email": {
@@ -4150,6 +4163,52 @@
           }
         },
         "summary": "Notification Stats",
+        "tags": [
+          "notifications"
+        ]
+      }
+    },
+    "/api/notifications/unsubscribe": {
+      "post": {
+        "description": "Turn ALL notifications off for the user a signed token names (W-23).\n\nNO SESSION REQUIRED, on purpose. Someone who wants the emails to stop is often\nexactly the person who will not log in to make it happen \u2014 and a recipient who\ncannot find the exit presses \"spam\" instead, which is the worst signal a sending\ndomain can collect. The token IS the authorisation.\n\nSafe to expose unauthenticated because of what it can do: the ONLY outcome is\nsilence. It cannot read anything, cannot change an address, and cannot be used to\nreach an account. A leaked token buys an attacker the ability to stop someone's\nemail, which the owner reverses by logging in and switching it back on.\n\nPOST, never GET. Email clients and security scanners prefetch links, and a\nstate-changing GET would unsubscribe people who never clicked \u2014 the same trap the\nmagic-link landing page already solves with a confirm button. The emailed URL\npoints at a frontend page; that page POSTs here when the human presses the button.\n\nIdempotent: unsubscribing twice is a success, not an error. A retry, a double-click\nor a second visit to an old email must not produce a scary failure page.",
+        "operationId": "unsubscribe_api_notifications_unsubscribe_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UnsubscribeRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "boolean"
+                  },
+                  "title": "Response Unsubscribe Api Notifications Unsubscribe Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Unsubscribe",
         "tags": [
           "notifications"
         ]

--- a/frontend/src/app/channels/page.tsx
+++ b/frontend/src/app/channels/page.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { useEffect, useState } from "react";
+import posthog from "posthog-js";
 import { toast } from "sonner";
 
 import {
@@ -55,6 +56,10 @@ function EmailAddForm({ onRefresh }: { onRefresh: () => void }) {
         display_name: email,
         credential: email,
       });
+      // W-27 — setting up a delivery channel is the moment a user opts INTO
+      // being reached. Nothing counted it, so the one action that turns a
+      // signup into a reachable person was invisible.
+      posthog.capture("channel_added", { channel_type: "email" });
       setEmail("");
       await onRefresh();
       toast.success("Email channel added");
@@ -120,6 +125,7 @@ function WebhookAddForm({ onRefresh }: { onRefresh: () => void }) {
         display_name: "Webhook",
         credential: url,
       });
+      posthog.capture("channel_added", { channel_type: "webhook" });
       setUrl("");
       await onRefresh();
       toast.success("Webhook added");

--- a/frontend/src/app/pipeline/page.tsx
+++ b/frontend/src/app/pipeline/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState, useCallback } from "react";
+import posthog from "posthog-js";
 import { toast } from "sonner";
 import {
   Kanban,
@@ -117,6 +118,10 @@ export default function PipelinePage() {
   async function handleAdvance(jobId: number, stage: string) {
     try {
       const updated = await advancePipelineStage(jobId, { stage });
+      // W-27 — captured AFTER the call succeeds, never on the attempt. An event
+      // fired on intent counts moves that failed, which is how a funnel quietly
+      // starts lying about itself.
+      posthog.capture("application_stage_changed", { job_id: jobId, stage });
       // Optimistic update: replace the app in local state
       setApplications((prev) =>
         prev.map((a) => (a.job_id === jobId ? { ...a, ...updated } : a))

--- a/frontend/src/app/unsubscribe/page.tsx
+++ b/frontend/src/app/unsubscribe/page.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+// One-click unsubscribe landing page (wiring.md W-23).
+//
+// WHY A PAGE WITH A BUTTON, and not a link that just does it:
+// email clients and security scanners PREFETCH links. A state-changing GET would
+// unsubscribe people who never clicked — silently, and with no way for them to know
+// it happened. This is the same trap /auth/magic already solves, and it is solved the
+// same way: the emailed URL only OPENS this page, and the human pressing the button
+// is what POSTs.
+//
+// No session is required. Someone who wants the emails to stop is often exactly the
+// person who will not log in to make it happen, and a recipient who cannot find the
+// exit presses "spam" instead — which costs the sending domain far more.
+
+import { Suspense, useState } from "react";
+import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+
+import { unsubscribeFromNotifications } from "@/lib/api";
+import { apiErrorMessage } from "@/lib/api-error";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+type State = "confirm" | "working" | "done" | "error";
+
+function UnsubscribeBody() {
+  const searchParams = useSearchParams();
+  const token = searchParams.get("token") ?? "";
+  const [state, setState] = useState<State>("confirm");
+  const [error, setError] = useState<string | null>(
+    token ? null : "This link is missing its code. Use the link from your email."
+  );
+
+  async function confirm() {
+    setState("working");
+    try {
+      await unsubscribeFromNotifications(token);
+      setState("done");
+    } catch (err) {
+      setState("error");
+      setError(
+        apiErrorMessage(err, "We could not stop the emails. Try the link again.")
+      );
+    }
+  }
+
+  if (state === "done") {
+    return (
+      <CardContent className="space-y-4">
+        <p className="text-sm text-foreground/80">
+          Done — we&apos;ve stopped all Job360 emails to you.
+        </p>
+        {/* Say how to undo it. An unsubscribe that feels permanent and
+            unexplained is one people regret and resent. */}
+        <p className="text-sm text-muted-foreground">
+          Changed your mind? Sign in and turn notifications back on in Settings —
+          your channels and quiet hours are still exactly as you left them.
+        </p>
+        <Button render={<Link href="/login" />} variant="outline">
+          Back to Job360
+        </Button>
+      </CardContent>
+    );
+  }
+
+  return (
+    <CardContent className="space-y-4">
+      <p className="text-sm text-foreground/80">
+        This stops <strong>all</strong> Job360 emails — job matches and application
+        reminders.
+      </p>
+      {error && (
+        <p role="alert" className="text-sm text-destructive">
+          {error}
+        </p>
+      )}
+      <Button onClick={confirm} disabled={!token || state === "working"}>
+        {state === "working" ? "Stopping…" : "Stop all emails"}
+      </Button>
+    </CardContent>
+  );
+}
+
+export default function UnsubscribePage() {
+  return (
+    <main className="mx-auto flex min-h-[60vh] max-w-md items-center px-4">
+      <Card className="w-full">
+        <CardHeader>
+          <CardTitle>Unsubscribe</CardTitle>
+          <CardDescription>Stop Job360 emails to this address.</CardDescription>
+        </CardHeader>
+        {/* useSearchParams needs a Suspense boundary in the App Router. */}
+        <Suspense fallback={<CardContent>Loading…</CardContent>}>
+          <UnsubscribeBody />
+        </Suspense>
+      </Card>
+    </main>
+  );
+}

--- a/frontend/src/components/profile/CVViewer.tsx
+++ b/frontend/src/components/profile/CVViewer.tsx
@@ -534,6 +534,49 @@ export function CVViewer({
           </div>
         )}
 
+        {/* W-29 — these three MOVE THE SCORE. They are read into the LLM
+            matcher's prompt (backend llm_matcher.py:249-260), and until now the
+            user could never see them, so could never correct a wrong one. Each
+            section stays silent when empty (rule #29: unfilled means "don't
+            care", never a guess). */}
+        {(cv.career_domain ||
+          (cv.cv_languages?.length ?? 0) > 0 ||
+          (cv.cv_education_details?.length ?? 0) > 0) && (
+          <div className="mb-5">
+            <div className="flex items-center gap-2 mb-2">
+              <Languages className="h-3.5 w-3.5 text-primary" />
+              <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                Used for matching
+              </span>
+            </div>
+            <p className="mb-2 text-xs text-muted-foreground/80">
+              We use these when scoring how well a job fits you. If one looks
+              wrong, re-upload your CV to correct it.
+            </p>
+            {cv.career_domain && (
+              <p className="text-sm text-foreground/80">
+                <span className="text-muted-foreground">Career field: </span>
+                {cv.career_domain}
+              </p>
+            )}
+            {(cv.cv_languages?.length ?? 0) > 0 && (
+              <p className="text-sm text-foreground/80">
+                <span className="text-muted-foreground">Languages: </span>
+                {cv.cv_languages.join(", ")}
+              </p>
+            )}
+            {(cv.cv_education_details?.length ?? 0) > 0 && (
+              <ul className="mt-1 space-y-1 pl-5 text-sm text-foreground/80">
+                {cv.cv_education_details.map((detail, i) => (
+                  <li key={i} className="leading-relaxed">
+                    {detail}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        )}
+
         {/* Certifications */}
         {cv.certifications.length > 0 && (
           <div className="mb-5">

--- a/frontend/src/components/tailor/TailorPanel.tsx
+++ b/frontend/src/components/tailor/TailorPanel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
+import posthog from "posthog-js";
 import { Download, Loader2, Sparkles, Eye } from "lucide-react";
 import {
   Dialog,
@@ -134,6 +135,9 @@ export function TailorPanel({ jobId, open, onOpenChange, initialKind = "cv" }: T
     setGenerating(true);
     try {
       const b = await generateTailored(jobId);
+      // W-27 — the funnel went dark right after Apply. Tailoring is the most
+      // expensive thing the product does per user and nothing counted it.
+      posthog.capture("tailored_document_generated", { job_id: jobId });
       applyBundle(b);
       toast.success("Tailored CV + cover letter generated");
     } catch (err) {
@@ -176,6 +180,13 @@ export function TailorPanel({ jobId, open, onOpenChange, initialKind = "cv" }: T
     setDownloading(true);
     try {
       await downloadTailored(jobId, kind, fmt);
+      // Which KIND and which FORMAT — a bare "downloaded" count cannot tell a
+      // CV from a cover letter, or PDF from DOCX.
+      posthog.capture("tailored_document_downloaded", {
+        job_id: jobId,
+        doc_kind: kind,
+        format: fmt,
+      });
       toast.success(`${fmt.toUpperCase()} download started`);
     } catch (err) {
       toast.apiError(err, "Download failed");

--- a/frontend/src/lib/api-types.ts
+++ b/frontend/src/lib/api-types.ts
@@ -588,6 +588,44 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/notifications/unsubscribe": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Unsubscribe
+         * @description Turn ALL notifications off for the user a signed token names (W-23).
+         *
+         *     NO SESSION REQUIRED, on purpose. Someone who wants the emails to stop is often
+         *     exactly the person who will not log in to make it happen — and a recipient who
+         *     cannot find the exit presses "spam" instead, which is the worst signal a sending
+         *     domain can collect. The token IS the authorisation.
+         *
+         *     Safe to expose unauthenticated because of what it can do: the ONLY outcome is
+         *     silence. It cannot read anything, cannot change an address, and cannot be used to
+         *     reach an account. A leaked token buys an attacker the ability to stop someone's
+         *     email, which the owner reverses by logging in and switching it back on.
+         *
+         *     POST, never GET. Email clients and security scanners prefetch links, and a
+         *     state-changing GET would unsubscribe people who never clicked — the same trap the
+         *     magic-link landing page already solves with a confirm button. The emailed URL
+         *     points at a frontend page; that page POSTs here when the human presses the button.
+         *
+         *     Idempotent: unsubscribing twice is a success, not an error. A retry, a double-click
+         *     or a second visit to an old email must not produce a scary failure page.
+         */
+        post: operations["unsubscribe_api_notifications_unsubscribe_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/pipeline": {
         parameters: {
             query?: never;
@@ -2480,6 +2518,11 @@ export interface components {
             /** User Id */
             user_id: string;
         };
+        /** UnsubscribeRequest */
+        UnsubscribeRequest: {
+            /** Token */
+            token: string;
+        };
         /** UserResponse */
         UserResponse: {
             /** Email */
@@ -3400,6 +3443,41 @@ export interface operations {
                         [key: string]: {
                             [key: string]: number;
                         };
+                    };
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    unsubscribe_api_notifications_unsubscribe_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UnsubscribeRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: boolean;
                     };
                 };
             };

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -209,10 +209,6 @@ export async function getActions(): Promise<{ actions: ActionResponse[] }> {
   return request<{ actions: ActionResponse[] }>("/api/actions");
 }
 
-export async function getActionCounts(): Promise<Record<string, number>> {
-  return request<Record<string, number>>("/api/actions/counts");
-}
-
 // ---------------------------------------------------------------------------
 // Profile
 // ---------------------------------------------------------------------------
@@ -427,6 +423,21 @@ export async function requestMagicLink(
   await request<void>("/api/auth/magic-link/request", {
     method: "POST",
     body: JSON.stringify(next ? { email, next } : { email }),
+  });
+}
+
+/**
+ * Turn ALL notifications off, authorised by a signed token from an email (W-23).
+ *
+ * No session needed — someone who wants the emails to stop is often exactly the
+ * person who will not log in to make it happen, and a recipient who cannot find the
+ * exit presses "spam" instead.
+ */
+export async function unsubscribeFromNotifications(token: string): Promise<void> {
+  await request<void>("/api/notifications/unsubscribe", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ token }),
   });
 }
 
@@ -710,15 +721,6 @@ export async function saveTailored(
   return request<TailoredDocOut>(`/api/tailor/${jobId}/${kind}`, {
     method: "PATCH",
     body: JSON.stringify({ text }),
-  });
-}
-
-export async function keepTailored(
-  jobId: number,
-  kind: TailorDocKind
-): Promise<TailoredDocOut> {
-  return request<TailoredDocOut>(`/api/tailor/${jobId}/${kind}/keep`, {
-    method: "POST",
   });
 }
 

--- a/wiring.md
+++ b/wiring.md
@@ -409,7 +409,7 @@ enqueue sites are feed-driven (`main.py:509` enqueues *for feed rows*; `tasks.py
 fires straight after `upsert_feed_row`), so production always has the row. Four existing
 tests encoded the old contract and were updated to seed a feed row, not the code weakened.
 
-### [ ] W-19 — Nothing ever notices "no reply"
+### [x] W-19 — Nothing ever notices "no reply"  ✅ RUNGS 1-4 VERIFIED (PR 2)
 **Severity:** breaks the loop — **THE ONE BREAK**
 **What happens:** the query **already exists** — `get_stale_applications`, 7+ days dormant,
 correctly excludes offer/rejected. It is wired to exactly one consumer: an in-app banner on
@@ -419,13 +419,27 @@ if he remembers to open that page and look.
 **Proof missing:** `git grep -n "get_stale_applications" origin/main -- backend/src` → exactly 2 hits, the definition and that one route. `workers/settings.py:220-241` is the complete cron list — `nightly_ghost_sweep`, `refresh_catalog`, `notification_tick`, `enrichment_sweep` — **none** references applications or pipeline.
 **Smallest fix:** one daily cron next to the existing four → `get_stale_applications` per user → existing dispatcher.
 
-### [ ] W-20 — Every message is about a NEW JOB, never about HIM
+### [~] W-20 — Every message is about a NEW JOB, never about HIM  ⚠️ PARTIAL — see note
 **Severity:** breaks the loop
 **What happens:** email bodies are built from the shared catalog + his feed score + the LLM
 verdict. The engine has **never** read `applications`. There is no "your application moved
 to interview", no "your week: 3 applied, 1 interview, 2 quiet".
 **Proof missing:** `git grep -n "applications" origin/main -- backend/src/services/delivery backend/src/services/notifications` → **zero hits**.
 **Smallest fix:** a "your pipeline" section in the digest build, plus a notify call inside `advance_application`.
+
+**W-20 is PARTIAL and the earlier tick was wrong.** The chase cron (W-19) means the
+product can now say something about the user's OWN applications — that is the half that
+landed. Two halves did NOT:
+
+* the **digest has no "your pipeline" section** ("your week: 3 applied, 1 interview,
+  2 gone quiet"). Blocked on **D-G** — whether the digest should talk about him at all
+  is a tone decision, not an engineering one.
+* **stage transitions notify nobody.** Moving a card to interview/offer/rejected sends
+  nothing. Unblocked, just not built.
+
+`grep "applications" backend/src/services/delivery backend/src/services/notifications`
+still returns zero — the digest builder itself has still never read that table. Only the
+new cron has.
 
 ### [ ] W-21 — No deadline / interview / CV-staleness reminders exist at all
 **Severity:** breaks the loop — **design gap, not a quick wire**

--- a/wiring.md
+++ b/wiring.md
@@ -47,8 +47,8 @@ Work top to bottom. Each block is independently shippable.
 | 4 | **Don't lose the CV he sent** | W-08, W-10 | ✅ **rungs 1-4 verified** (tailor→apply→regenerate walked on real Postgres) · rung 5 = merge, owner's call | Data is being destroyed today. Every day we wait, more is gone. |
 | 5 | **Pipeline card truth** | W-05, W-15, W-16 (deadline half) | ✅ **rungs 1-4 verified** (board read off real Postgres) · rung 5 = merge, owner's call | Cards lie about dead jobs, drop deadlines, and the Applied filter always returns zero. |
 | 6 | **Close the silent holes** | W-06, W-12, W-28, W-29 | ✅ **rungs 1-4 verified** · rung 5 = merge, owner's call | One-liners: an untracked exit, a stale-doc warning, a feed that shows old scores as fresh. |
-| 7 | **Launch gates** | W-23, W-27 | ready | No unsubscribe = cannot email the public. No analytics = the launch teaches nothing. |
-| 8 | **Delete sweep** | D-01…D-05 | ready | Deleting dead code is a real fix. Fan out — 5 unrelated files. |
+| 7 | **Launch gates** | W-23, W-27 | ✅ **rungs 1-4 verified** (unsubscribe drill fires on real Postgres) · rung 5 = merge, owner's call | No unsubscribe = cannot email the public. No analytics = the launch teaches nothing. |
+| 8 | **Delete sweep** | D-01…D-05 | ⚠️ **PARTIAL — 2 of 5 done**, 3 blocked on decisions (see below) | Deleting dead code is a real fix. Fan out — 5 unrelated files. |
 
 > **STATUS WORDS MEAN SPECIFIC THINGS HERE. Corrected 2026-08-25.**
 > An earlier version of this table said PR 1 was "✅ shipped". That was false and it
@@ -445,7 +445,7 @@ application* going quiet.
 
 # STEP 6 — Channels, the email, and the click that must come back
 
-### [ ] W-23 — No unsubscribe link. At all.
+### [x] W-23 — No unsubscribe link. At all.  ✅ RUNGS 1-4 VERIFIED
 **Severity:** blocks public launch (deliverability + legal), technically small
 **What happens:** the only way to stop the emails is to log in and delete the channel.
 **Proof exists:** `services/delivery/email_body.py` — full body construction, no unsubscribe line.
@@ -471,7 +471,7 @@ application* going quiet.
 
 # CROSS-CUTTING (found in sweep 1)
 
-### [ ] W-27 — The funnel goes dark right after Apply
+### [x] W-27 — The funnel goes dark right after Apply  ✅ RUNGS 1-4 VERIFIED
 **Severity:** blocks a useful launch — **4 one-line fixes, cheapest item here**
 **What happens:** 6 analytics events exist total: `signup_completed`, `cv_uploaded`,
 `extraction_completed`, `search_run`, `job_viewed`, `application_created`. **Nothing** fires
@@ -505,12 +505,20 @@ scoring prompt. He can never see or correct them.
 Dead schema. Nothing reads or writes it. Delete now; re-add properly when a real user
 reaches an interview. Dead columns lie to future you. *(Conditional on D-D.)*
 
-### [ ] D-02 — "Keep without downloading"
+### [~] D-02 — "Keep without downloading"  ✅ DEAD CLIENT DELETED · backend route KEPT, see note
 Backend route + typed API client wrapper exist; **no button calls them**. Your own code
 comment says download = keep. Delete the route and the wrapper.
 
-### [ ] D-03 — `getActionCounts()` in `lib/api.ts:212`
+### [x] D-03 — `getActionCounts()` in `lib/api.ts:212`  ✅ DELETED
 Defined, exported, **zero callers** anywhere in frontend or backend.
+
+**D-02 was only half-deleted, deliberately.** The frontend `keepTailored` client had
+zero callers and is gone. The BACKEND route is not: it is exercised by
+`tests/test_cv_coverletter.py`, it is public API surface, and PR 4 made
+`keep_tailored_doc` load-bearing — the download path now uses it to bind the document a
+user applied with. Deleting a tested route to tidy up is a bigger and riskier change
+than the note that proposed it assumed, and it earns nothing today. If it goes, it goes
+with its tests, on purpose, as its own change.
 
 ### [ ] D-04 — `applications.notes_history`
 Written on every notes edit (`database.py:1784-1808`), never returned by any model or

--- a/wiring.md
+++ b/wiring.md
@@ -546,39 +546,36 @@ it would erase the user's `liked`.
 
 ---
 
-# DECISIONS ONLY YOU CAN MAKE
+# DECISIONS — ANSWERED BY THE OWNER 2026-08-26
 
-These are product calls, not engineering. Work below them is blocked until you answer.
+All seven are settled. Nothing below is open; each line is now a spec.
 
-### [ ] D-A — What does "applied" mean?
-Clicked the link, or confirmed submitted? Two different products. **Blocks W-04.**
+| # | Decision | ANSWER | What it unblocks |
+|---|---|---|---|
+| D-A | What does "applied" mean? | **Confirm before it counts.** Clicking Apply is not an application until the user says they submitted it. | W-04 |
+| D-B | What does "outreach" mean? | **"I chased them."** Moving a card there RESETS the silence clock, so we stop nagging about a job just followed up on. | W-14 |
+| D-C | Who decides ghosted? | **The user decides. We only suggest — never auto-move a card.** | W-14, chase escalation |
+| D-D | Track interviews? | **Yes — build it.** Moving a card to Interview asks for a date; remind the day before. | W-16 interview half, W-21, D-01 |
+| D-E | Email click tracking? | **Yes — build it.** | W-24, W-25, W-26 |
+| D-F | Keep the "Applied" filter? | **Keep it.** | D-05 (nothing to delete) |
+| D-G | Should the digest talk about him? | **Yes** — add a "your pipeline" section. | W-20's second half |
 
-### [ ] D-B — What does "outreach" mean?
-Today it is a word on a column with no code behind it. Is it "I chased them"? Does entering
-it reset the silence clock? **Blocks W-14.**
+**Two of these went against my recommendation, and that is fine — they are product calls,
+not engineering ones. Recording the trade-off ONCE so it is not re-argued later:**
 
-### [ ] D-C — When is a job ghosted — 14 days? 21? 30?
-And does the product **suggest** ghosted (you confirm) or **decide** it? Recommendation:
-suggest. Never auto-move a card before D-B is answered. **Blocks W-14, W-19.**
+* **D-D (interviews):** I argued to delete the dead column instead, because there is
+  roughly one application in ninety days and nobody has reached an interview yet.
+  Owner says build it. Building it.
+* **D-E (click tracking):** I argued no, strongly. The current emails are plain text
+  with no tracking pixels and no redirect hops, which quietly HELPS them reach the
+  inbox — and the chase cron plus the apply record already show that an email worked.
+  Adding redirects makes the mail look more like marketing to a spam filter. Owner says
+  build it. Building it, and the deliverability cost is stated here rather than
+  re-raised each time.
 
-### [ ] D-D — Do you track interviews at all?
-`interview_dates` is a feature you never decided to build. Wire it with a real date prompt,
-or delete the column. **Blocks W-16, W-21, D-01.**
-
-### [ ] D-E — Do you want click tracking in email at all?
-Privacy and deliverability trade, not an engineering default. **You get ~90% of the value
-free:** the chase cron (W-19) plus the apply row already tell you the email worked.
-**Blocks W-24, W-25, W-26.**
-
-### [ ] D-F — Should the job list have an "Applied" filter at all?
-The pipeline page already shows applied jobs. Either derive the filter from `applications`
-or delete the option. **Blocks W-05, D-05.**
-
-### [ ] D-G — Should the digest talk about *him*?
-"Your week: 3 applied, 1 interview, 2 gone quiet." Tone call first, then a small wire.
-**Shapes W-20.**
-
----
+**An open threshold, not a decision:** D-C settles WHO decides, not WHEN we suggest.
+Using **21 days** of silence as the trigger for the "this looks ghosted" suggestion
+until told otherwise. Changing it is one constant.
 
 # ALREADY FINE — do not rebuild
 


### PR DESCRIPTION
Stacked on #453. Last in the stack.

## W-23 — there was no unsubscribe link. At all.

The only way to stop the emails was to log in and delete the channel. That is a **deliverability problem before it is a legal one**: a recipient who cannot find the exit presses "spam" instead, and that is the worst signal a sending domain can collect.

**Stateless token, no table:** `{user_id}.{hmac_sha256(SESSION_SECRET, user_id)[:32]}`. No migration, no cleanup job, no row that can drift out of sync with the account it names. Not guessable without the secret; revocable in bulk by rotating it.

**Safe to expose unauthenticated because of what it can do:** the only outcome is silence. It cannot read anything, change an address, or reach an account. A leaked token buys an attacker the ability to *stop someone's email*, which the owner reverses by logging in.

**Deliberately never expires** — an unsubscribe link must work in a year-old email.

**POST behind a confirm button, never a GET.** Email clients and security scanners *prefetch* links, so a state-changing GET would unsubscribe people who never clicked. Same trap `/auth/magic` already solves, solved the same way.

Unsubscribing sets `notification_rules.enabled = 0` and **deletes nothing** — channels, quiet hours and mode all survive, so turning it back on restores exactly what they had rather than an empty default. The confirmation page says how to undo it.

**Known bound, in the code:** Apprise's mailto transport carries no custom headers, so a `List-Unsubscribe` header is **not available on this path**. The in-body link is what reaches recipients.

## W-27 — the funnel went dark right after Apply

Four events, each fired when the action **succeeds**, never on the attempt — an event on intent counts moves that failed, which is how a funnel quietly starts lying about itself:

`application_stage_changed` · `tailored_document_generated` · `tailored_document_downloaded` (with `doc_kind` **and** `format` — a bare count cannot tell a CV from a cover letter) · `channel_added`

## Delete sweep — partial, deliberately

- **D-03 `getActionCounts`** — zero references anywhere. Deleted.
- **D-02 `keepTailored`** — the dead frontend client is deleted. **The backend route is kept**: it is exercised by `test_cv_coverletter.py`, it is public API surface, and PR 5 made `keep_tailored_doc` load-bearing for document binding. Deleting a tested route to tidy up is riskier than the note proposing it assumed, and earns nothing today.

`tsc --noEmit` passing *after* the deletions is the actual proof they were dead — grep tells you what it can see, the type checker tells you what the program needs.

## Also carries the owner's seven decisions

The final commit records all seven product calls as spec, including the two that went **against** my recommendation (build interview tracking; add email click tracking) with the trade-off stated once so it is not re-argued later.

## Verified

14 unsubscribe tests — **the forgery cases are the ones that matter**: a token that silences an account must not be guessable, must not accept a swapped user id, and must fail closed when an email client truncates the URL. 61 passed across the email, worker and chase suites. A fourth drill fires the real unsubscribe path against real Postgres and prints the exact line that goes into every email.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpxEMPz2ZWG9Qed5BsFHvg
