### PR TITLE
docs(product): VISION.md — what we build, what we never build, in what order

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,7 +1,29 @@
 # Job360 Project Status
-<!-- doc: LIVING | last-verified: 2026-08-24 by /sync -->
+<!-- doc: LIVING | last-verified: 2026-09-03 -->
 
-## Current State: Funnel batch LIVE (2026-08-05) — retrieve→enrich→rank→judge in prod
+## Current State: PIVOTED (2026-09-02) — the memory layer for the seeker's AI agent
+
+> **Direction lives in [`docs/product/VISION.md`](docs/product/VISION.md).** Read it
+> first; everything below this block describes the sourcing-era product and is
+> history. In one line: the user (or their agent) brings the job; the agent
+> judges fit, writes the CV, reads the inbox, applies; **Job360 keeps the
+> structured profile, every artifact version, every event and the receipt.**
+> We never source, rank or recommend jobs (product rule 4).
+>
+> **Live on `main` (89cd1dd, 2026-09-03):** bring-a-job (paste) + append-only
+> receipts (#469); personal API tokens + MCP server at `/api/mcp`, 8 tools (#473);
+> token-cap race fix (#476); mypy at 0 (#477). Railway runs backend + frontend +
+> Postgres only — **worker and Redis were deleted 2026-09-02**, so nothing runs in
+> the background (no notifications, no crons; Redis-unreachable log lines are expected).
+>
+> **Next, in order (VISION.md):** 1 OAuth 2.1 for ChatGPT/Grok clients → 2 the spine
+> (one Application object, typed event log, versioned artifacts, `save_artifact` /
+> `record_event` / `whats_new` / `export_history`; home = your applications; old
+> search UI hidden, scorer off) → 3 URL fetch on the web (link or text, paste as
+> fallback) → 4 contacts/outreach, stats, `update_profile`. Measure: the owner uses
+> it daily for his own hunt.
+
+## Sourcing era (history) — Funnel batch LIVE (2026-08-05) — retrieve→enrich→rank→judge in prod
 
 > **Freshest history:** `docs/harness/IMPLEMENTATION_LOG.md` § "2026-08-05 — The funnel batch"
 > (PRs #224/#226/#227/#228/#229): bounded per-user candidate set (top-800), revived

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,7 @@ docs at the repo root). Start here to find the right doc fast.
 
 | I want to… | Read |
 |---|---|
+| **Know what we are building (and not)** | [`product/VISION.md`](product/VISION.md) — the 2026-09-03 decisions; wins over every older product doc |
 | **Understand the project fast** | [`../CLAUDE.md`](../CLAUDE.md) → [`../STATUS.md`](../STATUS.md) |
 | **Pick up where work left off** | [`IMPLEMENTATION_LOG.md`](harness/IMPLEMENTATION_LOG.md) (read first) → [`../STATUS.md`](../STATUS.md) |
 | **Run it locally** | [`../backend/README.md`](../backend/README.md) · [`../frontend/README.md`](../frontend/README.md) |

--- a/docs/plans/2026-09-02-bring-a-job/intent.md
+++ b/docs/plans/2026-09-02-bring-a-job/intent.md
@@ -1,5 +1,10 @@
 # Intent: bring a job, keep the receipt
-Author: Ranjith (owner), captured from chat 2026-09-02 by Claude. Status: draft — owner approves by merging.
+Author: Ranjith (owner), captured from chat 2026-09-02 by Claude. Status: shipped as PR #469 (slice one).
+
+> **Superseded in part by [`docs/product/VISION.md`](../../product/VISION.md) (2026-09-03):** "we score it
+> and tailor the CV" is now the *agent's* job — Job360 stores the verdict and the versions (rule 5).
+> The receipt, append-only, and the constraints below still hold. URL fetch is no longer deferred:
+> link and text must both work on the web (decision 16), paste is the fallback.
 
 ## Problem
 Job360 spent a year sourcing jobs. Nobody needed that — every board already does it. What nobody does well is

--- a/docs/product/VISION.md
+++ b/docs/product/VISION.md
@@ -1,0 +1,152 @@
+# Job360 — what we are building
+<!-- doc: LIVING | decided 2026-09-03 in an 18-question interview with the owner -->
+
+> **Read this before any feature work.** It is the single source of truth for
+> what Job360 is, what it is not, and the order things get built. If code or an
+> older doc disagrees with this file, this file wins and the other one is stale.
+> Change it only with the owner, and change it *here* first — the reason this
+> file exists is that without it every new session re-derives the product and
+> we go round in a loop.
+
+## One line
+
+**Job360 is the memory and context layer for whatever AI agent a job seeker
+already uses.** The agent (Claude Code, Claude, ChatGPT, Grok, Gemini, a
+browser agent) finds the job, reads it, judges fit, writes the CV, finds the
+recruiter, reads the inbox, fills the form. Job360 gives that agent the
+candidate's structured context, keeps every version of what it made, records
+every event that happened, and answers "what did I send, what happened, what
+changed, what worked".
+
+Job boards find jobs. Agents think and act. Job360 remembers.
+
+## Why this and not the old Job360
+
+Job360 spent a year sourcing and ranking jobs. Every board already does that
+better, and every seeker now has an AI subscription that can search, reason
+and write. What nobody keeps is the **state**: which CV version went to which
+company, who replied, when the interview was, why it was a no. Chat history
+loses it; the seeker forgets it; the next application starts from zero.
+That persistent, agent-accessible record is the product.
+
+## What we build / what we never build
+
+| We build (the plate) | We never build (the ingredients) — the agent or the ecosystem does it |
+|---|---|
+| Structured candidate profile (CV + LinkedIn + GitHub + prefs), agent can edit it | Job search, job feeds, ranking, "recommended for you" |
+| One **Application** object per job, born the moment the job is brought | Fit judging, CV / cover-letter / answer writing (we store, the agent writes) |
+| **Every version** of every artifact, forever, stamped with who/when/which profile | Gmail OAuth, inbox polling, email classification (the agent's connector reads; we store the event) |
+| A **typed event log**, one door (`record_event`), every event says who wrote it | People databases (Apollo, LinkedIn lookups) — the agent finds, we store the contact |
+| A rich **receipt** on "I applied" — fields, answers, confirmation, exact CV version | Form filling, browser automation, auto-submit at volume |
+| `whats_new` — pull, not push | Push notifications, WhatsApp, mobile apps (later, on evidence) |
+| OAuth 2.1 so ChatGPT / Grok / any client can connect | Our own LLM, our own general agent |
+| Cheap counts (reply rate per CV version / role) + full `export_history` | Charts-heavy analytics; the agent analyses the export |
+| Bring a job by **link or pasted text**, both, on the web | Chrome extensions, iOS/Android |
+| A web page that is the **record** (home = your applications) | A web page that is the product |
+
+Recruiter side: later, consent-first only, never selling candidate access.
+Pricing: free for seekers and recruiters until value is proven. No credits,
+no per-application charge, nothing that rewards volume.
+
+## The object model
+
+```
+Candidate (one profile per user, versioned; multiple named profiles = later)
+ └── Application            born at bring_job; status starts "considering"
+      ├── Job snapshot      title, company, location, URL, ad text as it read that day
+      ├── Fit verdict       written by the agent: fit, gaps, reasoning (stored, not computed by us)
+      ├── Artifacts[]       cv | cover_letter | answers | outreach — every version kept
+      │                     each: version_no, text, made_by (agent/model/human), profile_version, created_at
+      ├── Contacts[]        name, role, email, linkedin — found by the agent
+      ├── Receipt           frozen on "I applied": artifact versions sent, fields filled, answers,
+      │                     confirmation text/number, channel, sent_at — append-only
+      └── Events[]          the history; the current status is just the last status event
+```
+
+**Event types (fixed list, plus free-text detail):**
+`brought`, `fit_judged`, `artifact_saved`, `contact_added`, `outreach_sent`,
+`applied`, `replied`, `interview_requested`, `interview_scheduled`,
+`interview_done`, `offer`, `rejected`, `withdrawn`, `ghosted`, `note`,
+`lesson` ("flag for next time"). Every event: `type`, `detail`, `occurred_at`,
+`recorded_by` (which token/agent/web), `recorded_at`. Nothing is deleted.
+
+Today's `applications` (stage) + `application_receipts` (snapshot) +
+`application_stage_history` + `tailored_documents` (unversioned, DELETE+INSERT)
+fold into this. Receipts stay append-only (bring-a-job constraint 4).
+
+## The agent surface (MCP + same REST)
+
+| Tool | Does |
+|---|---|
+| `get_profile` / `update_profile` | structured candidate context; agent may fix or add fields |
+| `bring_job` | link or text → Application (status `considering`) |
+| `get_application` / `list_applications` | full object with events and artifact versions |
+| `save_artifact` | new version of cv / cover_letter / answers / outreach |
+| `save_fit` | agent's verdict + gaps on this application |
+| `add_contact` | recruiter / hiring manager on this application |
+| `record_event` | typed event, free-text detail |
+| `record_application` | the receipt — what was actually sent |
+| `whats_new` | everything since a timestamp (replaces push for now) |
+| `export_history` | applications + events + versions + outcomes as clean JSON |
+| `stats` | cheap counts: reply / interview rate per CV version, per role |
+| `tailor_documents` | **web fallback only** — our own tailoring for users with no agent |
+
+Auth: personal tokens (`j360_…`) today; **OAuth 2.1 with short-lived tokens
+is the next slice** so ChatGPT and Grok connectors can be added. Tokens stay
+as a fallback for CLI clients.
+
+## Build order (decided 2026-09-03)
+
+1. **OAuth 2.1 authorization server** — unblocks ChatGPT + Grok.
+2. **The spine** — one Application object, event log, versioned artifacts, the
+   tools above; home page = your applications; old search UI hidden behind a
+   flag (off), batch scorer / judge / enrichment switched off with it.
+3. **URL fetch** on the web — paste a link OR the text; paste is the fallback
+   when a site blocks us. SSRF guard mandatory.
+4. Contacts + outreach artifacts; `stats`; `update_profile`.
+5. Delete the hidden search code, the 41 sources and the scorer once step 2
+   has been live for a release.
+6. Later, on evidence only: WhatsApp ("text your agent" + pushes, needs worker
+   + Redis back), multiple named profiles, our own Gmail watcher, recruiters.
+
+## The one measure
+
+**The owner uses it daily for his own job hunt through Claude Code / ChatGPT.**
+Every application he makes goes through Job360. If he skips it for a week the
+product is wrong — fix that before adding anything. Proof is his own
+applications and events in the database, not a doc.
+
+## Decision log (the interview, 2026-09-03)
+
+| # | Question | Decision |
+|---|---|---|
+| 1 | "AI finds the job" vs never-source rule | **Not ours.** Agents find jobs with their own tools and hand them over. We never search or rank. |
+| 2 | Old search UI on the dashboard | **Hide now** (flag off), delete later. Home = your applications. |
+| 3 | When is an Application born | **At `bring_job`**, status `considering`. Merge the two half-objects. |
+| 4 | Who writes the tailored CV | **The agent writes, we store.** Ours stays as a web fallback. |
+| 5 | Who judges fit | **The agent.** We give context and store the verdict. Our scorer off. |
+| 6 | Artifact versions | **Every version, forever**, stamped who/when/profile version. |
+| 7 | Who writes events | **Anyone with a token**, typed events + free text, author recorded. |
+| 8 | Gmail | **Agent reads via its own connector**, calls `record_event`. No Gmail code from us now. |
+| 9 | Outreach / people | **We store contacts + messages.** Agent finds and writes. No provider integration. |
+| 10 | Execution readiness | **One rich `record_application`** receipt that takes what the executing agent saw. |
+| 11 | Notifications | **Pull, not push** — `whats_new` + web home. Push/WhatsApp later. |
+| 12 | Agent auth | **OAuth 2.1 now** (owner overrode "tokens first"). Tokens stay as fallback. |
+| 13 | Improvement loop | **Both** — cheap counts on our side + full export for the agent. |
+| 14 | Profile | **Keep our extraction, add `update_profile`.** One profile; multiple = later. |
+| 15 | Build order | **OAuth → spine → URL fetch → contacts/stats/profile edits.** |
+| 16 | URL fetch | **Both link and text must work on the web.** Paste is the fallback. |
+| 17 | Our LLM code | **Tailor stays as web fallback; scorer/judge/enrichment off.** |
+| 18 | Success measure | **Owner uses it daily for his own hunt.** |
+
+Taken from the 2026-09-02 pivot without re-asking: recruiters later and
+consent-first; everything free; no auto-submit at volume; global from day one.
+
+## Older docs this supersedes
+
+`docs/product/PRD.md`, `docs/product/pillars/02-search-and-match-engine.md`,
+`docs/product/pillars/03-job-providers.md`, `docs/product/pillars/CATALOG_STATE.md`
+and every `docs/product/plans/PRICING_*` file describe the sourcing-era product.
+They are kept as history of how the code got here, not as direction.
+`docs/plans/2026-09-02-bring-a-job/intent.md` is slice one of this vision and
+still holds.

--- a/docs/product/product_design_rules.md
+++ b/docs/product/product_design_rules.md
@@ -203,3 +203,58 @@ recruitment boilerplate. Reading stored text took visa coverage from **3% to
 
 **This is Rule 1 applied to a filter:** what the user turns on *sharpens the
 ranking*; it never silently deletes the catalog.
+
+---
+
+## Rule 4 — The user brings the job. We never source, rank or recommend.
+
+*Set by the owner 2026-09-02, confirmed 2026-09-03 (VISION.md, decision 1).*
+
+**The rule.** A job enters Job360 only because the user or their agent brought
+it — a pasted ad, a link, or an MCP call. There is no feed, no ranking, no
+"jobs for you". Job boards and the user's own AI agent find jobs; we do not.
+
+**What this means in code:** the search pipeline, the 41 sources and the batch
+scorer/judge/enrichment are hidden behind a flag (off) and will be deleted
+(VISION.md build order, step 5). Rules 1–3 above still govern the one place
+matching-like logic survives: the *fit context* we hand the agent for a job
+the user brought. An empty preference is still silent; UK/visa are still
+spotlights, never walls — applied to one job, not to a catalog.
+
+---
+
+## Rule 5 — The agent thinks. Job360 remembers.
+
+*Set by the owner 2026-09-03 (VISION.md, decisions 4, 5, 7, 8, 9).*
+
+**The rule.** Do not build what the user's AI agent can already do: judge fit,
+write a CV or cover letter, read Gmail, find a recruiter, fill a form. Build
+what the agent cannot keep: the candidate's structured context, every version
+of every artifact, every event with its author, the receipt of what was sent.
+
+**The test for a new feature:** "Could Claude Code / ChatGPT do this today
+with its own tools?" If yes, we expose a *store* tool for the result, not a
+*do* tool. Exceptions are explicit and web-only (our tailoring stays as a
+fallback button for users with no agent).
+
+**Corollary — one door, typed events.** Anything that changes an application
+goes through `record_event` with a fixed event type, free-text detail and
+`recorded_by`. Current status is derived from the last status event, never
+stored as the only truth. Nothing is deleted or rewritten; a receipt is
+append-only.
+
+---
+
+## Rule 6 — Free, pull, consent-first
+
+*Set by the owner 2026-09-02 / 2026-09-03 (VISION.md, decisions 11, 12; pivot memo).*
+
+- **Free** for seekers and recruiters until value is proven. No credits, no
+  per-application charge — nothing that rewards volume. No auto-submit.
+- **Pull, not push** while there is no worker: the agent asks `whats_new`;
+  the web home shows it. Push (email digest, WhatsApp) returns only with the
+  worker, on evidence.
+- **Recruiters later, consent-first only.** Never sell candidate access
+  (Hired and Triplebyte died doing it).
+- **Any client connects.** OAuth 2.1 with short-lived tokens is the auth
+  shape; personal tokens remain a CLI fallback.


### PR DESCRIPTION
## What

The owner was interviewed on 2026-09-03 (18 questions, one at a time, with options) about the product vision. The answers become **`docs/product/VISION.md`** — one doc that wins over every older product doc — so the next session does not re-derive the product.

**One line:** Job360 is the memory and context layer for whatever AI agent the seeker already uses. The agent finds, judges, writes, reads Gmail, applies. Job360 keeps the profile, every artifact version, every typed event, the receipt.

## Files

- `docs/product/VISION.md` — NEW: build/never-build table, object model, event types, MCP tool set, build order (OAuth 2.1 → spine → URL fetch → contacts/stats), the one measure, decision log Q1–Q18, superseded docs.
- `docs/product/product_design_rules.md` — rules 4 (user brings the job), 5 (the agent thinks, Job360 remembers — the store-not-do test), 6 (free, pull, consent-first).
- `STATUS.md` — pivot head: what is live on main (89cd1dd), worker+Redis deleted, what is next. Funnel-era section marked history.
- `docs/README.md`, `docs/plans/2026-09-02-bring-a-job/intent.md` — pointers.

## No code

Docs only. Gate PASS. Merging changes no behaviour; it changes what every future session reads first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011wAduRqokWdPEByUkcVbvc