### PR TITLE
fix(tokens): enforce the per-user token cap under a row lock (#475)

### DIFF
--- a/backend/src/api/routes/tokens.py
+++ b/backend/src/api/routes/tokens.py
@@ -51,12 +51,12 @@ async def create_token(
     user: CurrentUser = Depends(require_session_user),  # noqa: B008 — FastAPI DI idiom
 ) -> TokenCreated:
     cap = settings.API_TOKENS_PER_USER
-    if cap > 0 and await api_tokens.count_active(str(DB_PATH), user.id) >= cap:
+    made = await api_tokens.mint(str(DB_PATH), user_id=user.id, name=body.name, cap=cap)
+    if made is None:
         raise HTTPException(
             status_code=409,
             detail=f"You already have {cap} active tokens. Revoke one to create another.",
         )
-    made = await api_tokens.mint(str(DB_PATH), user_id=user.id, name=body.name)
     return TokenCreated(**made)
 
 

--- a/backend/src/services/auth/api_tokens.py
+++ b/backend/src/services/auth/api_tokens.py
@@ -69,21 +69,34 @@ async def count_active(db_path: str, user_id: str) -> int:
     return int(row[0]) if row else 0
 
 
-async def mint(db_path: str, *, user_id: str, name: str) -> dict[str, Any]:
-    """Create a token. Returns the row fields PLUS ``token`` — the only time it exists in plaintext."""
+async def mint(db_path: str, *, user_id: str, name: str, cap: int = 0) -> Optional[dict[str, Any]]:
+    """Create a token, enforcing ``cap`` under a per-user row lock so concurrent
+    mints for the same user serialise and can never together exceed it; returns
+    ``None`` (nothing inserted) when the cap is already reached."""
     token = TOKEN_PREFIX + secrets.token_urlsafe(32)
     prefix = token[:PREFIX_DISPLAY_CHARS]
     created_at = _now().isoformat()
     async with open_db(db_path) as db:
-        cur = await db.execute(
-            """
-            INSERT INTO api_tokens(user_id, name, token_hash, prefix, created_at)
-            VALUES (?, ?, ?, ?, ?)
-            """,
-            (user_id, name, _hash(token), prefix, created_at),
-        )
-        token_id = cur.lastrowid
-        await db.commit()
+        async with db.transaction():
+            lock_cur = await db.execute("SELECT id FROM users WHERE id = ? FOR UPDATE", (user_id,))
+            if await lock_cur.fetchone() is None:
+                return None  # unknown user — route can't reach this, but stay safe
+            count_cur = await db.execute(
+                "SELECT COUNT(*) FROM api_tokens WHERE user_id = ? AND revoked_at IS NULL",
+                (user_id,),
+            )
+            count_row = await count_cur.fetchone()
+            active_count = int(count_row[0]) if count_row else 0
+            if cap > 0 and active_count >= cap:
+                return None
+            cur = await db.execute(
+                """
+                INSERT INTO api_tokens(user_id, name, token_hash, prefix, created_at)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                (user_id, name, _hash(token), prefix, created_at),
+            )
+            token_id = cur.lastrowid
     get_audit_logger().info(
         "api_token_create",
         extra={"event": "api_token_create", "user_id": user_id, "token_id": token_id, "prefix": prefix},

--- a/backend/tests/test_api_tokens.py
+++ b/backend/tests/test_api_tokens.py
@@ -10,6 +10,7 @@ Contract (docs/plans/2026-09-03-mcp-server/spec.md R1–R3, R6):
 """
 from __future__ import annotations
 
+import asyncio
 import hashlib
 
 import pytest
@@ -17,6 +18,7 @@ from httpx import ASGITransport, AsyncClient
 
 from src.api import dependencies as api_deps
 from src.core import settings
+from src.services.auth import api_tokens
 
 
 async def _mint(client, name: str = "claude code") -> dict:
@@ -156,3 +158,24 @@ async def test_tokens_die_with_the_account_and_export_hides_the_hash(
         cur = await db._conn.execute("SELECT count(*) FROM api_tokens WHERE user_id = ?", (fixture_user_id,))
         (left,) = await cur.fetchone()
         assert left == 0
+
+
+@pytest.mark.asyncio
+async def test_concurrent_mints_never_exceed_cap(authenticated_async_context, fixture_user_id, monkeypatch):
+    """Issue #475 — 5+ concurrent POSTs with room for 1 must not all squeeze through."""
+    monkeypatch.setattr(settings, "API_TOKENS_PER_USER", 3)
+    async with authenticated_async_context():
+        db_path = str(settings.DB_PATH)
+        uid = fixture_user_id
+        await api_tokens.mint(db_path, user_id=uid, name="pre-1", cap=3)
+        await api_tokens.mint(db_path, user_id=uid, name="pre-2", cap=3)
+        assert await api_tokens.count_active(db_path, uid) == 2
+
+        results = await asyncio.gather(
+            *[api_tokens.mint(db_path, user_id=uid, name=f"t{i}", cap=3) for i in range(6)]
+        )
+        successes = [r for r in results if r is not None]
+        failures = [r for r in results if r is None]
+        assert len(successes) == 1, f"expected exactly 1 mint to win the last slot, got {len(successes)}"
+        assert len(failures) == 5, f"expected exactly 5 mints to lose to the cap, got {len(failures)}"
+        assert await api_tokens.count_active(db_path, uid) == 3


### PR DESCRIPTION
## What

Closes #475 (Minor from the #473 bugs review). The per-user token cap was read-then-write on two connections: N concurrent `POST /api/tokens` with one slot left all saw room and all inserted.

## Fix

`api_tokens.mint()` now takes the cap and runs `SELECT id FROM users WHERE id = ? FOR UPDATE` → count → insert **in one transaction** (`db.transaction()`, the shim's psycopg passthrough). The row lock serialises mints per user. `None` = cap reached → the route answers 409 exactly as before. The route's separate pre-check is gone.

Why not the single-statement `INSERT … SELECT … WHERE COUNT < cap` the issue suggested: under READ COMMITTED each statement's snapshot ignores concurrent uncommitted rows, so two such statements can both count 9 and both insert. The lock is the only thing that actually serialises.

## Proof

`test_concurrent_mints_never_exceed_cap`: cap 3, 2 pre-minted, 6 concurrent `mint()` calls on separate connections.
- old code: `expected exactly 1 mint to win the last slot, got 6` (8 tokens against a cap of 3)
- new code: exactly 1 wins, 5 get `None`, `count_active == 3`

`test_api_tokens.py` 9/9, `test_mcp_server.py` + `test_mcp_gate_parity.py` 10/10 on real Postgres; ruff clean; mypy ratchet unchanged (96/96). Gate PASS.

## Process

Built manager/worker: Sonnet implemented from a written spec (incl. the red-run proof), Fable reviewed the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011wAduRqokWdPEByUkcVbvc
