### PR TITLE
feat(spine): one Application object, typed event log, versioned artifacts, 8 agent tools (#480)

### DIFF
--- a/.claude/skills/hard-rules/SKILL.md
+++ b/.claude/skills/hard-rules/SKILL.md
@@ -20,7 +20,7 @@ Nothing here is weaker for being a skill. It loads when the work touches it.
 
 - **M1. The user brings the job; we never source, rank or recommend** (product rule 4). Never add a source, a scorer weight, a feed, or a "recommended for you". `SOURCE_REGISTRY` and `JobScorer` are legacy code waiting for slice 5 — obey their rules while they exist, never extend them.
 - **M2. The agent thinks, Job360 remembers** (product rule 5). Before adding a feature ask: *could Claude Code / ChatGPT do this with its own tools?* If yes, expose a **store** tool, not a **do** tool. No Gmail readers, no fit judges, no outreach writers of our own.
-- **M3. One door for history: `record_event`** — fixed event types (VISION.md), free text, `recorded_by`. Every artifact version is kept forever with `made_by` + `profile_version`. A receipt is append-only. Nothing rewrites history.
+- **M3. One door for history: `record_event`** — fixed event types (VISION.md), free text, `recorded_by`. Every artifact version is kept forever with `made_by` + `profile_version`. A receipt is append-only. Nothing rewrites history. **Built in slice 2 (application spine):** `application_events` + `application_artifacts` (migration `0037_application_spine`) — no runtime code in `backend/src/` may `UPDATE`/`DELETE` either table (guard: `tests/test_application_spine.py::test_events_are_append_only`, a grep over `backend/src/`); `applications.status`/`stage` are the one cache SLOT that IS updated (S7 — a slot is not history). `application_receipts.application_id` is set at INSERT time, never backfilled by an UPDATE (guard: `tests/test_receipts.py::test_receipts_are_append_only`).
 - **M4. Free, pull, consent-first** (product rule 6). No credits, no paywall, no push. Agents connect over MCP with OAuth 2.1; personal `j360_…` tokens stay as the fallback.
 - **M5. Every MCP tool = the same per-user route the web uses** (#12/#25 apply) and every new route gate must be re-applied in `backend/src/api/mcp_server.py` — parity is by hand, there is no shared gate.
 
@@ -61,7 +61,7 @@ An index, one line each. Where a test guards a rule, the test is named — that 
 
 ### Schema + data integrity
 1. **`normalized_key()` in `models.py`** — never change without re-verifying the deduplicator AND the DB UNIQUE constraint. Wrong normalization = duplicate rows or missed dedup. (Still bites `bring_job`: two users pasting the same ad share one row.)
-3. **`purge_old_jobs()` in `database.py`** — never change without explicit confirmation. Wrong threshold = data loss. **Slice 2 must make sure a brought job is never purged.**
+3. **`purge_old_jobs()` in `database.py`** — never change without explicit confirmation. Wrong threshold = data loss. **Slice 2 (application spine) did this: `source <> USER_BROUGHT_SOURCE` on both the direct DELETE and the cascade-child subquery — a brought job (and its application snapshot) survives the catalog purge. Guards: `tests/test_application_spine.py::test_purge_spares_a_brought_job` / `::test_the_job_snapshot_survives_a_purge`.**
 17. **`job_enrichment` + `job_embeddings` must NOT gain `user_id`** (same reason as #10). Per-user scoring happens at read time via `JobScorer(..., user_preferences=…, enrichment_lookup=…)`.
 
 ### Catalog scope + filters (owner product rules — full text: `docs/product/product_design_rules.md`)

--- a/.env.example
+++ b/.env.example
@@ -241,3 +241,44 @@ CEREBRAS_MODEL=gpt-oss-120b
 # Auto-injected by Railway on every deployed service — used for prod detection
 # (cookie Secure / HSTS / Sentry / the E2E-bypass guard). Do NOT set locally.
 RAILWAY_ENVIRONMENT=
+
+# ---------------------------------------------------------------------------
+# The application spine (docs/plans/2026-09-04-application-spine/spec.md)
+# ---------------------------------------------------------------------------
+
+# R12/R13 — the legacy search UI + catalog crons, both default OFF. The
+# mission (docs/product/VISION.md) is "the agent finds the job, Job360
+# remembers" — Job360 never sources or ranks. Not security controls (the
+# gated routes keep their normal auth either way).
+SEARCH_UI_ENABLED=false
+CATALOG_CRONS_ENABLED=false
+
+# R7 — non-status event types an operator can add WITHOUT a migration
+# (comma-separated). A STATUS event also needs an R4 mapping entry in
+# src/services/applications/status.py, so it can never be env-added.
+APPLICATION_EXTRA_EVENT_TYPES=
+
+# S5 — input caps (defaults shown). Every breach is a 422/429 naming the
+# field and the limit, never a silent drop/clip.
+APPLICATION_EVENT_DETAIL_MAX_CHARS=2000
+APPLICATION_EVENT_PAYLOAD_MAX_BYTES=8192
+APPLICATION_EVENT_MAX_FUTURE_SECONDS=300
+APPLICATION_ARTIFACT_MAX_CHARS=60000
+APPLICATION_ARTIFACT_MAX_VERSIONS=200
+APPLICATION_RECEIPT_ANSWERS_MAX=50
+APPLICATION_RECEIPT_ANSWER_MAX_CHARS=2000
+APPLICATION_RECEIPT_FIELDS_MAX_BYTES=8192
+APPLICATION_FIT_REASONING_MAX_CHARS=4000
+
+# S3 — how much of an OAuth client's attacker-supplied name `actor_for`
+# keeps as `agent:<name>` authorship (C8: was hardcoded before).
+APPLICATION_ACTOR_NAME_MAX_CHARS=60
+
+# R9 — whats_new.
+WHATS_NEW_DEFAULT_WINDOW_DAYS=7
+WHATS_NEW_MAX_EVENTS=200
+
+# R10/S8 — export_history bounds + per-user rate limit.
+EXPORT_HISTORY_MAX_APPLICATIONS=500
+EXPORT_HISTORY_MAX_BYTES=8388608
+EXPORT_HISTORY_MAX_PER_HOUR=12

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -21,13 +21,13 @@ Job360 *was* a UK-focused multi-domain job search aggregator. This path fetches 
 | Unique source classes | **40** | same dict — `indeed` and `glassdoor` both alias `JobSpySource` |
 | `RATE_LIMITS` entries | **41** | `core/settings.py` `RATE_LIMITS` |
 | `LOCATIONS` entries | **26** | `core/keywords.py` `LOCATIONS` |
-| Migration head | **0036** | `backend/migrations/` |
+| Migration head | **0037** | `backend/migrations/` |
 | `SCORER_VERSION` | **8** | `services/skill_matcher.SCORER_VERSION` |
 | `BaseJobSource` subclasses | **40** | `src/sources/` |
 | ATS board slugs | **302** across **11** platforms | `src/data/` ATS slug files |
 | Enrichment enum values | **7** | `services/enrichment` schema |
-| Migration files | **37** | `backend/migrations/*.up.sql` |
-| `test_*.py` files | **237** | `backend/tests/` |
+| Migration files | **38** | `backend/migrations/*.up.sql` |
+| `test_*.py` files | **241** | `backend/tests/` |
 | GitHub Actions workflows | **30** | `.github/workflows/` |
 | Hard rules | **31** | `.claude/skills/hard-rules/SKILL.md` |
 <!-- /generated -->
@@ -679,6 +679,15 @@ routers — a wrong endpoint reads like a contract and 404s whoever trusts it.
 | `GET` | `/api/actions/counts` | `actions.py` |
 | `DELETE` | `/api/jobs/{job_id}/action` | `actions.py` |
 | `POST` | `/api/jobs/{job_id}/action` | `actions.py` |
+| `GET` | `/api/applications` | `applications.py` |
+| `GET` | `/api/applications/export` | `applications.py` |
+| `GET` | `/api/applications/{application_id}` | `applications.py` |
+| `POST` | `/api/applications/{application_id}/artifacts` | `applications.py` |
+| `GET` | `/api/applications/{application_id}/artifacts/{artifact_id}` | `applications.py` |
+| `POST` | `/api/applications/{application_id}/events` | `applications.py` |
+| `PUT` | `/api/applications/{application_id}/fit` | `applications.py` |
+| `POST` | `/api/applications/{application_id}/receipt` | `applications.py` |
+| `GET` | `/api/whats-new` | `applications.py` |
 | `POST` | `/api/auth/login` | `auth.py` |
 | `POST` | `/api/auth/logout` | `auth.py` |
 | `POST` | `/api/auth/magic-link/consume` | `auth.py` |
@@ -759,7 +768,7 @@ routers — a wrong endpoint reads like a contract and 404s whoever trusts it.
 | `GET` | `/.well-known/oauth-protected-resource` | `well_known.py` |
 | `GET` | `/.well-known/oauth-protected-resource/api/mcp` | `well_known.py` |
 
-**83 routes.** Generated from the routers; a path is assembled from `APIRouter(prefix=…)` + the decorator + the `include_router(prefix=…)` in `main.py` (`/api` for all but the root-mounted `/.well-known/*` discovery documents).
+**92 routes.** Generated from the routers; a path is assembled from `APIRouter(prefix=…)` + the decorator + the `include_router(prefix=…)` in `main.py` (`/api` for all but the root-mounted `/.well-known/*` discovery documents).
 <!-- /generated -->
 
 ## Configuration
@@ -830,6 +839,25 @@ routers — a wrong endpoint reads like a contract and 404s whoever trusts it.
 | `NOTIFY_DEFAULT_MODE` | No (default `daily`) | `notify_mode` given to a seeded rulebook. Keep it a BUNDLING mode — `instant` plus the nightly cron means one email per matching job (~280/tick) |
 | `NOTIFY_DEFAULT_SEND_TIME` / `NOTIFY_DEFAULT_INTERVAL_HOURS` | No (default `08:00` / `6`) | Seeded digest send time and every-N-hours interval |
 | `REFRESH_CATALOG_NOTIFY` | No (default `0` = off) | Lets the 04:00 `refresh_catalog` cron notify. OFF keeps today's behaviour (the nightly refill is silent, so new jobs reach a user only when they search). Only safe to enable while seeded users default to a bundling `NOTIFY_DEFAULT_MODE` — see `workers/tasks._refresh_catalog_notifies` |
+| `SEARCH_UI_ENABLED` | No (default `false`) | Application-spine slice 2 (R12): `POST /api/search` and `GET /api/search/{run_id}/status` answer 404 when off — the legacy sourcing UI is hidden ahead of its slice-5 deletion. Not a security control (the routes keep `Depends(require_user)` either way). Frontend counterpart `NEXT_PUBLIC_SEARCH_UI_ENABLED` is inlined at Next.js **build** time — flipping it needs a redeploy, not a restart |
+| `CATALOG_CRONS_ENABLED` | No (default `false`) | Application-spine slice 2 (R13): gates whether `refresh_catalog` / `enrichment_sweep` are appended to `WorkerSettings.cron_jobs` (`src/workers/settings.py`). `nightly_ghost_sweep` and `notification_tick` stay unconditional. No production effect today — the `worker` and `Redis` services were deleted 2026-09-02, so nothing runs any cron |
+| `APPLICATION_EXTRA_EVENT_TYPES` | No (default empty) | Comma-separated list extending the application-spine's event vocabulary (R7) with NON-status note-type events only — a status event also needs an R4 status mapping, which an env var cannot add. Unknown types still 422 naming the allowed list |
+| `APPLICATION_ARTIFACT_MAX_CHARS` | No (default `60000`) | Per-artifact-version character cap (`POST /applications/{id}/artifacts`, S5) — over the cap is a 422 naming this variable |
+| `APPLICATION_ARTIFACT_MAX_VERSIONS` | No (default `200`) | Per-`(application_id, kind)` version-count cap — over the cap is a 429 naming this variable, never a silent drop |
+| `APPLICATION_EVENT_DETAIL_MAX_CHARS` | No (default `2000`) | S5 — `detail` char cap on `POST /applications/{id}/events`; over the cap is a 422 naming this variable |
+| `APPLICATION_EVENT_PAYLOAD_MAX_BYTES` | No (default `8192`) | S5 — event `payload` cap, checked on the SERIALISED (`json.dumps`) size, because that is what the column costs; the payload must also be a JSON object, never a list/scalar |
+| `APPLICATION_EVENT_MAX_FUTURE_SECONDS` | No (default `300`) | S6 — how far into the future `occurred_at` may claim to be before it is refused as implausible. No lower bound: backdating is the normal case |
+| `APPLICATION_RECEIPT_ANSWERS_MAX` | No (default `50`) | S5 — max `answers` items on `POST /applications/{id}/receipt` |
+| `APPLICATION_RECEIPT_ANSWER_MAX_CHARS` | No (default `2000`) | S5 — max chars per receipt answer |
+| `APPLICATION_RECEIPT_FIELDS_MAX_BYTES` | No (default `8192`) | S5 — `fields_filled` cap on the receipt, checked on the serialised size |
+| `APPLICATION_FIT_REASONING_MAX_CHARS` | No (default `4000`) | S5 — `reasoning` char cap on `PUT /applications/{id}/fit` |
+| `APPLICATION_ACTOR_NAME_MAX_CHARS` | No (default `60`) | S3 — how much of an OAuth client's attacker-supplied name `actor_for` keeps as `agent:<name>` authorship (`src/services/applications/authorship.py`) |
+| `WHATS_NEW_DEFAULT_WINDOW_DAYS` | No (default `7`) | R9 — how far back `GET /whats-new` looks when `since` is omitted |
+| `WHATS_NEW_MAX_EVENTS` | No (default `200`) | R9 — `whats_new`'s page-size ceiling; `limit` above it is clamped, `truncated: true` when the cap bites |
+| `EXPORT_HISTORY_MAX_APPLICATIONS` | No (default `500`) | R10/S8 — `export_history` stops at this many applications and reports `truncated: true` with `next_since` |
+| `EXPORT_HISTORY_MAX_BYTES` | No (default `8388608` = 8 MiB) | R10/S8 — `export_history`'s response-size ceiling; also bounds how much artifact text `get_application(with_artifact_text=true)` will inline (`EXPORT_HISTORY_MAX_BYTES / 4`) |
+| `EXPORT_HISTORY_MAX_PER_HOUR` | No (default `12`) | R10/S8 — `export_history` rate limit, keyed on `user.id` (never per IP — every agent shares the proxy IP behind the Next rewrite unless `JOB360_TRUST_PROXY=1`) |
+| `NEXT_PUBLIC_SEARCH_UI_ENABLED` (frontend) | No (default `false`) | R12 — frontend counterpart to `SEARCH_UI_ENABLED`: `middleware.ts` 404s `/dashboard` and `/jobs`, `Navbar.tsx` drops the Dashboard link, when off. Inlined at Next.js **build** time — flipping it needs a redeploy, not a restart |
 
 ### Constants (`settings.py`)
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -16,12 +16,13 @@
 > Postgres only — **worker and Redis were deleted 2026-09-02**, so nothing runs in
 > the background (no notifications, no crons; Redis-unreachable log lines are expected).
 >
-> **Next, in order (VISION.md):** 1 OAuth 2.1 for ChatGPT/Grok clients → 2 the spine
-> (one Application object, typed event log, versioned artifacts, `save_artifact` /
-> `record_event` / `whats_new` / `export_history`; home = your applications; old
-> search UI hidden, scorer off) → 3 URL fetch on the web (link or text, paste as
-> fallback) → 4 contacts/outreach, stats, `update_profile`. Measure: the owner uses
-> it daily for his own hunt.
+> **Next, in order (VISION.md):** 1 OAuth 2.1 for ChatGPT/Grok clients (draft PR #488,
+> awaiting merge) → 2 the spine — **built on branch `feat/application-spine`, awaiting
+> review/PR** (one Application object, typed event log, versioned artifacts,
+> `save_artifact` / `record_event` / `whats_new` / `export_history`; home = your
+> applications; old search UI hidden behind `SEARCH_UI_ENABLED`, scorer off) → 3 URL
+> fetch on the web (link or text, paste as fallback) → 4 contacts/outreach, stats,
+> `update_profile`. Measure: the owner uses it daily for his own hunt.
 
 ## Sourcing era (history) — Funnel batch LIVE (2026-08-05) — retrieve→enrich→rank→judge in prod
 

--- a/backend/migrations/0037_application_spine.down.sql
+++ b/backend/migrations/0037_application_spine.down.sql
@@ -1,0 +1,45 @@
+-- 0037 down: reverses the DDL only. Every pre-migration row in `applications`,
+-- `application_stage_history`, `application_receipts` and `tailored_documents`
+-- survives untouched — the fold only ever COPIED forward (see the up file's
+-- header). A rollback the day after deploy loses nothing.
+--
+-- WHAT THIS COSTS, STATED PLAINLY: every `application_events` row and every
+-- `application_artifacts` row — including any created AFTER this migration
+-- by real product usage (a save_artifact, a record_event, a save_fit call) —
+-- is dropped with its table and is NOT recoverable except from a backup.
+-- `application_receipts.application_id` and the fit slot on `applications`
+-- are also lost, so `record_application` calls made after the up-migration
+-- lose their link back to an application until 0037 is re-applied. This is
+-- the SQLite-can't-DROP-COLUMN caveat from 0014's down file made obsolete in
+-- the other direction: the store has been Postgres since the pg migration,
+-- so a plain `DROP COLUMN` here is correct and complete.
+
+DROP TABLE IF EXISTS application_artifacts;
+DROP TABLE IF EXISTS application_events;
+
+DROP INDEX IF EXISTS idx_receipts_application;
+ALTER TABLE application_receipts DROP COLUMN IF EXISTS recorded_by;
+ALTER TABLE application_receipts DROP COLUMN IF EXISTS confirmation;
+ALTER TABLE application_receipts DROP COLUMN IF EXISTS fields_filled;
+ALTER TABLE application_receipts DROP COLUMN IF EXISTS answers;
+ALTER TABLE application_receipts DROP COLUMN IF EXISTS cover_letter_artifact_id;
+ALTER TABLE application_receipts DROP COLUMN IF EXISTS cv_artifact_id;
+ALTER TABLE application_receipts DROP COLUMN IF EXISTS application_id;
+
+DROP INDEX IF EXISTS idx_applications_user_status;
+DROP INDEX IF EXISTS idx_applications_user_last_event;
+ALTER TABLE applications DROP COLUMN IF EXISTS fit_recorded_at;
+ALTER TABLE applications DROP COLUMN IF EXISTS fit_recorded_by;
+ALTER TABLE applications DROP COLUMN IF EXISTS fit_reasoning;
+ALTER TABLE applications DROP COLUMN IF EXISTS fit_gaps;
+ALTER TABLE applications DROP COLUMN IF EXISTS fit_verdict;
+ALTER TABLE applications DROP COLUMN IF EXISTS fit_score;
+ALTER TABLE applications DROP COLUMN IF EXISTS snapshot_at;
+ALTER TABLE applications DROP COLUMN IF EXISTS job_description_snapshot;
+ALTER TABLE applications DROP COLUMN IF EXISTS job_source;
+ALTER TABLE applications DROP COLUMN IF EXISTS job_url;
+ALTER TABLE applications DROP COLUMN IF EXISTS job_location;
+ALTER TABLE applications DROP COLUMN IF EXISTS job_company;
+ALTER TABLE applications DROP COLUMN IF EXISTS job_title;
+ALTER TABLE applications DROP COLUMN IF EXISTS last_event_at;
+ALTER TABLE applications DROP COLUMN IF EXISTS status;

--- a/backend/migrations/0037_application_spine.up.sql
+++ b/backend/migrations/0037_application_spine.up.sql
@@ -159,6 +159,14 @@ END;
 -- the catalog row is already gone: honest, and better than a NULL join later.
 -- Scoped to `job_title = ''` so this only touches rows the ALTER just created
 -- (their default), never a snapshot a later run already filled in.
+--
+-- Precondition, declared not assumed: `jobs.location` / `jobs.description`
+-- come from 0011's CREATE TABLE IF NOT EXISTS — a database whose `jobs` was
+-- created BEFORE the chain ran (the app's inline schema, or a test's minimal
+-- fixture) may lack them, and 0011 then skips. The pg shim's translate()
+-- rewrites ADD COLUMN to ADD COLUMN IF NOT EXISTS, so these are idempotent.
+ALTER TABLE jobs ADD COLUMN location TEXT DEFAULT '';
+ALTER TABLE jobs ADD COLUMN description TEXT DEFAULT '';
 UPDATE applications SET
     job_title = COALESCE((SELECT j.title FROM jobs j WHERE j.id = applications.job_id), ''),
     job_company = COALESCE((SELECT j.company FROM jobs j WHERE j.id = applications.job_id), ''),

--- a/backend/migrations/0037_application_spine.up.sql
+++ b/backend/migrations/0037_application_spine.up.sql
@@ -1,0 +1,252 @@
+-- 0037_application_spine: the application spine
+-- (docs/plans/2026-09-04-application-spine/spec.md).
+--
+-- WHY. `applications` today is a bare Kanban stage (rule #10's per-user
+-- table); nothing remembers the job as it read when the user brought it, no
+-- append-only history exists beyond the legacy stage-transition log, and
+-- artifacts (`tailored_documents`) are DELETE+INSERT — a re-tailor destroys
+-- the version that was actually sent. This migration adds: a durable job
+-- snapshot + status cache on `applications` (R2/R4), the one append-only
+-- event log `application_events` (R3/R7), versioned-forever artifacts in
+-- `application_artifacts` (R5), and the receipt columns `record_application`
+-- needs to freeze a NAMED artifact version (R8).
+--
+-- FOLD, NOT MIGRATE. Every row already in `applications`,
+-- `application_stage_history`, `application_receipts` and
+-- `tailored_documents` is COPIED forward, never moved or deleted — see the
+-- "no-row-loss" count table in spec.md §Migration fold. The whole body below
+-- runs in ONE transaction (migrations/runner.py wraps every stem), so a
+-- failure partway rolls back completely; no stem is ever recorded half-done.
+--
+-- THE ONE UPDATE THIS FILE MAKES AGAINST A RECEIPT ROW (step 6 below) sets
+-- `application_id` on `application_receipts` — a column that does not exist
+-- until the ALTER two statements earlier in THIS SAME file runs, and it
+-- changes no user-visible field of the receipt. It is a migration-time
+-- backfill, not a runtime rewrite, and is therefore outside the append-only
+-- guard's scope: that guard greps `backend/src/`, never `migrations/`
+-- (tests/test_receipts.py:129-135 pins this same carve-out for 0034's own
+-- receipts table). Runtime code (`backend/src/**`) NEVER updates or deletes
+-- an `application_events` / `application_artifacts` row — see
+-- tests/test_application_spine.py::test_events_are_append_only, which greps
+-- `backend/src/` for exactly that.
+--
+-- Conventions copied from 0034/0036: TEXT ISO-8601 timestamps, IF NOT
+-- EXISTS, INTEGER PRIMARY KEY AUTOINCREMENT (the shim rewrites this to
+-- BIGSERIAL-equivalent identity, pg.py:193-195). REFERENCES clauses below are
+-- written for documentation value even though the shim strips every FK
+-- clause (pg.py:217-226) — there is no DB-level cascade here; every read
+-- filters on user_id by hand and account deletion goes through
+-- `JobDatabase._PER_USER_TABLES`.
+
+-- ── Step 1: DDL only — add columns, create the two new tables. No row touched. ──
+
+ALTER TABLE applications ADD COLUMN status TEXT NOT NULL DEFAULT 'considering';
+ALTER TABLE applications ADD COLUMN last_event_at TEXT;
+ALTER TABLE applications ADD COLUMN job_title TEXT NOT NULL DEFAULT '';
+ALTER TABLE applications ADD COLUMN job_company TEXT NOT NULL DEFAULT '';
+ALTER TABLE applications ADD COLUMN job_location TEXT NOT NULL DEFAULT '';
+ALTER TABLE applications ADD COLUMN job_url TEXT NOT NULL DEFAULT '';
+ALTER TABLE applications ADD COLUMN job_source TEXT NOT NULL DEFAULT '';
+ALTER TABLE applications ADD COLUMN job_description_snapshot TEXT NOT NULL DEFAULT '';
+ALTER TABLE applications ADD COLUMN snapshot_at TEXT;
+ALTER TABLE applications ADD COLUMN fit_score INTEGER;
+ALTER TABLE applications ADD COLUMN fit_verdict TEXT;
+ALTER TABLE applications ADD COLUMN fit_gaps TEXT DEFAULT '[]';
+ALTER TABLE applications ADD COLUMN fit_reasoning TEXT;
+ALTER TABLE applications ADD COLUMN fit_recorded_by TEXT;
+ALTER TABLE applications ADD COLUMN fit_recorded_at TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_applications_user_last_event
+    ON applications(user_id, last_event_at DESC);
+CREATE INDEX IF NOT EXISTS idx_applications_user_status
+    ON applications(user_id, status);
+
+-- R3/R7 — the whole history. App-validated event_type (deliberately no CHECK
+-- constraint — constraint 5: a new type must never need a migration).
+CREATE TABLE IF NOT EXISTS application_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    application_id INTEGER NOT NULL,
+    event_type TEXT NOT NULL,
+    detail TEXT NOT NULL DEFAULT '',
+    payload TEXT NOT NULL DEFAULT '{}',
+    occurred_at TEXT NOT NULL,
+    recorded_at TEXT NOT NULL,
+    recorded_by TEXT NOT NULL,
+    corrects_event_id INTEGER
+);
+CREATE INDEX IF NOT EXISTS idx_application_events_user_recorded
+    ON application_events(user_id, recorded_at, id);
+CREATE INDEX IF NOT EXISTS idx_application_events_app_occurred
+    ON application_events(application_id, occurred_at, id);
+CREATE INDEX IF NOT EXISTS idx_application_events_user_type
+    ON application_events(user_id, event_type);
+
+-- R5 — artifacts versioned forever. UNIQUE(application_id, kind, version_no)
+-- turns a version-allocation race into a retry, never a duplicate.
+CREATE TABLE IF NOT EXISTS application_artifacts (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    application_id INTEGER NOT NULL,
+    kind TEXT NOT NULL,
+    version_no INTEGER NOT NULL,
+    text TEXT NOT NULL,
+    made_by TEXT NOT NULL,
+    model TEXT,
+    profile_version INTEGER,
+    label TEXT NOT NULL DEFAULT '',
+    chars INTEGER NOT NULL,
+    created_at TEXT NOT NULL,
+    UNIQUE(application_id, kind, version_no)
+);
+CREATE INDEX IF NOT EXISTS idx_application_artifacts_user_app_kind
+    ON application_artifacts(user_id, application_id, kind, version_no DESC);
+
+-- R8 — the rich receipt: name a version, don't just copy text.
+ALTER TABLE application_receipts ADD COLUMN application_id INTEGER;
+ALTER TABLE application_receipts ADD COLUMN cv_artifact_id INTEGER;
+ALTER TABLE application_receipts ADD COLUMN cover_letter_artifact_id INTEGER;
+ALTER TABLE application_receipts ADD COLUMN answers TEXT NOT NULL DEFAULT '[]';
+ALTER TABLE application_receipts ADD COLUMN fields_filled TEXT NOT NULL DEFAULT '{}';
+ALTER TABLE application_receipts ADD COLUMN confirmation TEXT NOT NULL DEFAULT '';
+ALTER TABLE application_receipts ADD COLUMN recorded_by TEXT NOT NULL DEFAULT 'web';
+
+CREATE INDEX IF NOT EXISTS idx_receipts_application
+    ON application_receipts(user_id, application_id);
+
+-- ── Step 2: no orphans. An applications row for every (user_id, job_id) that ──
+-- appears in a legacy child table but not yet in `applications`. Written as
+-- INSERT ... SELECT DISTINCT ... WHERE NOT EXISTS (not INSERT OR IGNORE) so it
+-- needs no translate() rule and reads the same in either dialect. Each source
+-- is its own statement so a pair present in TWO sources is only inserted once
+-- (the second statement's WHERE NOT EXISTS sees the first statement's rows,
+-- inside the same transaction).
+
+INSERT INTO applications (user_id, job_id, stage, status, created_at, updated_at)
+SELECT DISTINCT ar.user_id, ar.job_id, 'applied', 'applied', ar.created_at, ar.created_at
+FROM application_receipts ar
+WHERE NOT EXISTS (
+    SELECT 1 FROM applications a WHERE a.user_id = ar.user_id AND a.job_id = ar.job_id
+);
+
+INSERT INTO applications (user_id, job_id, stage, status, created_at, updated_at)
+SELECT DISTINCT td.user_id, td.job_id, 'applied', 'applied', td.created_at, td.created_at
+FROM tailored_documents td
+WHERE NOT EXISTS (
+    SELECT 1 FROM applications a WHERE a.user_id = td.user_id AND a.job_id = td.job_id
+);
+
+INSERT INTO applications (user_id, job_id, stage, status, created_at, updated_at)
+SELECT DISTINCT ash.user_id, ash.job_id, 'applied', 'applied', ash.transitioned_at, ash.transitioned_at
+FROM application_stage_history ash
+WHERE NOT EXISTS (
+    SELECT 1 FROM applications a WHERE a.user_id = ash.user_id AND a.job_id = ash.job_id
+);
+
+-- ── Step 3: backfill `status` from `stage` — R4's mapping, reversed. ──
+UPDATE applications SET status = CASE stage
+    WHEN 'applied' THEN 'applied'
+    WHEN 'outreach' THEN 'applied'
+    WHEN 'interview' THEN 'interview_scheduled'
+    WHEN 'offer' THEN 'offer'
+    WHEN 'rejected' THEN 'rejected'
+    WHEN 'ghosted' THEN 'ghosted'
+    ELSE 'applied'
+END;
+
+-- ── Step 4: backfill the job snapshot from `jobs` (LEFT JOIN semantics via a ──
+-- correlated subquery — portable across both dialects). Blank strings where
+-- the catalog row is already gone: honest, and better than a NULL join later.
+-- Scoped to `job_title = ''` so this only touches rows the ALTER just created
+-- (their default), never a snapshot a later run already filled in.
+UPDATE applications SET
+    job_title = COALESCE((SELECT j.title FROM jobs j WHERE j.id = applications.job_id), ''),
+    job_company = COALESCE((SELECT j.company FROM jobs j WHERE j.id = applications.job_id), ''),
+    job_location = COALESCE((SELECT j.location FROM jobs j WHERE j.id = applications.job_id), ''),
+    job_url = COALESCE((SELECT j.apply_url FROM jobs j WHERE j.id = applications.job_id), ''),
+    job_source = COALESCE((SELECT j.source FROM jobs j WHERE j.id = applications.job_id), ''),
+    job_description_snapshot = COALESCE((SELECT j.description FROM jobs j WHERE j.id = applications.job_id), ''),
+    snapshot_at = datetime('now')
+WHERE job_title = '';
+
+-- ── Step 5: application_stage_history -> events. One event per row. ──
+INSERT INTO application_events
+    (user_id, application_id, event_type, detail, payload, occurred_at, recorded_at, recorded_by)
+SELECT
+    ash.user_id,
+    a.id,
+    CASE ash.to_stage
+        WHEN 'interview' THEN 'interview_scheduled'
+        WHEN 'offer' THEN 'offer'
+        WHEN 'rejected' THEN 'rejected'
+        WHEN 'ghosted' THEN 'ghosted'
+        WHEN 'outreach' THEN 'applied'
+        ELSE 'applied'
+    END,
+    COALESCE(ash.notes, ''),
+    '{"from_stage": ' || (CASE WHEN ash.from_stage IS NULL THEN 'null' ELSE '"' || ash.from_stage || '"' END)
+        || ', "to_stage": "' || ash.to_stage || '"}',
+    ash.transitioned_at,
+    ash.transitioned_at,
+    'migration:0014_history'
+FROM application_stage_history ash
+JOIN applications a ON a.user_id = ash.user_id AND a.job_id = ash.job_id;
+
+-- ── Step 6: application_receipts -> application_id + one 'applied' event each. ──
+-- The ONE UPDATE this migration makes against a receipt row (see header note).
+UPDATE application_receipts SET application_id = (
+    SELECT a.id FROM applications a
+    WHERE a.user_id = application_receipts.user_id AND a.job_id = application_receipts.job_id
+)
+WHERE application_id IS NULL;
+
+INSERT INTO application_events
+    (user_id, application_id, event_type, detail, payload, occurred_at, recorded_at, recorded_by)
+SELECT ar.user_id, ar.application_id, 'applied', COALESCE(ar.note, ''), '{}', ar.sent_at, ar.sent_at,
+       'migration:0034_receipts'
+FROM application_receipts ar
+WHERE ar.application_id IS NOT NULL;
+
+-- ── Step 7: tailored_documents -> artifact versions. A draft + a polish fold ──
+-- into TWO versions (both the draft AND the edit survive — precisely what
+-- upsert_tailored_doc's DELETE+INSERT has been destroying); a draft-only row
+-- folds into exactly one.
+INSERT INTO application_artifacts
+    (user_id, application_id, kind, version_no, text, made_by, model, profile_version, label, chars, created_at)
+SELECT td.user_id, a.id, td.doc_kind, 1, td.ai_draft, 'migration:0023_tailored',
+       td.model, td.profile_version, '', LENGTH(td.ai_draft), td.created_at
+FROM tailored_documents td
+JOIN applications a ON a.user_id = td.user_id AND a.job_id = td.job_id
+WHERE td.ai_draft IS NOT NULL AND td.ai_draft <> '';
+
+INSERT INTO application_artifacts
+    (user_id, application_id, kind, version_no, text, made_by, model, profile_version, label, chars, created_at)
+SELECT td.user_id, a.id, td.doc_kind, 2, td.polished, 'human',
+       td.model, td.profile_version, '', LENGTH(td.polished), td.updated_at
+FROM tailored_documents td
+JOIN applications a ON a.user_id = td.user_id AND a.job_id = td.job_id
+WHERE td.polished IS NOT NULL;
+
+-- ── Step 7b: a synthetic status event for any application that STILL has ──
+-- zero events after steps 5-7 (B1 fix). A legacy row with no stage_history,
+-- no receipt and no tailored_documents row (or one that folded into no
+-- artifact) reaches here with `status` already backfilled by step 3 but
+-- NOTHING in `application_events` naming it. Without this row,
+-- `append_event`'s status recompute (`replay_status`, which replays the
+-- WHOLE log) defaults to 'considering' on the very first REAL event this
+-- application ever gets — silently wiping a legacy 'offer'/'rejected'/etc.
+-- `a.status` is always one of `_VALID_STAGES`' step-3 targets here, which are
+-- all real APPLICATION_STATUS_EVENT_TYPES (never 'considering' — no
+-- pre-migration row can hold that value), so it needs no CASE mapping.
+INSERT INTO application_events
+    (user_id, application_id, event_type, detail, payload, occurred_at, recorded_at, recorded_by)
+SELECT a.user_id, a.id, a.status, '', '{}', a.updated_at, a.updated_at, 'migration:0037_status_backfill'
+FROM applications a
+WHERE NOT EXISTS (SELECT 1 FROM application_events e WHERE e.application_id = a.id);
+
+-- ── Step 8: last_event_at = MAX(recorded_at) of that application's events, ──
+-- else updated_at.
+UPDATE applications SET last_event_at = COALESCE(
+    (SELECT MAX(e.recorded_at) FROM application_events e WHERE e.application_id = applications.id),
+    updated_at
+);

--- a/backend/scripts/observe.py
+++ b/backend/scripts/observe.py
@@ -52,6 +52,9 @@ PER_USER_TABLES: tuple[tuple[str, str], ...] = (
     ("notification_ledger", "user_id"),
     ("user_notification_digests", "user_id"),
     ("application_receipts", "user_id"),
+    # Application spine (docs/plans/2026-09-04-application-spine/spec.md).
+    ("application_events", "user_id"),
+    ("application_artifacts", "user_id"),
     ("api_tokens", "user_id"),
     ("tailored_documents", "user_id"),
     ("tailored_usage", "user_id"),

--- a/backend/src/api/auth_deps.py
+++ b/backend/src/api/auth_deps.py
@@ -65,6 +65,12 @@ class CurrentUser:
     # 2026-09-03-oauth-mcp R6/S13). None for a session or a personal token —
     # only an OAuth bearer ever carries one, and only `/api/mcp` checks it.
     audience: Optional[str] = None
+    # The application-spine actor name (spec 2026-09-04-application-spine
+    # S3): the personal token's own `name` for auth_via="token", the OAuth
+    # client's `client_name` for auth_via="oauth", unused for a session.
+    # `src/services/applications/authorship.py::actor_for` is the ONLY place
+    # this is read.
+    actor_name: Optional[str] = None
 
 
 def _client_ip(request: Request) -> str:
@@ -137,6 +143,7 @@ async def _current_user_from_personal_bearer(request: Request, token: str) -> Cu
         email=owner.email,
         email_verified=owner.email_verified,
         auth_via="token",
+        actor_name=owner.name,
     )
 
 
@@ -174,6 +181,7 @@ async def _current_user_from_oauth_bearer(request: Request, token: str) -> Curre
         email_verified=owner.email_verified,
         auth_via="oauth",
         audience=owner.audience,
+        actor_name=owner.client_name,
     )
 
 

--- a/backend/src/api/main.py
+++ b/backend/src/api/main.py
@@ -30,6 +30,7 @@ from src.api.middleware import (
 )
 from src.api.routes import (
     actions,
+    applications,
     auth,
     bring,
     channels,
@@ -217,6 +218,7 @@ app.include_router(pipeline.router, prefix="/api")
 # Career-ops pivot (plan §8, slice one) — bring-a-job + application receipts
 app.include_router(bring.router, prefix="/api")
 app.include_router(receipts.router, prefix="/api")
+app.include_router(applications.router, prefix="/api")
 # Batch 2 — auth + channel config
 app.include_router(auth.router, prefix="/api")
 app.include_router(channels.router, prefix="/api")

--- a/backend/src/api/mcp_server.py
+++ b/backend/src/api/mcp_server.py
@@ -222,11 +222,13 @@ def build_server() -> MCPServer:
     from mcp.server import MCPServer
     from pydantic import ValidationError
 
+    from src.api.routes import applications as applications_route
     from src.api.routes import bring as bring_route
     from src.api.routes import jobs as jobs_route
     from src.api.routes import profile as profile_route
     from src.api.routes import receipts as receipts_route
     from src.api.routes import tailor as tailor_route
+    from src.services.applications import spine as applications_spine
 
     mcp = MCPServer(SERVER_NAME, instructions=INSTRUCTIONS)
 
@@ -285,7 +287,10 @@ def build_server() -> MCPServer:
             raise _tool_error(exc) from None
         _audit("bring_job", "ok", job_id=resp.job.id, existing=resp.existing)
         out = _job_summary(resp.job)
-        out.update({"existing": resp.existing, "scored": resp.scored})
+        out.update({
+            "existing": resp.existing, "scored": resp.scored,
+            "application_id": resp.application_id, "status": resp.status,
+        })
         return out
 
     @mcp.tool()
@@ -330,30 +335,60 @@ def build_server() -> MCPServer:
         return _bundle(resp)
 
     @mcp.tool()
-    async def record_application(job_id: int, channel: str = "", note: str = "") -> dict[str, Any]:
+    async def record_application(
+        job_id: int,
+        channel: str = "",
+        note: str = "",
+        confirmation: str = "",
+        answers: Optional[list[dict[str, str]]] = None,
+        fields_filled: Optional[dict[str, Any]] = None,
+        cv_artifact_id: Optional[int] = None,
+        cover_letter_artifact_id: Optional[int] = None,
+        applied_at: Optional[str] = None,
+    ) -> dict[str, Any]:
         """Record that the user has applied to this job — ONLY after they say so. Freezes
-        the job and the tailored documents as sent into an immutable receipt. Sends
-        nothing anywhere. `channel` is where they applied ("company site", "LinkedIn",
-        "email"); `note` is free text."""
+        the named CV / cover-letter version (or the newest saved one, if none named) and
+        any answers/fields into an immutable receipt, and appends an `applied` event to
+        the application's history. Sends nothing anywhere. `channel` is where they
+        applied ("company site", "LinkedIn", "email"); `note` is free text.
+
+        C1 (application-spine review) — this is the SAME tool as before (`job_id`,
+        `channel`, `note` still work unchanged), rewired onto the rich
+        `POST /applications/{id}/receipt` route instead of the legacy
+        `POST /receipts/{job_id}` — the new optional fields (`confirmation`, `answers`,
+        `fields_filled`, `cv_artifact_id`, `cover_letter_artifact_id`, `applied_at`)
+        are exactly spec R8/S4's tool contract.
+        """
         try:
-            body = receipts_route.CreateReceiptRequest(channel=channel, note=note)
+            body = applications_route.RecordApplicationReceiptRequest(
+                channel=channel, note=note, confirmation=confirmation,
+                answers=[applications_route.ReceiptAnswer(**a) for a in (answers or [])],
+                fields_filled=fields_filled or {}, cv_artifact_id=cv_artifact_id,
+                cover_letter_artifact_id=cover_letter_artifact_id, applied_at=applied_at,
+            )
         except ValidationError as exc:
             raise _validation_error(exc) from None
         try:
             async with _request_db() as db:
-                resp = await receipts_route.create_receipt(job_id, body, db, _user())
+                job = await db.get_job_by_id(job_id)
+                if job is None:
+                    raise HTTPException(status_code=404, detail=f"Job {job_id} not found")
+                # Upsert-by-read, same as the legacy `/receipts/{job_id}` route
+                # (receipts.py:126-128): a job the caller never explicitly
+                # `bring_job`-ed still gets an application row here, so
+                # "record I applied" never 404s on a job that plainly exists.
+                await db.create_application(job_id, _user().id)
+                application = await applications_spine.get_application_by_job(db, _user().id, job_id)
+                if application is None:  # pragma: no cover — create_application always upserts one
+                    raise HTTPException(status_code=404, detail="application not found")
+                resp = await applications_route.record_application_receipt(
+                    application["id"], body, db, _user()
+                )
         except HTTPException as exc:
             _audit("record_application", "error", job_id=job_id, http_status=exc.status_code)
             raise _tool_error(exc) from None
-        _audit("record_application", "ok", job_id=job_id, receipt_id=resp.id)
-        return _receipt_summary(
-            receipts_route.ReceiptSummary(
-                id=resp.id, job_id=resp.job_id, sent_at=resp.sent_at, job_title=resp.job_title,
-                job_company=resp.job_company, job_location=resp.job_location,
-                job_apply_url=resp.job_apply_url, has_cv=resp.cv_text is not None,
-                has_cover_letter=resp.cover_letter_text is not None, channel=resp.channel, note=resp.note,
-            )
-        )
+        _audit("record_application", "ok", job_id=job_id, receipt_id=resp["receipt_id"])
+        return {"job_id": job_id, **resp}
 
     @mcp.tool()
     async def list_receipts(job_id: Optional[int] = None, limit: int = 20) -> dict[str, Any]:
@@ -381,6 +416,149 @@ def build_server() -> MCPServer:
             raise _tool_error(exc) from None
         _audit("get_receipt", "ok", receipt_id=receipt_id)
         return _receipt_full(resp)
+
+    # ── Application spine (spec 2026-09-04-application-spine, S11) ──────────
+    # Seven tools, each calling its route FUNCTION directly. None of these
+    # routes is `require_verified_user` (spec: "nothing here spends an LLM
+    # call"), so every one uses `_user()`, never `_verified_user()` — the
+    # parity test (test_mcp_gate_parity.py) checks exactly this.
+
+    @mcp.tool()
+    async def get_application(application_id: int, with_artifact_text: bool = False) -> dict[str, Any]:
+        """One application in full: status, the job snapshot, the fit verdict,
+        every artifact version (text omitted unless with_artifact_text=true),
+        the whole event timeline, and receipts."""
+        try:
+            async with _request_db() as db:
+                resp = await applications_route.get_application(application_id, with_artifact_text, db, _user())
+        except HTTPException as exc:
+            _audit("get_application", "error", application_id=application_id, http_status=exc.status_code)
+            raise _tool_error(exc) from None
+        _audit("get_application", "ok", application_id=application_id)
+        return resp
+
+    @mcp.tool()
+    async def list_applications(
+        status: Optional[str] = None, updated_since: Optional[str] = None, limit: int = 20, offset: int = 0
+    ) -> dict[str, Any]:
+        """The user's applications (newest activity first). Filter by status
+        (e.g. "considering", "applied", "interview_scheduled")."""
+        try:
+            async with _request_db() as db:
+                resp = await applications_route.list_applications(status, updated_since, limit, offset, db, _user())
+        except HTTPException as exc:
+            _audit("list_applications", "error", http_status=exc.status_code)
+            raise _tool_error(exc) from None
+        _audit("list_applications", "ok", count=len(resp.get("applications", [])))
+        return resp
+
+    @mcp.tool()
+    async def save_artifact(
+        application_id: int, kind: str, text: str, label: str = "", model: Optional[str] = None
+    ) -> dict[str, Any]:
+        """Save a new version of a CV / cover letter / answers / outreach note
+        for this application. Every save is a NEW version — nothing is ever
+        overwritten; both old and new stay readable forever."""
+        try:
+            body = applications_route.SaveArtifactRequest(kind=kind, text=text, label=label, model=model)
+        except ValidationError as exc:
+            raise _validation_error(exc) from None
+        try:
+            async with _request_db() as db:
+                resp = await applications_route.save_artifact(application_id, body, db, _user())
+        except HTTPException as exc:
+            _audit("save_artifact", "error", application_id=application_id, http_status=exc.status_code)
+            raise _tool_error(exc) from None
+        _audit("save_artifact", "ok", application_id=application_id, kind=kind)
+        return resp
+
+    @mcp.tool()
+    async def save_fit(
+        application_id: int,
+        score: Optional[int] = None,
+        verdict: Optional[str] = None,
+        gaps: Optional[list[str]] = None,
+        reasoning: Optional[str] = None,
+    ) -> dict[str, Any]:
+        """Record YOUR OWN fit judgement for this application — never computed
+        by Job360 (VISION rule 4). Overwrites the current verdict; the log
+        keeps every past judgement too."""
+        try:
+            body = applications_route.SaveFitRequest(score=score, verdict=verdict, gaps=gaps, reasoning=reasoning)
+        except ValidationError as exc:
+            raise _validation_error(exc) from None
+        try:
+            async with _request_db() as db:
+                resp = await applications_route.save_fit(application_id, body, db, _user())
+        except HTTPException as exc:
+            _audit("save_fit", "error", application_id=application_id, http_status=exc.status_code)
+            raise _tool_error(exc) from None
+        _audit("save_fit", "ok", application_id=application_id)
+        return resp
+
+    @mcp.tool()
+    async def record_event(
+        application_id: int,
+        event_type: str,
+        detail: str = "",
+        payload: Optional[dict[str, Any]] = None,
+        occurred_at: Optional[str] = None,
+        corrects_event_id: Optional[int] = None,
+    ) -> dict[str, Any]:
+        """Append one event to this application's history — replied, an
+        interview stage, a note, a lesson learned. `occurred_at` may be in the
+        past (backdating a reply you just found is normal); it may not be
+        implausibly in the future. A status event (applied/replied/interview_*/
+        offer/rejected/withdrawn/ghosted) moves the application's status; a
+        note-family event never does."""
+        try:
+            body = applications_route.RecordEventRequest(
+                event_type=event_type, detail=detail, payload=payload or {},
+                occurred_at=occurred_at, corrects_event_id=corrects_event_id,
+            )
+        except ValidationError as exc:
+            raise _validation_error(exc) from None
+        try:
+            async with _request_db() as db:
+                resp = await applications_route.record_event(application_id, body, db, _user())
+        except HTTPException as exc:
+            _audit("record_event", "error", application_id=application_id, http_status=exc.status_code)
+            raise _tool_error(exc) from None
+        _audit("record_event", "ok", application_id=application_id, event_type=event_type)
+        return resp
+
+    @mcp.tool()
+    async def whats_new(since: Optional[str] = None, after_id: Optional[int] = None, limit: int = 50) -> dict[str, Any]:
+        """What happened across ALL of the user's applications since a given
+        time — for an agent waking up and asking "what did I miss?". Paged by
+        when Job360 recorded each event, never by when it happened in the
+        world, so a backdated event can never be silently skipped."""
+        try:
+            async with _request_db() as db:
+                resp = await applications_route.whats_new(since, after_id, limit, db, _user())
+        except HTTPException as exc:
+            _audit("whats_new", "error", http_status=exc.status_code)
+            raise _tool_error(exc) from None
+        _audit("whats_new", "ok", count=len(resp.get("events", [])))
+        return resp
+
+    @mcp.tool()
+    async def export_history(since: Optional[str] = None, include_text: bool = False) -> dict[str, Any]:
+        """Export the user's whole application history: every application,
+        its events, and artifact metadata (full text only when
+        include_text=true). Bounded and rate-limited — a truncated response
+        names next_since to page from."""
+        try:
+            async with _request_db() as db:
+                resp = await applications_route.export_history(since, include_text, db, _user())
+        except HTTPException as exc:
+            _audit("export_history", "error", http_status=exc.status_code)
+            raise _tool_error(exc) from None
+        _audit(
+            "export_history", "ok",
+            applications=len(resp.get("applications", [])), truncated=resp.get("truncated", False),
+        )
+        return resp
 
     return mcp
 

--- a/backend/src/api/routes/applications.py
+++ b/backend/src/api/routes/applications.py
@@ -1,0 +1,511 @@
+"""The application spine's REST surface (docs/plans/2026-09-04-application-
+spine/spec.md, §Tool contracts). Every route here is also an MCP tool
+(``src/api/mcp_server.py``) calling the SAME function — one API for every
+surface.
+
+Auth: every route ``Depends(require_user)`` (session cookie, personal
+``j360_…`` token, or OAuth ``j360a_…`` bearer — S1). None of these routes
+spend an LLM call, so none is ``require_verified_user``.
+
+Route-declaration order matters: ``/applications/export`` is declared BEFORE
+``/applications/{application_id}`` (spec §Tool contracts) so a stray literal
+path can never be swallowed by the dynamic one.
+
+``recorded_by`` / ``made_by`` are NEVER read from a request body — every
+request model here sets ``model_config = ConfigDict(extra="forbid")``, so a
+body carrying either field is rejected by Pydantic with 422 before this
+module's code ever runs (S3).
+"""
+from __future__ import annotations
+
+import json
+from typing import Any, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, ConfigDict, Field
+
+from src.api.auth_deps import CurrentUser, require_user
+from src.api.dependencies import get_request_db
+from src.core import settings
+from src.repositories.database import JobDatabase
+from src.services.applications import spine
+from src.services.applications.authorship import actor_for
+from src.services.applications.spine import SpineError
+
+router = APIRouter(tags=["applications"])
+
+
+def _raise(exc: SpineError) -> None:
+    raise HTTPException(status_code=exc.status_code, detail=exc.detail) from None
+
+
+# ── Request models ───────────────────────────────────────────────────────────
+
+
+class SaveArtifactRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    kind: str
+    text: str
+    label: str = Field("", max_length=100)
+    model: Optional[str] = Field(None, max_length=200)
+
+
+class SaveFitRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    score: Optional[int] = Field(None, ge=0, le=100)
+    verdict: Optional[str] = Field(None, max_length=200)
+    gaps: Optional[list[str]] = Field(None, max_length=50)
+    reasoning: Optional[str] = None
+
+    def clamp_reasoning(self) -> Optional[str]:
+        if self.reasoning is None:
+            return None
+        cap = settings.APPLICATION_FIT_REASONING_MAX_CHARS
+        if len(self.reasoning) > cap:
+            raise SpineError(422, f"reasoning exceeds APPLICATION_FIT_REASONING_MAX_CHARS ({cap} chars)")
+        return self.reasoning
+
+
+class RecordEventRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    event_type: str
+    detail: str = ""
+    payload: dict[str, Any] = Field(default_factory=dict)
+    occurred_at: Optional[str] = None
+    corrects_event_id: Optional[int] = None
+
+    def clamp_detail(self) -> str:
+        cap = settings.APPLICATION_EVENT_DETAIL_MAX_CHARS
+        if len(self.detail) > cap:
+            raise SpineError(422, f"detail exceeds APPLICATION_EVENT_DETAIL_MAX_CHARS ({cap} chars)")
+        return self.detail
+
+
+class ReceiptAnswer(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    question: str = Field(..., max_length=500)
+    answer: str = Field(..., max_length=settings.APPLICATION_RECEIPT_ANSWER_MAX_CHARS)
+
+
+class RecordApplicationReceiptRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    channel: str = Field("", max_length=100)
+    note: str = Field("", max_length=2_000)
+    confirmation: str = Field("", max_length=200)
+    answers: list[ReceiptAnswer] = Field(default_factory=list, max_length=settings.APPLICATION_RECEIPT_ANSWERS_MAX)
+    fields_filled: dict[str, Any] = Field(default_factory=dict)
+    cv_artifact_id: Optional[int] = None
+    cover_letter_artifact_id: Optional[int] = None
+    applied_at: Optional[str] = None
+
+    def clamp_fields_filled(self) -> dict[str, Any]:
+        cap = settings.APPLICATION_RECEIPT_FIELDS_MAX_BYTES
+        size = len(json.dumps(self.fields_filled).encode("utf-8"))
+        if size > cap:
+            raise SpineError(422, f"fields_filled exceeds APPLICATION_RECEIPT_FIELDS_MAX_BYTES ({cap} bytes)")
+        return self.fields_filled
+
+
+# ── Response models ──────────────────────────────────────────────────────────
+#
+# Every route here carries `response_model` so the generated `api-types.ts`
+# (and its drift gate) sees a real shape — same reasoning as oauth.py's
+# comment above `ConsentRequestResponse`. Field types follow the rule the
+# request models already use: `Optional[X]` with NO default means the key is
+# ALWAYS present but may be `null`; `Optional[X] = None` means the key can be
+# ABSENT from the response entirely (openapi-typescript renders the first as
+# `X | null` and the second as an optional key).
+
+
+class ApplicationJobOut(BaseModel):
+    job_title: str
+    job_company: str
+    job_location: str
+    job_url: str
+    job_source: str
+    job_description_snapshot: str
+    snapshot_at: Optional[str]
+    catalog_present: bool
+
+
+class ApplicationFitOut(BaseModel):
+    score: Optional[int]
+    verdict: Optional[str]
+    gaps: list[str]
+    reasoning: Optional[str]
+    recorded_by: str
+    recorded_at: str
+
+
+class ApplicationEventOut(BaseModel):
+    """The timeline shape (``list_events_for_display``) — used by
+    ``get_application`` and ``export_history``. Carries ``superseded``;
+    ``whats_new``'s events do not (see ``WhatsNewEventOut``)."""
+
+    id: int
+    event_type: str
+    detail: str
+    payload: dict[str, Any]
+    occurred_at: str
+    recorded_at: str
+    recorded_by: str
+    corrects_event_id: Optional[int]
+    superseded: bool
+
+
+class ApplicationArtifactOut(BaseModel):
+    """The ``get_application`` artifacts-list shape: ``text`` is ALWAYS a key
+    (null unless ``with_artifact_text=true`` and under the byte cap)."""
+
+    id: int
+    kind: str
+    version_no: int
+    made_by: str
+    model: Optional[str]
+    profile_version: Optional[int]
+    label: str
+    chars: int
+    created_at: str
+    text: Optional[str]
+    truncated: bool
+
+
+class ApplicationArtifactRowOut(BaseModel):
+    """``get_application_artifact`` — one version in full. No ``truncated``:
+    this route always returns the real row, never a capped read."""
+
+    id: int
+    kind: str
+    version_no: int
+    text: str
+    made_by: str
+    model: Optional[str]
+    profile_version: Optional[int]
+    label: str
+    chars: int
+    created_at: str
+
+
+class ApplicationReceiptOut(BaseModel):
+    """``get_application``'s receipts list — never carries the receipt text
+    (that call site never passes ``include_text``; see
+    ``ApplicationReceiptExportOut`` for the ``export_history`` shape)."""
+
+    id: int
+    sent_at: str
+    channel: str
+    confirmation: str
+    cv_artifact_id: Optional[int]
+    cover_letter_artifact_id: Optional[int]
+    note: str
+
+
+class ApplicationReceiptExportOut(ApplicationReceiptOut):
+    cv_text: Optional[str] = None
+    cover_letter_text: Optional[str] = None
+
+
+class ApplicationDetailOut(BaseModel):
+    id: int
+    job_id: int
+    status: str
+    created_at: str
+    updated_at: str
+    last_event_at: Optional[str]
+    job: ApplicationJobOut
+    fit: Optional[ApplicationFitOut]
+    artifacts: list[ApplicationArtifactOut]
+    events: list[ApplicationEventOut]
+    receipts: list[ApplicationReceiptOut]
+
+
+class ApplicationSummaryOut(BaseModel):
+    id: int
+    job_id: int
+    job_title: str
+    job_company: str
+    status: str
+    last_event_at: Optional[str]
+    events: int
+    artifacts: dict[str, int]
+    receipts: int
+
+
+class ListApplicationsResponse(BaseModel):
+    applications: list[ApplicationSummaryOut]
+    total: int
+
+
+class SaveArtifactResponse(BaseModel):
+    artifact_id: int
+    kind: str
+    version_no: int
+    chars: int
+    made_by: str
+    model: Optional[str]
+    profile_version: Optional[int]
+    created_at: str
+    event_id: int
+
+
+class SaveFitResponse(BaseModel):
+    application_id: int
+    fit: ApplicationFitOut
+    event_id: int
+
+
+class RecordEventResponse(BaseModel):
+    event_id: int
+    event_type: str
+    occurred_at: str
+    recorded_at: str
+    recorded_by: str
+    status: str
+
+
+class RecordApplicationReceiptResponse(BaseModel):
+    receipt_id: int
+    sent_at: str
+    cv_artifact_id: Optional[int]
+    cv_version_no: Optional[int]
+    cover_letter_artifact_id: Optional[int]
+    channel: str
+    confirmation: str
+    url: str
+    event_id: int
+
+
+class WhatsNewEventOut(BaseModel):
+    """``whats_new``'s raw event rows — no ``superseded`` (unlike
+    ``ApplicationEventOut``); carries ``application_id`` instead."""
+
+    id: int
+    application_id: int
+    event_type: str
+    detail: str
+    payload: dict[str, Any]
+    occurred_at: str
+    recorded_at: str
+    recorded_by: str
+    corrects_event_id: Optional[int]
+
+
+class WhatsNewApplicationOut(BaseModel):
+    id: int
+    job_title: str
+    job_company: str
+    status: str
+    last_event_at: Optional[str]
+
+
+class WhatsNewResponse(BaseModel):
+    now: str
+    since: str
+    events: list[WhatsNewEventOut]
+    applications: list[WhatsNewApplicationOut]
+    next_since: str
+    next_after_id: Optional[int]
+    truncated: bool
+
+
+class ExportArtifactOut(BaseModel):
+    """``export_history``'s artifact METADATA (not the full row): ``text`` is
+    only a key at all when ``include_text=true`` — hence the default."""
+
+    id: int
+    kind: str
+    version_no: int
+    made_by: str
+    model: Optional[str]
+    profile_version: Optional[int]
+    label: str
+    chars: int
+    created_at: str
+    text: Optional[str] = None
+
+
+class ExportApplicationOut(BaseModel):
+    id: int
+    job_id: int
+    status: str
+    job_title: str
+    job_company: str
+    created_at: str
+    updated_at: str
+    last_event_at: Optional[str]
+    events: list[ApplicationEventOut]
+    artifacts: list[ExportArtifactOut]
+    receipts: list[ApplicationReceiptExportOut]
+
+
+class ExportHistoryResponse(BaseModel):
+    applications: list[ExportApplicationOut]
+    truncated: bool
+    bytes: int
+    next_since: Optional[str] = None
+
+
+# ── Routes — order matters: /export before /{application_id} ────────────────
+
+
+@router.get("/applications/export", response_model=ExportHistoryResponse)
+async def export_history(
+    since: Optional[str] = Query(None),
+    include_text: bool = Query(False),
+    db: JobDatabase = Depends(get_request_db),  # noqa: B008
+    user: CurrentUser = Depends(require_user),  # noqa: B008
+) -> dict[str, Any]:
+    try:
+        return await spine.export_history(db, user.id, since=since, include_text=include_text)
+    except SpineError as exc:
+        _raise(exc)
+        raise AssertionError("unreachable")  # pragma: no cover — _raise always raises
+
+
+@router.get("/applications", response_model=ListApplicationsResponse)
+async def list_applications(
+    status: Optional[str] = Query(None),
+    updated_since: Optional[str] = Query(None),
+    limit: int = Query(20, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+    db: JobDatabase = Depends(get_request_db),  # noqa: B008
+    user: CurrentUser = Depends(require_user),  # noqa: B008
+) -> dict[str, Any]:
+    return await spine.list_applications(
+        db, user.id, status=status, updated_since=updated_since, limit=limit, offset=offset
+    )
+
+
+@router.get("/applications/{application_id}", response_model=ApplicationDetailOut)
+async def get_application(
+    application_id: int,
+    with_artifact_text: bool = Query(False),
+    db: JobDatabase = Depends(get_request_db),  # noqa: B008
+    user: CurrentUser = Depends(require_user),  # noqa: B008
+) -> dict[str, Any]:
+    detail = await spine.get_application_detail(
+        db, user.id, application_id, with_artifact_text=with_artifact_text
+    )
+    if detail is None:
+        raise HTTPException(status_code=404, detail="application not found")
+    return detail
+
+
+@router.get(
+    "/applications/{application_id}/artifacts/{artifact_id}", response_model=ApplicationArtifactRowOut
+)
+async def get_application_artifact(
+    application_id: int,
+    artifact_id: int,
+    db: JobDatabase = Depends(get_request_db),  # noqa: B008
+    user: CurrentUser = Depends(require_user),  # noqa: B008
+) -> dict[str, Any]:
+    row = await spine.get_artifact(db, user.id, application_id, artifact_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="artifact not found")
+    return row
+
+
+@router.post(
+    "/applications/{application_id}/artifacts", status_code=201, response_model=SaveArtifactResponse
+)
+async def save_artifact(
+    application_id: int,
+    body: SaveArtifactRequest,
+    db: JobDatabase = Depends(get_request_db),  # noqa: B008
+    user: CurrentUser = Depends(require_user),  # noqa: B008
+) -> dict[str, Any]:
+    try:
+        return await spine.save_artifact(
+            db, user_id=user.id, application_id=application_id, kind=body.kind, text=body.text,
+            made_by=actor_for(user), label=body.label, model=body.model,
+        )
+    except SpineError as exc:
+        _raise(exc)
+        raise AssertionError("unreachable")  # pragma: no cover
+
+
+@router.put("/applications/{application_id}/fit", response_model=SaveFitResponse)
+async def save_fit(
+    application_id: int,
+    body: SaveFitRequest,
+    db: JobDatabase = Depends(get_request_db),  # noqa: B008
+    user: CurrentUser = Depends(require_user),  # noqa: B008
+) -> dict[str, Any]:
+    try:
+        reasoning = body.clamp_reasoning()
+        return await spine.save_fit(
+            db, user_id=user.id, application_id=application_id, recorded_by=actor_for(user),
+            score=body.score, verdict=body.verdict, gaps=body.gaps, reasoning=reasoning,
+        )
+    except SpineError as exc:
+        _raise(exc)
+        raise AssertionError("unreachable")  # pragma: no cover
+
+
+@router.post(
+    "/applications/{application_id}/events", status_code=201, response_model=RecordEventResponse
+)
+async def record_event(
+    application_id: int,
+    body: RecordEventRequest,
+    db: JobDatabase = Depends(get_request_db),  # noqa: B008
+    user: CurrentUser = Depends(require_user),  # noqa: B008
+) -> dict[str, Any]:
+    try:
+        spine.validate_event_type(body.event_type)
+        detail = body.clamp_detail()
+        payload = spine.validate_payload(body.payload)
+        occurred_at = spine.parse_occurred_at(body.occurred_at)
+        app_row = await spine.get_owned_application(db, user.id, application_id)
+        if app_row is None:
+            raise SpineError(404, "application not found")
+        return await spine.append_event(
+            db, user_id=user.id, application_id=application_id, event_type=body.event_type,
+            detail=detail, payload=payload, occurred_at=occurred_at, recorded_by=actor_for(user),
+            corrects_event_id=body.corrects_event_id,
+        )
+    except SpineError as exc:
+        _raise(exc)
+        raise AssertionError("unreachable")  # pragma: no cover
+
+
+@router.post(
+    "/applications/{application_id}/receipt",
+    status_code=201,
+    response_model=RecordApplicationReceiptResponse,
+)
+async def record_application_receipt(
+    application_id: int,
+    body: RecordApplicationReceiptRequest,
+    db: JobDatabase = Depends(get_request_db),  # noqa: B008
+    user: CurrentUser = Depends(require_user),  # noqa: B008
+) -> dict[str, Any]:
+    try:
+        fields_filled = body.clamp_fields_filled()
+        return await spine.record_receipt(
+            db, user_id=user.id, application_id=application_id, recorded_by=actor_for(user),
+            channel=body.channel, note=body.note, confirmation=body.confirmation,
+            answers=[a.model_dump() for a in body.answers], fields_filled=fields_filled,
+            cv_artifact_id=body.cv_artifact_id, cover_letter_artifact_id=body.cover_letter_artifact_id,
+            applied_at=body.applied_at,
+        )
+    except SpineError as exc:
+        _raise(exc)
+        raise AssertionError("unreachable")  # pragma: no cover
+
+
+@router.get("/whats-new", response_model=WhatsNewResponse)
+async def whats_new(
+    since: Optional[str] = Query(None),
+    after_id: Optional[int] = Query(None),
+    limit: int = Query(50, ge=1, le=200),
+    db: JobDatabase = Depends(get_request_db),  # noqa: B008
+    user: CurrentUser = Depends(require_user),  # noqa: B008
+) -> dict[str, Any]:
+    return await spine.whats_new(db, user.id, since=since, after_id=after_id, limit=limit)

--- a/backend/src/api/routes/bring.py
+++ b/backend/src/api/routes/bring.py
@@ -74,6 +74,9 @@ class BringJobResponse(BaseModel):
     job: JobResponse
     existing: bool   # the same (company, title) was already in the catalog
     scored: bool     # False when the user has no complete profile yet
+    # spec 2026-09-04-application-spine R1 — an Application is born HERE.
+    application_id: int
+    status: str
 
 
 @router.post("/jobs/bring", response_model=BringJobResponse)
@@ -88,6 +91,8 @@ async def bring_job(
     """
     # Lazy: Job + the shelf gate pull the scoring stack (rule #16).
     from src.models import Job  # noqa: PLC0415
+    from src.services.applications import spine as applications_spine  # noqa: PLC0415
+    from src.services.applications.authorship import actor_for  # noqa: PLC0415
     from src.services.feed import FeedService  # noqa: PLC0415
     from src.services.profile.storage import current_profile_version_id  # noqa: PLC0415
     from src.services.shelf_gate import fill_shelves  # noqa: PLC0415
@@ -147,6 +152,15 @@ async def bring_job(
         scorer_version=SCORER_VERSION,
     )
 
+    # R1/R2 — the Application is born HERE, in the same request: upsert the
+    # `applications` row for (user, job) with status='considering', copy the
+    # ad onto it (the snapshot purge_old_jobs can no longer erase), append a
+    # `brought` event. Bringing the same job twice reuses the row and appends
+    # no second event (birth_application reads-before-inserting).
+    birth = await applications_spine.birth_application(
+        db, user_id=user.id, job_id=job_id, job_row=dict(row), recorded_by=actor_for(user),
+    )
+
     get_audit_logger().info(
         "job_brought",
         extra={
@@ -157,4 +171,7 @@ async def bring_job(
     job_action = await db.get_action_for_job(job_id, user.id)
     resp = _row_to_job_response(personalised, job_action)
     resp.description = personalised.get("description") or None
-    return BringJobResponse(job=resp, existing=not inserted, scored=scored)
+    return BringJobResponse(
+        job=resp, existing=not inserted, scored=scored,
+        application_id=birth["application_id"], status=birth["status"],
+    )

--- a/backend/src/api/routes/pipeline.py
+++ b/backend/src/api/routes/pipeline.py
@@ -33,7 +33,14 @@ router = APIRouter(tags=["pipeline"])
 # (Contrast services/ghost_detection.py, which infers staleness from a listing
 # DISAPPEARING from its source — usually a sign the role was filled, i.e. the
 # opposite of a ghost job. User-confirmed silence is the stronger signal.)
-_VALID_STAGES = {"applied", "outreach", "interview", "offer", "rejected", "ghosted"}
+#
+# "considering" (B2 fix, application-spine review) — a job merely brought via
+# the spine (`bring_job`) and not yet actively worked. `birth_application`
+# writes this stage explicitly so a freshly-brought job does not read as
+# "applied" on the legacy board; it is not a legal ADVANCE target in the
+# product sense, but belongs in the set because it is a real value the
+# `stage` column now holds.
+_VALID_STAGES = {"considering", "applied", "outreach", "interview", "offer", "rejected", "ghosted"}
 
 
 def _to_pipeline_application(row: dict[str, Any]) -> PipelineApplication:

--- a/backend/src/api/routes/receipts.py
+++ b/backend/src/api/routes/receipts.py
@@ -107,6 +107,7 @@ async def create_receipt(
     existing per-user tables (`user_actions` for the card, `applications` for
     the pipeline) so every surface agrees.
     """
+    from src.services.applications import spine as applications_spine  # noqa: PLC0415
     from src.services.profile.storage import current_profile_version_id  # noqa: PLC0415
 
     job = await db.get_job_by_id(job_id)
@@ -115,6 +116,16 @@ async def create_receipt(
 
     cv_text, cv_origin = _sent_text(await db.get_tailored_doc(user.id, job_id, "cv"))
     cl_text, cl_origin = _sent_text(await db.get_tailored_doc(user.id, job_id, "cover_letter"))
+
+    # Mark applied on the existing surfaces FIRST — `create_application` is an
+    # upsert (INSERT OR IGNORE), so the application row (and its id) exists
+    # before the receipt does. R8's `application_id` is then part of the
+    # receipt's own INSERT (below), never a later UPDATE:
+    # tests/test_receipts.py::test_receipts_are_append_only greps
+    # `backend/src/` for any UPDATE/DELETE against `application_receipts`.
+    await db.insert_action(job_id, "applied", user.id)
+    await db.create_application(job_id, user.id)
+    application = await applications_spine.get_application_by_job(db, user.id, job_id)
 
     receipt = await db.insert_receipt(
         user_id=user.id,
@@ -126,12 +137,17 @@ async def create_receipt(
         profile_version=current_profile_version_id(user.id),
         channel=body.channel.strip(),
         note=body.note.strip(),
+        application_id=application["id"] if application else None,
     )
-    # Mark applied on both existing surfaces. Both writes are idempotent
-    # (ON CONFLICT / INSERT OR IGNORE), so a second receipt for the same job
-    # is fine — that is a re-application, and it gets its own receipt.
-    await db.insert_action(job_id, "applied", user.id)
-    await db.create_application(job_id, user.id)
+
+    # R8 — write-through to the spine: append the `applied` event. The
+    # route's OWN shape and behaviour are unchanged for the caller
+    # (constraint 4).
+    if application is not None:
+        await applications_spine.write_through_legacy_receipt(
+            db, user_id=user.id, application_id=application["id"],
+            receipt_id=receipt["id"], sent_at=receipt["sent_at"], note=body.note.strip(),
+        )
 
     get_audit_logger().info(
         "receipt_create",

--- a/backend/src/api/routes/search.py
+++ b/backend/src/api/routes/search.py
@@ -186,6 +186,11 @@ async def start_search(
     queued, returns HTTP 429. Counting is per-user, so other users are
     unaffected by one user's burst.
     """
+    if not settings.SEARCH_UI_ENABLED:
+        # R12 — hidden feature, not a security control (S10): the route keeps
+        # its existing Depends(require_verified_user) regardless of the flag.
+        raise HTTPException(status_code=404, detail="Not Found")
+
     if _active_run_count_for_user(user.id) >= settings.MAX_CONCURRENT_SEARCHES_PER_USER:
         raise HTTPException(
             status_code=429,
@@ -272,6 +277,9 @@ async def search_status(
     both return 404 with the same body. An attacker enumerating run_ids
     cannot distinguish "does not exist" from "exists but not mine".
     """
+    if not settings.SEARCH_UI_ENABLED:
+        raise HTTPException(status_code=404, detail="Not Found")
+
     run = _runs.get(run_id)
     if run is None or run.get("user_id") != user.id:
         raise HTTPException(status_code=404, detail="run not found")

--- a/backend/src/api/routes/tailor.py
+++ b/backend/src/api/routes/tailor.py
@@ -96,6 +96,32 @@ async def _bundle(db: JobDatabase, user_id: str, job_id: int) -> TailorBundle:
     )
 
 
+async def _mirror_artifact_version(
+    db: JobDatabase, user_id: str, job_id: int, kind: str, text: str, *, made_by: str, model: str | None
+) -> None:
+    """R15 — write-through into the application spine's version history.
+
+    ``tailored_documents`` keeps its DELETE+INSERT behaviour (it is the
+    editor's working copy); this is the memory. Non-fatal by design: a
+    (user, job) pair reached via the legacy search path may have no
+    `applications` row at all (nothing was ever brought), and a mirror
+    failure must never break the tailoring feature it is mirroring.
+    """
+    from src.services.applications import spine as applications_spine  # noqa: PLC0415
+    from src.services.applications.spine import SpineError  # noqa: PLC0415
+
+    application = await applications_spine.get_application_by_job(db, user_id, job_id)
+    if application is None:
+        return
+    try:
+        await applications_spine.save_artifact(
+            db, user_id=user_id, application_id=application["id"], kind=kind, text=text,
+            made_by=made_by, model=model,
+        )
+    except SpineError:
+        logger.warning("tailor artifact mirror failed", extra={"job_id": job_id, "kind": kind})
+
+
 def _load_cv_text(user_id: str) -> str:
     """Full CV text = stored CV + LinkedIn text (the ONLY facts the LLM may use)."""
     profile = load_profile(user_id)  # sync (pgsync shim), fast single-row
@@ -192,6 +218,7 @@ async def generate(
             model=doc.model, flagged_terms=doc.flagged_terms,
             profile_version=profile_version,
         )
+        await _mirror_artifact_version(db, user.id, job_id, kind, doc.document, made_by="web:tailor", model=doc.model)
 
     await db.record_tailored_usage(user.id, job_id)
     get_audit_logger().info(
@@ -251,6 +278,7 @@ async def save_edit(
         # Without this guard _doc_out(None) raised TypeError -> HTTP 500, which
         # tells the user "we broke" for what is really "it's gone".
         raise HTTPException(status_code=404, detail="Draft no longer exists.")
+    await _mirror_artifact_version(db, user.id, job_id, doc_kind, body.text, made_by="human", model=row.get("model"))
     return _doc_out(row)
 
 

--- a/backend/src/core/settings.py
+++ b/backend/src/core/settings.py
@@ -423,6 +423,81 @@ def _env_flag(name: str, default: bool) -> bool:
     return raw.lower() in {"1", "true", "yes", "on"}
 
 
+def _env_list(name: str, default: tuple[str, ...]) -> tuple[str, ...]:
+    """Comma-separated env var -> tuple of non-empty, stripped strings."""
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    return tuple(v.strip() for v in raw.split(",") if v.strip())
+
+
+# ---------------------------------------------------------------------------
+# The application spine (docs/plans/2026-09-04-application-spine/spec.md).
+#
+# R12/R13 — the old search UI and the catalog crons go behind parameters,
+# both default OFF: the mission (docs/product/VISION.md) is "the agent finds
+# the job, Job360 remembers" — Job360 never sources or ranks. Flipping either
+# flag ON is a deliberate opt-in, never a silent behaviour change.
+SEARCH_UI_ENABLED = _env_flag("SEARCH_UI_ENABLED", False)
+CATALOG_CRONS_ENABLED = _env_flag("CATALOG_CRONS_ENABLED", False)
+
+# R7 — the event vocabulary. Closed set in CODE, not a DB CHECK constraint, so
+# a new event type is a settings.py edit, never a migration (constraint 5).
+# `brought` maps to status `considering`; every other status event's NAME is
+# the status itself (src/services/applications/status.py's mapping dict).
+# A frozen test (test_event_types_match_vision_doc) pins these two tuples to
+# docs/product/VISION.md:66-71 so doc and code cannot drift apart silently.
+APPLICATION_STATUS_EVENT_TYPES = (
+    "brought", "applied", "replied", "interview_requested",
+    "interview_scheduled", "interview_done", "offer", "rejected",
+    "withdrawn", "ghosted",
+)
+APPLICATION_NOTE_EVENT_TYPES = (
+    "fit_judged", "artifact_saved", "contact_added", "outreach_sent", "note", "lesson",
+)
+# Env-added types are non-status only — a status type also needs an R4
+# mapping entry, which an env var cannot supply.
+APPLICATION_EXTRA_EVENT_TYPES = _env_list("APPLICATION_EXTRA_EVENT_TYPES", ())
+
+# S5 — input caps for the application spine. Every one a parameter; every
+# breach a 422/429 naming the field and the limit, never a silent drop/clip.
+APPLICATION_EVENT_DETAIL_MAX_CHARS = int(os.getenv("APPLICATION_EVENT_DETAIL_MAX_CHARS", "2000"))
+APPLICATION_EVENT_PAYLOAD_MAX_BYTES = int(os.getenv("APPLICATION_EVENT_PAYLOAD_MAX_BYTES", "8192"))
+# S6 — how far into the future `occurred_at` may claim to be before it is
+# refused as implausible. No lower bound: backdating is the normal case.
+APPLICATION_EVENT_MAX_FUTURE_SECONDS = int(os.getenv("APPLICATION_EVENT_MAX_FUTURE_SECONDS", "300"))
+
+# R5 — artifact versions. Storage decision: TEXT in Postgres, not a file store
+# (spec §Data model) — a tailored CV measured on this codebase is 2-8 KB.
+APPLICATION_ARTIFACT_KINDS = ("cv", "cover_letter", "answers", "outreach")
+APPLICATION_ARTIFACT_MAX_CHARS = int(os.getenv("APPLICATION_ARTIFACT_MAX_CHARS", "60000"))
+APPLICATION_ARTIFACT_MAX_VERSIONS = int(os.getenv("APPLICATION_ARTIFACT_MAX_VERSIONS", "200"))
+
+# R8 — record_application (the rich receipt).
+APPLICATION_RECEIPT_ANSWERS_MAX = int(os.getenv("APPLICATION_RECEIPT_ANSWERS_MAX", "50"))
+APPLICATION_RECEIPT_ANSWER_MAX_CHARS = int(os.getenv("APPLICATION_RECEIPT_ANSWER_MAX_CHARS", "2000"))
+APPLICATION_RECEIPT_FIELDS_MAX_BYTES = int(os.getenv("APPLICATION_RECEIPT_FIELDS_MAX_BYTES", "8192"))
+
+# R6 — the fit verdict is stored, never computed.
+APPLICATION_FIT_REASONING_MAX_CHARS = int(os.getenv("APPLICATION_FIT_REASONING_MAX_CHARS", "4000"))
+
+# S3 — how much of an OAuth client's attacker-supplied name `actor_for` keeps
+# as `agent:<name>` authorship. Env-backed like every other spine cap (C8);
+# was hardcoded in authorship.py before.
+APPLICATION_ACTOR_NAME_MAX_CHARS = int(os.getenv("APPLICATION_ACTOR_NAME_MAX_CHARS", "60"))
+
+# R9 — whats_new.
+WHATS_NEW_DEFAULT_WINDOW_DAYS = int(os.getenv("WHATS_NEW_DEFAULT_WINDOW_DAYS", "7"))
+WHATS_NEW_MAX_EVENTS = int(os.getenv("WHATS_NEW_MAX_EVENTS", "200"))
+
+# R10/S8 — export_history: bounds explicit, never silent; rate-limited per USER
+# (never per IP — every agent shares the proxy IP behind the Next rewrite
+# unless JOB360_TRUST_PROXY=1, the trap the OAuth slice documented).
+EXPORT_HISTORY_MAX_APPLICATIONS = int(os.getenv("EXPORT_HISTORY_MAX_APPLICATIONS", "500"))
+EXPORT_HISTORY_MAX_BYTES = int(os.getenv("EXPORT_HISTORY_MAX_BYTES", str(8 * 1024 * 1024)))
+EXPORT_HISTORY_MAX_PER_HOUR = int(os.getenv("EXPORT_HISTORY_MAX_PER_HOUR", "12"))
+
+
 # --- Independent per-engine switches -------------------------------------
 # Four scoring engines, each with its own on/off switch so ANY combination
 # can be selected (e.g. E1+E3 on, E2+E4 off). Each switch DEFAULTS to its

--- a/backend/src/repositories/database.py
+++ b/backend/src/repositories/database.py
@@ -13,6 +13,7 @@ _VALID_COL_NAME = re.compile(r"^[a-z_][a-z0-9_]{0,63}$")
 # see 0032_universal_shelf.up.sql for why.
 _VALID_COL_TYPES = {"TEXT", "INTEGER", "REAL", "BLOB", "NUMERIC", "BOOLEAN", "JSONB"}
 
+from src.core.settings import USER_BROUGHT_SOURCE  # noqa: E402
 from src.models import Job  # noqa: E402  # after the regex constants to avoid circular import
 from src.utils.logger import get_logger  # noqa: E402
 
@@ -786,7 +787,17 @@ class JobDatabase:
         ``user_feed`` is the big one: one row per user per job.
         """
         cutoff = (datetime.now(timezone.utc) - timedelta(days=days)).isoformat()
-        stale = "SELECT id FROM jobs WHERE COALESCE(last_seen_at, first_seen) < ?"
+        # R2 amendment (spec 2026-09-04-application-spine, hard rule #3): a
+        # `user_brought` row is never a scrape aging out — the user is
+        # tracking it, and the application snapshot needs the live catalog
+        # row for the detail page. Both the direct DELETE below AND this
+        # `stale` subquery (which feeds the cascade-child DELETEs) exclude
+        # it, so neither the job row nor its user_feed/enrichment children
+        # are purged out from under a brought application.
+        stale = (
+            "SELECT id FROM jobs WHERE COALESCE(last_seen_at, first_seen) < ? "
+            "AND source <> ?"
+        )
         # Children first (the subquery needs the jobs rows to still exist).
         #
         # Skip a child table that does not exist IN THIS SCHEMA. EVERY table in
@@ -818,10 +829,12 @@ class JobDatabase:
             if table not in present:
                 continue
             await self._db.execute(
-                f"DELETE FROM {table} WHERE job_id IN ({stale})", (cutoff,)  # noqa: S608 — table name is a module constant, never user input
+                f"DELETE FROM {table} WHERE job_id IN ({stale})",  # noqa: S608 — table name is a module constant, never user input
+                (cutoff, USER_BROUGHT_SOURCE),
             )
         cursor = await self._db.execute(
-            "DELETE FROM jobs WHERE COALESCE(last_seen_at, first_seen) < ?", (cutoff,)
+            "DELETE FROM jobs WHERE COALESCE(last_seen_at, first_seen) < ? AND source <> ?",
+            (cutoff, USER_BROUGHT_SOURCE),
         )
         await self._db.commit()
         _log.info(
@@ -1320,7 +1333,7 @@ class JobDatabase:
                FROM applications a LEFT JOIN jobs j ON a.job_id = j.id
                WHERE a.user_id = ?
                  AND a.updated_at < ?
-                 AND a.stage NOT IN ('offer', 'rejected')
+                 AND a.stage NOT IN ('offer', 'rejected', 'considering')
                ORDER BY a.updated_at ASC""",
             (user_id, cutoff),
         )
@@ -1385,10 +1398,16 @@ class JobDatabase:
         profile_version: int | None,
         channel: str = "",
         note: str = "",
+        application_id: int | None = None,
     ) -> dict[str, Any]:
         """Freeze one application: the job row as it reads NOW plus the documents
         as sent. `job` is a `get_job_by_id` dict; its fields are COPIED, never
         referenced, so the receipt survives re-description, expiry and purge.
+
+        `application_id` (spec 2026-09-04-application-spine R8) is set HERE, at
+        INSERT time, never by a later UPDATE — tests/test_receipts.py::
+        test_receipts_are_append_only greps `backend/src/` for any UPDATE/DELETE
+        against `application_receipts` and must stay green.
         """
         now = datetime.now(timezone.utc).isoformat()
         cursor = await self._db.execute(
@@ -1396,15 +1415,15 @@ class JobDatabase:
                (user_id, job_id, sent_at, job_title, job_company, job_location,
                 job_apply_url, job_source, job_description, cv_text, cv_origin,
                 cover_letter_text, cover_letter_origin, profile_version, channel,
-                note, created_at)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                note, created_at, application_id)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
             (
                 user_id, int(job["id"]), now,
                 job.get("title") or "", job.get("company") or "",
                 job.get("location") or "", job.get("apply_url") or "",
                 job.get("source") or "", job.get("description") or "",
                 cv_text, cv_origin, cover_letter_text, cover_letter_origin,
-                profile_version, channel, note, now,
+                profile_version, channel, note, now, application_id,
             ),
         )
         await self._db.commit()
@@ -1777,7 +1796,7 @@ class JobDatabase:
     # schema turns "delete my account" into an UndefinedTable crash (rule #26).
     # The list and the schema must move together, in the same commit.
     _PER_USER_TABLES = (
-        "api_tokens", "application_receipts",
+        "api_tokens", "application_artifacts", "application_events", "application_receipts",
         "application_stage_history", "applications", "email_verifications",
         "notification_ledger", "notification_rules", "oauth_grants",
         "password_resets", "sessions", "tailored_documents", "tailored_usage",
@@ -1796,7 +1815,8 @@ class JobDatabase:
     # connect?") but its `token_hash` is redacted below; the plaintext was never
     # stored, so the export can hand out nothing usable as a credential.
     _EXPORT_TABLES = (
-        "api_tokens", "application_receipts", "applications", "application_stage_history", "audit_log",
+        "api_tokens", "application_artifacts", "application_events", "application_receipts",
+        "applications", "application_stage_history", "audit_log",
         "notification_ledger", "notification_rules", "oauth_grants", "tailored_documents",
         "tailored_usage", "user_actions", "user_channels", "user_feed",
         "user_profile_versions", "user_profiles",

--- a/backend/src/services/applications/__init__.py
+++ b/backend/src/services/applications/__init__.py
@@ -1,0 +1,8 @@
+"""The application spine (docs/plans/2026-09-04-application-spine/spec.md).
+
+An Application is born at `bring_job`, carries a durable job snapshot, and
+its whole history is one append-only event log whose last status event is
+cached on `applications.status`. Everything here is pure/DB-thin helpers —
+the routes in `src.api.routes.applications` and the seven MCP tools in
+`src.api.mcp_server` are the callers.
+"""

--- a/backend/src/services/applications/authorship.py
+++ b/backend/src/services/applications/authorship.py
@@ -1,0 +1,34 @@
+"""``recorded_by`` / ``made_by`` are derived, never accepted (spec S3).
+
+One function, one source of truth: a request body field named ``recorded_by``
+or ``made_by`` is rejected with 422 at the Pydantic layer (``extra="forbid"``
+on every applications request model) — silently dropping it would let a
+caller believe it worked, and forging authorship is the one thing an
+append-only log must not permit.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from src.core import settings
+
+if TYPE_CHECKING:  # pragma: no cover — type-only
+    from src.api.auth_deps import CurrentUser
+
+
+def actor_for(user: CurrentUser) -> str:
+    """``"web"`` for a session, ``"token:<name>"`` for a personal token,
+    ``"agent:<client>"`` for an OAuth grant.
+
+    The OAuth client name is attacker-supplied text by construction (slice 1
+    R2 sanitises it at registration; this re-truncates it to
+    ``settings.APPLICATION_ACTOR_NAME_MAX_CHARS`` — spec C5). It is stored as
+    data here, never rendered as markup.
+    """
+    if user.auth_via == "token":
+        name = (user.actor_name or "").strip() or "unknown"
+        return f"token:{name}"
+    if user.auth_via == "oauth":
+        name = (user.actor_name or "").strip()[: settings.APPLICATION_ACTOR_NAME_MAX_CHARS] or "unknown"
+        return f"agent:{name}"
+    return "web"

--- a/backend/src/services/applications/spine.py
+++ b/backend/src/services/applications/spine.py
@@ -1,0 +1,914 @@
+"""The application spine's DB-facing core (spec.md R1-R11).
+
+Every write here goes through ``from src.repositories import pg as aiosqlite``
+indirectly via ``db._db`` (the guarded accessor over ``db._conn`` — C5; the
+same connection every route already depends on) — SQLite-shaped SQL,
+``pg.py``'s ``translate()`` rewrites it for Postgres at execute time. No
+route or MCP tool talks to the tables directly; they all come through this
+module, so there is exactly one place that can get the event log wrong.
+
+Append-only, for real: nothing in this file issues ``UPDATE``/``DELETE``
+against ``application_events`` or ``application_artifacts`` (grep-guarded by
+``tests/test_application_spine.py::test_events_are_append_only``). The only
+``UPDATE`` targets are the ``applications`` CACHE SLOT (status/fit — S7: an
+update of the slot is explicitly not history) and, once, a legacy
+``application_receipts`` row picking up its ``application_id``.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from typing import TYPE_CHECKING, Any, Mapping, Optional
+
+from src.core import settings
+from src.repositories import pg
+from src.services.applications.status import replay_status, stage_for_status
+from src.services.auth import rate_limit
+from src.utils.logger import get_audit_logger
+
+if TYPE_CHECKING:  # pragma: no cover — type-only; avoids a runtime import of
+    # database.py (rule #16-adjacent: this module stays light at import time).
+    from src.repositories.database import JobDatabase
+
+
+class SpineError(Exception):
+    """Domain error a route turns into ``HTTPException(status_code, detail)``."""
+
+    def __init__(self, status_code: int, detail: str) -> None:
+        super().__init__(detail)
+        self.status_code = status_code
+        self.detail = detail
+
+
+# ── Pure validation helpers (no DB — hit directly by tests) ────────────────
+
+
+def validate_event_type(event_type: str) -> None:
+    """R7 — closed set in code. 422 naming the allowed list on a miss."""
+    allowed = (
+        set(settings.APPLICATION_STATUS_EVENT_TYPES)
+        | set(settings.APPLICATION_NOTE_EVENT_TYPES)
+        | set(settings.APPLICATION_EXTRA_EVENT_TYPES)
+    )
+    if event_type not in allowed:
+        raise SpineError(
+            422,
+            f"unknown event_type {event_type!r}; allowed: {sorted(allowed)}",
+        )
+
+
+def payload_bytes(payload: Mapping[str, Any]) -> int:
+    """The SERIALISED size of an event payload, in bytes — what the column
+    actually costs, not ``len()`` of the Python object (S5)."""
+    return len(json.dumps(payload).encode("utf-8"))
+
+
+def validate_payload(payload: Any) -> dict[str, Any]:
+    """S5 — payload must be a JSON OBJECT (never a list/scalar), size-capped
+    on the SERIALISED form, because that is what the column costs."""
+    if payload is None:
+        return {}
+    if not isinstance(payload, dict):
+        raise SpineError(422, "payload must be a JSON object")
+    size = payload_bytes(payload)
+    if size > settings.APPLICATION_EVENT_PAYLOAD_MAX_BYTES:
+        raise SpineError(
+            422,
+            f"payload exceeds APPLICATION_EVENT_PAYLOAD_MAX_BYTES "
+            f"({settings.APPLICATION_EVENT_PAYLOAD_MAX_BYTES} bytes)",
+        )
+    return payload
+
+
+def parse_occurred_at(raw: Optional[str]) -> str:
+    """S6 — ISO-8601 with a timezone, bounded on the future side only."""
+    now = datetime.now(timezone.utc)
+    if raw is None:
+        return now.isoformat()
+    try:
+        parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        raise SpineError(422, "occurred_at must be ISO-8601 (e.g. 2026-09-04T12:00:00+00:00)") from None
+    if parsed.tzinfo is None:
+        raise SpineError(422, "occurred_at must include a timezone offset")
+    max_future = timedelta(seconds=settings.APPLICATION_EVENT_MAX_FUTURE_SECONDS)
+    if parsed > now + max_future:
+        raise SpineError(
+            422,
+            f"occurred_at is more than APPLICATION_EVENT_MAX_FUTURE_SECONDS "
+            f"({settings.APPLICATION_EVENT_MAX_FUTURE_SECONDS}s) in the future",
+        )
+    # B3 fix — normalise to the canonical +00:00 offset (pg.py:178-184's own
+    # convention) before storing. `application_events.occurred_at` is a TEXT
+    # column ordered lexically (list_events_for_display's ORDER BY occurred_at
+    # ASC); two instants recorded under different offsets (e.g. "+05:30" vs
+    # "+00:00") do NOT compare correctly as strings even though they compare
+    # correctly as instants, so every caller's offset must collapse to the
+    # same one before it ever reaches SQL.
+    return parsed.astimezone(timezone.utc).isoformat()
+
+
+# ── Ownership lookups ───────────────────────────────────────────────────────
+
+
+async def get_application_by_job(db: JobDatabase, user_id: str, job_id: int) -> Optional[dict[str, Any]]:
+    """The caller's application for a given job, or ``None`` if they never
+    brought it — the lookup ``birth_application``'s upsert-by-read and every
+    write-through helper (legacy receipts, MCP ``record_application``) use to
+    find the row a raw ``job_id`` maps to."""
+    cur = await db._db.execute(
+        "SELECT id, status FROM applications WHERE user_id = ? AND job_id = ?", (user_id, job_id)
+    )
+    row = await cur.fetchone()
+    return dict(row) if row else None
+
+
+async def get_owned_application(db: JobDatabase, user_id: str, application_id: int) -> Optional[dict[str, Any]]:
+    """S2 — the only lookup every other function here builds on. A foreign or
+    unknown id reads as None (the route turns that into 404, never 403)."""
+    cur = await db._db.execute(
+        "SELECT * FROM applications WHERE id = ? AND user_id = ?", (application_id, user_id)
+    )
+    row = await cur.fetchone()
+    return dict(row) if row else None
+
+
+# ── The event log ────────────────────────────────────────────────────────────
+
+
+async def _events_for_replay(db: JobDatabase, application_id: int) -> list[dict[str, Any]]:
+    cur = await db._db.execute(
+        "SELECT id, event_type, corrects_event_id, recorded_at FROM application_events "
+        "WHERE application_id = ?",
+        (application_id,),
+    )
+    return [dict(r) for r in await cur.fetchall()]
+
+
+async def list_events_for_display(db: JobDatabase, application_id: int) -> list[dict[str, Any]]:
+    """Timeline order — ``occurred_at`` (backdated events included), NOT the
+    ``recorded_at`` order the status recompute uses."""
+    cur = await db._db.execute(
+        "SELECT id, event_type, detail, payload, occurred_at, recorded_at, recorded_by, corrects_event_id "
+        "FROM application_events WHERE application_id = ? ORDER BY occurred_at ASC, id ASC",
+        (application_id,),
+    )
+    rows = [dict(r) for r in await cur.fetchall()]
+    superseded_ids = {r["corrects_event_id"] for r in rows if r.get("corrects_event_id") is not None}
+    out = []
+    for r in rows:
+        out.append(
+            {
+                "id": r["id"],
+                "event_type": r["event_type"],
+                "detail": r["detail"],
+                "payload": json.loads(r["payload"] or "{}"),
+                "occurred_at": r["occurred_at"],
+                "recorded_at": r["recorded_at"],
+                "recorded_by": r["recorded_by"],
+                "corrects_event_id": r["corrects_event_id"],
+                "superseded": r["id"] in superseded_ids,
+            }
+        )
+    return out
+
+
+async def append_event(
+    db: JobDatabase,
+    *,
+    user_id: str,
+    application_id: int,
+    event_type: str,
+    occurred_at: str,
+    recorded_by: str,
+    detail: str = "",
+    payload: Optional[dict[str, Any]] = None,
+    corrects_event_id: Optional[int] = None,
+) -> dict[str, Any]:
+    """R3/R4 — append one event, then recompute + write-through the status
+    cache (and its legacy `stage` projection) in the SAME logical operation.
+
+    No caller of this module ever computes `status` any other way — this is
+    the ONE place `applications.status`/`stage`/`last_event_at` are written.
+
+    B5 — ``corrects_event_id``, when given, must name a real event on THIS
+    SAME application; otherwise a caller could silently supersede a stranger's
+    event (or a typo'd id that never existed) and ``list_events_for_display``
+    would mark the wrong thing (or nothing) as superseded. 422, not 404 — this
+    is a body-field validation error, not a missing resource.
+    """
+    if corrects_event_id is not None:
+        cur = await db._db.execute(
+            "SELECT 1 FROM application_events WHERE id = ? AND application_id = ?",
+            (corrects_event_id, application_id),
+        )
+        if (await cur.fetchone()) is None:
+            raise SpineError(
+                422,
+                f"corrects_event_id {corrects_event_id} does not exist on this application",
+            )
+
+    now = datetime.now(timezone.utc).isoformat()
+    payload_json = json.dumps(payload or {})
+    cur = await db._db.execute(
+        "INSERT INTO application_events "
+        "(user_id, application_id, event_type, detail, payload, occurred_at, recorded_at, "
+        " recorded_by, corrects_event_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (user_id, application_id, event_type, detail, payload_json, occurred_at, now, recorded_by, corrects_event_id),
+    )
+    event_id = cur.lastrowid
+
+    new_status = replay_status(await _events_for_replay(db, application_id))
+    stage = stage_for_status(new_status)
+    if stage is not None:
+        await db._db.execute(
+            "UPDATE applications SET status = ?, last_event_at = ?, updated_at = ?, stage = ? WHERE id = ?",
+            (new_status, now, now, stage, application_id),
+        )
+    else:
+        # `considering` has no legacy stage — leave the column untouched (R4).
+        await db._db.execute(
+            "UPDATE applications SET status = ?, last_event_at = ?, updated_at = ? WHERE id = ?",
+            (new_status, now, now, application_id),
+        )
+    await db._db.commit()
+    get_audit_logger().info(
+        "application_event_recorded",
+        extra={
+            "event": "application_event_recorded",
+            "application_id": application_id,
+            "event_type": event_type,
+            "recorded_by": recorded_by,
+        },
+    )
+    return {
+        "event_id": event_id,
+        "event_type": event_type,
+        "occurred_at": occurred_at,
+        "recorded_at": now,
+        "recorded_by": recorded_by,
+        "status": new_status,
+    }
+
+
+# ── R1/R2 — birth at bring_job ───────────────────────────────────────────────
+
+
+async def birth_application(
+    db: JobDatabase, *, user_id: str, job_id: int, job_row: Mapping[str, Any], recorded_by: str
+) -> dict[str, Any]:
+    """Upsert-by-read: bringing the same job twice returns the SAME
+    application_id and appends NO second `brought` event."""
+    existing = await get_application_by_job(db, user_id, job_id)
+    if existing is not None:
+        return {"application_id": existing["id"], "status": existing["status"], "existing": True}
+
+    now = datetime.now(timezone.utc).isoformat()
+    cur = await db._db.execute(
+        "INSERT INTO applications "
+        "(user_id, job_id, status, stage, job_title, job_company, job_location, job_url, job_source, "
+        " job_description_snapshot, snapshot_at, created_at, updated_at, last_event_at) "
+        "VALUES (?, ?, 'considering', 'considering', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            user_id, job_id,
+            job_row.get("title") or "", job_row.get("company") or "", job_row.get("location") or "",
+            job_row.get("apply_url") or "", job_row.get("source") or "", job_row.get("description") or "",
+            now, now, now, now,
+        ),
+    )
+    application_id = int(cur.lastrowid or 0)
+    await append_event(
+        db, user_id=user_id, application_id=application_id, event_type="brought",
+        occurred_at=now, recorded_by=recorded_by,
+    )
+    get_audit_logger().info(
+        "application_born",
+        extra={"event": "application_born", "application_id": application_id, "user_id": user_id, "job_id": job_id},
+    )
+    return {"application_id": application_id, "status": "considering", "existing": False}
+
+
+# ── R5 — artifacts, versioned forever ────────────────────────────────────────
+
+
+async def _artifact_version_count_and_max(db: JobDatabase, application_id: int, kind: str) -> tuple[int, int]:
+    cur = await db._db.execute(
+        "SELECT COUNT(*), COALESCE(MAX(version_no), 0) FROM application_artifacts "
+        "WHERE application_id = ? AND kind = ?",
+        (application_id, kind),
+    )
+    row = await cur.fetchone()
+    return int(row[0]), int(row[1])
+
+
+async def save_artifact(
+    db: JobDatabase,
+    *,
+    user_id: str,
+    application_id: int,
+    kind: str,
+    text: str,
+    made_by: str,
+    label: str = "",
+    model: Optional[str] = None,
+) -> dict[str, Any]:
+    """R5 — save a NEW version of an artifact (never an update): allocates
+    ``version_no = MAX(version_no) + 1`` per ``(application_id, kind)`` inside
+    the insert, retrying on a ``UNIQUE`` race (C4 — caught by ``pg.
+    IntegrityError``, not a string sniff over a bare ``Exception``), and
+    appends the ``artifact_saved`` event that names the new id/kind/version.
+    """
+    app_row = await get_owned_application(db, user_id, application_id)
+    if app_row is None:
+        raise SpineError(404, "application not found")
+    if kind not in settings.APPLICATION_ARTIFACT_KINDS:
+        raise SpineError(422, f"kind must be one of {settings.APPLICATION_ARTIFACT_KINDS}")
+    if len(text) > settings.APPLICATION_ARTIFACT_MAX_CHARS:
+        raise SpineError(
+            422,
+            f"text exceeds APPLICATION_ARTIFACT_MAX_CHARS ({settings.APPLICATION_ARTIFACT_MAX_CHARS} chars)",
+        )
+
+    # Lazy: profile storage pulls the scoring stack transitively (rule #16).
+    from src.services.profile.storage import current_profile_version_id  # noqa: PLC0415
+
+    profile_version = current_profile_version_id(user_id)
+    now = datetime.now(timezone.utc).isoformat()
+
+    artifact_id: Optional[int] = None
+    version_no = 0
+    for _attempt in range(5):
+        count, max_version = await _artifact_version_count_and_max(db, application_id, kind)
+        if count >= settings.APPLICATION_ARTIFACT_MAX_VERSIONS:
+            raise SpineError(
+                429,
+                f"too many {kind!r} versions; cap is APPLICATION_ARTIFACT_MAX_VERSIONS "
+                f"({settings.APPLICATION_ARTIFACT_MAX_VERSIONS})",
+            )
+        version_no = max_version + 1
+        try:
+            ins = await db._db.execute(
+                "INSERT INTO application_artifacts "
+                "(user_id, application_id, kind, version_no, text, made_by, model, profile_version, "
+                " label, chars, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    user_id, application_id, kind, version_no, text, made_by, model,
+                    profile_version, label or "", len(text), now,
+                ),
+            )
+        except pg.IntegrityError:
+            # C4 — a real UNIQUE(application_id, kind, version_no) violation
+            # (a concurrent save landed the same version_no first); retry with
+            # a freshly-read MAX(version_no). Any OTHER integrity error (a
+            # genuine bug, e.g. a bad foreign value) is exactly what this
+            # exception type means too, so a bounded retry loop still bails
+            # out via the `artifact_id is None` check below rather than
+            # looping forever on something that will never succeed.
+            await db._db.rollback()
+            continue
+        artifact_id = int(ins.lastrowid or 0)
+        break
+    if artifact_id is None:
+        raise SpineError(429, "could not allocate a version number under concurrent writes — retry")
+
+    event = await append_event(
+        db, user_id=user_id, application_id=application_id, event_type="artifact_saved",
+        payload={"artifact_id": artifact_id, "kind": kind, "version_no": version_no},
+        occurred_at=now, recorded_by=made_by,
+    )
+    get_audit_logger().info(
+        "artifact_saved",
+        extra={
+            "event": "artifact_saved", "artifact_id": artifact_id, "kind": kind,
+            "version_no": version_no, "chars": len(text),
+        },
+    )
+    return {
+        "artifact_id": artifact_id, "kind": kind, "version_no": version_no, "chars": len(text),
+        "made_by": made_by, "model": model, "profile_version": profile_version, "created_at": now,
+        "event_id": event["event_id"],
+    }
+
+
+async def get_artifact(
+    db: JobDatabase, user_id: str, application_id: int, artifact_id: int
+) -> Optional[dict[str, Any]]:
+    """One artifact version IN FULL (never capped/truncated) — the one-version
+    read `get_application`'s byte-capped list defers to (spec R11). ``None``
+    for a foreign/unknown application OR artifact id; the route turns either
+    into 404 (S2)."""
+    app_row = await get_owned_application(db, user_id, application_id)
+    if app_row is None:
+        return None
+    cur = await db._db.execute(
+        "SELECT id, kind, version_no, text, made_by, model, profile_version, label, chars, created_at "
+        "FROM application_artifacts WHERE id = ? AND application_id = ?",
+        (artifact_id, application_id),
+    )
+    row = await cur.fetchone()
+    return dict(row) if row else None
+
+
+async def _list_artifacts(db: JobDatabase, application_id: int, *, with_text: bool) -> list[dict[str, Any]]:
+    cur = await db._db.execute(
+        "SELECT id, kind, version_no, text, made_by, model, profile_version, label, chars, created_at "
+        "FROM application_artifacts WHERE application_id = ? ORDER BY created_at DESC, id DESC",
+        (application_id,),
+    )
+    rows = [dict(r) for r in await cur.fetchall()]
+    cap_bytes = max(1, settings.EXPORT_HISTORY_MAX_BYTES // 4)
+    used = 0
+    out = []
+    for r in rows:
+        entry = {
+            "id": r["id"], "kind": r["kind"], "version_no": r["version_no"], "made_by": r["made_by"],
+            "model": r.get("model"), "profile_version": r.get("profile_version"), "label": r.get("label") or "",
+            "chars": r["chars"], "created_at": r["created_at"], "text": None, "truncated": False,
+        }
+        if with_text:
+            size = len((r["text"] or "").encode("utf-8"))
+            if used + size <= cap_bytes:
+                entry["text"] = r["text"]
+                used += size
+            else:
+                entry["truncated"] = True
+        out.append(entry)
+    return out
+
+
+# ── R6 — the fit verdict is stored, never computed ───────────────────────────
+
+
+async def save_fit(
+    db: JobDatabase,
+    *,
+    user_id: str,
+    application_id: int,
+    recorded_by: str,
+    score: Optional[int],
+    verdict: Optional[str],
+    gaps: Optional[list[str]],
+    reasoning: Optional[str],
+) -> dict[str, Any]:
+    """R6 — overwrite the fit-verdict SLOT on ``applications`` (the current
+    answer) and append a ``fit_judged`` event carrying the whole verdict (the
+    version history) — S7's "update of the slot is not history" case. Never
+    calls a scorer, matcher or judge; the verdict is always the caller's own
+    (VISION rule 4)."""
+    app_row = await get_owned_application(db, user_id, application_id)
+    if app_row is None:
+        raise SpineError(404, "application not found")
+
+    now = datetime.now(timezone.utc).isoformat()
+    gaps_list = gaps or []
+    gaps_json = json.dumps(gaps_list)
+    await db._db.execute(
+        "UPDATE applications SET fit_score = ?, fit_verdict = ?, fit_gaps = ?, fit_reasoning = ?, "
+        "fit_recorded_by = ?, fit_recorded_at = ?, updated_at = ? WHERE id = ?",
+        (score, verdict, gaps_json, reasoning, recorded_by, now, now, application_id),
+    )
+    event = await append_event(
+        db, user_id=user_id, application_id=application_id, event_type="fit_judged",
+        payload={"score": score, "verdict": verdict, "gaps": gaps_list, "reasoning": reasoning},
+        occurred_at=now, recorded_by=recorded_by,
+    )
+    get_audit_logger().info("fit_saved", extra={"event": "fit_saved", "application_id": application_id})
+    return {
+        "application_id": application_id,
+        "fit": {
+            "score": score, "verdict": verdict, "gaps": gaps_list, "reasoning": reasoning,
+            "recorded_by": recorded_by, "recorded_at": now,
+        },
+        "event_id": event["event_id"],
+    }
+
+
+# ── R8 — record_application, the rich receipt ────────────────────────────────
+
+
+async def _resolve_receipt_artifact(
+    db: JobDatabase, user_id: str, application_id: int, kind: str, artifact_id: Optional[int]
+) -> Optional[dict[str, Any]]:
+    if artifact_id is not None:
+        cur = await db._db.execute(
+            "SELECT id, version_no, text FROM application_artifacts "
+            "WHERE id = ? AND application_id = ? AND user_id = ? AND kind = ?",
+            (artifact_id, application_id, user_id, kind),
+        )
+        row = await cur.fetchone()
+        if row is None:
+            raise SpineError(404, f"{kind} artifact not found")
+        return dict(row)
+    cur = await db._db.execute(
+        "SELECT id, version_no, text FROM application_artifacts "
+        "WHERE application_id = ? AND user_id = ? AND kind = ? ORDER BY version_no DESC LIMIT 1",
+        (application_id, user_id, kind),
+    )
+    row = await cur.fetchone()
+    return dict(row) if row else None
+
+
+async def record_receipt(
+    db: JobDatabase,
+    *,
+    user_id: str,
+    application_id: int,
+    recorded_by: str,
+    channel: str = "",
+    note: str = "",
+    confirmation: str = "",
+    answers: Optional[list[dict[str, str]]] = None,
+    fields_filled: Optional[dict[str, Any]] = None,
+    cv_artifact_id: Optional[int] = None,
+    cover_letter_artifact_id: Optional[int] = None,
+    applied_at: Optional[str] = None,
+) -> dict[str, Any]:
+    """R8/S3 — the rich receipt: freeze the named artifact versions (or the
+    newest, if none named — ``_resolve_receipt_artifact``) as text, and
+    append the ``applied`` event. ``profile_version`` is stamped from the
+    CALLER's current profile (B6 fix — this used to be hardcoded ``None``,
+    unlike the legacy ``/receipts/{job_id}`` route which has always stamped
+    it via ``current_profile_version_id``).
+    """
+    app_row = await get_owned_application(db, user_id, application_id)
+    if app_row is None:
+        raise SpineError(404, "application not found")
+
+    cv_artifact = await _resolve_receipt_artifact(db, user_id, application_id, "cv", cv_artifact_id)
+    cl_artifact = await _resolve_receipt_artifact(
+        db, user_id, application_id, "cover_letter", cover_letter_artifact_id
+    )
+
+    # Lazy: profile storage pulls the scoring stack transitively (rule #16),
+    # same reasoning as save_artifact's identical import above.
+    from src.services.profile.storage import current_profile_version_id  # noqa: PLC0415
+
+    profile_version = current_profile_version_id(user_id)
+    now = datetime.now(timezone.utc).isoformat()
+    sent_at = applied_at or now
+    answers_json = json.dumps(answers or [])
+    fields_json = json.dumps(fields_filled or {})
+
+    cur = await db._db.execute(
+        "INSERT INTO application_receipts "
+        "(user_id, job_id, sent_at, job_title, job_company, job_location, job_apply_url, job_source, "
+        " job_description, cv_text, cv_origin, cover_letter_text, cover_letter_origin, profile_version, "
+        " channel, note, created_at, application_id, cv_artifact_id, cover_letter_artifact_id, answers, "
+        " fields_filled, confirmation, recorded_by) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            user_id, app_row["job_id"], sent_at,
+            app_row.get("job_title") or "", app_row.get("job_company") or "",
+            app_row.get("job_location") or "", app_row.get("job_url") or "",
+            app_row.get("job_source") or "", app_row.get("job_description_snapshot") or "",
+            cv_artifact["text"] if cv_artifact else None, "artifact" if cv_artifact else None,
+            cl_artifact["text"] if cl_artifact else None, "artifact" if cl_artifact else None,
+            profile_version, channel or "", note or "", now,
+            application_id, cv_artifact["id"] if cv_artifact else None,
+            cl_artifact["id"] if cl_artifact else None, answers_json, fields_json,
+            confirmation or "", recorded_by,
+        ),
+    )
+    receipt_id = int(cur.lastrowid or 0)
+
+    event = await append_event(
+        db, user_id=user_id, application_id=application_id, event_type="applied",
+        payload={"receipt_id": receipt_id, "channel": channel or ""},
+        occurred_at=sent_at, recorded_by=recorded_by,
+    )
+    get_audit_logger().info(
+        "receipt_created",
+        extra={
+            "event": "receipt_created", "receipt_id": receipt_id,
+            "cv_artifact_id": cv_artifact["id"] if cv_artifact else None,
+        },
+    )
+    return {
+        "receipt_id": receipt_id, "sent_at": sent_at,
+        "cv_artifact_id": cv_artifact["id"] if cv_artifact else None,
+        "cv_version_no": cv_artifact["version_no"] if cv_artifact else None,
+        "cover_letter_artifact_id": cl_artifact["id"] if cl_artifact else None,
+        "channel": channel or "", "confirmation": confirmation or "",
+        "url": f"/applications/{application_id}", "event_id": event["event_id"],
+    }
+
+
+async def write_through_legacy_receipt(
+    db: JobDatabase, *, user_id: str, application_id: int, receipt_id: int, sent_at: str, note: str = ""
+) -> dict[str, Any]:
+    """The legacy `POST /receipts/{job_id}` write-through (spec R8): appends
+    the `applied` event for a receipt whose `application_id` the caller
+    already resolved and passed into `db.insert_receipt`'s own INSERT — never
+    backfilled by an UPDATE (tests/test_receipts.py::
+    test_receipts_are_append_only greps `backend/src/` for any UPDATE/DELETE
+    against `application_receipts` and must stay green).
+    """
+    return await append_event(
+        db, user_id=user_id, application_id=application_id, event_type="applied",
+        detail=note or "", payload={"receipt_id": receipt_id}, occurred_at=sent_at, recorded_by="web",
+    )
+
+
+# ── R11 — get_application / list_applications ────────────────────────────────
+
+
+async def _list_receipts_for_application(
+    db: JobDatabase, user_id: str, application_id: int, *, include_text: bool = False
+) -> list[dict[str, Any]]:
+    cols = "id, sent_at, channel, confirmation, cv_artifact_id, cover_letter_artifact_id, note"
+    if include_text:
+        cols += ", cv_text, cover_letter_text"
+    cur = await db._db.execute(
+        f"SELECT {cols} FROM application_receipts WHERE user_id = ? AND application_id = ? "  # noqa: S608
+        f"ORDER BY sent_at DESC, id DESC",
+        (user_id, application_id),
+    )
+    return [dict(r) for r in await cur.fetchall()]
+
+
+async def get_application_detail(
+    db: JobDatabase, user_id: str, application_id: int, *, with_artifact_text: bool = False
+) -> Optional[dict[str, Any]]:
+    """R11's full ``GET /applications/{id}`` shape: the job snapshot (plus
+    whether the catalog row still exists), the fit slot, every artifact
+    version (text omitted unless ``with_artifact_text``), the whole event
+    timeline, and receipts. ``None`` for a foreign/unknown id (404, S2)."""
+    app_row = await get_owned_application(db, user_id, application_id)
+    if app_row is None:
+        return None
+    job_id = app_row["job_id"]
+    cur = await db._db.execute("SELECT 1 FROM jobs WHERE id = ?", (job_id,))
+    catalog_present = (await cur.fetchone()) is not None
+
+    fit = None
+    if app_row.get("fit_recorded_at"):
+        fit = {
+            "score": app_row.get("fit_score"),
+            "verdict": app_row.get("fit_verdict"),
+            "gaps": json.loads(app_row.get("fit_gaps") or "[]"),
+            "reasoning": app_row.get("fit_reasoning"),
+            "recorded_by": app_row.get("fit_recorded_by"),
+            "recorded_at": app_row.get("fit_recorded_at"),
+        }
+
+    return {
+        "id": app_row["id"],
+        "job_id": job_id,
+        "status": app_row["status"],
+        "created_at": app_row["created_at"],
+        "updated_at": app_row["updated_at"],
+        "last_event_at": app_row.get("last_event_at"),
+        "job": {
+            "job_title": app_row.get("job_title") or "",
+            "job_company": app_row.get("job_company") or "",
+            "job_location": app_row.get("job_location") or "",
+            "job_url": app_row.get("job_url") or "",
+            "job_source": app_row.get("job_source") or "",
+            "job_description_snapshot": app_row.get("job_description_snapshot") or "",
+            "snapshot_at": app_row.get("snapshot_at"),
+            "catalog_present": catalog_present,
+        },
+        "fit": fit,
+        "artifacts": await _list_artifacts(db, application_id, with_text=with_artifact_text),
+        "events": await list_events_for_display(db, application_id),
+        "receipts": await _list_receipts_for_application(db, user_id, application_id),
+    }
+
+
+async def _count(db: JobDatabase, table: str, col: str, value: Any) -> int:
+    cur = await db._db.execute(f"SELECT COUNT(*) FROM {table} WHERE {col} = ?", (value,))  # noqa: S608 — table/col are constants
+    row = await cur.fetchone()
+    return int(row[0]) if row else 0
+
+
+async def _artifact_counts_by_kind(db: JobDatabase, application_id: int) -> dict[str, int]:
+    cur = await db._db.execute(
+        "SELECT kind, COUNT(*) FROM application_artifacts WHERE application_id = ? GROUP BY kind",
+        (application_id,),
+    )
+    return {r[0]: int(r[1]) for r in await cur.fetchall()}
+
+
+async def list_applications(
+    db: JobDatabase,
+    user_id: str,
+    *,
+    status: Optional[str] = None,
+    updated_since: Optional[str] = None,
+    limit: int = 20,
+    offset: int = 0,
+) -> dict[str, Any]:
+    """R11's ``GET /applications`` list: summaries only (snapshot fields,
+    status, per-kind counts) — no event/artifact bodies. Newest
+    ``last_event_at`` first; optionally filtered by ``status`` and/or
+    ``updated_since``."""
+    limit = max(1, min(int(limit), 200))
+    offset = max(0, int(offset))
+    where = ["user_id = ?"]
+    params: list[Any] = [user_id]
+    if status:
+        where.append("status = ?")
+        params.append(status)
+    if updated_since:
+        where.append("updated_at >= ?")
+        params.append(updated_since)
+    where_sql = " AND ".join(where)
+
+    cur = await db._db.execute(
+        f"SELECT COUNT(*) FROM applications WHERE {where_sql}", params  # noqa: S608 — where_sql built from constants
+    )
+    total = int((await cur.fetchone())[0])
+
+    cur = await db._db.execute(
+        f"SELECT id, job_id, job_title, job_company, status, last_event_at FROM applications "  # noqa: S608
+        f"WHERE {where_sql} ORDER BY last_event_at DESC NULLS LAST, id DESC LIMIT ? OFFSET ?",
+        [*params, limit, offset],
+    )
+    rows = [dict(r) for r in await cur.fetchall()]
+
+    out = []
+    for r in rows:
+        app_id = r["id"]
+        out.append(
+            {
+                "id": app_id, "job_id": r["job_id"], "job_title": r["job_title"] or "",
+                "job_company": r["job_company"] or "", "status": r["status"],
+                "last_event_at": r.get("last_event_at"),
+                "events": await _count(db, "application_events", "application_id", app_id),
+                "artifacts": await _artifact_counts_by_kind(db, app_id),
+                "receipts": await _count(db, "application_receipts", "application_id", app_id),
+            }
+        )
+    return {"applications": out, "total": total}
+
+
+# ── R9 — whats_new ────────────────────────────────────────────────────────────
+
+
+async def whats_new(
+    db: JobDatabase,
+    user_id: str,
+    *,
+    since: Optional[str] = None,
+    after_id: Optional[int] = None,
+    limit: int = 50,
+) -> dict[str, Any]:
+    """R9 — what changed across ALL of the caller's applications since a
+    cursor. Paged and ordered by ``recorded_at`` (when Job360 learned it),
+    NEVER ``occurred_at`` (when it happened in the world, which may be
+    backdated) — a cursor on the latter could silently skip a backdated
+    event forever. ``(recorded_at, id)`` is a real keyset pair (B4 fix): the
+    ``after_id`` half only fires alongside its own ``recorded_at`` boundary,
+    never as an independent predicate, so a row from either side of that
+    boundary is never dropped."""
+    limit = max(1, min(int(limit), settings.WHATS_NEW_MAX_EVENTS))
+    now = datetime.now(timezone.utc).isoformat()
+    since_val = since or (
+        datetime.now(timezone.utc) - timedelta(days=settings.WHATS_NEW_DEFAULT_WINDOW_DAYS)
+    ).isoformat()
+
+    # B4 fix — a REAL keyset cursor. `recorded_at >= since AND id > after_id`
+    # as two INDEPENDENT predicates drops any event whose `recorded_at` is
+    # <= the page boundary's but whose `id` is higher (a concurrently
+    # committed write can easily land in that gap): it satisfies neither half
+    # of the AND, so it is skipped on this page AND on the next ("since" moved
+    # past it), forever. The correct predicate paginates on the PAIR:
+    # everything strictly after (recorded_at, id) in that lexicographic order.
+    where = ["user_id = ?"]
+    params: list[Any] = [user_id]
+    if after_id is not None:
+        where.append("(recorded_at > ? OR (recorded_at = ? AND id > ?))")
+        params.extend([since_val, since_val, after_id])
+    else:
+        where.append("recorded_at >= ?")
+        params.append(since_val)
+    where_sql = " AND ".join(where)
+
+    cur = await db._db.execute(
+        f"SELECT id, application_id, event_type, detail, payload, occurred_at, recorded_at, "  # noqa: S608
+        f"recorded_by, corrects_event_id FROM application_events WHERE {where_sql} "
+        f"ORDER BY recorded_at ASC, id ASC LIMIT ?",
+        [*params, limit + 1],
+    )
+    rows = [dict(r) for r in await cur.fetchall()]
+    truncated = len(rows) > limit
+    rows = rows[:limit]
+
+    events = []
+    app_ids: list[int] = []
+    seen = set()
+    for r in rows:
+        events.append(
+            {
+                "id": r["id"], "application_id": r["application_id"], "event_type": r["event_type"],
+                "detail": r["detail"], "payload": json.loads(r["payload"] or "{}"),
+                "occurred_at": r["occurred_at"], "recorded_at": r["recorded_at"],
+                "recorded_by": r["recorded_by"], "corrects_event_id": r["corrects_event_id"],
+            }
+        )
+        if r["application_id"] not in seen:
+            seen.add(r["application_id"])
+            app_ids.append(r["application_id"])
+
+    applications: list[dict[str, Any]] = []
+    if app_ids:
+        placeholders = ",".join("?" for _ in app_ids)
+        cur = await db._db.execute(
+            f"SELECT id, job_title, job_company, status, last_event_at FROM applications "  # noqa: S608
+            f"WHERE id IN ({placeholders})",
+            app_ids,
+        )
+        applications = [dict(r) for r in await cur.fetchall()]
+
+    next_since = rows[-1]["recorded_at"] if rows else since_val
+    next_after_id = rows[-1]["id"] if rows else after_id
+
+    return {
+        "now": now, "since": since_val, "events": events, "applications": applications,
+        "next_since": next_since, "next_after_id": next_after_id, "truncated": truncated,
+    }
+
+
+# ── R10 — export_history ──────────────────────────────────────────────────────
+
+
+async def _artifact_metadata(db: JobDatabase, application_id: int, *, include_text: bool) -> list[dict[str, Any]]:
+    cur = await db._db.execute(
+        "SELECT id, kind, version_no, made_by, model, profile_version, label, chars, created_at, text "
+        "FROM application_artifacts WHERE application_id = ? ORDER BY kind, version_no",
+        (application_id,),
+    )
+    rows = [dict(r) for r in await cur.fetchall()]
+    out = []
+    meta_cols = (
+        "id", "kind", "version_no", "made_by", "model", "profile_version",
+        "label", "chars", "created_at",
+    )
+    for r in rows:
+        entry = {k: r[k] for k in meta_cols}
+        if include_text:
+            entry["text"] = r["text"]
+        out.append(entry)
+    return out
+
+
+async def export_history(
+    db: JobDatabase, user_id: str, *, since: Optional[str] = None, include_text: bool = False
+) -> dict[str, Any]:
+    """R10/S8 — bounded on applications AND bytes; rate-limited per USER."""
+    key = f"export_history:{user_id}"
+    if not rate_limit.check_and_record(
+        key, max_in_window=settings.EXPORT_HISTORY_MAX_PER_HOUR, window_seconds=3600
+    ):
+        raise SpineError(429, "export rate limit exceeded; try again in an hour")
+
+    where = ["user_id = ?"]
+    params: list[Any] = [user_id]
+    if since:
+        where.append("updated_at >= ?")
+        params.append(since)
+    where_sql = " AND ".join(where)
+
+    cur = await db._db.execute(
+        f"SELECT id, job_id, status, job_title, job_company, created_at, updated_at, last_event_at "  # noqa: S608
+        f"FROM applications WHERE {where_sql} ORDER BY updated_at ASC, id ASC",
+        params,
+    )
+    all_rows = [dict(r) for r in await cur.fetchall()]
+
+    out_apps: list[dict[str, Any]] = []
+    total_bytes = 0
+    truncated = False
+    next_since: Optional[str] = None
+    for r in all_rows:
+        if len(out_apps) >= settings.EXPORT_HISTORY_MAX_APPLICATIONS:
+            truncated = True
+            next_since = r["updated_at"]
+            break
+        app_blob = {
+            "id": r["id"], "job_id": r["job_id"], "status": r["status"],
+            "job_title": r["job_title"] or "", "job_company": r["job_company"] or "",
+            "created_at": r["created_at"], "updated_at": r["updated_at"], "last_event_at": r.get("last_event_at"),
+            "events": await list_events_for_display(db, r["id"]),
+            "artifacts": await _artifact_metadata(db, r["id"], include_text=include_text),
+            "receipts": await _list_receipts_for_application(db, user_id, r["id"], include_text=include_text),
+        }
+        blob_size = len(json.dumps(app_blob, default=str).encode("utf-8"))
+        if out_apps and total_bytes + blob_size > settings.EXPORT_HISTORY_MAX_BYTES:
+            truncated = True
+            next_since = r["updated_at"]
+            break
+        out_apps.append(app_blob)
+        total_bytes += blob_size
+
+    result: dict[str, Any] = {"applications": out_apps, "truncated": truncated, "bytes": total_bytes}
+    if truncated:
+        result["next_since"] = next_since
+    get_audit_logger().info(
+        "history_exported",
+        extra={
+            "event": "history_exported", "applications": len(out_apps),
+            "bytes": total_bytes, "truncated": truncated,
+        },
+    )
+    return result

--- a/backend/src/services/applications/status.py
+++ b/backend/src/services/applications/status.py
@@ -1,0 +1,79 @@
+"""Status cache + the one place the two vocabularies meet (spec R4).
+
+``applications.status`` is a CACHE of the last status-bearing event — never
+the source of truth, always rebuildable by replaying the event log. This
+module has zero DB access so both the writer (``spine.py``) and the frozen
+test (``test_status_is_rebuildable_from_the_event_log``) can call the exact
+same function.
+"""
+from __future__ import annotations
+
+from typing import Any, Mapping, Optional, Sequence
+
+# `brought` is the one status event whose name is NOT the status; every other
+# status event's name IS the status (spec R7).
+_EVENT_TO_STATUS: dict[str, str] = {"brought": "considering"}
+
+# R4 — the ONLY place the spine's `status` vocabulary and the legacy Kanban
+# `stage` vocabulary meet. `considering` is deliberately ABSENT: a
+# `considering` row has no legacy stage yet, so `stage` keeps whatever it
+# already holds (its `applied` default for a freshly-born row) rather than
+# being overwritten.
+STATUS_TO_STAGE: dict[str, str] = {
+    "applied": "applied",
+    "replied": "applied",
+    "interview_requested": "interview",
+    "interview_scheduled": "interview",
+    "interview_done": "interview",
+    "offer": "offer",
+    "rejected": "rejected",
+    "withdrawn": "rejected",
+    "ghosted": "ghosted",
+}
+
+
+def status_for_event(event_type: str) -> Optional[str]:
+    """The status a STATUS-bearing event moves the application to, or None
+    for a non-status (note-family) event — which must never touch the cache."""
+    from src.core import settings
+
+    if event_type not in settings.APPLICATION_STATUS_EVENT_TYPES:
+        return None
+    return _EVENT_TO_STATUS.get(event_type, event_type)
+
+
+def stage_for_status(status: str) -> Optional[str]:
+    """The legacy `stage` a given spine `status` projects to, or None when
+    the status has no legacy equivalent yet (`considering`) — the caller must
+    then leave `stage` untouched."""
+    return STATUS_TO_STAGE.get(status)
+
+
+def replay_status(
+    events: Sequence[Mapping[str, Any]],
+    *,
+    default: str = "considering",
+) -> str:
+    """Recompute the cached status by replaying the WHOLE event log.
+
+    Ordered by ``(recorded_at, id)`` — the order events were actually
+    RECORDED, not ``occurred_at`` (which may be backdated and would make "the
+    last thing that happened" mean something different from "the last thing
+    we learned"). A correcting event's TARGET (named by ``corrects_event_id``)
+    is skipped entirely, so a mis-recorded status event never contributes.
+
+    Pure function, no DB — the frozen test calls this directly and compares
+    against the stored column.
+    """
+    superseded_ids = {
+        e["corrects_event_id"] for e in events if e.get("corrects_event_id") is not None
+    }
+    ordered = sorted(events, key=lambda e: (e.get("recorded_at") or "", e.get("id") or 0))
+    status = default
+    for e in ordered:
+        if e.get("id") in superseded_ids:
+            continue
+        mapped = status_for_event(e.get("event_type", ""))
+        if mapped is not None:
+            status = mapped
+    return status

--- a/backend/src/services/auth/api_tokens.py
+++ b/backend/src/services/auth/api_tokens.py
@@ -36,6 +36,10 @@ class TokenOwner:
     user_id: str
     email: str
     email_verified: bool
+    # The token's own display name ("my-agent"), fed straight to
+    # `made_by="token:<name>"` / `recorded_by="token:<name>"` on the
+    # application spine (spec 2026-09-04-application-spine S3).
+    name: str
 
 
 def _hash(token: str) -> str:
@@ -165,7 +169,7 @@ async def resolve(db_path: str, token: str) -> Optional[TokenOwner]:
         db.row_factory = pg.Row
         cur = await db.execute(
             """
-            SELECT t.id AS token_id, t.last_used_at,
+            SELECT t.id AS token_id, t.last_used_at, t.name AS token_name,
                    u.id AS user_id, u.email, u.email_verified_at
             FROM api_tokens t
             JOIN users u ON u.id = t.user_id
@@ -189,4 +193,5 @@ async def resolve(db_path: str, token: str) -> Optional[TokenOwner]:
         user_id=row["user_id"],
         email=row["email"],
         email_verified=row["email_verified_at"] is not None,
+        name=row["token_name"],
     )

--- a/backend/src/services/auth/oauth_flow.py
+++ b/backend/src/services/auth/oauth_flow.py
@@ -526,6 +526,10 @@ class OAuthTokenOwner:
     email: str
     email_verified: bool
     audience: str
+    # The registering client's display name — untrusted attacker text by
+    # construction (slice 1 R2 sanitises it at registration; the application
+    # spine re-truncates it — spec 2026-09-04-application-spine S3/C5).
+    client_name: str
 
 
 @dataclass(frozen=True)
@@ -557,10 +561,12 @@ async def resolve_access_token(db_path: str, token: str) -> AccessTokenResolutio
         cur = await db.execute(
             "SELECT t.audience, t.revoked_at AS token_revoked_at, t.expires_at AS token_expires_at, "
             "g.id AS grant_id, g.revoked_at AS grant_revoked_at, g.last_used_at, "
-            "u.id AS user_id, u.email, u.email_verified_at, u.deleted_at AS user_deleted_at "
+            "u.id AS user_id, u.email, u.email_verified_at, u.deleted_at AS user_deleted_at, "
+            "c.client_name "
             "FROM oauth_tokens t "
             "JOIN oauth_grants g ON g.id = t.grant_id "
             "JOIN users u ON u.id = g.user_id "
+            "JOIN oauth_clients c ON c.id = g.client_id "
             "WHERE t.token_hash = ? AND t.kind = 'access'",
             (token_hash,),
         )
@@ -588,6 +594,7 @@ async def resolve_access_token(db_path: str, token: str) -> AccessTokenResolutio
         owner=OAuthTokenOwner(
             user_id=row["user_id"], email=row["email"],
             email_verified=row["email_verified_at"] is not None, audience=row["audience"],
+            client_name=row["client_name"],
         ),
         hash_known=True,
     )

--- a/backend/src/workers/settings.py
+++ b/backend/src/workers/settings.py
@@ -217,27 +217,38 @@ class WorkerSettings:
     try:
         from arq.cron import cron as _cron  # noqa: PLC0415
 
+        from src.core.settings import CATALOG_CRONS_ENABLED as _CATALOG_CRONS_ENABLED  # noqa: PLC0415
+
         cron_jobs = [
+            # nightly_ghost_sweep + notification_tick stay UNCONDITIONAL (spec
+            # R13) — neither sources/ranks/pushes a job, so the mission rule
+            # (VISION.md, "never source or rank") does not touch them.
             _cron(nightly_ghost_sweep, hour=2, minute=0),
-            # THE PRODUCTION LOOP. Nothing fetched jobs on a timer before
-            # this: run_search fired only on a human click, while
-            # purge_old_jobs deleted anything >30 days, so the catalog
-            # drained (prod 2026-07-27: 11 run_log rows in 25 days, 112 jobs
-            # visible of 5,827 fetched). Daily is the right cadence — jobs are
-            # posted daily and the purge window is 30 days — and it keeps
-            # keyed-API quota modest (~30 runs/month, not ~120). 04:00 UTC:
-            # clear of the 02:00 ghost sweep, done before UK morning.
-            # Cost is CPU only; user_id=None makes the paid LLM stages
-            # structurally unreachable (see refresh_catalog's docstring).
-            _cron(refresh_catalog, hour=4, minute=0),
             _cron(notification_tick, minute=set(range(0, 60, 5))),
-            # Self-heal enrichment coverage: every 30 min, enrich the
-            # ENRICHMENT_SWEEP_PER_TICK (default 100) highest-value candidate
-            # jobs still missing enrichment. Prod gap at ship time: 738/6,589
-            # candidates enriched — this cron closes it in ~1-2 days and keeps
-            # it closed as new jobs arrive. No-op when E2 flags are off.
-            _cron(enrichment_sweep, minute={10, 40}),
         ]
+        if _CATALOG_CRONS_ENABLED:
+            cron_jobs.extend(
+                [
+                    # THE PRODUCTION LOOP (legacy — slated for deletion, slice
+                    # 5). Nothing fetched jobs on a timer before this:
+                    # run_search fired only on a human click, while
+                    # purge_old_jobs deleted anything >30 days, so the catalog
+                    # drained (prod 2026-07-27: 11 run_log rows in 25 days,
+                    # 112 jobs visible of 5,827 fetched). Daily is the right
+                    # cadence — jobs are posted daily and the purge window is
+                    # 30 days — and it keeps keyed-API quota modest (~30
+                    # runs/month, not ~120). 04:00 UTC: clear of the 02:00
+                    # ghost sweep, done before UK morning. Cost is CPU only;
+                    # user_id=None makes the paid LLM stages structurally
+                    # unreachable (see refresh_catalog's docstring).
+                    _cron(refresh_catalog, hour=4, minute=0),
+                    # Self-heal enrichment coverage: every 30 min, enrich the
+                    # ENRICHMENT_SWEEP_PER_TICK (default 100) highest-value
+                    # candidate jobs still missing enrichment. No-op when E2
+                    # flags are off.
+                    _cron(enrichment_sweep, minute={10, 40}),
+                ]
+            )
         del _cron
     except Exception:  # noqa: BLE001 — arq absent in a minimal env
         cron_jobs = []

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -149,6 +149,24 @@ def _loop_guard_strict(monkeypatch):
 
 
 @pytest.fixture(autouse=True)
+def _search_ui_enabled_for_legacy_suite(monkeypatch):
+    """R12 (spec 2026-09-04-application-spine) — SEARCH_UI_ENABLED defaults to
+    OFF in production, but the legacy search suite (hundreds of tests,
+    slated for deletion in slice 5) still exercises the real routes. Force
+    it ON for the whole suite here; tests/test_search_flag.py pins BOTH
+    positions of the flag explicitly via monkeypatch.setattr(settings, ...).
+
+    Its own fixture (C6, split out of ``_loop_guard_strict``, which is about
+    the event-loop guard and unrelated): same autouse/function scope, so this
+    changes nothing about schema isolation between tests — only which fixture
+    function the setattr call lives in.
+    """
+    from src.core import settings as _settings
+
+    monkeypatch.setattr(_settings, "SEARCH_UI_ENABLED", True, raising=False)
+
+
+@pytest.fixture(autouse=True)
 def _offline_openai(monkeypatch):
     """Keep the WHOLE suite offline for LLMs (rule #4).
 

--- a/backend/tests/test_application_spine.py
+++ b/backend/tests/test_application_spine.py
@@ -347,9 +347,8 @@ async def test_status_event_moves_status_and_note_does_not(authenticated_async_c
 
 @pytest.mark.asyncio
 async def test_status_is_rebuildable_from_the_event_log(authenticated_async_context):
-    from src.services.applications.status import replay_status
-
     from src.api import dependencies as api_deps
+    from src.services.applications.status import replay_status
 
     async with authenticated_async_context() as client:
         app_id = (await _bring(client))["application_id"]

--- a/backend/tests/test_application_spine.py
+++ b/backend/tests/test_application_spine.py
@@ -1,0 +1,788 @@
+"""The application spine (docs/plans/2026-09-04-application-spine/spec.md).
+
+Frozen per spec.md's own list (§Frozen tests) — once written these are not
+edited to make the implementation pass; a test believed wrong is left as-is
+and called out in the build report instead.
+
+An Application is born at ``POST /jobs/bring`` (R1), carries a durable job
+snapshot (R2), and its whole history is one append-only event log (R3) whose
+last status event is cached on ``applications.status`` (R4). Artifacts
+(R5), the fit verdict (R6), receipts (R8), ``whats_new`` (R9) and
+``export_history`` (R10) all read/write through that log. New modules
+(``src.services.applications.*``, ``src.api.routes.applications``) do not
+exist yet — every test below is expected to fail with an ImportError or
+AttributeError until slice 2 is built; that is the intended RED state.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+_AD = {
+    "title": "Data Engineer",
+    "company": "Northwind",
+    "location": "Remote",
+    "apply_url": "https://northwind.example/careers/7",
+    "description": "Build the pipelines. Python, dbt, Snowflake. Fully remote.",
+}
+
+_AD_2 = {
+    "title": "Platform Engineer",
+    "company": "Southwind",
+    "location": "London",
+    "apply_url": "https://southwind.example/careers/3",
+    "description": "Own the platform. Kubernetes, Terraform, Go.",
+}
+
+
+# ── Shared helpers ────────────────────────────────────────────────────────────
+
+
+async def _bring(client: AsyncClient, ad: dict[str, Any] = _AD) -> dict[str, Any]:
+    resp = await client.post("/api/jobs/bring", json=ad)
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+async def _get_application(client: AsyncClient, application_id: int, **params: Any):
+    return await client.get(f"/api/applications/{application_id}", params=params)
+
+
+async def _save_artifact(
+    client: AsyncClient, application_id: int, kind: str, text: str, **extra: Any
+):
+    body = {"kind": kind, "text": text, **extra}
+    return await client.post(f"/api/applications/{application_id}/artifacts", json=body)
+
+
+async def _save_fit(client: AsyncClient, application_id: int, **body: Any):
+    return await client.put(f"/api/applications/{application_id}/fit", json=body)
+
+
+async def _record_event(client: AsyncClient, application_id: int, event_type: str, **extra: Any):
+    body = {"event_type": event_type, **extra}
+    return await client.post(f"/api/applications/{application_id}/events", json=body)
+
+
+async def _record_receipt(client: AsyncClient, application_id: int, **body: Any):
+    return await client.post(f"/api/applications/{application_id}/receipt", json=body)
+
+
+async def _mint_token(client: AsyncClient, name: str = "cli") -> str:
+    resp = await client.post("/api/tokens", json={"name": name})
+    assert resp.status_code == 201, resp.text
+    return resp.json()["token"]
+
+
+def _bearer_client(token: str) -> AsyncClient:
+    from src.api.main import app
+
+    return AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test", headers={"Authorization": f"Bearer {token}"}
+    )
+
+
+async def _second_user_session_cookie(email: str = "second@example.com") -> str:
+    """Register + verify + log in a SECOND user against the same (already
+    DB_PATH-patched) app the fixture user lives in, and return their session
+    cookie. Mirrors what ``authenticated_async_context`` does for the first
+    user (conftest.py) — a second call to that fixture within one test would
+    just re-use the SAME registered user, since the DB/tmp_path is bound once
+    at fixture setup, not per invocation.
+    """
+    from fastapi.testclient import TestClient
+
+    from src.api.main import app
+    from src.core import settings
+    from src.repositories import pgsync
+
+    sync_client = TestClient(app)
+    r = sync_client.post("/api/auth/register", json={"email": email, "password": "s3cretpassword"})
+    assert r.status_code == 201, r.text
+    conn = pgsync.connect(str(settings.DB_PATH))
+    conn.execute("UPDATE users SET email_verified_at = ? WHERE email = ?", ("2026-01-01T00:00:00Z", email))
+    conn.commit()
+    conn.close()
+    lr = sync_client.post("/api/auth/login", json={"email": email, "password": "s3cretpassword"})
+    assert lr.status_code == 200, lr.text
+    cookie = sync_client.cookies.get("job360_session")
+    assert cookie, "failed to capture second user's session cookie"
+    sync_client.close()
+    return cookie
+
+
+def _session_client(cookie: str) -> AsyncClient:
+    from src.api.main import app
+
+    return AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test", cookies={"job360_session": cookie}
+    )
+
+
+class _CapturingAuditHandler(logging.Handler):
+    """Collects every ``job360.audit`` LogRecord's ``extra`` fields (S9)."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.records: list[dict[str, Any]] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(dict(record.__dict__))
+
+
+@pytest.fixture
+def audit_capture():
+    logger = logging.getLogger("job360.audit")
+    handler = _CapturingAuditHandler()
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+    yield handler
+    logger.removeHandler(handler)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# R1/R2 — birth at bring_job, the durable snapshot
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_bring_creates_one_application_considering(authenticated_async_context):
+    async with authenticated_async_context() as client:
+        body = await _bring(client)
+        assert isinstance(body["application_id"], int)
+        assert body["status"] == "considering"
+        # constraint 4 — legacy shape untouched (also pinned standalone below).
+        assert "job" in body and "existing" in body and "scored" in body
+
+        detail = await _get_application(client, body["application_id"])
+        assert detail.status_code == 200, detail.text
+        events = detail.json()["events"]
+        brought = [e for e in events if e["event_type"] == "brought"]
+        assert len(brought) == 1
+
+
+@pytest.mark.asyncio
+async def test_bringing_twice_reuses_the_application(authenticated_async_context):
+    async with authenticated_async_context() as client:
+        first = await _bring(client)
+        second = await _bring(client)
+        assert second["application_id"] == first["application_id"]
+        assert second["existing"] is True
+
+        detail = await _get_application(client, first["application_id"])
+        brought = [e for e in detail.json()["events"] if e["event_type"] == "brought"]
+        assert len(brought) == 1, "bringing the same job twice must not append a second brought event"
+
+
+@pytest.mark.asyncio
+async def test_the_job_snapshot_survives_a_purge(authenticated_async_context):
+    from src.api import dependencies as api_deps
+
+    async with authenticated_async_context() as client:
+        body = await _bring(client)
+        job_id = body["job"]["id"]
+
+        db = await api_deps.get_db()
+        await db._conn.execute("DELETE FROM jobs WHERE id = ?", (job_id,))
+        await db._conn.commit()
+
+        detail = await _get_application(client, body["application_id"])
+        assert detail.status_code == 200, detail.text
+        job = detail.json()["job"]
+        # R2 snapshot column names, copied at birth — never joined off `jobs`.
+        assert job["job_title"] == _AD["title"]
+        assert job["job_company"] == _AD["company"]
+        assert job["catalog_present"] is False
+
+
+@pytest.mark.asyncio
+async def test_purge_spares_a_brought_job(authenticated_async_context):
+    """Hard rule #3 amendment (R2): ``purge_old_jobs`` must not delete a
+    ``user_brought`` row even when it is old, while an equally-old scraped row
+    is still deleted on schedule."""
+    from datetime import datetime, timedelta, timezone
+
+    from src.api import dependencies as api_deps
+    from src.core.settings import USER_BROUGHT_SOURCE
+    from src.models import Job
+
+    old = (datetime.now(timezone.utc) - timedelta(days=45)).isoformat()
+
+    async with authenticated_async_context():
+        pass
+    db = await api_deps.get_db()
+
+    scraped = Job(
+        title="Old Scraped Role", company="Acme Scrape", apply_url="https://acme.test/scraped",
+        source="reed", date_found=old, last_seen_at=old, first_seen_at=old,
+    )
+    brought = Job(
+        title="Old Brought Role", company="Acme Brought", apply_url="https://acme.test/brought",
+        source=USER_BROUGHT_SOURCE, date_found=old, last_seen_at=old, first_seen_at=old,
+    )
+    await db.insert_job(scraped)
+    await db.insert_job(brought)
+    await db.commit()
+    scraped_id = await db.get_job_id_by_key(scraped.normalized_key())
+    brought_id = await db.get_job_id_by_key(brought.normalized_key())
+    assert scraped_id and brought_id
+
+    await db.purge_old_jobs(days=30)
+
+    assert await db.get_job_by_id(scraped_id) is None, "an old SCRAPED row must still be purged"
+    assert await db.get_job_by_id(brought_id) is not None, "an old USER_BROUGHT row must survive the purge"
+
+
+@pytest.mark.asyncio
+async def test_legacy_bring_response_shape_is_unchanged(authenticated_async_context):
+    """Constraint 4 — job/existing/scored keep working for any existing caller."""
+    async with authenticated_async_context() as client:
+        body = await _bring(client)
+        assert set(("job", "existing", "scored")).issubset(body)
+        assert isinstance(body["job"]["id"], int)
+        assert body["existing"] is False
+        assert isinstance(body["scored"], bool)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# R5 — artifacts are versioned forever
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_two_cv_versions_both_readable(authenticated_async_context):
+    async with authenticated_async_context() as client:
+        app_id = (await _bring(client))["application_id"]
+
+        v1 = await _save_artifact(client, app_id, "cv", "CV VERSION ONE")
+        assert v1.status_code == 201, v1.text
+        assert v1.json()["version_no"] == 1
+        v2 = await _save_artifact(client, app_id, "cv", "CV VERSION TWO")
+        assert v2.status_code == 201, v2.text
+        assert v2.json()["version_no"] == 2
+
+        got_v1 = await client.get(f"/api/applications/{app_id}/artifacts/{v1.json()['artifact_id']}")
+        got_v2 = await client.get(f"/api/applications/{app_id}/artifacts/{v2.json()['artifact_id']}")
+        assert got_v1.status_code == 200 and got_v2.status_code == 200
+        assert got_v1.json()["text"] == "CV VERSION ONE", "v1's text must survive v2 being written byte-identical"
+        assert got_v2.json()["text"] == "CV VERSION TWO"
+
+
+@pytest.mark.asyncio
+async def test_version_numbers_are_per_kind(authenticated_async_context):
+    async with authenticated_async_context() as client:
+        app_id = (await _bring(client))["application_id"]
+
+        cv1 = await _save_artifact(client, app_id, "cv", "cv draft")
+        cv2 = await _save_artifact(client, app_id, "cv", "cv edited")
+        cl1 = await _save_artifact(client, app_id, "cover_letter", "dear hiring manager")
+
+        assert cv1.json()["version_no"] == 1
+        assert cv2.json()["version_no"] == 2
+        assert cl1.json()["version_no"] == 1, "cover_letter's own version series must not inherit cv's counter"
+
+
+@pytest.mark.asyncio
+async def test_artifact_over_the_cap_is_422(authenticated_async_context):
+    from src.core import settings
+
+    async with authenticated_async_context() as client:
+        app_id = (await _bring(client))["application_id"]
+        too_long = "x" * (settings.APPLICATION_ARTIFACT_MAX_CHARS + 1)
+        resp = await _save_artifact(client, app_id, "cv", too_long)
+        assert resp.status_code == 422, resp.text
+        assert "APPLICATION_ARTIFACT_MAX_CHARS" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_made_by_and_recorded_by_come_from_the_credential(authenticated_async_context):
+    async with authenticated_async_context() as client:
+        app_id = (await _bring(client))["application_id"]
+
+        via_session = await _save_artifact(client, app_id, "cv", "session-written cv")
+        assert via_session.status_code == 201, via_session.text
+        assert via_session.json()["made_by"] == "web"
+
+        token = await _mint_token(client, name="my-agent")
+
+    async with _bearer_client(token) as agent:
+        via_token = await _save_artifact(agent, app_id, "cv", "token-written cv")
+        assert via_token.status_code == 201, via_token.text
+        assert via_token.json()["made_by"] == "token:my-agent"
+
+        forged = await _record_event(agent, app_id, "note", recorded_by="someone-else")
+        assert forged.status_code == 422, forged.text
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# R3/R4/R7 — the event log, status cache, and vocabulary
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_unknown_event_type_is_422_listing_the_allowed_types(authenticated_async_context):
+    async with authenticated_async_context() as client:
+        app_id = (await _bring(client))["application_id"]
+        resp = await _record_event(client, app_id, "definitely_not_a_real_type")
+        assert resp.status_code == 422, resp.text
+        assert "brought" in resp.text  # the allowed list is named in the error
+
+
+@pytest.mark.asyncio
+async def test_status_event_moves_status_and_note_does_not(authenticated_async_context):
+    async with authenticated_async_context() as client:
+        app_id = (await _bring(client))["application_id"]
+
+        applied = await _record_event(client, app_id, "applied")
+        assert applied.status_code == 201, applied.text
+        assert applied.json()["status"] == "applied"
+
+        noted = await _record_event(client, app_id, "note", detail="left a good impression")
+        assert noted.status_code == 201, noted.text
+        assert noted.json()["status"] == "applied", "a non-status event must not move the cached status"
+
+
+@pytest.mark.asyncio
+async def test_status_is_rebuildable_from_the_event_log(authenticated_async_context):
+    from src.services.applications.status import replay_status
+
+    from src.api import dependencies as api_deps
+
+    async with authenticated_async_context() as client:
+        app_id = (await _bring(client))["application_id"]
+        await _record_event(client, app_id, "applied")
+        await _record_event(client, app_id, "replied")
+        interview = await _record_event(client, app_id, "interview_requested")
+        assert interview.json()["status"] == "interview_requested"
+
+        detail = await _get_application(client, app_id)
+        events = detail.json()["events"]
+
+    db = await api_deps.get_db()
+    cur = await db._conn.execute("SELECT status FROM applications WHERE id = ?", (app_id,))
+    row = await cur.fetchone()
+    stored_status = row["status"]
+
+    # #21 — assert a NON-DEFAULT value, not merely that replay ran.
+    assert stored_status == "interview_requested"
+    assert replay_status(events) == stored_status
+
+
+@pytest.mark.asyncio
+async def test_a_correcting_event_supersedes_and_is_skipped_by_the_recompute(authenticated_async_context):
+
+    async with authenticated_async_context() as client:
+        app_id = (await _bring(client))["application_id"]
+        await _record_event(client, app_id, "applied")
+        mistake = await _record_event(client, app_id, "rejected")
+        assert mistake.json()["status"] == "rejected"
+        mistake_id = mistake.json()["event_id"]
+
+        # The agent notices the "rejected" was a mistake and retires it with a
+        # NOTE (non-status) event, rather than another status event — so the
+        # only way the correct final status comes back is if the recompute
+        # actually SKIPS the superseded event.
+        correction = await _record_event(
+            client, app_id, "note", detail="mis-recorded, employer never replied", corrects_event_id=mistake_id
+        )
+        assert correction.status_code == 201, correction.text
+        assert correction.json()["status"] == "applied", "recompute must skip the superseded event"
+
+        detail = await _get_application(client, app_id)
+    events = detail.json()["events"]
+    target = next(e for e in events if e["id"] == mistake_id)
+    assert target["superseded"] is True
+
+
+@pytest.mark.asyncio
+async def test_events_are_append_only(authenticated_async_context):
+    import re
+    from pathlib import Path
+
+    src = Path(__file__).resolve().parent.parent / "src"
+    offenders = []
+    for py in src.rglob("*.py"):
+        text = py.read_text(encoding="utf-8")
+        if re.search(r"(UPDATE|DELETE\s+FROM)\s+application_events", text, re.IGNORECASE):
+            offenders.append(str(py))
+        if re.search(r"(UPDATE|DELETE\s+FROM)\s+application_artifacts", text, re.IGNORECASE):
+            offenders.append(str(py))
+    assert offenders == [], f"application_events/application_artifacts must be append-only: {offenders}"
+
+    from src.api.main import app
+
+    for route in app.routes:
+        path = getattr(route, "path", "")
+        methods = getattr(route, "methods", set()) or set()
+        if path.startswith("/api/applications") and ("/events" in path or "/artifacts" in path):
+            assert not (methods & {"PATCH", "PUT", "DELETE"}), f"{path} exposes {methods}"
+
+
+@pytest.mark.asyncio
+async def test_backdated_occurred_at_is_accepted_and_ordered(authenticated_async_context):
+    from datetime import datetime, timedelta, timezone
+
+    now = datetime.now(timezone.utc)
+    long_ago = (now - timedelta(days=10)).isoformat()
+    recent = (now - timedelta(hours=1)).isoformat()
+
+    async with authenticated_async_context() as client:
+        app_id = (await _bring(client))["application_id"]
+        # Recorded FIRST but happened MORE RECENTLY than the backdated one below.
+        recent_evt = await _record_event(client, app_id, "note", detail="today's note", occurred_at=recent)
+        assert recent_evt.status_code == 201, recent_evt.text
+        backdated = await _record_event(
+            client, app_id, "note", detail="a note about last week", occurred_at=long_ago
+        )
+        assert backdated.status_code == 201, backdated.text
+
+        detail = await _get_application(client, app_id)
+    events = [e for e in detail.json()["events"] if e["event_type"] == "note"]
+    occurred = [e["occurred_at"] for e in events]
+    assert occurred == sorted(occurred), "the timeline must be ordered by occurred_at, backdated events included"
+
+
+@pytest.mark.asyncio
+async def test_future_occurred_at_is_422(authenticated_async_context):
+    from datetime import datetime, timedelta, timezone
+
+    from src.core import settings
+
+    too_far = (
+        datetime.now(timezone.utc)
+        + timedelta(seconds=settings.APPLICATION_EVENT_MAX_FUTURE_SECONDS + 3600)
+    ).isoformat()
+
+    async with authenticated_async_context() as client:
+        app_id = (await _bring(client))["application_id"]
+        resp = await _record_event(client, app_id, "note", occurred_at=too_far)
+        assert resp.status_code == 422, resp.text
+
+
+@pytest.mark.asyncio
+async def test_event_types_match_vision_doc(authenticated_async_context):
+    """docs/product/VISION.md:66-71 is the one place the event vocabulary is
+    written in prose; this pins code and doc to the same set so they cannot
+    drift apart silently."""
+    from src.core import settings
+
+    vision_types = {
+        "brought", "fit_judged", "artifact_saved", "contact_added", "outreach_sent",
+        "applied", "replied", "interview_requested", "interview_scheduled",
+        "interview_done", "offer", "rejected", "withdrawn", "ghosted", "note", "lesson",
+    }
+    code_types = set(settings.APPLICATION_STATUS_EVENT_TYPES) | set(settings.APPLICATION_NOTE_EVENT_TYPES)
+    assert code_types == vision_types
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# S2/S4 — cross-user isolation
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_a_foreign_application_id_is_404_on_every_route(authenticated_async_context):
+    async with authenticated_async_context() as owner:
+        owned = await _bring(owner)
+        app_id = owned["application_id"]
+        artifact = await _save_artifact(owner, app_id, "cv", "owner's cv")
+        artifact_id = artifact.json()["artifact_id"]
+
+    cookie = await _second_user_session_cookie("intruder-a@example.com")
+    async with _session_client(cookie) as intruder:
+        assert (await _get_application(intruder, app_id)).status_code == 404
+        assert (await _save_artifact(intruder, app_id, "cv", "not yours")).status_code == 404
+        assert (await _save_fit(intruder, app_id, score=50, verdict="x")).status_code == 404
+        assert (await _record_event(intruder, app_id, "note", detail="x")).status_code == 404
+        assert (await _record_receipt(intruder, app_id)).status_code == 404
+        assert (await intruder.get(f"/api/applications/{app_id}/artifacts/{artifact_id}")).status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_a_foreign_artifact_id_on_a_receipt_is_404(authenticated_async_context):
+    async with authenticated_async_context() as owner:
+        owned = await _bring(owner)
+        artifact = await _save_artifact(owner, owned["application_id"], "cv", "owner's cv")
+        foreign_artifact_id = artifact.json()["artifact_id"]
+
+    cookie = await _second_user_session_cookie("intruder-b@example.com")
+    async with _session_client(cookie) as intruder:
+        own = await _bring(intruder, _AD_2)
+        resp = await _record_receipt(intruder, own["application_id"], cv_artifact_id=foreign_artifact_id)
+        assert resp.status_code == 404, resp.text
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# R6 — the fit verdict is stored, never computed
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_save_fit_stores_the_verdict_and_keeps_both_judgements(authenticated_async_context):
+    async with authenticated_async_context() as client:
+        app_id = (await _bring(client))["application_id"]
+
+        first = await _save_fit(client, app_id, score=40, verdict="weak match", gaps=["no Go"], reasoning="early read")
+        assert first.status_code == 200, first.text
+        second = await _save_fit(client, app_id, score=80, verdict="strong match", gaps=[], reasoning="after reading the JD closely")
+        assert second.status_code == 200, second.text
+        assert second.json()["fit"]["score"] == 80
+
+        detail = await _get_application(client, app_id)
+    body = detail.json()
+    assert body["fit"]["score"] == 80, "the slot holds only the CURRENT answer"
+    judged = [e for e in body["events"] if e["event_type"] == "fit_judged"]
+    assert len(judged) == 2, "the log keeps BOTH judgements"
+
+
+@pytest.mark.asyncio
+async def test_save_fit_computes_nothing(authenticated_async_context, monkeypatch):
+    import sys
+
+    class _Explosive:
+        def __getattr__(self, name: str) -> Any:
+            raise AssertionError(f"save_fit touched skill_matcher.{name} — it must never score")
+
+    async with authenticated_async_context() as client:
+        app_id = (await _bring(client))["application_id"]  # bring is allowed to score; poison AFTER
+        monkeypatch.setitem(sys.modules, "src.services.skill_matcher", _Explosive())
+
+        resp = await _save_fit(client, app_id, score=70, verdict="looks fine", reasoning="agent's own read")
+        assert resp.status_code == 200, resp.text
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# R8 — record_application is the rich receipt
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_record_application_freezes_the_named_version(authenticated_async_context):
+    async with authenticated_async_context() as client:
+        app_id = (await _bring(client))["application_id"]
+        await _save_artifact(client, app_id, "cv", "cv v1")
+        v2 = await _save_artifact(client, app_id, "cv", "cv v2 — the one actually sent")
+
+        resp = await _record_receipt(
+            client, app_id, cv_artifact_id=v2.json()["artifact_id"], channel="company site", confirmation="REF-123"
+        )
+        assert resp.status_code == 201, resp.text
+        body = resp.json()
+        assert body["cv_artifact_id"] == v2.json()["artifact_id"]
+        assert body["cv_version_no"] == 2
+
+        detail = await _get_application(client, app_id)
+    payload = detail.json()
+    assert any(e["event_type"] == "applied" for e in payload["events"])
+    assert payload["receipts"][0]["cv_artifact_id"] == v2.json()["artifact_id"]
+
+
+@pytest.mark.asyncio
+async def test_legacy_receipts_route_writes_through(authenticated_async_context):
+    async with authenticated_async_context() as client:
+        bring_resp = await client.post("/api/jobs/bring", json=_AD)
+        assert bring_resp.status_code == 200, bring_resp.text
+        job_id = bring_resp.json()["job"]["id"]
+        application_id = bring_resp.json()["application_id"]
+
+        legacy = await client.post(f"/api/receipts/{job_id}", json={"channel": "email"})
+        assert legacy.status_code == 201, legacy.text
+
+        detail = await _get_application(client, application_id)
+    payload = detail.json()
+    assert any(e["event_type"] == "applied" for e in payload["events"])
+    assert payload["receipts"], "the legacy route must fill application_id and be visible from the spine"
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# R9 — whats_new
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_whats_new_pages_on_recorded_at_not_occurred_at(authenticated_async_context):
+    from datetime import datetime, timedelta, timezone
+
+    now = datetime.now(timezone.utc)
+    a_moment_ago = (now - timedelta(seconds=5)).isoformat()
+    long_ago_in_the_world = (now - timedelta(days=30)).isoformat()
+
+    async with authenticated_async_context() as client:
+        app_id = (await _bring(client))["application_id"]
+        # since is set to "a moment ago" — recorded NOW, but occurred 30 days
+        # ago in the world. A cursor on occurred_at would wrongly skip this.
+        resp = await _record_event(
+            client, app_id, "note", detail="found an old email thread", occurred_at=long_ago_in_the_world
+        )
+        assert resp.status_code == 201, resp.text
+
+        whats_new = await client.get("/api/whats-new", params={"since": a_moment_ago})
+    assert whats_new.status_code == 200, whats_new.text
+    body = whats_new.json()
+    assert any(e["detail"] == "found an old email thread" for e in body["events"])
+
+
+@pytest.mark.asyncio
+async def test_whats_new_truncates_explicitly(authenticated_async_context, monkeypatch):
+    from src.core import settings
+
+    monkeypatch.setattr(settings, "WHATS_NEW_MAX_EVENTS", 3)
+
+    async with authenticated_async_context() as client:
+        app_id = (await _bring(client))["application_id"]
+        for i in range(5):
+            r = await _record_event(client, app_id, "note", detail=f"note {i}")
+            assert r.status_code == 201, r.text
+
+        resp = await client.get("/api/whats-new")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["truncated"] is True
+    assert len(body["events"]) <= 3
+    assert body["next_since"], "a usable cursor must be returned when truncated"
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# R10 — export_history
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_export_history_bounds_and_truncates(authenticated_async_context, monkeypatch):
+    from src.core import settings
+
+    monkeypatch.setattr(settings, "EXPORT_HISTORY_MAX_APPLICATIONS", 2)
+
+    async with authenticated_async_context() as client:
+        for i in range(4):
+            await _bring(client, {**_AD, "apply_url": f"https://northwind.example/careers/{i}", "title": f"Role {i}"})
+
+        resp = await client.get("/api/applications/export")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["truncated"] is True
+    assert len(body["applications"]) <= 2
+    assert body.get("next_since")
+
+
+@pytest.mark.asyncio
+async def test_export_history_is_rate_limited_per_user(authenticated_async_context, monkeypatch):
+    from src.core import settings
+
+    monkeypatch.setattr(settings, "EXPORT_HISTORY_MAX_PER_HOUR", 2)
+
+    async with authenticated_async_context() as client:
+        await _bring(client)
+        assert (await client.get("/api/applications/export")).status_code == 200
+        assert (await client.get("/api/applications/export")).status_code == 200
+        limited = await client.get("/api/applications/export")
+        assert limited.status_code == 429, limited.text
+
+    cookie = await _second_user_session_cookie("export-other-user@example.com")
+    async with _session_client(cookie) as other:
+        await _bring(other, _AD_2)
+        unaffected = await other.get("/api/applications/export")
+        assert unaffected.status_code == 200, "the limit is per USER, not per IP/process"
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# R11 — get_application / list_applications
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_get_application_omits_artifact_text_by_default(authenticated_async_context):
+    async with authenticated_async_context() as client:
+        app_id = (await _bring(client))["application_id"]
+        await _save_artifact(client, app_id, "cv", "the actual cv text")
+
+        default = await _get_application(client, app_id)
+        assert default.status_code == 200, default.text
+        for artifact in default.json()["artifacts"]:
+            assert artifact.get("text") is None, "artifact text must be OFF by default"
+
+        with_text = await _get_application(client, app_id, with_artifact_text="true")
+    assert with_text.status_code == 200, with_text.text
+    texts = [a.get("text") for a in with_text.json()["artifacts"]]
+    assert "the actual cv text" in texts
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# R15 — tailoring stays, as a web fallback that also versions
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_tailor_generate_also_writes_an_artifact_version(authenticated_async_context, monkeypatch):
+    from src.api.routes import tailor as tailor_route
+    from src.services.tailoring.generator import GeneratedDoc
+
+    async def _fake_generate(*, doc_kind: str, **kwargs: Any) -> GeneratedDoc:
+        return GeneratedDoc(doc_kind=doc_kind, document=f"a generated {doc_kind}", model="test-model", flagged_terms=[])
+
+    monkeypatch.setattr(tailor_route, "generate_document", _fake_generate)
+    monkeypatch.setattr(
+        tailor_route, "_load_cv_text", lambda user_id: "Real CV text with enough content to generate from."
+    )
+
+    async with authenticated_async_context() as client:
+        bring_resp = await client.post("/api/jobs/bring", json=_AD)
+        job_id = bring_resp.json()["job"]["id"]
+        application_id = bring_resp.json()["application_id"]
+
+        gen = await client.post(f"/api/tailor/{job_id}/generate")
+        assert gen.status_code == 200, gen.text
+
+        detail = await _get_application(client, application_id)
+    artifacts = detail.json()["artifacts"]
+    assert any(a["made_by"] == "web:tailor" for a in artifacts)
+
+
+@pytest.mark.asyncio
+async def test_tailor_save_edit_writes_a_human_version(authenticated_async_context, monkeypatch):
+    from src.api.routes import tailor as tailor_route
+    from src.services.tailoring.generator import GeneratedDoc
+
+    async def _fake_generate(*, doc_kind: str, **kwargs: Any) -> GeneratedDoc:
+        return GeneratedDoc(doc_kind=doc_kind, document=f"a generated {doc_kind}", model="test-model", flagged_terms=[])
+
+    monkeypatch.setattr(tailor_route, "generate_document", _fake_generate)
+    monkeypatch.setattr(
+        tailor_route, "_load_cv_text", lambda user_id: "Real CV text with enough content to generate from."
+    )
+
+    async with authenticated_async_context() as client:
+        bring_resp = await client.post("/api/jobs/bring", json=_AD)
+        job_id = bring_resp.json()["job"]["id"]
+        application_id = bring_resp.json()["application_id"]
+        await client.post(f"/api/tailor/{job_id}/generate")
+
+        edited = await client.patch(f"/api/tailor/{job_id}/cv", json={"text": "my hand-edited cv"})
+        assert edited.status_code == 200, edited.text
+
+        detail = await _get_application(client, application_id)
+    artifacts = detail.json()["artifacts"]
+    assert any(a["made_by"] == "human" for a in artifacts)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# S9 — audit log never carries a body
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_audit_log_never_carries_a_body(authenticated_async_context, audit_capture):
+    async with authenticated_async_context() as client:
+        app_id = (await _bring(client))["application_id"]
+        await _save_artifact(client, app_id, "cv", "SECRET_ARTIFACT_MARKER_TEXT")
+        await _record_event(client, app_id, "note", detail="SECRET_DETAIL_MARKER", payload={"x": "SECRET_PAYLOAD_MARKER"})
+        await _save_fit(client, app_id, score=10, verdict="v", reasoning="SECRET_REASONING_MARKER")
+
+    markers = ("SECRET_ARTIFACT_MARKER_TEXT", "SECRET_DETAIL_MARKER", "SECRET_PAYLOAD_MARKER", "SECRET_REASONING_MARKER")
+    for record in audit_capture.records:
+        blob = " ".join(f"{k}={v!r}" for k, v in record.items())
+        for marker in markers:
+            assert marker not in blob, f"audit log leaked a body field: {marker} in {blob[:300]}"

--- a/backend/tests/test_application_spine_fixes.py
+++ b/backend/tests/test_application_spine_fixes.py
@@ -1,0 +1,327 @@
+"""Fixes for the application-spine review findings (docs/plans/2026-09-04-
+application-spine/spec.md build). Each test pins ONE finding so it stays
+fixed:
+
+B1 — migration 0037 backfills `status` from `stage` but leaves a legacy
+     application with no stage_history/receipt/tailored-doc row with ZERO
+     events; the next real event's status recompute then defaults to
+     'considering', wiping the real status.
+B2 — `birth_application` used to omit `stage`, so a freshly-brought
+     (`considering`) job read as `applied` on the legacy `/api/pipeline` and
+     could be nagged about by reminders.
+B3 — `parse_occurred_at` kept the caller's UTC offset; the TEXT column is
+     ordered lexically, so mixed offsets can sort out of real chronological
+     order.
+B4 — `whats_new`'s cursor used `recorded_at >= since AND id > after_id` as
+     two INDEPENDENT predicates, so an event with a lower id than the cursor
+     boundary but a newer `recorded_at` was skipped forever.
+B5 — `corrects_event_id` was accepted without checking the target event
+     exists and belongs to the SAME application.
+B6 — `record_receipt` hardcoded `profile_version=None` instead of stamping
+     the caller's current profile version, unlike the legacy receipts route.
+
+Helpers are imported from ``tests.test_application_spine`` (frozen, not
+edited) rather than duplicated.
+"""
+from __future__ import annotations
+
+import contextlib
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from tests.test_application_spine import _AD_2, _bring, _get_application, _record_event, _record_receipt
+
+_NOW = "2026-01-01T00:00:00Z"
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# B1 — a legacy application with no fold-generated events keeps its status
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+async def _seed_pre_migration_offer_app(db_path: str) -> None:
+    """A single legacy `applications` row at stage='offer' with NO matching
+    `application_stage_history` / `application_receipts` / `tailored_documents`
+    row — the exact B1 scenario: after the fold, this row's `status` is
+    backfilled to 'offer' (step 3) but gets no event at all from steps 5-7.
+    """
+    from migrations import runner
+    from src.repositories import pg as _pg
+    from src.repositories.database import JobDatabase
+
+    db = JobDatabase(db_path)
+    await db.init_db()
+    await db.close()
+    await runner.up(db_path, target="0036_oauth")
+
+    async with _pg.connect(db_path) as conn:
+        conn.row_factory = _pg.Row
+        await conn.execute(
+            "INSERT INTO users (id, email, password_hash, created_at) VALUES (?, ?, ?, ?)",
+            ("b1-user", "b1@example.com", "!", _NOW),
+        )
+        await conn.execute(
+            "INSERT INTO applications (user_id, job_id, stage, notes, created_at, updated_at) "
+            "VALUES (?, ?, 'offer', '', ?, ?)",
+            ("b1-user", 900_100, _NOW, _NOW),
+        )
+        await conn.commit()
+
+    await runner.up(db_path)
+
+
+@pytest.mark.asyncio
+async def test_b1_a_legacy_offer_survives_its_first_new_event(tmp_path):
+    from src.repositories import pg as _pg
+    from src.services.applications import spine
+
+    db_path = str(tmp_path / "b1.db")
+    await _seed_pre_migration_offer_app(db_path)
+
+    async with _pg.connect(db_path) as conn:
+        conn.row_factory = _pg.Row
+        cur = await conn.execute(
+            "SELECT id, status FROM applications WHERE user_id = ? AND job_id = ?", ("b1-user", 900_100)
+        )
+        row = await cur.fetchone()
+        assert row["status"] == "offer", "step 3's backfill must still land 'offer'"
+        application_id = row["id"]
+
+        # Sanity: the fold's synthetic backfill (B1 fix) really did give this
+        # application an event — otherwise this test would pass for the WRONG
+        # reason (an empty log replaying to the 'considering' default would
+        # never even be exercised by the assertion below).
+        cur = await conn.execute(
+            "SELECT COUNT(*) FROM application_events WHERE application_id = ?", (application_id,)
+        )
+        assert (await cur.fetchone())[0] > 0, "B1 fix: a legacy row with no fold history must still get ONE event"
+
+        from src.repositories.database import JobDatabase
+
+        db = JobDatabase.from_connection(db_path, conn)
+        result = await spine.append_event(
+            db, user_id="b1-user", application_id=application_id, event_type="artifact_saved",
+            occurred_at=datetime.now(timezone.utc).isoformat(), recorded_by="test",
+            payload={"artifact_id": 1, "kind": "cv", "version_no": 1},
+        )
+        assert result["status"] == "offer", (
+            "B1: appending a note-family-adjacent event on a legacy app with "
+            "no fold history must NOT reset status to the 'considering' default"
+        )
+
+        cur = await conn.execute("SELECT status FROM applications WHERE id = ?", (application_id,))
+        assert (await cur.fetchone())["status"] == "offer"
+
+    with contextlib.suppress(Exception):
+        await _pg.drop_schema(db_path)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# B2 — a brought job is 'considering' on the legacy pipeline, never 'applied',
+# and never nagged about by reminders
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_b2_a_brought_job_shows_considering_not_applied_on_the_pipeline(
+    authenticated_async_context, fixture_user_id
+):
+    async with authenticated_async_context() as client:
+        brought = await _bring(client)
+        job_id = brought["job"]["id"]
+
+        pipeline = await client.get("/api/pipeline")
+        assert pipeline.status_code == 200, pipeline.text
+        row = next(a for a in pipeline.json()["applications"] if a["job_id"] == job_id)
+        assert row["stage"] == "considering", (
+            "B2: birth_application must write stage='considering' explicitly — "
+            "the column's 'applied' default must never leak through"
+        )
+
+    # Age the row past the 7-day reminder window and confirm reminders still
+    # never fire for a merely-considered job (database.py get_stale_applications).
+    old = (datetime.now(timezone.utc) - timedelta(days=30)).isoformat()
+    from src.core import settings
+    from src.repositories import pgsync
+
+    conn = pgsync.connect(str(settings.DB_PATH))
+    conn.execute(
+        "UPDATE applications SET updated_at = ? WHERE user_id = ? AND job_id = ?",
+        (old, fixture_user_id, job_id),
+    )
+    conn.commit()
+    conn.close()
+
+    async with authenticated_async_context() as client:
+        reminders = await client.get("/api/pipeline/reminders")
+        assert reminders.status_code == 200, reminders.text
+        assert all(r["job_id"] != job_id for r in reminders.json()["reminders"]), (
+            "B2: reminders must not fire for a 'considering' application"
+        )
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# B3 — occurred_at is normalised to UTC so mixed offsets sort correctly
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_b3_mixed_offsets_sort_by_real_time_not_by_string(authenticated_async_context):
+    async with authenticated_async_context() as client:
+        brought = await _bring(client)
+        app_id = brought["application_id"]
+
+        # 2026-01-01T17:30:00Z, written under a +05:30 offset. Its RAW string
+        # ("...T23:00:00+05:30") is lexically GREATER than the second event's
+        # raw string below, even though it happened EARLIER in real time —
+        # the exact "+05:30 case" the review named.
+        earlier_utc_odd_offset = "2026-01-01T23:00:00+05:30"
+        # 2026-01-01T20:00:00Z under +00:00 — later in real time, but its raw
+        # string sorts BEFORE the one above under naive lexical comparison.
+        later_utc_zulu_offset = "2026-01-01T20:00:00+00:00"
+
+        await _record_event(client, app_id, "note", detail="earlier-real-time", occurred_at=earlier_utc_odd_offset)
+        await _record_event(client, app_id, "note", detail="later-real-time", occurred_at=later_utc_zulu_offset)
+
+        detail = await _get_application(client, app_id)
+        assert detail.status_code == 200, detail.text
+        notes = [e["detail"] for e in detail.json()["events"] if e["event_type"] == "note"]
+        assert notes == ["earlier-real-time", "later-real-time"], (
+            "B3: the timeline must order by the real instant, not by the "
+            "caller's original offset string"
+        )
+        # And the stored strings themselves are canonical +00:00, not the
+        # caller's raw offset (pg.py's own convention — see spine.py comment).
+        raw = [e["occurred_at"] for e in detail.json()["events"] if e["event_type"] == "note"]
+        assert all(o.endswith("+00:00") for o in raw), raw
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# B4 — whats_new's cursor is a REAL keyset pair, not two independent AND
+# predicates
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_b4_a_lower_id_recorded_after_the_cursor_boundary_is_not_skipped(
+    authenticated_async_context, fixture_user_id
+):
+    from src.core import settings
+    from src.repositories import pgsync
+
+    async with authenticated_async_context() as client:
+        brought = await _bring(client)
+        app_id = brought["application_id"]
+
+    conn = pgsync.connect(str(settings.DB_PATH))
+    baseline = conn.execute("SELECT MAX(id) FROM application_events").fetchone()[0]
+
+    boundary_id = baseline + 2
+    late_id = baseline + 1  # LOWER id than the boundary
+    boundary_recorded_at = "2030-01-01T00:10:00+00:00"
+    late_recorded_at = "2030-01-01T00:20:00+00:00"  # NEWER than the boundary
+
+    # Explicit ids, deliberately out of natural auto-increment order — this
+    # makes the review's "a concurrently-committed event with a lower id is
+    # skipped forever" scenario deterministic instead of timing-dependent: a
+    # transaction that grabbed a low sequence value but took longer to commit
+    # than one that grabbed a higher value produces exactly this shape.
+    conn.execute(
+        "INSERT INTO application_events "
+        "(id, user_id, application_id, event_type, detail, payload, occurred_at, recorded_at, recorded_by) "
+        "VALUES (?, ?, ?, 'note', 'boundary-row', '{}', ?, ?, 'test')",
+        (boundary_id, fixture_user_id, app_id, boundary_recorded_at, boundary_recorded_at),
+    )
+    conn.execute(
+        "INSERT INTO application_events "
+        "(id, user_id, application_id, event_type, detail, payload, occurred_at, recorded_at, recorded_by) "
+        "VALUES (?, ?, ?, 'note', 'late-lower-id-row', '{}', ?, ?, 'test')",
+        (late_id, fixture_user_id, app_id, late_recorded_at, late_recorded_at),
+    )
+    conn.commit()
+    conn.close()
+
+    async with authenticated_async_context() as client:
+        # Simulates a client that already consumed a page ending exactly at
+        # the boundary row (since=boundary's recorded_at, after_id=boundary's id).
+        resp = await client.get(
+            "/api/whats-new", params={"since": boundary_recorded_at, "after_id": boundary_id}
+        )
+        assert resp.status_code == 200, resp.text
+        details = [e["detail"] for e in resp.json()["events"]]
+        assert "late-lower-id-row" in details, (
+            "B4: an event recorded strictly AFTER the cursor boundary must "
+            "never be skipped just because its id is lower than the boundary's"
+        )
+        # And walking forward from this page never re-shows the boundary itself.
+        assert "boundary-row" not in details
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# B5 — corrects_event_id must name a real event on the SAME application
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_b5_corrects_event_id_must_exist_on_the_same_application(authenticated_async_context):
+    async with authenticated_async_context() as client:
+        app_id = (await _bring(client))["application_id"]
+
+        made_up = await _record_event(client, app_id, "note", detail="oops", corrects_event_id=999_999_999)
+        assert made_up.status_code == 422, made_up.text
+
+        other_app_id = (await _bring(client, _AD_2))["application_id"]
+        other_event = await _record_event(client, other_app_id, "note", detail="lives on the other application")
+        assert other_event.status_code == 201, other_event.text
+        other_event_id = other_event.json()["event_id"]
+
+        cross_application = await _record_event(
+            client, app_id, "note", detail="nice try", corrects_event_id=other_event_id
+        )
+        assert cross_application.status_code == 422, (
+            "B5: corrects_event_id naming a REAL event on a DIFFERENT "
+            "application must still be refused"
+        )
+
+        real_event = await _record_event(client, app_id, "note", detail="the mistake")
+        assert real_event.status_code == 201, real_event.text
+        real_event_id = real_event.json()["event_id"]
+
+        fix = await _record_event(client, app_id, "note", detail="corrected", corrects_event_id=real_event_id)
+        assert fix.status_code == 201, "a corrects_event_id naming a real event on THIS application must succeed"
+
+        detail = await _get_application(client, app_id)
+        by_id = {e["id"]: e for e in detail.json()["events"]}
+        assert by_id[real_event_id]["superseded"] is True
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# B6 — record_receipt stamps the caller's current profile version
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_b6_record_receipt_stamps_the_current_profile_version(authenticated_async_context, monkeypatch):
+    import src.services.profile.storage as storage
+
+    monkeypatch.setattr(storage, "current_profile_version_id", lambda user_id: 777)
+
+    async with authenticated_async_context() as client:
+        app_id = (await _bring(client))["application_id"]
+        receipt = await _record_receipt(client, app_id, channel="email")
+        assert receipt.status_code == 201, receipt.text
+        receipt_id = receipt.json()["receipt_id"]
+
+    from src.core import settings
+    from src.repositories import pgsync
+
+    conn = pgsync.connect(str(settings.DB_PATH))
+    row = conn.execute(
+        "SELECT profile_version FROM application_receipts WHERE id = ?", (receipt_id,)
+    ).fetchone()
+    conn.close()
+    assert row[0] == 777, (
+        "B6: record_receipt must stamp the CALLER's current profile version, "
+        "not hardcode None (the legacy /receipts/{job_id} route has always done this)"
+    )

--- a/backend/tests/test_mcp_gate_parity.py
+++ b/backend/tests/test_mcp_gate_parity.py
@@ -10,6 +10,20 @@
 2. A valid token is never throttled. The failed-bearer limiter is keyed by
    client IP, and behind the Next.js rewrite every agent shares the proxy's IP.
    The lock must apply to junk only — one bad client must not 429 everyone.
+
+Extended for the application spine (docs/plans/2026-09-04-application-spine/
+spec.md S11): seven new tools land on ``src.api.routes.applications`` — each
+one MUST get a ``TOOL_ROUTES`` row here or ``test_the_parity_table_covers_
+every_tool`` turns red, by design. ``record_application`` is NOT a new TOOL
+(spec: "the existing tool enriched, not a new one") — its NAME and call
+shape (``job_id``, ``channel``, ``note`` still work) are unchanged — but a
+review finding (C1) rewired its IMPLEMENTATION off the legacy
+``receipts.create_receipt`` onto the new rich
+``applications.record_application_receipt`` route, so this row's
+(module, function) pair now points there too. None of the eight
+(the seven new tools, plus this rewired one) are ``require_verified_user``
+(spec: "Every route Depends(require_user)... not require_verified_user —
+nothing here spends an LLM call").
 """
 from __future__ import annotations
 
@@ -38,9 +52,24 @@ TOOL_ROUTES = {
     "get_job": ("jobs", "get_job", {"job_id": 987654321}),
     "tailor_documents": ("tailor", "generate", {"job_id": 987654321}),
     "get_tailored_documents": ("tailor", "get_tailored", {"job_id": 987654321}),
-    "record_application": ("receipts", "create_receipt", {"job_id": 987654321}),
+    # C1 (application-spine review) — rewired onto the rich receipt route;
+    # the tool's own call shape (job_id, channel, note) is unchanged.
+    "record_application": ("applications", "record_application_receipt", {"job_id": 987654321}),
     "list_receipts": ("receipts", "list_receipts", {}),
     "get_receipt": ("receipts", "get_receipt", {"receipt_id": 987654321}),
+    # Application spine (spec 2026-09-04, S11) — seven new tools, all on the
+    # new "applications" route module, none require_verified_user.
+    "get_application": ("applications", "get_application", {"application_id": 987654321}),
+    "list_applications": ("applications", "list_applications", {}),
+    "save_artifact": (
+        "applications", "save_artifact", {"application_id": 987654321, "kind": "cv", "text": "x"}
+    ),
+    "save_fit": ("applications", "save_fit", {"application_id": 987654321}),
+    "record_event": (
+        "applications", "record_event", {"application_id": 987654321, "event_type": "note"}
+    ),
+    "whats_new": ("applications", "whats_new", {}),
+    "export_history": ("applications", "export_history", {}),
 }
 
 

--- a/backend/tests/test_mcp_server.py
+++ b/backend/tests/test_mcp_server.py
@@ -26,6 +26,15 @@ EXPECTED_TOOLS = {
     "record_application",
     "list_receipts",
     "get_receipt",
+    # Application spine (docs/plans/2026-09-04-application-spine/spec.md
+    # §Tool contracts) — seven new tools, 8 -> 15 total.
+    "get_application",
+    "list_applications",
+    "save_artifact",
+    "save_fit",
+    "record_event",
+    "whats_new",
+    "export_history",
 }
 
 JOB = {
@@ -106,7 +115,7 @@ async def test_without_the_runtime_the_endpoint_says_503_not_crash(authenticated
 
 
 @pytest.mark.asyncio
-async def test_tools_list_is_exactly_the_eight_tools(authenticated_async_context):
+async def test_tools_list_is_exactly_the_expected_tools(authenticated_async_context):
     from src.api.mcp_server import mcp_runtime
 
     token = await _mint_token(authenticated_async_context)
@@ -138,25 +147,31 @@ async def test_bring_then_read_then_record_then_list_round_trip(authenticated_as
             job = _payload(await mcp.call_tool("get_job", {"job_id": job_id}))
             assert job["job_id"] == job_id and "description" in job
 
+            # C1 (application-spine review) — record_application is rewired onto
+            # the rich `POST /applications/{id}/receipt` route; its response is
+            # now the R8 shape (receipt_id/event_id/etc, plus job_id echoed back
+            # for continuity), not the legacy ReceiptSummary shape.
             receipt = _payload(
                 await mcp.call_tool(
                     "record_application", {"job_id": job_id, "channel": "company site", "note": "via MCP"}
                 )
             )
             assert receipt["job_id"] == job_id and receipt["sent_at"]
+            assert receipt["channel"] == "company site"
+            assert receipt["event_id"]
 
             listed = _payload(await mcp.call_tool("list_receipts", {}))
             assert listed["total"] == 1
-            assert listed["receipts"][0]["id"] == receipt["id"]
+            assert listed["receipts"][0]["id"] == receipt["receipt_id"]
 
-            full = _payload(await mcp.call_tool("get_receipt", {"receipt_id": receipt["id"]}))
+            full = _payload(await mcp.call_tool("get_receipt", {"receipt_id": receipt["receipt_id"]}))
             assert full["note"] == "via MCP" and full["channel"] == "company site"
 
     # The web app sees the same record — one API, every surface.
     async with authenticated_async_context() as client:
         resp = await client.get("/api/receipts")
         assert resp.status_code == 200
-        assert [r["id"] for r in resp.json()["receipts"]] == [receipt["id"]]
+        assert [r["id"] for r in resp.json()["receipts"]] == [receipt["receipt_id"]]
 
 
 @pytest.mark.asyncio
@@ -187,7 +202,7 @@ async def test_another_users_receipt_is_unreachable(authenticated_async_context)
     async with mcp_runtime():
         async with _mcp_client(token) as mcp:
             job_id = _payload(await mcp.call_tool("bring_job", JOB))["job_id"]
-            receipt_id = _payload(await mcp.call_tool("record_application", {"job_id": job_id}))["id"]
+            receipt_id = _payload(await mcp.call_tool("record_application", {"job_id": job_id}))["receipt_id"]
 
     # A second account, with its own token.
     from src.api.main import app
@@ -220,3 +235,55 @@ async def test_another_users_receipt_is_unreachable(authenticated_async_context)
             assert stolen.is_error and "404" in stolen.content[0].text
             mine = _payload(await mcp.call_tool("list_receipts", {}))
             assert mine["total"] == 0
+
+
+@pytest.mark.asyncio
+async def test_record_application_writes_a_rich_receipt_through_the_new_route(authenticated_async_context):
+    """C1 (application-spine review) — `record_application` must go through
+    `applications.record_application_receipt` (the rich receipt), not the
+    legacy `receipts.create_receipt`: a NAMED artifact version and
+    `confirmation` passed to the MCP tool must land on the receipt exactly as
+    the web's `POST /applications/{id}/receipt` would record them — the old
+    legacy route has no `confirmation` or `cv_artifact_id` field at all, so
+    this would 422/be silently dropped if the tool still called it.
+    """
+    from src.api.mcp_server import mcp_runtime
+
+    token = await _mint_token(authenticated_async_context)
+    async with mcp_runtime():
+        async with _mcp_client(token) as mcp:
+            job_id = _payload(await mcp.call_tool("bring_job", JOB))["job_id"]
+
+    async with authenticated_async_context() as client:
+        apps = await client.get("/api/applications")
+        assert apps.status_code == 200, apps.text
+        application_id = apps.json()["applications"][0]["id"]
+        saved = await client.post(
+            f"/api/applications/{application_id}/artifacts",
+            json={"kind": "cv", "text": "my tailored cv"},
+        )
+        assert saved.status_code == 201, saved.text
+        cv_artifact_id = saved.json()["artifact_id"]
+
+    async with mcp_runtime():
+        async with _mcp_client(token) as mcp:
+            receipt = _payload(
+                await mcp.call_tool(
+                    "record_application",
+                    {"job_id": job_id, "confirmation": "REF-12345", "cv_artifact_id": cv_artifact_id},
+                )
+            )
+
+    assert receipt["confirmation"] == "REF-12345"
+    assert receipt["cv_artifact_id"] == cv_artifact_id
+    assert receipt["cv_version_no"] == 1
+
+    async with authenticated_async_context() as client:
+        detail = await client.get(f"/api/applications/{application_id}")
+        assert detail.status_code == 200, detail.text
+        receipts = detail.json()["receipts"]
+        assert receipts[0]["confirmation"] == "REF-12345"
+        assert receipts[0]["cv_artifact_id"] == cv_artifact_id
+        # The event log recorded it too — not just the receipts table.
+        statuses = [e["event_type"] for e in detail.json()["events"]]
+        assert "applied" in statuses

--- a/backend/tests/test_migration_0037.py
+++ b/backend/tests/test_migration_0037.py
@@ -1,0 +1,292 @@
+"""Migration 0037 — the application spine fold (spec.md §Migration fold).
+
+Frozen — not edited to make the implementation pass (see test_application_spine.py's
+module docstring for the same contract). Migration `0037_application_spine` does not
+exist on this branch yet, so every test below is expected to FAIL: either the new
+tables/columns are missing, or `runner.up()` simply never reaches a stem that isn't
+on disk. That is the intended RED state.
+
+The fold's whole argument is COUNTS: nothing already in `applications`,
+`application_stage_history`, `application_receipts` or `tailored_documents` is
+moved or deleted — only copied forward into the new `application_events` /
+`application_artifacts` tables and the new `applications` columns. Seeded data
+here is chosen to exercise every step of the fold (§Migration fold, steps 2-7).
+"""
+from __future__ import annotations
+
+import asyncio
+import contextlib
+
+import pytest
+
+from migrations import runner
+from src.repositories import pg as _pg
+
+_NOW = "2026-01-01T00:00:00Z"
+_USER = "fold-test-user"
+_ORPHAN_JOB_ID = 999_001
+
+# The six legacy stages a real `applications` row can hold
+# (`routes/pipeline.py::_VALID_STAGES`) — the fold's status backfill (R4,
+# reversed) must map every one of them.
+_STAGES = ("applied", "outreach", "interview", "offer", "rejected", "ghosted")
+
+
+async def _seed_user(db: _pg.Connection) -> None:
+    await db.execute(
+        "INSERT INTO users (id, email, password_hash, created_at) VALUES (?, ?, ?, ?)",
+        (_USER, "fold-test@example.com", "!", _NOW),
+    )
+
+
+async def _seed_applications(db: _pg.Connection) -> dict[str, int]:
+    """One application per legacy stage; returns {stage: job_id}."""
+    job_ids: dict[str, int] = {}
+    for i, stage in enumerate(_STAGES):
+        job_id = 900 + i
+        job_ids[stage] = job_id
+        await db.execute(
+            "INSERT INTO applications (user_id, job_id, stage, notes, created_at, updated_at) "
+            "VALUES (?, ?, ?, '', ?, ?)",
+            (_USER, job_id, stage, _NOW, _NOW),
+        )
+    return job_ids
+
+
+async def _seed_stage_history(db: _pg.Connection, job_id: int) -> None:
+    """Two transitions on one application — exercises the 1-row-per-history-row fold."""
+    await db.execute(
+        "INSERT INTO application_stage_history (job_id, user_id, from_stage, to_stage, transitioned_at, notes) "
+        "VALUES (?, ?, NULL, 'applied', ?, '')",
+        (job_id, _USER, _NOW),
+    )
+    await db.execute(
+        "INSERT INTO application_stage_history (job_id, user_id, from_stage, to_stage, transitioned_at, notes) "
+        "VALUES (?, ?, 'applied', 'interview', ?, 'moved forward')",
+        (job_id, _USER, _NOW),
+    )
+
+
+async def _seed_receipts(db: _pg.Connection, matched_job_id: int, orphan_job_id: int) -> None:
+    for job_id, note in ((matched_job_id, "matched receipt"), (orphan_job_id, "orphan receipt")):
+        await db.execute(
+            "INSERT INTO application_receipts "
+            "(user_id, job_id, sent_at, job_title, job_company, job_location, job_apply_url, "
+            " job_source, job_description, cv_text, cv_origin, cover_letter_text, cover_letter_origin, "
+            " profile_version, channel, note, created_at) "
+            "VALUES (?, ?, ?, 'Data Engineer', 'Northwind', 'Remote', 'https://x.test/1', 'test', "
+            " 'desc', NULL, NULL, NULL, NULL, NULL, '', ?, ?)",
+            (_USER, job_id, _NOW, note, _NOW),
+        )
+
+
+async def _seed_tailored_documents(db: _pg.Connection, polished_job_id: int, draft_only_job_id: int) -> None:
+    # A polish exists — this row must become TWO artifact versions.
+    await db.execute(
+        "INSERT INTO tailored_documents "
+        "(user_id, job_id, doc_kind, ai_draft, polished, status, model, profile_version, created_at, updated_at) "
+        "VALUES (?, ?, 'cv', 'draft text', 'polished text — the edit', 'kept', 'test-model', 1, ?, ?)",
+        (_USER, polished_job_id, _NOW, _NOW),
+    )
+    # No polish — this row must become exactly ONE artifact version.
+    await db.execute(
+        "INSERT INTO tailored_documents "
+        "(user_id, job_id, doc_kind, ai_draft, polished, status, model, profile_version, created_at, updated_at) "
+        "VALUES (?, ?, 'cover_letter', 'cover draft only', NULL, 'draft', 'test-model', 1, ?, ?)",
+        (_USER, draft_only_job_id, _NOW, _NOW),
+    )
+
+
+async def _counts(db_path: str) -> dict[str, int]:
+    tables = ("applications", "application_stage_history", "application_receipts", "tailored_documents")
+    out: dict[str, int] = {}
+    async with _pg.connect(db_path) as db:
+        for t in tables:
+            cur = await db.execute(f"SELECT COUNT(*) FROM {t}")  # noqa: S608 — fixed table-name tuple, not user input
+            row = await cur.fetchone()
+            out[t] = int(row[0])
+    return out
+
+
+async def _has_table(db_path: str, name: str) -> bool:
+    async with _pg.connect(db_path) as db:
+        cur = await db.execute("SELECT name FROM sqlite_master WHERE type='table' AND name = ?", (name,))
+        return (await cur.fetchone()) is not None
+
+
+@pytest.fixture
+def pre_fold_db_path(tmp_path):
+    """Full schema, every migration EXCEPT the fold itself.
+
+    Target pinned to ``0036_oauth`` (today's newest migration) rather than
+    left open, so this fixture seeds legacy data BEFORE 0037 exists — the
+    moment 0037.up.sql lands, ``runner.up(db_path)`` in each test below is
+    what carries it forward, and this fixture's seed data is exactly the
+    "before" half of the fold's own count table.
+    """
+    db_path = str(tmp_path / "pre_fold.db")
+
+    async def _bootstrap() -> None:
+        from src.repositories.database import JobDatabase
+
+        db = JobDatabase(db_path)
+        await db.init_db()
+        await db.close()
+        await runner.up(db_path, target="0036_oauth")
+
+        async with _pg.connect(db_path) as conn:
+            conn.row_factory = _pg.Row
+            await _seed_user(conn)
+            job_ids = await _seed_applications(conn)
+            await _seed_stage_history(conn, job_ids["interview"])
+            await _seed_receipts(conn, matched_job_id=job_ids["applied"], orphan_job_id=_ORPHAN_JOB_ID)
+            await _seed_tailored_documents(
+                conn, polished_job_id=job_ids["applied"], draft_only_job_id=job_ids["outreach"]
+            )
+            await conn.commit()
+
+    asyncio.run(_bootstrap())
+    yield db_path
+    with contextlib.suppress(Exception):
+        asyncio.run(_pg.drop_schema(db_path))
+
+
+@pytest.mark.asyncio
+async def test_up_down_up_is_clean(pre_fold_db_path):
+    applied = await runner.up(pre_fold_db_path)
+    assert "0037_application_spine" in applied, f"0037 never applied: {applied}"
+
+    for table in ("application_events", "application_artifacts"):
+        assert await _has_table(pre_fold_db_path, table), f"{table} missing after up()"
+
+    reverted = await runner.down(pre_fold_db_path)
+    assert reverted == "0037_application_spine"
+    for table in ("application_events", "application_artifacts"):
+        assert not await _has_table(pre_fold_db_path, table), f"{table} still present after down()"
+
+    reapplied = await runner.up(pre_fold_db_path)
+    assert reapplied == ["0037_application_spine"]
+    for table in ("application_events", "application_artifacts"):
+        assert await _has_table(pre_fold_db_path, table), f"{table} missing after re-up()"
+
+
+@pytest.mark.asyncio
+async def test_no_legacy_row_is_lost(pre_fold_db_path):
+    before = await _counts(pre_fold_db_path)
+    await runner.up(pre_fold_db_path)
+    after = await _counts(pre_fold_db_path)
+
+    assert after["applications"] >= before["applications"], "the fold may only ADD applications rows (orphans)"
+    assert after["application_stage_history"] == before["application_stage_history"]
+    assert after["application_receipts"] == before["application_receipts"]
+    assert after["tailored_documents"] == before["tailored_documents"]
+
+    async with _pg.connect(pre_fold_db_path) as db:
+        cur = await db.execute("SELECT COUNT(*) FROM application_receipts WHERE application_id IS NULL")
+        row = await cur.fetchone()
+    assert row[0] == 0, "every receipt must come out with a non-NULL application_id"
+
+
+@pytest.mark.asyncio
+async def test_stage_history_becomes_events(pre_fold_db_path):
+    async with _pg.connect(pre_fold_db_path) as db:
+        cur = await db.execute("SELECT COUNT(*) FROM application_stage_history")
+        history_count = (await cur.fetchone())[0]
+    assert history_count > 0, "test fixture sanity: seed data must include stage-history rows"
+
+    await runner.up(pre_fold_db_path)
+
+    async with _pg.connect(pre_fold_db_path) as db:
+        cur = await db.execute(
+            "SELECT COUNT(*) FROM application_events WHERE recorded_by = 'migration:0014_history'"
+        )
+        migrated_count = (await cur.fetchone())[0]
+    assert migrated_count == history_count, "one event per stage-history row, no more, no fewer"
+
+
+@pytest.mark.asyncio
+async def test_receipts_get_an_application_id_and_an_event(pre_fold_db_path):
+    async with _pg.connect(pre_fold_db_path) as db:
+        cur = await db.execute("SELECT COUNT(*) FROM application_receipts")
+        receipt_count = (await cur.fetchone())[0]
+    assert receipt_count > 0, "test fixture sanity: seed data must include receipts"
+
+    await runner.up(pre_fold_db_path)
+
+    async with _pg.connect(pre_fold_db_path) as db:
+        db.row_factory = _pg.Row
+        cur = await db.execute("SELECT application_id FROM application_receipts")
+        app_ids = [r["application_id"] for r in await cur.fetchall()]
+        cur = await db.execute(
+            "SELECT COUNT(*) FROM application_events WHERE recorded_by = 'migration:0034_receipts'"
+        )
+        migrated_events = (await cur.fetchone())[0]
+
+    assert all(a is not None for a in app_ids), "every receipt must be backfilled with an application_id"
+    assert migrated_events == receipt_count, "one 'applied' event per receipt, no more, no fewer"
+
+
+@pytest.mark.asyncio
+async def test_a_tailored_doc_with_a_polish_becomes_two_versions(pre_fold_db_path):
+    await runner.up(pre_fold_db_path)
+
+    async with _pg.connect(pre_fold_db_path) as db:
+        db.row_factory = _pg.Row
+        cur = await db.execute(
+            "SELECT version_no, made_by, text FROM application_artifacts "
+            "WHERE user_id = ? AND kind = 'cv' ORDER BY version_no",
+            (_USER,),
+        )
+        cv_rows = [dict(r) for r in await cur.fetchall()]
+        cur = await db.execute(
+            "SELECT version_no FROM application_artifacts WHERE user_id = ? AND kind = 'cover_letter'",
+            (_USER,),
+        )
+        cl_rows = [dict(r) for r in await cur.fetchall()]
+
+    assert [r["version_no"] for r in cv_rows] == [1, 2], "a draft + a polish must fold into TWO versions"
+    assert cv_rows[0]["made_by"] == "migration:0023_tailored"
+    assert cv_rows[0]["text"] == "draft text", "the draft must survive as its own version, not be overwritten"
+    assert cv_rows[1]["made_by"] == "human"
+    assert cv_rows[1]["text"] == "polished text — the edit"
+
+    assert [r["version_no"] for r in cl_rows] == [1], "a draft-only doc must fold into exactly ONE version"
+
+
+@pytest.mark.asyncio
+async def test_an_orphan_receipt_gets_its_application_row(pre_fold_db_path):
+    await runner.up(pre_fold_db_path)
+
+    async with _pg.connect(pre_fold_db_path) as db:
+        db.row_factory = _pg.Row
+        cur = await db.execute(
+            "SELECT status FROM applications WHERE user_id = ? AND job_id = ?", (_USER, _ORPHAN_JOB_ID)
+        )
+        row = await cur.fetchone()
+    assert row is not None, "a (user, job) present only in receipts must get its own applications row"
+    assert row["status"] == "applied", "a receipt means the user got at least that far (spec step 2)"
+
+
+@pytest.mark.asyncio
+async def test_status_backfill_maps_every_legacy_stage(pre_fold_db_path):
+    expected = {
+        "applied": "applied",
+        "outreach": "applied",
+        "interview": "interview_scheduled",
+        "offer": "offer",
+        "rejected": "rejected",
+        "ghosted": "ghosted",
+    }
+    await runner.up(pre_fold_db_path)
+
+    async with _pg.connect(pre_fold_db_path) as db:
+        db.row_factory = _pg.Row
+        for stage, want in expected.items():
+            job_id = 900 + _STAGES.index(stage)
+            cur = await db.execute(
+                "SELECT status, stage FROM applications WHERE user_id = ? AND job_id = ?", (_USER, job_id)
+            )
+            row = await cur.fetchone()
+            assert row is not None, f"seeded stage {stage!r} row went missing"
+            assert row["status"] == want, f"stage {stage!r} backfilled to {row['status']!r}, want {want!r}"
+            assert row["stage"] == stage, "the fold must never rewrite the legacy `stage` column"

--- a/backend/tests/test_oauth_server.py
+++ b/backend/tests/test_oauth_server.py
@@ -940,13 +940,18 @@ async def test_revoke_access_kills_refresh_too_and_always_200(authenticated_asyn
 
 @pytest.mark.asyncio
 async def test_migration_0036_up_down_up(migrated_db_path):
-    """`migrated_db_path` already ran `init_db()` + every migration (0036
-    included, since it's the newest) — this only exercises down()/up() on it,
-    matching the runner's real "reverse the LAST migration" contract."""
+    """`migrated_db_path` already ran `init_db()` + every migration — this
+    only exercises down()/up() on it, matching the runner's real "reverse the
+    LAST migration" contract. 0037 (application spine) is now the newest, so
+    it is reverted first to put 0036 back at the top before this test's own
+    up/down/up cycle."""
     from migrations import runner
     from src.repositories import pg as _pg
 
     db_path = migrated_db_path
+    reverted_0037 = await runner.down(db_path)
+    assert reverted_0037 == "0037_application_spine"
+
     oauth_tables = (
         "oauth_clients", "oauth_authorization_requests", "oauth_grants",
         "oauth_authorization_codes", "oauth_tokens",
@@ -967,7 +972,9 @@ async def test_migration_0036_up_down_up(migrated_db_path):
     for table in oauth_tables:
         assert not await _has_table(table), f"{table} still present after down()"
 
+    # `up()` with no target applies EVERY pending migration — 0037 (already
+    # reverted above) comes back along with 0036.
     reapplied = await runner.up(db_path)
-    assert reapplied == ["0036_oauth"]
+    assert reapplied == ["0036_oauth", "0037_application_spine"]
     for table in oauth_tables:
         assert await _has_table(table), f"{table} missing after re-up()"

--- a/backend/tests/test_search_flag.py
+++ b/backend/tests/test_search_flag.py
@@ -1,0 +1,87 @@
+"""The old search UI goes behind a flag, off by default (spec R12/R13).
+
+Frozen. `SEARCH_UI_ENABLED` and `CATALOG_CRONS_ENABLED` do not exist in
+`src/core/settings.py` yet, so every test below is expected to fail
+(AttributeError) until slice 2 adds them. Not a security control (S10): the
+search routes keep their existing `Depends` auth regardless of the flag —
+these tests only pin whether the FEATURE exists.
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_search_routes_404_when_the_flag_is_off(authenticated_async_context, monkeypatch):
+    from src.core import settings
+
+    monkeypatch.setattr(settings, "SEARCH_UI_ENABLED", False)
+
+    async with authenticated_async_context() as client:
+        started = await client.post("/api/search")
+        assert started.status_code == 404, started.text
+        status = await client.get("/api/search/anything/status")
+        assert status.status_code == 404, status.text
+
+
+@pytest.mark.asyncio
+async def test_search_routes_work_when_on(authenticated_async_context, monkeypatch):
+    from src.core import settings
+
+    monkeypatch.setattr(settings, "SEARCH_UI_ENABLED", True)
+
+    async with authenticated_async_context() as client:
+        started = await client.post("/api/search")
+        assert started.status_code != 404, started.text
+        assert started.status_code == 200, started.text
+        run_id = started.json()["run_id"]
+
+        status = await client.get(f"/api/search/{run_id}/status")
+        assert status.status_code != 404, status.text
+
+
+def test_catalog_crons_are_off_by_default(monkeypatch):
+    """`WorkerSettings.cron_jobs` builds ONCE at class-definition time (module
+    import), so exercising both flag states means re-importing both the
+    settings module (which defines the flag) and `src.workers.settings`
+    (whose class body reads it) — reassigning the constant after the fact
+    would test nothing about how `cron_jobs` is actually built.
+    """
+    monkeypatch.delenv("CATALOG_CRONS_ENABLED", raising=False)
+
+    import src.core.settings as settings
+    import src.workers.settings as worker_settings
+
+    importlib.reload(settings)
+    importlib.reload(worker_settings)
+    try:
+        names = {getattr(c.coroutine, "__name__", "") for c in worker_settings.WorkerSettings.cron_jobs}
+        assert "refresh_catalog" not in names, "refresh_catalog must be OFF by default"
+        assert "enrichment_sweep" not in names, "enrichment_sweep must be OFF by default"
+        assert "nightly_ghost_sweep" in names, "nightly_ghost_sweep must stay unconditional"
+        assert "notification_tick" in names, "notification_tick must stay unconditional"
+    finally:
+        importlib.reload(settings)
+        importlib.reload(worker_settings)
+
+
+def test_catalog_crons_on_with_the_flag(monkeypatch):
+    monkeypatch.setenv("CATALOG_CRONS_ENABLED", "1")
+
+    import src.core.settings as settings
+    import src.workers.settings as worker_settings
+
+    importlib.reload(settings)
+    importlib.reload(worker_settings)
+    try:
+        names = {getattr(c.coroutine, "__name__", "") for c in worker_settings.WorkerSettings.cron_jobs}
+        assert "refresh_catalog" in names
+        assert "enrichment_sweep" in names
+        assert "nightly_ghost_sweep" in names
+        assert "notification_tick" in names
+    finally:
+        monkeypatch.delenv("CATALOG_CRONS_ENABLED", raising=False)
+        importlib.reload(settings)
+        importlib.reload(worker_settings)

--- a/backend/tests/test_worker_settings.py
+++ b/backend/tests/test_worker_settings.py
@@ -94,23 +94,40 @@ def test_arq_not_imported_at_module_top():
             del sys.modules["src.workers.settings"]
 
 
-def test_worker_schedules_the_daily_catalog_refresh():
-    """The SHARED job catalog must refill on a schedule, not only when a human
-    clicks Search.
+def test_worker_schedules_the_daily_catalog_refresh(monkeypatch):
+    """The SHARED job catalog refills on a schedule when the operator opts in.
 
     Measured in prod 2026-07-27: `run_log` held 11 rows in 25 days and the
     catalog showed 5,827 jobs fetched all-time vs 112 visible — because nothing
     refills it between user searches while `purge_old_jobs` removes anything
     older than 30 days. Every instrument stayed green the whole time: this is an
     ABSENCE failure, which no presence-detector can see.
-    """
-    from src.workers.settings import WorkerSettings
 
-    crons = WorkerSettings.__dict__.get("cron_jobs", [])
-    names = {
-        getattr(getattr(c, "coroutine", None), "__name__", "") for c in crons
-    }
-    assert "refresh_catalog" in names, f"no catalog-refresh cron registered: {names}"
+    R13 (docs/plans/2026-09-04-application-spine/spec.md) — the mission is
+    "the agent finds the job, Job360 remembers" (VISION rule 4: never source
+    or rank). `refresh_catalog` is legacy sourcing, so it is now OFF by
+    default and only cron-scheduled when `CATALOG_CRONS_ENABLED=1`; the
+    default-off state is pinned by
+    tests/test_search_flag.py::test_catalog_crons_are_off_by_default.
+    """
+    import importlib
+
+    monkeypatch.setenv("CATALOG_CRONS_ENABLED", "1")
+    import src.core.settings as settings
+    import src.workers.settings as worker_settings
+
+    importlib.reload(settings)
+    importlib.reload(worker_settings)
+    try:
+        crons = worker_settings.WorkerSettings.__dict__.get("cron_jobs", [])
+        names = {
+            getattr(getattr(c, "coroutine", None), "__name__", "") for c in crons
+        }
+        assert "refresh_catalog" in names, f"no catalog-refresh cron registered: {names}"
+    finally:
+        monkeypatch.delenv("CATALOG_CRONS_ENABLED", raising=False)
+        importlib.reload(settings)
+        importlib.reload(worker_settings)
 
 
 def test_worker_settings_functions_includes_refresh_catalog():

--- a/docs/README.md
+++ b/docs/README.md
@@ -83,6 +83,7 @@ docs at the repo root). Start here to find the right doc fast.
 | [`post_application.md`](product/post_application.md) | 🗄️ "After you apply" co-pilot design — the agent does this now (rule 5); we store what happened. |
 | [`plans/2026-06-21-free-premium-plans.md`](product/plans/2026-06-21-free-premium-plans.md) | 🗄️ Free/Premium tier design — not planned (rule 6). |
 | [`plans/2026-09-03-oauth-mcp/`](plans/2026-09-03-oauth-mcp/) | Slice 1 of the pivot (shipped, PR #488): OAuth 2.1 authorization server for MCP clients (intent / spec with security section / plan + diff-vs-plan). |
+| [`plans/2026-09-04-application-spine/`](plans/2026-09-04-application-spine/) | Slice 2 of the pivot (branch `feat/application-spine`, awaiting review/PR): one Application object, an append-only typed event log, versioned artifacts, the stored (never computed) fit verdict, `whats_new` / `export_history`, the applications home (intent / spec with security section / plan). |
 | [`References.md`](harness/References.md) | Source-of-truth list of external references and research links. |
 
 ## 📘 Engine evaluation

--- a/docs/plans/2026-09-04-application-spine/intent.md
+++ b/docs/plans/2026-09-04-application-spine/intent.md
@@ -1,0 +1,102 @@
+<!-- doc: PLAN | status: ACTIVE | pr: — -->
+# Intent: one Application object that remembers everything (the spine)
+Author: Ranjith (owner), decisions 3, 6, 7, 10, 11, 13 and build-order step 2 of
+`docs/product/VISION.md` (2026-09-03). Issue #480. Status: draft — owner approves by merging.
+
+## Problem
+The thing Job360 exists to be — *the memory of a job hunt* — is currently four half-objects
+that do not know about each other:
+
+| Table | Born | Holds | Loses |
+|---|---|---|---|
+| `applications` (0002 + 0014) | only at "I applied" | one `stage` string, free-text `notes` | everything before the click; a stage move overwrites the last one |
+| `application_stage_history` (0014) | on `advance_application` | from→to stage | who moved it, why, anything that is not a stage |
+| `application_receipts` (0034) | at "I applied" | frozen job + document text | which *version* of the CV; nothing after the click |
+| `tailored_documents` (0023) | on tailor | ONE row per (user, job, kind) | every earlier draft — `upsert_tailored_doc` is DELETE+INSERT (`database.py:1011-1043`) |
+
+So the four questions the product is *for* have no answer: **which CV version did I send,
+what happened afterwards, who recorded it, what changed since Tuesday.** An agent that
+brings a job today gets a `job_id` and a score — there is nowhere to put the fit verdict it
+just wrote, the third draft it just produced, or the recruiter reply it just read in Gmail.
+
+Two live facts make this urgent rather than tidy:
+- **A brought job is deleted after 30 days.** `purge_old_jobs` (`backend/src/repositories/
+  database.py:775-830`) keys on `last_seen_at` and has **no `source='user_brought'`
+  exemption**; `applications` is not in `_PURGE_CASCADE_TABLES` (`database.py:35-40`), so the
+  application survives pointing at a job row that no longer exists and `_get_application`'s
+  LEFT JOIN returns a blank title. Hard rule #3 already flags this as slice 2's job.
+- **Nothing that runs today writes history.** Prod, measured 2026-09-04 via
+  `railway run -s Postgres`: `applications` 3, `application_stage_history` **0**,
+  `application_receipts` **0**, `tailored_documents` 8, `jobs` 19 196, `users` 14.
+
+## Proposed outcome
+One **Application** object, born the moment a job is brought, that owns its own history.
+
+The owner pastes a job into Claude Code. Job360 answers with an `application_id` and status
+`considering`, having copied the ad onto the application so it can never go blank. The agent
+writes a fit verdict — Job360 **stores** it, never computes it. The agent writes a CV; that
+is artifact `cv` v1, kept forever with the model and profile version that made it. It writes
+a better one: v2. **v1 is still readable.** The owner applies with v2 and the receipt names
+that exact version. A week later the agent reads Gmail with its own connector and calls
+`record_event("replied")`, then `record_event("interview_requested")`. Nothing is ever
+overwritten and nothing is ever deleted; a mistake is corrected by a new event that points
+at the old one.
+
+`whats_new` answers "what changed since I last looked" — pull, not push (decision 11). The
+web home stops being a search dashboard and becomes **your applications**. The old search UI
+goes behind `SEARCH_UI_ENABLED=false` and the catalog crons go off, so the code stops
+claiming to do a thing the product no longer does.
+
+Same object over REST and MCP — eight tools: `get_application`, `list_applications`,
+`save_artifact`, `save_fit`, `record_event`, `record_application`, `whats_new`,
+`export_history`.
+
+## Affected users and systems
+- **The owner first** — the one measure is that he runs his own hunt through this.
+- Backend: migration `0037_application_spine` (three new tables, new columns on
+  `applications` and `application_receipts`, a lossless fold of the four legacy tables); a
+  new `src/api/routes/applications.py`; `bring.py` and `receipts.py` write through to the
+  spine; seven new MCP tools plus an enriched `record_application`; `purge_old_jobs` learns
+  to spare a brought job; `src/workers/settings.py` cron list becomes conditional.
+- Frontend: `/applications` and `/applications/[id]`; root `/` becomes the applications home
+  for a signed-in user (and stops advertising "41 Sources"); `/dashboard` behind the flag.
+- Nothing in production is running the crons anyway — `worker` and `Redis` were deleted from
+  Railway 2026-09-02. Turning them off is about the code telling the truth, and about local
+  and dev runs.
+
+## Constraints (owner's words + VISION rules, made rules)
+1. **We store, the agent thinks** (product rules 4–5, hard rules M1/M2). The fit verdict is
+   a column we write what we are told into — never a number we compute. No ranking, no
+   recommending, no scorer in the product path. New-feature test: if Claude Code could do it
+   with its own tools, expose a **store** tool, not a **do** tool.
+2. **Nothing rewrites history** (M3). The event log and the artifact table are append-only:
+   no `UPDATE`, no `DELETE`, no PATCH/PUT/DELETE route. A wrong event is retired by a
+   correcting event that names it, exactly like a ledger reversal.
+3. **Not one row may be lost.** The fold copies; it never moves or deletes. Every legacy
+   table is still there and still readable after the migration, and the down migration
+   leaves every pre-migration row exactly where it was.
+4. **Backwards compatible on purpose.** Agents in the wild already call `POST /jobs/bring`
+   and `POST /receipts/{job_id}`. Both keep working and write through to the spine.
+5. **Anything that varies is a parameter**: the event vocabulary, every size cap, the export
+   bounds, the search-UI flag, the cron switch. No CHECK constraint on the event type — a
+   new event type must never need a migration.
+6. **Authorship is derived, never declared.** `recorded_by` comes from the credential that
+   made the call (session, personal token, OAuth grant). A caller cannot claim to be someone
+   else, because the field is not in the request body.
+7. **Same routes, same rules** (M5). Every MCP tool calls the route function, and every gate
+   the route declares is re-applied by hand in `mcp_server.py` — parity is enforced by
+   `tests/test_mcp_gate_parity.py`, which turns red for any tool without a table row.
+
+## Open questions (resolved here, so the build does not re-litigate them)
+- **Two homes for one fact, for a while.** `applications.status` (spine) and
+  `applications.stage` (legacy pipeline UI) both exist until slice 5. Resolved: `status` is
+  the truth, `stage` is a written-through projection via one mapping table. Same for
+  `tailored_documents`, which the web tailor keeps writing *and* now also mirrors into an
+  artifact version.
+- **One Application per (user, job), or one per attempt?** Resolved: one per (user, job) —
+  the existing `UNIQUE(user_id, job_id)` stands. Re-applying months later is a second
+  `applied` event and a second receipt under the same application, which is what
+  `application_receipts` already allows by design (0034's header).
+- **Contacts and `stats`** are slice 4 (#482), not here. `outreach` is a valid artifact kind
+  from day one so slice 4 adds no schema.
+- **URL fetch** is slice 3 (#481). `bring_job` still takes pasted text.

--- a/docs/plans/2026-09-04-application-spine/plan.md
+++ b/docs/plans/2026-09-04-application-spine/plan.md
@@ -1,0 +1,157 @@
+<!-- doc: PLAN | status: ACTIVE | pr: — -->
+# Plan: the application spine
+Reads: `intent.md`, `spec.md`. Branch `feat/application-spine` off `main` 90ab21b. Process
+(issue #480): Opus attacks the spec's security + fold sections → Sonnet writes the frozen
+tests red → Sonnet builds → Fable reviews (bugs + conventions + spec compliance) → verifier
+walks the real browser and a real MCP client → draft PR → **owner merges**.
+
+## Files that change
+
+Backend — migration
+- `backend/migrations/0037_application_spine.up.sql` / `.down.sql` — two new tables, 12
+  columns on `applications`, 7 on `application_receipts`, the eight fold steps, the down
+  header stating exactly what a rollback costs (spec §Migration fold).
+
+Backend — settings and services
+- `backend/src/core/settings.py` — `SEARCH_UI_ENABLED`, `CATALOG_CRONS_ENABLED`,
+  `APPLICATION_STATUS_EVENT_TYPES`, `APPLICATION_NOTE_EVENT_TYPES`,
+  `APPLICATION_EXTRA_EVENT_TYPES`, `APPLICATION_EVENT_DETAIL_MAX_CHARS`,
+  `APPLICATION_EVENT_PAYLOAD_MAX_BYTES`, `APPLICATION_EVENT_MAX_FUTURE_SECONDS`,
+  `APPLICATION_ARTIFACT_MAX_CHARS`, `APPLICATION_ARTIFACT_MAX_VERSIONS`,
+  `APPLICATION_ARTIFACT_KINDS`, `APPLICATION_RECEIPT_ANSWERS_MAX`,
+  `APPLICATION_RECEIPT_FIELDS_MAX_BYTES`, `APPLICATION_FIT_REASONING_MAX_CHARS`,
+  `WHATS_NEW_DEFAULT_WINDOW_DAYS`, `WHATS_NEW_MAX_EVENTS`,
+  `EXPORT_HISTORY_MAX_APPLICATIONS`, `EXPORT_HISTORY_MAX_BYTES`,
+  `EXPORT_HISTORY_MAX_PER_HOUR`. All via the existing `_env_flag` (`settings.py:418`) /
+  `int(os.getenv(...))` style, plus one small `_env_list`.
+- `backend/src/services/applications/__init__.py` (new).
+- `backend/src/services/applications/status.py` (new) — event→status map, the legacy
+  `stage` projection dict (spec R4), `replay_status(events)` used by both the writer and
+  the frozen rebuildability test.
+- `backend/src/services/applications/authorship.py` (new) — `actor_for(user) -> str`
+  (`web` / `token:<name>` / `agent:<client>`), the single place `recorded_by` and `made_by`
+  are produced (spec S3).
+- `backend/src/services/applications/spine.py` (new) — birth-at-bring, `record_event`,
+  `save_artifact` (version allocation), `save_fit`, `record_receipt`, `whats_new`,
+  `export_history`. Pure validation helpers (`validate_event_type`, `parse_occurred_at`,
+  `payload_bytes`) are module-level so tests hit them with no DB.
+
+Backend — routes and the agent surface
+- `backend/src/api/routes/applications.py` (new) — the eight tools' REST side plus
+  `GET /applications/{id}/artifacts/{artifact_id}`; `/applications/export` declared **before**
+  `/applications/{application_id}` (spec §Tool contracts).
+- `backend/src/api/main.py` — `include_router(applications.router, prefix="/api")`.
+- `backend/src/api/routes/bring.py` — create/find the application, snapshot the ad, append
+  `brought`, return `application_id` + `status` (spec R1/R2).
+- `backend/src/api/routes/receipts.py` — `create_receipt` writes through to the spine
+  (spec R8); route shape unchanged.
+- `backend/src/api/routes/tailor.py` — `generate` and `save_edit` also write an artifact
+  version (spec R15).
+- `backend/src/api/routes/search.py` — 404 both routes when `SEARCH_UI_ENABLED` is off
+  (spec R12).
+- `backend/src/api/mcp_server.py` — seven new tools, `record_application` enriched,
+  `bring_job` returns `application_id`; each tool re-applies its route's gate by hand (M5).
+- `backend/src/repositories/database.py` — spine query helpers; `application_events` +
+  `application_artifacts` into `_PER_USER_TABLES` (`:1779`) and `_EXPORT_TABLES` (`:1798`);
+  `purge_old_jobs` (`:775`) excludes `settings.USER_BROUGHT_SOURCE`.
+- `backend/src/workers/settings.py:232,239` — `refresh_catalog` and `enrichment_sweep`
+  appended only when `CATALOG_CRONS_ENABLED`.
+- `backend/scripts/observe.py:43` — both new tables in `PER_USER_TABLES`.
+
+Backend — tests
+- `backend/tests/test_application_spine.py` (new, frozen — spec items 1–29).
+- `backend/tests/test_migration_0037.py` (new, frozen — items 30–35).
+- `backend/tests/test_search_flag.py` (new, frozen — items 36–37).
+- `backend/tests/test_mcp_gate_parity.py` — seven `TOOL_ROUTES` rows (`:33-42`).
+- `backend/tests/conftest.py` — `monkeypatch.setenv("SEARCH_UI_ENABLED", "1")` beside the
+  existing `LOOP_WATCHDOG_ENABLED` line (`:148`) so the legacy search suite still runs.
+
+Frontend
+- `frontend/src/app/page.tsx` — applications home when the session cookie is present, the
+  existing landing when not; landing copy loses "41 Sources" (spec R14).
+- `frontend/src/app/applications/page.tsx` (new) — the list.
+- `frontend/src/app/applications/[id]/page.tsx` + `ApplicationClient.tsx` (new) — server
+  page **awaits `params`** (Next 16, hard rule #22) with a client child for interactivity,
+  same shape as `oauth/consent/[rid]`.
+- `frontend/src/components/applications/{ApplicationList,Timeline,ArtifactVersions,FitPanel}.tsx`
+  (new).
+- `frontend/src/components/layout/Navbar.tsx:22-29` — `NAV_LINKS` gains Applications, drops
+  Dashboard when the flag is off.
+- `frontend/src/middleware.ts` — `/applications` into `PROTECTED_PATHS:7-18`; `/dashboard`
+  and `/jobs` 404 when `NEXT_PUBLIC_SEARCH_UI_ENABLED` is off. `/` stays public.
+- `frontend/src/lib/api.ts` — eight helpers + `getArtifact`;
+  `frontend/src/lib/api-types.ts` + `frontend/openapi.json` regenerated by
+  `npm run gen:types` (never hand-edited; `check:types-drift` blocks the commit otherwise).
+- `frontend/tests/e2e/applications-home.spec.ts` (new, frozen — item 38).
+
+Docs and config
+- `.env.example` + `frontend/.env.example` — `SEARCH_UI_ENABLED`,
+  `NEXT_PUBLIC_SEARCH_UI_ENABLED`, `CATALOG_CRONS_ENABLED` and the caps.
+- `ARCHITECTURE.md` — regenerated blocks (migration head, route table, env table) via
+  `scripts/gen_doc_blocks.py`; DB-schema section gains the two tables.
+- `docs/README.md` — index row for `plans/2026-09-04-application-spine/`.
+- `.claude/skills/hard-rules/SKILL.md` — rule #3 records that slice 2 exempted
+  `user_brought` from `purge_old_jobs`; M3 gains the two new append-only tables and their
+  guard test names.
+- `STATUS.md` — head moves to slice 2.
+
+## Order of work
+1. **Opus adversarial pass** on `spec.md` §Security guardrails and §Migration fold (effort
+   high). Fold findings into the spec **before** any code — especially the fold's
+   transaction boundaries and the `recorded_by` derivation.
+2. **Sonnet A**: migration `0037` up/down + `test_migration_0037.py` red.
+   **Sonnet B** (parallel): `test_application_spine.py` + `test_search_flag.py` red, and the
+   `TOOL_ROUTES` rows.
+   **Sonnet C** (parallel): the Playwright spec red + `api.ts` helper stubs.
+3. **Sonnet A**: `services/applications/*` + `routes/applications.py` + `database.py`
+   helpers until the spine tests pass.
+   **Sonnet B**: write-through in `bring.py` / `receipts.py` / `tailor.py`, the search flag,
+   the cron switch, `mcp_server.py` tools + gate parity.
+   **Sonnet C**: the applications pages, the home split, nav, middleware.
+4. Regenerate `api-types`; `python -m mypy` ratchet at zero; `ruff`; targeted pytest;
+   `npm run type-check`, `lint`, `test:unit`, `check:types-drift`.
+5. **Fable review**: `reviewer-bugs` + `reviewer-conventions` on the diff, plus a
+   spec-compliance table (every R and S numbered against a file:line). Fix Important
+   findings **in the code, never in the frozen tests**.
+6. **Verifier** (`verify-job360`): a real MCP client walks the done-when — bring → save
+   `cv` v1 → save `cv` v2 → `record_application` naming v2 → `record_event replied` →
+   `record_event interview_requested` → `whats_new`; then the browser opens `/` and the
+   application page and reads both CV versions. The table goes in the PR body.
+7. `git add -A && bash scripts/agent-gate.sh` (run from `D:\dev\job360` — the gate hashes
+   the session cwd and is worktree-blind); commit; push; **draft** PR; memory note.
+
+Model economy: Opus for the migration fold, the authorship/ownership code and the review;
+Sonnet for the routes, the MCP tool wrappers, the pages and the test bodies. Nobody
+self-certifies — worker output comes back through the manager.
+
+## Risks
+- **The fold is the only irreversible-feeling step.** Mitigated by design: it copies and
+  never deletes, so the down migration leaves every pre-migration row untouched (spec
+  §Migration fold). The residual risk is post-migration events being dropped on a rollback;
+  the down file says so in its header, and the owner should take a `db-backup` run before
+  merging.
+- **Two vocabularies (`status` vs `stage`) until slice 5** — a wrong mapping dict silently
+  changes what the Kanban board shows. One dict, one frozen test over all six legacy stages.
+- **Route-order collision** on `/applications/export` vs `/applications/{id}` — declared in
+  the right order, and a test hits `/applications/export` to prove it.
+- **`test_route_auth_coverage.py` and `test_mcp_gate_parity.py` will both go red** on the
+  first new route/tool. That is the guard working; the fix is a row, never a skip.
+- **`conftest` turning `SEARCH_UI_ENABLED` on for the suite** hides the off-state everywhere
+  except `test_search_flag.py`. Accepted deliberately: the alternative is touching hundreds
+  of legacy search tests that slice 5 deletes anyway.
+- **Windows full-suite flake** (psycopg exit 139 on a second back-to-back run) — targeted
+  gate locally, Linux CI is the verdict.
+- **`NEXT_PUBLIC_SEARCH_UI_ENABLED` is build-time** — a redeploy, not a restart (spec C2).
+
+## Proof
+- Every frozen test in `spec.md` §Frozen tests green, plus `test_mcp_gate_parity.py` and
+  `test_receipts.py::test_receipts_are_append_only` still green and untouched.
+- Migration proof measured, not quoted: row counts for the four legacy tables before and
+  after `up`, then after `down`, then after `up` again — the table in spec §Migration fold,
+  printed in the PR body.
+- The verifier's done-when walk (step 6) as a table in the PR: each step, the tool called,
+  the id returned, what `whats_new` showed.
+- After merge, on production: `railway run -s Postgres` re-runs the same count query
+  (baseline recorded 2026-09-04: applications 3 · stage_history 0 · receipts 0 ·
+  tailored_documents 8) and the owner brings one real job through Claude Code. Prod is the
+  only place the owner's daily-use measure can be closed.

--- a/docs/plans/2026-09-04-application-spine/spec.md
+++ b/docs/plans/2026-09-04-application-spine/spec.md
@@ -1,0 +1,537 @@
+<!-- doc: PLAN | status: ACTIVE | pr: — -->
+# Spec: the application spine
+Reads: `intent.md`. Skills applied: `hard-rules` (M1 never source/rank, M2 store-not-do,
+M3 one door for history, M5 MCP gate parity, #3 purge, #10 no `user_id` on `jobs`,
+#12/#25 every per-user route scopes by `user.id`, #16 lazy imports, #21 value-presence
+tests). Status: draft, pre-adversarial-review.
+
+## Measured starting point (2026-09-04, `railway run -s Postgres`)
+`applications` 3 · `application_stage_history` 0 · `application_receipts` 0 ·
+`tailored_documents` 8 · `jobs` 19 196 · `users` 14. The fold touches 11 real rows in
+production; the migration is still written to be correct for any size.
+
+## Requirements
+
+R1. **An Application is born at `bring_job`.** `POST /jobs/bring` (`backend/src/api/routes/
+    bring.py:79`) additionally, in one transaction: upserts the `applications` row for
+    `(user.id, job_id)` with `status='considering'`, copies the ad onto it (R2 snapshot),
+    and appends a `brought` event. Response gains `application_id: int` and `status: str`;
+    `job`, `existing`, `scored` are unchanged (constraint 4). Bringing the same job twice
+    returns the same `application_id` and appends **no second** `brought` event
+    (`existing=true`), because the row already exists.
+
+R2. **The job snapshot lives on the application.** `job_title`, `job_company`,
+    `job_location`, `job_url`, `job_source`, `job_description_snapshot`, `snapshot_at` are
+    copied at birth, never joined. Reason, verified: `purge_old_jobs`
+    (`backend/src/repositories/database.py:775-830`) deletes any `jobs` row whose
+    `COALESCE(last_seen_at, first_seen)` is older than 30 days, has **no**
+    `source='user_brought'` exemption, and `applications` is not in
+    `_PURGE_CASCADE_TABLES` (`database.py:35-40`) — so today the application silently goes
+    blank. **Both fixes ship**: the snapshot (durable answer) *and*
+    `purge_old_jobs` gains `AND source <> ?` bound to `settings.USER_BROUGHT_SOURCE`
+    (`settings.py:169`) so the live catalog row also survives for the detail page. This is
+    the hard-rule-#3 amendment the rule itself asks for.
+
+R3. **The event log is the history, and it is append-only.** One door,
+    `POST /applications/{id}/events`. Every event carries `event_type` (R7 enum), `detail`
+    (free text), `payload` (JSON object), `occurred_at` (when it happened in the world —
+    the agent supplies it; backdating is legitimate), `recorded_at` (when we stored it),
+    `recorded_by` (S3, derived) and optional `corrects_event_id`. **No UPDATE and no DELETE
+    exists anywhere**: no PATCH/PUT/DELETE route, and a grep guard over `backend/src/`
+    (same shape as `tests/test_receipts.py::test_receipts_are_append_only:125`). A wrong
+    event is retired by a new event whose `corrects_event_id` names it; reads mark the
+    target `superseded: true` and the status recompute skips it.
+
+R4. **`applications.status` is a cache of the last status event, and must be rebuildable.**
+    A status-bearing event (R7) sets `status`, `last_event_at` and `updated_at` in the same
+    transaction that inserts the event. Denormalised because `list_applications` and the
+    web home sort and filter on it and must not read the whole log. A frozen test replays
+    the events and asserts the same value, so the cache can never drift silently.
+    Write-through: `applications.stage` (legacy, read by `/api/pipeline`) is set from the
+    new status by one mapping dict in `src/services/applications/status.py`:
+    `considering→applied` is **not** written (a considering row has no legacy stage; `stage`
+    keeps its `applied` default and the pipeline board is unchanged until slice 5),
+    `applied→applied`, `replied→applied`, `interview_requested|interview_scheduled|
+    interview_done→interview`, `offer→offer`, `rejected→rejected`, `withdrawn→rejected`,
+    `ghosted→ghosted`. The dict is the only place the two vocabularies meet.
+
+R5. **Artifacts are versioned forever.** `POST /applications/{id}/artifacts` with `kind`
+    (`cv` | `cover_letter` | `answers` | `outreach`), `text`, optional `label`, optional
+    `model`. The server allocates `version_no = COALESCE(MAX(version_no), 0) + 1` per
+    `(application_id, kind)` inside the insert transaction; `UNIQUE(application_id, kind,
+    version_no)` turns a race into a retry, never a duplicate. `made_by` and
+    `profile_version` are stamped by the server (S3), never taken from the body. An
+    `artifact_saved` event is appended with `{artifact_id, kind, version_no}` in `payload`.
+    Nothing ever updates or deletes an artifact row (same grep guard as R3).
+
+R6. **The fit verdict is stored, never computed** (VISION rule 4). `PUT /applications/{id}/
+    fit` with `score` (0–100, optional), `verdict` (short string), `gaps` (list of strings),
+    `reasoning` (text). It overwrites the slot on `applications` **and** appends a
+    `fit_judged` event carrying the whole verdict in `payload` — so the slot is "the current
+    answer" and the log is the version history. No scorer, matcher, judge or enrichment call
+    is made on this path; `save_fit` never reads `skill_matcher`.
+
+R7. **Event vocabulary — closed set in code, extensible without a migration.**
+    `src/core/settings.py`:
+    ```
+    APPLICATION_STATUS_EVENT_TYPES = ("brought", "applied", "replied", "interview_requested",
+        "interview_scheduled", "interview_done", "offer", "rejected", "withdrawn", "ghosted")
+    APPLICATION_NOTE_EVENT_TYPES  = ("fit_judged", "artifact_saved", "contact_added",
+        "outreach_sent", "note", "lesson")
+    APPLICATION_EXTRA_EVENT_TYPES = _env_list("APPLICATION_EXTRA_EVENT_TYPES", ())  # non-status only
+    ```
+    `brought` maps to status `considering`; every other status event's name **is** the
+    status. Validation is **app-level, not a CHECK constraint** — a new event type must
+    never need a migration (constraint 5), and an env-added type can only be a non-status
+    one because a status type also needs an R4 mapping. Unknown type → 422 naming the
+    allowed list. A frozen test asserts the two tuples equal the list in
+    `docs/product/VISION.md:66-71` so doc and code cannot drift.
+
+R8. **`record_application` is the rich receipt** (decision 10). `POST /applications/{id}/
+    receipt` takes `channel`, `note`, `confirmation`, `answers` (list of `{question,
+    answer}`), `fields_filled` (JSON object), `cv_artifact_id`, `cover_letter_artifact_id`,
+    `applied_at`. Artifact ids default to the newest version of that kind; a supplied id
+    must belong to this application and this user or the call is 404 (S4). The receipt
+    still **copies the text** as well as naming the version — the frozen copy is 0034's
+    whole contract and a version id is not a substitute. It appends an `applied` event.
+    The legacy `POST /receipts/{job_id}` (`receipts.py:99`) keeps working unchanged from the
+    caller's side and now writes through: resolves/creates the application, fills
+    `application_id`, appends the `applied` event.
+
+R9. **`whats_new`.** `GET /whats-new?since=<ISO8601>&after_id=<int>&limit=<n>` → 200
+    `{now, since, events: [...], applications: [{id, job_title, job_company, status,
+    last_event_at}], next_since, next_after_id, truncated}`. **Ordered and paged by
+    `recorded_at`, not `occurred_at`** — `occurred_at` is agent-supplied and may be in the
+    past, so a cursor on it would silently skip backdated events. `(recorded_at, id)` is the
+    cursor pair because `recorded_at` collides. `since` defaults to
+    `WHATS_NEW_DEFAULT_WINDOW_DAYS` (7) ago; `limit` capped at `WHATS_NEW_MAX_EVENTS` (200)
+    with `truncated: true` when the cap bites. `applications` lists only those touched in
+    the window.
+
+R10. **`export_history`.** `GET /applications/export?since=&include_text=false` → the user's
+     applications, their events, and artifact **metadata** (id, kind, version_no, made_by,
+     model, profile_version, chars, created_at); artifact and receipt text only when
+     `include_text=true`. Bounds are explicit, never silent: `EXPORT_HISTORY_MAX_APPLICATIONS`
+     (500) and `EXPORT_HISTORY_MAX_BYTES` (8 MiB) — on either, the response stops at an
+     application boundary and returns `truncated: true` with `next_since`. Rate-limited
+     `EXPORT_HISTORY_MAX_PER_HOUR` (12) per **user** (not per IP — every agent shares the
+     proxy IP behind the Next rewrite, the `JOB360_TRUST_PROXY` trap from the OAuth slice).
+
+R11. **`get_application` / `list_applications`.**
+     `GET /applications/{id}?with_artifact_text=false` → `{id, job_id, status, created_at,
+     updated_at, last_event_at, job: {…snapshot…, catalog_present}, fit: {…} | null,
+     artifacts: [{id, kind, version_no, made_by, model, profile_version, label, chars,
+     created_at, text?}], events: [{id, event_type, detail, payload, occurred_at,
+     recorded_at, recorded_by, corrects_event_id, superseded}], receipts: [{id, sent_at,
+     channel, confirmation, cv_artifact_id, cover_letter_artifact_id, note}]}`.
+     Artifact **text is off by default** — ten CV versions is ~80 KB and would blow an
+     agent's context on every read. With `with_artifact_text=true` the texts are included
+     newest-first up to `EXPORT_HISTORY_MAX_BYTES / 4`; versions past the cap come back with
+     `text: null, truncated: true`. One version in full is always available at
+     `GET /applications/{id}/artifacts/{artifact_id}` (this is how "every version still
+     readable" is met without an unbounded default read).
+     `GET /applications?status=&limit=&offset=&updated_since=` → `{applications: [summary],
+     total}`, newest `last_event_at` first; summary is the snapshot fields, status, counts
+     (`events`, `artifacts` per kind, `receipts`) — no bodies.
+
+R12. **The old search UI goes behind a flag, off.** New `SEARCH_UI_ENABLED` (default
+     **false**), both sides:
+     - Backend `src/core/settings.py` `SEARCH_UI_ENABLED = _env_flag("SEARCH_UI_ENABLED",
+       False)`. `POST /api/search` and `GET /api/search/{run_id}/status`
+       (`routes/search.py:174,264`) answer **404** when off — a hidden UI in front of a live
+       route is cosmetic, and slice 5 deletes a route nobody can reach. `backend/tests/
+       conftest.py` sets `SEARCH_UI_ENABLED=1` for the suite (one `monkeypatch.setenv`
+       beside the existing `LOOP_WATCHDOG_ENABLED` line at `conftest.py:148`) so the legacy
+       search tests keep running; two new tests pin the gate in both positions.
+     - Frontend `NEXT_PUBLIC_SEARCH_UI_ENABLED` (default false, read the same way as
+       `NEXT_PUBLIC_API_URL` at `frontend/src/lib/api.ts:47`): `middleware.ts` 404s
+       `/dashboard` and `/jobs` (the redirect page) when off, and `Navbar.tsx:22-29` drops
+       the Dashboard link. **Trap to state in the PR:** `NEXT_PUBLIC_*` is inlined at build
+       time, so flipping it needs a redeploy, not a restart.
+     - Not a security control. The search routes keep `Depends(require_user)` exactly as
+       today; the flag hides a feature, it does not protect anything.
+
+R13. **Catalog crons off by parameter, not deletion.** `src/workers/settings.py:232,239` —
+     `refresh_catalog` and `enrichment_sweep` are appended to `cron_jobs` only when
+     `CATALOG_CRONS_ENABLED` (default **false**). `nightly_ghost_sweep` and
+     `notification_tick` stay unconditional. Nothing runs any of this in production (the
+     `worker` and `Redis` services were deleted 2026-09-02); the change is code
+     truthfulness and local/dev behaviour.
+
+R14. **The web home is your applications.** `frontend/src/app/page.tsx` renders the
+     applications home for a signed-in user (session cookie present) and keeps the existing
+     landing page for a signed-out visitor — `/` is deliberately **not** in
+     `middleware.ts` `PROTECTED_PATHS:7-18` (unfurl bots and `landing-cta-auth.spec.ts`
+     depend on the public landing) and must stay out. The landing copy loses "41 Sources"
+     — advertising sourcing contradicts VISION rule 4. New `/applications` (list) and
+     `/applications/[id]` (the record: status, timeline, every artifact version, receipts,
+     fit verdict, the tailor button). `/pipeline` and `/receipts` keep working by URL but
+     leave `NAV_LINKS`; slice 5 removes them.
+
+R15. **Our tailoring stays, as a web fallback.** `POST /tailor/{job_id}/generate`
+     (`routes/tailor.py:111`) is unchanged for the caller and additionally writes each
+     generated document as an artifact version (`made_by="web:tailor"`, `model` from the
+     generator, `profile_version` as today). `tailored_documents` keeps its DELETE+INSERT
+     behaviour — that table is the editor's working copy; the artifact table is the memory.
+     `PATCH /tailor/{job_id}/{doc_kind}` (save an edit) writes a further artifact version
+     with `made_by="human"`.
+
+## Data model (migration `0037_application_spine`)
+
+Conventions copied from 0034/0036: TEXT ISO-8601 timestamps, `IF NOT EXISTS`,
+`INTEGER PRIMARY KEY AUTOINCREMENT` (the shim rewrites it to `BIGSERIAL`,
+`pg.py:193-195`), inline `REFERENCES users(id) ON DELETE CASCADE` written for documentation
+value even though **the shim strips every FK clause** (`pg.py:217-226`) — meaning there is
+no database-level cascade or integrity here, so every read filters on `user_id` by hand and
+account deletion goes through `_PER_USER_TABLES`.
+
+**`applications` — ALTER, 12 new columns** (existing `id, user_id, job_id, stage, notes,
+created_at, updated_at, last_advanced_at, interview_dates, notes_history` and
+`UNIQUE(user_id, job_id)` all stay):
+```
+status TEXT NOT NULL DEFAULT 'considering'
+last_event_at TEXT
+job_title TEXT NOT NULL DEFAULT ''      job_company TEXT NOT NULL DEFAULT ''
+job_location TEXT NOT NULL DEFAULT ''   job_url TEXT NOT NULL DEFAULT ''
+job_source TEXT NOT NULL DEFAULT ''     job_description_snapshot TEXT NOT NULL DEFAULT ''
+snapshot_at TEXT
+fit_score INTEGER   fit_verdict TEXT   fit_gaps TEXT DEFAULT '[]'   fit_reasoning TEXT
+fit_recorded_by TEXT   fit_recorded_at TEXT
+```
+Indexes: `idx_applications_user_last_event ON applications(user_id, last_event_at DESC)`,
+`idx_applications_user_status ON applications(user_id, status)`.
+
+**`application_events` — NEW:**
+```
+id INTEGER PRIMARY KEY AUTOINCREMENT
+user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE
+application_id INTEGER NOT NULL
+event_type TEXT NOT NULL          -- app-validated (R7), deliberately no CHECK
+detail TEXT NOT NULL DEFAULT ''
+payload TEXT NOT NULL DEFAULT '{}'   -- JSON object
+occurred_at TEXT NOT NULL            -- world time (agent-supplied, may be backdated)
+recorded_at TEXT NOT NULL            -- our time; the whats_new / export cursor
+recorded_by TEXT NOT NULL            -- derived (S3)
+corrects_event_id INTEGER
+```
+Indexes: `(user_id, recorded_at, id)` — the `whats_new` cursor; `(application_id,
+occurred_at, id)` — the timeline; `(user_id, event_type)` — slice-4 `stats`.
+
+**`application_artifacts` — NEW:**
+```
+id INTEGER PRIMARY KEY AUTOINCREMENT
+user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE
+application_id INTEGER NOT NULL
+kind TEXT NOT NULL                -- cv | cover_letter | answers | outreach
+version_no INTEGER NOT NULL
+text TEXT NOT NULL
+made_by TEXT NOT NULL             -- "agent:<client>" | "token:<name>" | "web:tailor" | "human"
+model TEXT   profile_version INTEGER   label TEXT NOT NULL DEFAULT ''
+chars INTEGER NOT NULL   created_at TEXT NOT NULL
+UNIQUE(application_id, kind, version_no)
+```
+Index: `(user_id, application_id, kind, version_no DESC)`.
+
+**Storage decision — TEXT in Postgres, not a file store.** A tailored CV measured on this
+codebase is 2–8 KB; the cap is `APPLICATION_ARTIFACT_MAX_CHARS` (60 000) and
+`APPLICATION_ARTIFACT_MAX_VERSIONS` (200) per kind, so the worst case is ~12 MB per
+(application, kind) and typically under 100 KB. Postgres TOASTs and compresses text that
+size out of line, and the existing `application_receipts.cv_text` already stores exactly
+this kind of blob. A file store would add a second consistency domain (orphan blobs, backup
+skew between DB and disk, a new secret) for no benefit at this size. Both numbers are
+parameters; if a user ever hits them the answer is to raise the parameter, and the 422 says
+which one bit.
+
+**`application_receipts` — ALTER, 7 new columns** (0034's table, still append-only):
+```
+application_id INTEGER          cv_artifact_id INTEGER      cover_letter_artifact_id INTEGER
+answers TEXT NOT NULL DEFAULT '[]'        fields_filled TEXT NOT NULL DEFAULT '{}'
+confirmation TEXT NOT NULL DEFAULT ''     recorded_by TEXT NOT NULL DEFAULT 'web'
+```
+Index: `idx_receipts_application ON application_receipts(user_id, application_id)`.
+
+**Registrations:** `application_events` and `application_artifacts` join
+`JobDatabase._PER_USER_TABLES` (`database.py:1779`), `_EXPORT_TABLES` (`:1798`) and
+`scripts/observe.py PER_USER_TABLES` (`:43`). Nothing goes in `_PURGE_CASCADE_TABLES` —
+these belong to the user, not to the catalog.
+
+## Migration fold — the no-row-loss argument
+
+The fold **copies; it never moves and never deletes.** After `0037` every one of the four
+legacy tables still holds exactly the rows it held before, and the routes that read them
+(`/api/pipeline`, `/api/receipts`, `/api/tailor`) still work. That is the whole argument,
+and it is checkable with counts.
+
+Order inside one transaction (the runner wraps each migration body — `pg.py:676-686`):
+
+1. **Add the columns and create the two tables.** Pure DDL, no row touched.
+2. **No orphans.** Insert a missing `applications` row for every `(user_id, job_id)` that
+   appears in `application_receipts`, `tailored_documents` or `application_stage_history`
+   but not in `applications` — written as `INSERT INTO … SELECT DISTINCT … WHERE NOT EXISTS
+   (…)` rather than `INSERT OR IGNORE`, so it needs no `translate()` rule and reads the same
+   in either dialect. These rows get `status='applied'` (a receipt or a stage row means the
+   user got at least that far) and `created_at` from the source row.
+3. **Backfill `status` from `stage`** by CASE, using R4's mapping in reverse:
+   `applied|outreach→applied`, `interview→interview_scheduled`, `offer→offer`,
+   `rejected→rejected`, `ghosted→ghosted`, anything else → `applied`. `stage` is left
+   exactly as it was.
+4. **Backfill the job snapshot** from `jobs` by `LEFT JOIN` on `job_id` (blank strings where
+   the catalog row is already gone — honest, and better than a NULL join at read time).
+5. **`application_stage_history` → events.** One event per row:
+   `event_type = CASE to_stage WHEN 'interview' THEN 'interview_scheduled' … END`,
+   `occurred_at = transitioned_at`, `recorded_at = transitioned_at`,
+   `recorded_by = 'migration:0014_history'`, `detail = COALESCE(notes, '')`,
+   `payload = json of {from_stage, to_stage}`. Source rows untouched.
+6. **`application_receipts` → `application_id` + one `applied` event each.** The
+   `application_id` backfill is the migration's only `UPDATE` against a receipt row; it sets
+   a column that did not exist a statement earlier, changes no user-visible field, and is
+   outside the append-only guard's scope (that guard greps `backend/src/`, not
+   `migrations/` — `tests/test_receipts.py:129-135`). Say so in the migration header, as
+   0034 says it about its own down file. Events get `recorded_by='migration:0034_receipts'`,
+   `occurred_at = sent_at`.
+7. **`tailored_documents` → artifact versions.** For each row: `ai_draft` (when non-empty)
+   becomes `version_no=1` with `made_by='migration:0023_tailored'`; `polished` (when NOT
+   NULL) becomes `version_no=2` with `made_by='human'` — so a user who edited keeps **both**
+   the draft and the edit, which is precisely what `upsert_tailored_doc`'s DELETE+INSERT
+   (`database.py:1011-1043`) has been destroying. `model` and `profile_version` carry over.
+   Source rows untouched.
+8. **`last_event_at`** = MAX(`recorded_at`) of that application's events, else
+   `updated_at`.
+
+**Count invariants, asserted by the frozen migration test** (before → after):
+| Check | Assertion |
+|---|---|
+| `applications` | `after >= before`, and `after - before == ` the orphans created in step 2 |
+| `application_stage_history` | unchanged |
+| `application_receipts` | unchanged; every row now has a non-NULL `application_id` |
+| `tailored_documents` | unchanged |
+| events from the fold | `count(events WHERE recorded_by='migration:0014_history') == count(application_stage_history)` and `… '0034_receipts') == count(application_receipts)` |
+| artifacts from the fold | `count(artifacts WHERE made_by LIKE 'migration:%' OR made_by='human') == count(td WHERE ai_draft <> '') + count(td WHERE polished IS NOT NULL)` |
+
+**Down migration** (`0037_application_spine.down.sql`): `DROP TABLE application_artifacts`,
+`DROP TABLE application_events`, then `ALTER TABLE … DROP COLUMN` for all 19 added columns
+(plain Postgres DDL; the SQLite-can't-DROP-COLUMN note in `0014_application_history.down.sql`
+is obsolete — the store has been Postgres since the pg migration). **What down costs, stated
+plainly:** every pre-migration row survives untouched, so a rollback the day after deploy
+loses nothing; events and artifact versions created *after* the migration are dropped with
+their tables and are not recoverable except from a backup. The down file says this in its
+header, in those words. `up → down → up` is a frozen test.
+
+## Tool contracts (8) — REST route and MCP tool are the same function
+
+New module `backend/src/api/routes/applications.py`, mounted `prefix="/api"` in
+`src/api/main.py` beside `bring`/`receipts`. Every route `Depends(require_user)` (matching
+`bring.py:83` and `receipts.py:104`; not `require_verified_user` — nothing here spends an
+LLM call). **Route-declaration order matters:** `/applications/export` and
+`/applications/{application_id}` collide, so `export` is declared first; `application_id: int`
+means a stray `"export"` would 422 rather than 500 either way.
+
+| # | MCP tool | REST | Request | Response |
+|---|---|---|---|---|
+| 1 | `get_application` | `GET /applications/{id}` | `application_id: int`, `with_artifact_text: bool = false` | R11 object; 404 for a foreign or unknown id |
+| 2 | `list_applications` | `GET /applications` | `status?: str`, `updated_since?: str`, `limit: int = 20 (≤200)`, `offset: int = 0` | `{applications: [summary], total}` |
+| 3 | `save_artifact` | `POST /applications/{id}/artifacts` | `application_id`, `kind`, `text`, `label?`, `model?` | `{artifact_id, kind, version_no, chars, made_by, model, profile_version, created_at, event_id}` |
+| 4 | `save_fit` | `PUT /applications/{id}/fit` | `application_id`, `score?: int 0-100`, `verdict?: str ≤200`, `gaps?: list[str] ≤50`, `reasoning?: str ≤4000` | `{application_id, fit: {...}, event_id}` |
+| 5 | `record_event` | `POST /applications/{id}/events` | `application_id`, `event_type`, `detail?: str`, `payload?: object`, `occurred_at?: ISO`, `corrects_event_id?: int` | `{event_id, event_type, occurred_at, recorded_at, recorded_by, status}` |
+| 6 | `record_application` | `POST /applications/{id}/receipt` | `application_id`, `channel?`, `note?`, `confirmation?`, `answers?: [{question, answer}]`, `fields_filled?: object`, `cv_artifact_id?`, `cover_letter_artifact_id?`, `applied_at?` | `{receipt_id, sent_at, cv_artifact_id, cv_version_no, cover_letter_artifact_id, channel, confirmation, url, event_id}` |
+| 7 | `whats_new` | `GET /whats-new` | `since?: ISO`, `after_id?: int`, `limit: int = 50 (≤200)` | R9 object |
+| 8 | `export_history` | `GET /applications/export` | `since?: ISO`, `include_text: bool = false` | R10 object |
+
+`record_application` **is the existing tool enriched** (`mcp_server.py:332-356`), not a new
+one; its old `(job_id, channel, note)` call shape keeps working — a `job_id` resolves to its
+application. `bring_job` (`mcp_server.py:262`) gains `application_id` and `status` in its
+return. Total MCP tools 8 → 15, and `tests/test_mcp_gate_parity.py TOOL_ROUTES:33-42` gains
+a row for each of the seven new ones (its
+`test_the_parity_table_covers_every_tool` turns red otherwise — that is the design).
+
+## Security guardrails (mandatory section)
+
+S1. **Auth on every new route.** All eleven new routes (8 tools + the single-artifact read +
+    two internal write-through helpers) declare `Depends(require_user)`, which accepts the
+    session cookie, a personal `j360_…` token and an OAuth `j360a_…` bearer identically
+    (`auth_deps`, slice 1 R6). No route accepts an unauthenticated call.
+    `backend/tests/test_route_auth_coverage.py` already enumerates routes and will fail on
+    any new one that is not gated or explicitly public — no new `PUBLIC_ROUTES` entry is
+    added by this slice.
+
+S2. **No cross-user read or write, ever.** Every statement filters `user_id = ?` from
+    `CurrentUser.id` — never from a path, query or body (#12/#25). A foreign or unknown
+    `application_id`, `artifact_id` or `event_id` returns **404, not 403** (existence is
+    itself information). Child writes verify ownership through the parent in the same
+    transaction: `INSERT … SELECT` guarded by `WHERE EXISTS (SELECT 1 FROM applications
+    WHERE id = ? AND user_id = ?)`, so a TOCTOU between "check" and "insert" cannot land a
+    row under someone else's application. **The pg shim strips every FK clause**
+    (`pg.py:217-226`), so there is no database-level protection to fall back on — this is
+    the only protection.
+
+S3. **`recorded_by` / `made_by` are derived, never accepted.** One helper,
+    `src/services/applications/authorship.py::actor_for(user)`, returns
+    `"web"` for `auth_via == "session"`, `"token:<token name>"` for a personal token, and
+    `"agent:<client_name>"` for an OAuth grant (client name sanitised and truncated to 60
+    chars — it is attacker-supplied text, sanitised at registration by slice 1 R2 and
+    re-truncated here, never rendered as markup). A `recorded_by` or `made_by` field in a
+    request body is **rejected with 422**, not ignored — silently dropping it would let a
+    caller believe it worked. Forging authorship is the one thing an append-only log must
+    not permit.
+
+S4. **Artifact ids on a receipt are ownership-checked.** `cv_artifact_id` /
+    `cover_letter_artifact_id` must resolve to a row with this `user_id` **and** this
+    `application_id`; otherwise 404. Without both checks a caller could name another
+    application's CV in their own receipt and read it back through `get_application`.
+
+S5. **Input caps** — every one a parameter in `src/core/settings.py`, every breach a 422
+    naming the field and the limit:
+    `APPLICATION_EVENT_DETAIL_MAX_CHARS` 2 000 · `APPLICATION_EVENT_PAYLOAD_MAX_BYTES` 8 192
+    (and the payload must be a JSON **object**, not a list or scalar — a list of 8 KB of
+    strings is a different read cost) · `APPLICATION_ARTIFACT_MAX_CHARS` 60 000 ·
+    `APPLICATION_ARTIFACT_MAX_VERSIONS` 200 per kind (429 with a plain-words message when
+    exceeded, never a silent drop) · `APPLICATION_RECEIPT_ANSWERS_MAX` 50 items, 2 000 chars
+    each · `APPLICATION_RECEIPT_FIELDS_MAX_BYTES` 8 192 · `APPLICATION_FIT_REASONING_MAX_CHARS`
+    4 000 · `label` 100 · `channel` 100 · `confirmation` 200. FastAPI/Pydantic enforces the
+    scalar ones with `Field(max_length=…)` exactly as `bring.py:42-47` does; the JSON ones
+    are checked after `json.dumps` on the server, on the **serialised** size, because that
+    is what the column costs.
+
+S6. **`occurred_at` is bounded on the future side only.** It must parse as ISO-8601 with a
+    timezone and be no more than `APPLICATION_EVENT_MAX_FUTURE_SECONDS` (300) ahead of now →
+    otherwise 422. There is deliberately **no** lower bound: backdating is the normal case
+    (the agent reads a reply from last Tuesday). `recorded_at` is always server time, so an
+    unbounded `occurred_at` cannot poison the `whats_new` cursor (R9) or hide an event from
+    an export.
+
+S7. **Append-only is enforced three ways, not one.** (a) No PATCH/PUT/DELETE route exists on
+    `/applications/{id}/events` or `/applications/{id}/artifacts` — asserted over
+    `app.routes`, the shape used at `tests/test_receipts.py:139-143`. (b) A grep guard over
+    `backend/src/**/*.py` for `UPDATE|DELETE FROM` against `application_events` or
+    `application_artifacts` → must be empty. (c) `_PER_USER_TABLES` membership means account
+    deletion is the only path that removes a row, and that is the user's own right.
+    `PUT /applications/{id}/fit` is an update of the `applications` **slot**, which is
+    explicitly not history — the history is the `fit_judged` event it appends.
+
+S8. **Export is bounded and rate-limited per user.** R10's caps plus
+    `EXPORT_HISTORY_MAX_PER_HOUR` (12) keyed on `user.id` via the existing `rate_limit`
+    helper → 429. Per **user**, not per IP: behind the Next.js rewrite every agent shares
+    the proxy address unless `JOB360_TRUST_PROXY=1` is set on the backend service (the trap
+    the OAuth slice documented at its S6), so an IP key would throttle everyone at once.
+    `whats_new` is bounded by its own limit and needs no separate budget.
+
+S9. **Audit log, no bodies.** `get_audit_logger()` events `application_born`,
+    `application_event_recorded` (`application_id`, `event_type`, `recorded_by`),
+    `artifact_saved` (`artifact_id`, `kind`, `version_no`, `chars`), `fit_saved`,
+    `receipt_created` (`receipt_id`, `cv_artifact_id`), `history_exported`
+    (`applications`, `bytes`, `truncated`). **Never** artifact text, receipt text, event
+    `detail`, `payload`, or the fit reasoning — the log is not a copy of the user's CV.
+
+S10. **The search flag is not a security control** (R12). The search routes keep their
+     existing auth; the flag only decides whether the feature exists. Nothing about the
+     flag's state is used to skip an authorisation check.
+
+S11. **MCP gate parity by hand** (M5). Tools call route *functions*, so `Depends` never
+     runs: each new tool re-applies its route's gate itself, and each gets a `TOOL_ROUTES`
+     row so `test_the_parity_table_covers_every_tool` proves nothing was forgotten. No new
+     tool is `require_verified_user`, and `test_the_tailor_routes_really_are_gated` keeps
+     proving the parity test is still testing something.
+
+S12. **Deletion and export stay complete.** Both new tables go into `_PER_USER_TABLES`
+     (Article 17 erase, and `hard_delete_user`'s survivor check will fail loudly if a table
+     is missed — `database.py:1996-2004`) and `_EXPORT_TABLES` (Article 20). `text`,
+     `detail` and `payload` are the user's own content and are exported as-is; nothing here
+     is a credential, so no new entry is needed in `_EXPORT_REDACT_COLUMNS`.
+
+## Frozen tests
+
+**`backend/tests/test_application_spine.py`** (written red first):
+1. `test_bring_creates_one_application_considering` — `POST /jobs/bring` returns an
+   `application_id`, status `considering`, and exactly one `brought` event.
+2. `test_bringing_twice_reuses_the_application` — same id, still one `brought` event.
+3. `test_the_job_snapshot_survives_a_purge` — purge the catalog row, `get_application` still
+   shows title and company; `catalog_present: false`.
+4. `test_purge_spares_a_brought_job` — `purge_old_jobs` deletes an old scraped row and keeps
+   an equally old `user_brought` row (hard rule #3).
+5. `test_two_cv_versions_both_readable` — save v1 then v2; both readable in full by id, v1's
+   text byte-identical after v2 exists.
+6. `test_version_numbers_are_per_kind` — `cv` v1/v2 and `cover_letter` v1 coexist.
+7. `test_artifact_over_the_cap_is_422` — and the message names `APPLICATION_ARTIFACT_MAX_CHARS`.
+8. `test_made_by_and_recorded_by_come_from_the_credential` — session → `web`, personal token
+   → `token:<name>`; a body field named `recorded_by` → 422.
+9. `test_unknown_event_type_is_422_listing_the_allowed_types`.
+10. `test_status_event_moves_status_and_note_does_not`.
+11. `test_status_is_rebuildable_from_the_event_log` — replay == stored column (#21: assert a
+    non-default value, not schema presence).
+12. `test_a_correcting_event_supersedes_and_is_skipped_by_the_recompute`.
+13. `test_events_are_append_only` — no PATCH/PUT/DELETE route; grep `backend/src/` clean for
+    both new tables.
+14. `test_backdated_occurred_at_is_accepted_and_ordered` / `test_future_occurred_at_is_422`.
+15. `test_a_foreign_application_id_is_404_on_every_route` — get, save_artifact, save_fit,
+    record_event, receipt, single-artifact read (two-user fixture).
+16. `test_a_foreign_artifact_id_on_a_receipt_is_404` (S4).
+17. `test_save_fit_stores_the_verdict_and_keeps_both_judgements` — slot overwritten, two
+    `fit_judged` events in the log.
+18. `test_save_fit_computes_nothing` — no `skill_matcher` / enrichment import or call on the
+    path (monkeypatched to explode).
+19. `test_record_application_freezes_the_named_version` — receipt names `cv` v2 and copies
+    its text; an `applied` event appears.
+20. `test_legacy_receipts_route_writes_through` — `POST /receipts/{job_id}` sets
+    `application_id` and appends `applied`.
+21. `test_legacy_bring_response_shape_is_unchanged` — `job`, `existing`, `scored` still there
+    (constraint 4).
+22. `test_whats_new_pages_on_recorded_at_not_occurred_at` — a backdated event still appears
+    after a later `since`.
+23. `test_whats_new_truncates_explicitly` — `truncated: true` + a usable `next_since`.
+24. `test_export_history_bounds_and_truncates` — over `EXPORT_HISTORY_MAX_APPLICATIONS`,
+    stops on a boundary and reports it.
+25. `test_export_history_is_rate_limited_per_user` — 429 after the cap; a second user is
+    unaffected (proves the key is the user, not the IP).
+26. `test_get_application_omits_artifact_text_by_default` — and includes it under the cap
+    with `with_artifact_text=true`.
+27. `test_tailor_generate_also_writes_an_artifact_version` (R15) and
+    `test_tailor_save_edit_writes_a_human_version`.
+28. `test_event_types_match_vision_doc` — the two tuples equal the list at
+    `docs/product/VISION.md:66-71`.
+29. `test_audit_log_never_carries_a_body` — artifact text and event detail absent from the
+    audit records (S9).
+
+**`backend/tests/test_migration_0037.py`:**
+30. `test_up_down_up_is_clean`.
+31. `test_no_legacy_row_is_lost` — the count table above, before and after.
+32. `test_stage_history_becomes_events` / `test_receipts_get_an_application_id_and_an_event`.
+33. `test_a_tailored_doc_with_a_polish_becomes_two_versions`.
+34. `test_an_orphan_receipt_gets_its_application_row` — a `(user, job)` present only in
+    receipts.
+35. `test_status_backfill_maps_every_legacy_stage` — all six values in `_VALID_STAGES`
+    (`routes/pipeline.py:36`).
+
+**`backend/tests/test_mcp_gate_parity.py`** (extended, not new): a `TOOL_ROUTES` row for each
+of the seven new tools; the existing coverage and email-gate tests then prove parity.
+
+**`backend/tests/test_search_flag.py`:**
+36. `test_search_routes_404_when_the_flag_is_off` / `test_search_routes_work_when_on`.
+37. `test_catalog_crons_are_off_by_default` — `WorkerSettings.cron_jobs` has no
+    `refresh_catalog` / `enrichment_sweep` and still has `nightly_ghost_sweep` /
+    `notification_tick`; both present with `CATALOG_CRONS_ENABLED=1`.
+
+**Playwright `frontend/tests/e2e/applications-home.spec.ts`** (house style: fake the
+`job360_session` cookie, `page.route` the API, assert the DOM — as
+`tests/e2e/feed-visibility.spec.ts:21`):
+38. Signed-in `/` shows the brought application with status `considering`, then `applied`
+    after the mocked receipt; the Dashboard nav link is absent with the flag off; opening
+    the application lists **two** CV versions and both open with their text.
+
+## Done when
+> The owner brings a job from Claude Code, saves two CV versions, records "applied" with the
+> second, later records "replied" and "interview_requested" — and `whats_new` + the web home
+> show exactly that, every version still readable.
+
+## Flagged concerns
+C1. **Two vocabularies until slice 5.** `status` (spine) and `stage` (pipeline UI) coexist,
+    joined by one mapping dict (R4). Every other place that reads `stage` — `KanbanBoard`,
+    `/api/pipeline`, `get_stale_applications` — is unchanged and still correct, but a
+    reviewer should check the dict, not the call sites.
+C2. **`NEXT_PUBLIC_SEARCH_UI_ENABLED` is baked at build time.** Flipping it is a redeploy.
+    Say so in the PR so nobody debugs a "flag that does not work".
+C3. **Windows full-suite flake** — targeted gate locally, Linux CI is the verdict.
+C4. **The fold is 11 rows in production** (measured above), so the migration will look
+    trivially green in prod. The real proof is the seeded migration test, not the deploy.
+C5. **`recorded_by` for an OAuth caller depends on slice 1's `client_name`**, which is
+    unverified attacker text by construction. It is truncated and stored as data, never
+    rendered as markup, and the audit log carries the client id, not the name (slice 1 R10).

--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -1,3 +1,14 @@
 # Copy to frontend/.env.local and adjust as needed.
-# Required: the URL of the FastAPI backend the dashboard talks to.
-NEXT_PUBLIC_API_URL=http://localhost:8000
+# The URL of the FastAPI backend the dashboard talks to.
+# ⚠️ For local dev, LEAVE THIS UNSET (or empty): the empty default routes every
+# call through Next's same-origin /api/* proxy (next.config.ts BACKEND_ORIGIN
+# already points at :8000). Setting it makes the browser hit :8000 directly,
+# and CSP's connect-src 'self' blocks every fetch — the app looks signed-out
+# with "Could not load…" on each page.
+# NEXT_PUBLIC_API_URL=
+
+# R12 (docs/plans/2026-09-04-application-spine/spec.md) — the legacy search
+# UI (Dashboard, /jobs redirect). Default OFF: Job360 never sources or ranks
+# jobs (VISION rule 4). NEXT_PUBLIC_* is inlined at BUILD TIME — flipping this
+# needs a redeploy, not a restart.
+NEXT_PUBLIC_SEARCH_UI_ENABLED=false

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -71,6 +71,627 @@
         "title": "ActionsListResponse",
         "type": "object"
       },
+      "ApplicationArtifactOut": {
+        "description": "The ``get_application`` artifacts-list shape: ``text`` is ALWAYS a key\n(null unless ``with_artifact_text=true`` and under the byte cap).",
+        "properties": {
+          "chars": {
+            "title": "Chars",
+            "type": "integer"
+          },
+          "created_at": {
+            "title": "Created At",
+            "type": "string"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "kind": {
+            "title": "Kind",
+            "type": "string"
+          },
+          "label": {
+            "title": "Label",
+            "type": "string"
+          },
+          "made_by": {
+            "title": "Made By",
+            "type": "string"
+          },
+          "model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model"
+          },
+          "profile_version": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Profile Version"
+          },
+          "text": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Text"
+          },
+          "truncated": {
+            "title": "Truncated",
+            "type": "boolean"
+          },
+          "version_no": {
+            "title": "Version No",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "id",
+          "kind",
+          "version_no",
+          "made_by",
+          "model",
+          "profile_version",
+          "label",
+          "chars",
+          "created_at",
+          "text",
+          "truncated"
+        ],
+        "title": "ApplicationArtifactOut",
+        "type": "object"
+      },
+      "ApplicationArtifactRowOut": {
+        "description": "``get_application_artifact`` \u2014 one version in full. No ``truncated``:\nthis route always returns the real row, never a capped read.",
+        "properties": {
+          "chars": {
+            "title": "Chars",
+            "type": "integer"
+          },
+          "created_at": {
+            "title": "Created At",
+            "type": "string"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "kind": {
+            "title": "Kind",
+            "type": "string"
+          },
+          "label": {
+            "title": "Label",
+            "type": "string"
+          },
+          "made_by": {
+            "title": "Made By",
+            "type": "string"
+          },
+          "model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model"
+          },
+          "profile_version": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Profile Version"
+          },
+          "text": {
+            "title": "Text",
+            "type": "string"
+          },
+          "version_no": {
+            "title": "Version No",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "id",
+          "kind",
+          "version_no",
+          "text",
+          "made_by",
+          "model",
+          "profile_version",
+          "label",
+          "chars",
+          "created_at"
+        ],
+        "title": "ApplicationArtifactRowOut",
+        "type": "object"
+      },
+      "ApplicationDetailOut": {
+        "properties": {
+          "artifacts": {
+            "items": {
+              "$ref": "#/components/schemas/ApplicationArtifactOut"
+            },
+            "title": "Artifacts",
+            "type": "array"
+          },
+          "created_at": {
+            "title": "Created At",
+            "type": "string"
+          },
+          "events": {
+            "items": {
+              "$ref": "#/components/schemas/ApplicationEventOut"
+            },
+            "title": "Events",
+            "type": "array"
+          },
+          "fit": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ApplicationFitOut"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "job": {
+            "$ref": "#/components/schemas/ApplicationJobOut"
+          },
+          "job_id": {
+            "title": "Job Id",
+            "type": "integer"
+          },
+          "last_event_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Event At"
+          },
+          "receipts": {
+            "items": {
+              "$ref": "#/components/schemas/ApplicationReceiptOut"
+            },
+            "title": "Receipts",
+            "type": "array"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          },
+          "updated_at": {
+            "title": "Updated At",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "job_id",
+          "status",
+          "created_at",
+          "updated_at",
+          "last_event_at",
+          "job",
+          "fit",
+          "artifacts",
+          "events",
+          "receipts"
+        ],
+        "title": "ApplicationDetailOut",
+        "type": "object"
+      },
+      "ApplicationEventOut": {
+        "description": "The timeline shape (``list_events_for_display``) \u2014 used by\n``get_application`` and ``export_history``. Carries ``superseded``;\n``whats_new``'s events do not (see ``WhatsNewEventOut``).",
+        "properties": {
+          "corrects_event_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Corrects Event Id"
+          },
+          "detail": {
+            "title": "Detail",
+            "type": "string"
+          },
+          "event_type": {
+            "title": "Event Type",
+            "type": "string"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "occurred_at": {
+            "title": "Occurred At",
+            "type": "string"
+          },
+          "payload": {
+            "additionalProperties": true,
+            "title": "Payload",
+            "type": "object"
+          },
+          "recorded_at": {
+            "title": "Recorded At",
+            "type": "string"
+          },
+          "recorded_by": {
+            "title": "Recorded By",
+            "type": "string"
+          },
+          "superseded": {
+            "title": "Superseded",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "id",
+          "event_type",
+          "detail",
+          "payload",
+          "occurred_at",
+          "recorded_at",
+          "recorded_by",
+          "corrects_event_id",
+          "superseded"
+        ],
+        "title": "ApplicationEventOut",
+        "type": "object"
+      },
+      "ApplicationFitOut": {
+        "properties": {
+          "gaps": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Gaps",
+            "type": "array"
+          },
+          "reasoning": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reasoning"
+          },
+          "recorded_at": {
+            "title": "Recorded At",
+            "type": "string"
+          },
+          "recorded_by": {
+            "title": "Recorded By",
+            "type": "string"
+          },
+          "score": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Score"
+          },
+          "verdict": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Verdict"
+          }
+        },
+        "required": [
+          "score",
+          "verdict",
+          "gaps",
+          "reasoning",
+          "recorded_by",
+          "recorded_at"
+        ],
+        "title": "ApplicationFitOut",
+        "type": "object"
+      },
+      "ApplicationJobOut": {
+        "properties": {
+          "catalog_present": {
+            "title": "Catalog Present",
+            "type": "boolean"
+          },
+          "job_company": {
+            "title": "Job Company",
+            "type": "string"
+          },
+          "job_description_snapshot": {
+            "title": "Job Description Snapshot",
+            "type": "string"
+          },
+          "job_location": {
+            "title": "Job Location",
+            "type": "string"
+          },
+          "job_source": {
+            "title": "Job Source",
+            "type": "string"
+          },
+          "job_title": {
+            "title": "Job Title",
+            "type": "string"
+          },
+          "job_url": {
+            "title": "Job Url",
+            "type": "string"
+          },
+          "snapshot_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Snapshot At"
+          }
+        },
+        "required": [
+          "job_title",
+          "job_company",
+          "job_location",
+          "job_url",
+          "job_source",
+          "job_description_snapshot",
+          "snapshot_at",
+          "catalog_present"
+        ],
+        "title": "ApplicationJobOut",
+        "type": "object"
+      },
+      "ApplicationReceiptExportOut": {
+        "properties": {
+          "channel": {
+            "title": "Channel",
+            "type": "string"
+          },
+          "confirmation": {
+            "title": "Confirmation",
+            "type": "string"
+          },
+          "cover_letter_artifact_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cover Letter Artifact Id"
+          },
+          "cover_letter_text": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cover Letter Text"
+          },
+          "cv_artifact_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cv Artifact Id"
+          },
+          "cv_text": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cv Text"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "note": {
+            "title": "Note",
+            "type": "string"
+          },
+          "sent_at": {
+            "title": "Sent At",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "sent_at",
+          "channel",
+          "confirmation",
+          "cv_artifact_id",
+          "cover_letter_artifact_id",
+          "note"
+        ],
+        "title": "ApplicationReceiptExportOut",
+        "type": "object"
+      },
+      "ApplicationReceiptOut": {
+        "description": "``get_application``'s receipts list \u2014 never carries the receipt text\n(that call site never passes ``include_text``; see\n``ApplicationReceiptExportOut`` for the ``export_history`` shape).",
+        "properties": {
+          "channel": {
+            "title": "Channel",
+            "type": "string"
+          },
+          "confirmation": {
+            "title": "Confirmation",
+            "type": "string"
+          },
+          "cover_letter_artifact_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cover Letter Artifact Id"
+          },
+          "cv_artifact_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cv Artifact Id"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "note": {
+            "title": "Note",
+            "type": "string"
+          },
+          "sent_at": {
+            "title": "Sent At",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "sent_at",
+          "channel",
+          "confirmation",
+          "cv_artifact_id",
+          "cover_letter_artifact_id",
+          "note"
+        ],
+        "title": "ApplicationReceiptOut",
+        "type": "object"
+      },
+      "ApplicationSummaryOut": {
+        "properties": {
+          "artifacts": {
+            "additionalProperties": {
+              "type": "integer"
+            },
+            "title": "Artifacts",
+            "type": "object"
+          },
+          "events": {
+            "title": "Events",
+            "type": "integer"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "job_company": {
+            "title": "Job Company",
+            "type": "string"
+          },
+          "job_id": {
+            "title": "Job Id",
+            "type": "integer"
+          },
+          "job_title": {
+            "title": "Job Title",
+            "type": "string"
+          },
+          "last_event_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Event At"
+          },
+          "receipts": {
+            "title": "Receipts",
+            "type": "integer"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "job_id",
+          "job_title",
+          "job_company",
+          "status",
+          "last_event_at",
+          "events",
+          "artifacts",
+          "receipts"
+        ],
+        "title": "ApplicationSummaryOut",
+        "type": "object"
+      },
       "ApplicationTimelineResponse": {
         "properties": {
           "job_id": {
@@ -217,6 +838,10 @@
       },
       "BringJobResponse": {
         "properties": {
+          "application_id": {
+            "title": "Application Id",
+            "type": "integer"
+          },
           "existing": {
             "title": "Existing",
             "type": "boolean"
@@ -227,12 +852,18 @@
           "scored": {
             "title": "Scored",
             "type": "boolean"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
           }
         },
         "required": [
           "job",
           "existing",
-          "scored"
+          "scored",
+          "application_id",
+          "status"
         ],
         "title": "BringJobResponse",
         "type": "object"
@@ -629,6 +1260,201 @@
           "token"
         ],
         "title": "EmailVerificationConfirmRequest",
+        "type": "object"
+      },
+      "ExportApplicationOut": {
+        "properties": {
+          "artifacts": {
+            "items": {
+              "$ref": "#/components/schemas/ExportArtifactOut"
+            },
+            "title": "Artifacts",
+            "type": "array"
+          },
+          "created_at": {
+            "title": "Created At",
+            "type": "string"
+          },
+          "events": {
+            "items": {
+              "$ref": "#/components/schemas/ApplicationEventOut"
+            },
+            "title": "Events",
+            "type": "array"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "job_company": {
+            "title": "Job Company",
+            "type": "string"
+          },
+          "job_id": {
+            "title": "Job Id",
+            "type": "integer"
+          },
+          "job_title": {
+            "title": "Job Title",
+            "type": "string"
+          },
+          "last_event_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Event At"
+          },
+          "receipts": {
+            "items": {
+              "$ref": "#/components/schemas/ApplicationReceiptExportOut"
+            },
+            "title": "Receipts",
+            "type": "array"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          },
+          "updated_at": {
+            "title": "Updated At",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "job_id",
+          "status",
+          "job_title",
+          "job_company",
+          "created_at",
+          "updated_at",
+          "last_event_at",
+          "events",
+          "artifacts",
+          "receipts"
+        ],
+        "title": "ExportApplicationOut",
+        "type": "object"
+      },
+      "ExportArtifactOut": {
+        "description": "``export_history``'s artifact METADATA (not the full row): ``text`` is\nonly a key at all when ``include_text=true`` \u2014 hence the default.",
+        "properties": {
+          "chars": {
+            "title": "Chars",
+            "type": "integer"
+          },
+          "created_at": {
+            "title": "Created At",
+            "type": "string"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "kind": {
+            "title": "Kind",
+            "type": "string"
+          },
+          "label": {
+            "title": "Label",
+            "type": "string"
+          },
+          "made_by": {
+            "title": "Made By",
+            "type": "string"
+          },
+          "model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model"
+          },
+          "profile_version": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Profile Version"
+          },
+          "text": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Text"
+          },
+          "version_no": {
+            "title": "Version No",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "id",
+          "kind",
+          "version_no",
+          "made_by",
+          "model",
+          "profile_version",
+          "label",
+          "chars",
+          "created_at"
+        ],
+        "title": "ExportArtifactOut",
+        "type": "object"
+      },
+      "ExportHistoryResponse": {
+        "properties": {
+          "applications": {
+            "items": {
+              "$ref": "#/components/schemas/ExportApplicationOut"
+            },
+            "title": "Applications",
+            "type": "array"
+          },
+          "bytes": {
+            "title": "Bytes",
+            "type": "integer"
+          },
+          "next_since": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Since"
+          },
+          "truncated": {
+            "title": "Truncated",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "applications",
+          "truncated",
+          "bytes"
+        ],
+        "title": "ExportHistoryResponse",
         "type": "object"
       },
       "GitHubResponse": {
@@ -1228,6 +2054,27 @@
           "merged"
         ],
         "title": "LinkedInResponse",
+        "type": "object"
+      },
+      "ListApplicationsResponse": {
+        "properties": {
+          "applications": {
+            "items": {
+              "$ref": "#/components/schemas/ApplicationSummaryOut"
+            },
+            "title": "Applications",
+            "type": "array"
+          },
+          "total": {
+            "title": "Total",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "applications",
+          "total"
+        ],
+        "title": "ListApplicationsResponse",
         "type": "object"
       },
       "LivezResponse": {
@@ -2205,6 +3052,27 @@
         "title": "Receipt",
         "type": "object"
       },
+      "ReceiptAnswer": {
+        "additionalProperties": false,
+        "properties": {
+          "answer": {
+            "maxLength": 2000,
+            "title": "Answer",
+            "type": "string"
+          },
+          "question": {
+            "maxLength": 500,
+            "title": "Question",
+            "type": "string"
+          }
+        },
+        "required": [
+          "question",
+          "answer"
+        ],
+        "title": "ReceiptAnswer",
+        "type": "object"
+      },
       "ReceiptListResponse": {
         "properties": {
           "receipts": {
@@ -2288,6 +3156,235 @@
           "note"
         ],
         "title": "ReceiptSummary",
+        "type": "object"
+      },
+      "RecordApplicationReceiptRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "answers": {
+            "items": {
+              "$ref": "#/components/schemas/ReceiptAnswer"
+            },
+            "maxItems": 50,
+            "title": "Answers",
+            "type": "array"
+          },
+          "applied_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Applied At"
+          },
+          "channel": {
+            "default": "",
+            "maxLength": 100,
+            "title": "Channel",
+            "type": "string"
+          },
+          "confirmation": {
+            "default": "",
+            "maxLength": 200,
+            "title": "Confirmation",
+            "type": "string"
+          },
+          "cover_letter_artifact_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cover Letter Artifact Id"
+          },
+          "cv_artifact_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cv Artifact Id"
+          },
+          "fields_filled": {
+            "additionalProperties": true,
+            "title": "Fields Filled",
+            "type": "object"
+          },
+          "note": {
+            "default": "",
+            "maxLength": 2000,
+            "title": "Note",
+            "type": "string"
+          }
+        },
+        "title": "RecordApplicationReceiptRequest",
+        "type": "object"
+      },
+      "RecordApplicationReceiptResponse": {
+        "properties": {
+          "channel": {
+            "title": "Channel",
+            "type": "string"
+          },
+          "confirmation": {
+            "title": "Confirmation",
+            "type": "string"
+          },
+          "cover_letter_artifact_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cover Letter Artifact Id"
+          },
+          "cv_artifact_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cv Artifact Id"
+          },
+          "cv_version_no": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cv Version No"
+          },
+          "event_id": {
+            "title": "Event Id",
+            "type": "integer"
+          },
+          "receipt_id": {
+            "title": "Receipt Id",
+            "type": "integer"
+          },
+          "sent_at": {
+            "title": "Sent At",
+            "type": "string"
+          },
+          "url": {
+            "title": "Url",
+            "type": "string"
+          }
+        },
+        "required": [
+          "receipt_id",
+          "sent_at",
+          "cv_artifact_id",
+          "cv_version_no",
+          "cover_letter_artifact_id",
+          "channel",
+          "confirmation",
+          "url",
+          "event_id"
+        ],
+        "title": "RecordApplicationReceiptResponse",
+        "type": "object"
+      },
+      "RecordEventRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "corrects_event_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Corrects Event Id"
+          },
+          "detail": {
+            "default": "",
+            "title": "Detail",
+            "type": "string"
+          },
+          "event_type": {
+            "title": "Event Type",
+            "type": "string"
+          },
+          "occurred_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Occurred At"
+          },
+          "payload": {
+            "additionalProperties": true,
+            "title": "Payload",
+            "type": "object"
+          }
+        },
+        "required": [
+          "event_type"
+        ],
+        "title": "RecordEventRequest",
+        "type": "object"
+      },
+      "RecordEventResponse": {
+        "properties": {
+          "event_id": {
+            "title": "Event Id",
+            "type": "integer"
+          },
+          "event_type": {
+            "title": "Event Type",
+            "type": "string"
+          },
+          "occurred_at": {
+            "title": "Occurred At",
+            "type": "string"
+          },
+          "recorded_at": {
+            "title": "Recorded At",
+            "type": "string"
+          },
+          "recorded_by": {
+            "title": "Recorded By",
+            "type": "string"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "event_id",
+          "event_type",
+          "occurred_at",
+          "recorded_at",
+          "recorded_by",
+          "status"
+        ],
+        "title": "RecordEventResponse",
         "type": "object"
       },
       "RegisterRequest": {
@@ -2474,6 +3571,190 @@
           "offset"
         ],
         "title": "RunsListResponse",
+        "type": "object"
+      },
+      "SaveArtifactRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "kind": {
+            "title": "Kind",
+            "type": "string"
+          },
+          "label": {
+            "default": "",
+            "maxLength": 100,
+            "title": "Label",
+            "type": "string"
+          },
+          "model": {
+            "anyOf": [
+              {
+                "maxLength": 200,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model"
+          },
+          "text": {
+            "title": "Text",
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "text"
+        ],
+        "title": "SaveArtifactRequest",
+        "type": "object"
+      },
+      "SaveArtifactResponse": {
+        "properties": {
+          "artifact_id": {
+            "title": "Artifact Id",
+            "type": "integer"
+          },
+          "chars": {
+            "title": "Chars",
+            "type": "integer"
+          },
+          "created_at": {
+            "title": "Created At",
+            "type": "string"
+          },
+          "event_id": {
+            "title": "Event Id",
+            "type": "integer"
+          },
+          "kind": {
+            "title": "Kind",
+            "type": "string"
+          },
+          "made_by": {
+            "title": "Made By",
+            "type": "string"
+          },
+          "model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model"
+          },
+          "profile_version": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Profile Version"
+          },
+          "version_no": {
+            "title": "Version No",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "artifact_id",
+          "kind",
+          "version_no",
+          "chars",
+          "made_by",
+          "model",
+          "profile_version",
+          "created_at",
+          "event_id"
+        ],
+        "title": "SaveArtifactResponse",
+        "type": "object"
+      },
+      "SaveFitRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "gaps": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "maxItems": 50,
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Gaps"
+          },
+          "reasoning": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reasoning"
+          },
+          "score": {
+            "anyOf": [
+              {
+                "maximum": 100.0,
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Score"
+          },
+          "verdict": {
+            "anyOf": [
+              {
+                "maxLength": 200,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Verdict"
+          }
+        },
+        "title": "SaveFitRequest",
+        "type": "object"
+      },
+      "SaveFitResponse": {
+        "properties": {
+          "application_id": {
+            "title": "Application Id",
+            "type": "integer"
+          },
+          "event_id": {
+            "title": "Event Id",
+            "type": "integer"
+          },
+          "fit": {
+            "$ref": "#/components/schemas/ApplicationFitOut"
+          }
+        },
+        "required": [
+          "application_id",
+          "fit",
+          "event_id"
+        ],
+        "title": "SaveFitResponse",
         "type": "object"
       },
       "SearchStartResponse": {
@@ -3046,6 +4327,164 @@
         ],
         "title": "ValidationError",
         "type": "object"
+      },
+      "WhatsNewApplicationOut": {
+        "properties": {
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "job_company": {
+            "title": "Job Company",
+            "type": "string"
+          },
+          "job_title": {
+            "title": "Job Title",
+            "type": "string"
+          },
+          "last_event_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Event At"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "job_title",
+          "job_company",
+          "status",
+          "last_event_at"
+        ],
+        "title": "WhatsNewApplicationOut",
+        "type": "object"
+      },
+      "WhatsNewEventOut": {
+        "description": "``whats_new``'s raw event rows \u2014 no ``superseded`` (unlike\n``ApplicationEventOut``); carries ``application_id`` instead.",
+        "properties": {
+          "application_id": {
+            "title": "Application Id",
+            "type": "integer"
+          },
+          "corrects_event_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Corrects Event Id"
+          },
+          "detail": {
+            "title": "Detail",
+            "type": "string"
+          },
+          "event_type": {
+            "title": "Event Type",
+            "type": "string"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "occurred_at": {
+            "title": "Occurred At",
+            "type": "string"
+          },
+          "payload": {
+            "additionalProperties": true,
+            "title": "Payload",
+            "type": "object"
+          },
+          "recorded_at": {
+            "title": "Recorded At",
+            "type": "string"
+          },
+          "recorded_by": {
+            "title": "Recorded By",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "application_id",
+          "event_type",
+          "detail",
+          "payload",
+          "occurred_at",
+          "recorded_at",
+          "recorded_by",
+          "corrects_event_id"
+        ],
+        "title": "WhatsNewEventOut",
+        "type": "object"
+      },
+      "WhatsNewResponse": {
+        "properties": {
+          "applications": {
+            "items": {
+              "$ref": "#/components/schemas/WhatsNewApplicationOut"
+            },
+            "title": "Applications",
+            "type": "array"
+          },
+          "events": {
+            "items": {
+              "$ref": "#/components/schemas/WhatsNewEventOut"
+            },
+            "title": "Events",
+            "type": "array"
+          },
+          "next_after_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next After Id"
+          },
+          "next_since": {
+            "title": "Next Since",
+            "type": "string"
+          },
+          "now": {
+            "title": "Now",
+            "type": "string"
+          },
+          "since": {
+            "title": "Since",
+            "type": "string"
+          },
+          "truncated": {
+            "title": "Truncated",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "now",
+          "since",
+          "events",
+          "applications",
+          "next_since",
+          "next_after_id",
+          "truncated"
+        ],
+        "title": "WhatsNewResponse",
+        "type": "object"
       }
     }
   },
@@ -3243,6 +4682,720 @@
         "summary": "Action Counts",
         "tags": [
           "actions"
+        ]
+      }
+    },
+    "/api/applications": {
+      "get": {
+        "operationId": "list_applications_api_applications_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Status"
+            }
+          },
+          {
+            "in": "query",
+            "name": "updated_since",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Updated Since"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "minimum": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "in": "cookie",
+            "name": "job360_session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Job360 Session"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListApplicationsResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Applications",
+        "tags": [
+          "applications"
+        ]
+      }
+    },
+    "/api/applications/export": {
+      "get": {
+        "operationId": "export_history_api_applications_export_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "since",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Since"
+            }
+          },
+          {
+            "in": "query",
+            "name": "include_text",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "Include Text",
+              "type": "boolean"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "in": "cookie",
+            "name": "job360_session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Job360 Session"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExportHistoryResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Export History",
+        "tags": [
+          "applications"
+        ]
+      }
+    },
+    "/api/applications/{application_id}": {
+      "get": {
+        "operationId": "get_application_api_applications__application_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "application_id",
+            "required": true,
+            "schema": {
+              "title": "Application Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "with_artifact_text",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "With Artifact Text",
+              "type": "boolean"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "in": "cookie",
+            "name": "job360_session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Job360 Session"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApplicationDetailOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Application",
+        "tags": [
+          "applications"
+        ]
+      }
+    },
+    "/api/applications/{application_id}/artifacts": {
+      "post": {
+        "operationId": "save_artifact_api_applications__application_id__artifacts_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "application_id",
+            "required": true,
+            "schema": {
+              "title": "Application Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "in": "cookie",
+            "name": "job360_session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Job360 Session"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SaveArtifactRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SaveArtifactResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Save Artifact",
+        "tags": [
+          "applications"
+        ]
+      }
+    },
+    "/api/applications/{application_id}/artifacts/{artifact_id}": {
+      "get": {
+        "operationId": "get_application_artifact_api_applications__application_id__artifacts__artifact_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "application_id",
+            "required": true,
+            "schema": {
+              "title": "Application Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "path",
+            "name": "artifact_id",
+            "required": true,
+            "schema": {
+              "title": "Artifact Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "in": "cookie",
+            "name": "job360_session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Job360 Session"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApplicationArtifactRowOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Application Artifact",
+        "tags": [
+          "applications"
+        ]
+      }
+    },
+    "/api/applications/{application_id}/events": {
+      "post": {
+        "operationId": "record_event_api_applications__application_id__events_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "application_id",
+            "required": true,
+            "schema": {
+              "title": "Application Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "in": "cookie",
+            "name": "job360_session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Job360 Session"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RecordEventRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RecordEventResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Record Event",
+        "tags": [
+          "applications"
+        ]
+      }
+    },
+    "/api/applications/{application_id}/fit": {
+      "put": {
+        "operationId": "save_fit_api_applications__application_id__fit_put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "application_id",
+            "required": true,
+            "schema": {
+              "title": "Application Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "in": "cookie",
+            "name": "job360_session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Job360 Session"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SaveFitRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SaveFitResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Save Fit",
+        "tags": [
+          "applications"
+        ]
+      }
+    },
+    "/api/applications/{application_id}/receipt": {
+      "post": {
+        "operationId": "record_application_receipt_api_applications__application_id__receipt_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "application_id",
+            "required": true,
+            "schema": {
+              "title": "Application Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "in": "cookie",
+            "name": "job360_session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Job360 Session"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RecordApplicationReceiptRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RecordApplicationReceiptResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Record Application Receipt",
+        "tags": [
+          "applications"
         ]
       }
     },
@@ -8572,6 +10725,115 @@
         "summary": "Revoke Token",
         "tags": [
           "tokens"
+        ]
+      }
+    },
+    "/api/whats-new": {
+      "get": {
+        "operationId": "whats_new_api_whats_new_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "since",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Since"
+            }
+          },
+          {
+            "in": "query",
+            "name": "after_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "After Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "in": "cookie",
+            "name": "job360_session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Job360 Session"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WhatsNewResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Whats New",
+        "tags": [
+          "applications"
         ]
       }
     }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1007,6 +1007,28 @@
         "@noble/ciphers": "^1.0.0"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.3.tgz",
+      "integrity": "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.3",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1007,29 +1007,6 @@
         "@noble/ciphers": "^1.0.0"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.3.tgz",
-      "integrity": "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.3",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
-      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",

--- a/frontend/src/app/Landing.tsx
+++ b/frontend/src/app/Landing.tsx
@@ -1,0 +1,387 @@
+import Link from "next/link";
+import {
+  Radar,
+  Globe,
+  Target,
+  Layers,
+  Kanban,
+  Brain,
+  ArrowRight,
+  Upload,
+  Zap,
+  Clock,
+  Shield,
+  Sparkles,
+} from "lucide-react";
+
+// R14 (docs/plans/2026-09-04-application-spine/spec.md) — the landing copy
+// no longer advertises a job-source count. Job360 never sources or ranks
+// jobs (VISION rule 4); the pitch is the memory layer AFTER the click, not
+// the catalog. See docs/product/VISION.md.
+const FEATURES = [
+  {
+    icon: Radar,
+    title: "8-Dimensional Scoring",
+    description:
+      "Role, Skill, Seniority, Experience, Credentials, Location, Recency, and Semantic similarity — every job scored 0-100 with evidence-backed reasons.",
+    stagger: 1,
+  },
+  {
+    icon: Globe,
+    title: "Bring Any Job",
+    description:
+      "Paste a job you found anywhere — LinkedIn, a company site, a referral. Job360 stores it, keeps the ad even after the listing disappears, and starts your record.",
+    stagger: 2,
+  },
+  {
+    icon: Target,
+    title: "Skill Gap Analysis",
+    description:
+      "Instantly see matched, missing, and transferable skills for every listing. Know exactly where you stand before you apply.",
+    stagger: 3,
+  },
+  {
+    icon: Layers,
+    title: "Every Version, Forever",
+    description:
+      "Every CV, cover letter and edit you ever save is kept — nothing is overwritten. Come back a year later and read exactly what you sent.",
+    stagger: 4,
+  },
+  {
+    icon: Kanban,
+    title: "Application Pipeline",
+    description:
+      "Track every opportunity from discovery to offer. Bookmarks, applications, interviews, and outcomes — all in one view.",
+    stagger: 5,
+  },
+  {
+    icon: Brain,
+    title: "Career Intelligence",
+    description:
+      "AI-powered matching with 424 synonym groups, a 563-edge skill graph, and cross-encoder reranking. It understands your career, not just keywords.",
+    stagger: 6,
+  },
+] as const;
+
+const STATS = [
+  {
+    icon: Layers,
+    value: "∞",
+    label: "Versions",
+    description: "Every CV & cover letter kept",
+  },
+  {
+    icon: Radar,
+    value: "8D",
+    label: "Scoring",
+    description: "Multi-dimensional match engine",
+  },
+  {
+    icon: Clock,
+    value: "Real-time",
+    label: "Updates",
+    description: "Fresh jobs every run",
+  },
+  {
+    icon: Shield,
+    value: "Any",
+    label: "Domain",
+    description: "Tech, finance, health & more",
+  },
+] as const;
+
+export default function Landing() {
+  return (
+    <div className="relative">
+      {/* ── Hero ambient glow — dramatic multi-layer aurora ── */}
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0 overflow-hidden"
+      >
+        {/* Primary top beam — strong, animated */}
+        <div
+          className="absolute -top-[20%] left-1/2 h-[900px] w-[1200px] -translate-x-1/2 rounded-full bg-primary/[0.15] blur-[140px]"
+          style={{ animation: 'aurora-drift 8s ease-in-out infinite' }}
+        />
+        {/* Secondary top-right accent */}
+        <div
+          className="absolute -top-[10%] right-[5%] h-[500px] w-[500px] rounded-full bg-primary/[0.08] blur-[100px]"
+          style={{ animation: 'aurora-drift 12s ease-in-out infinite reverse' }}
+        />
+        {/* Left side beam */}
+        <div className="absolute top-[20%] -left-[15%] h-[600px] w-[400px] rounded-full bg-primary/[0.10] blur-[100px]" />
+        {/* Right side beam */}
+        <div className="absolute top-[40%] -right-[10%] h-[500px] w-[400px] rounded-full bg-primary/[0.06] blur-[80px]" />
+        {/* Bottom center glow */}
+        <div className="absolute -bottom-[15%] left-1/2 -translate-x-1/2 h-[400px] w-[800px] rounded-full bg-primary/[0.08] blur-[120px]" />
+        {/* Horizontal scan line effect */}
+        <div
+          className="absolute inset-0 opacity-[0.03]"
+          style={{
+            backgroundImage: 'repeating-linear-gradient(0deg, transparent, transparent 2px, oklch(0.89 0.29 128 / 0.15) 2px, transparent 4px)',
+            backgroundSize: '100% 4px',
+          }}
+        />
+      </div>
+
+      {/* ═══════════════════════════════════════════════════
+          HERO SECTION
+          ═══════════════════════════════════════════════════ */}
+      {/* Vertical centring is right on a desktop viewport and wrong on a phone.
+          At 390x844 it left ~210px of empty background above the badge and
+          pushed "Get Started" down into the consent banner's ~200px, so the
+          landing page's only call to action was unreadable and untappable on a
+          first visit. Start the content near the top on small screens; keep the
+          centred composition from `sm` up, where there is room for it. */}
+      <section className="relative flex min-h-[calc(100vh-3.5rem)] flex-col items-center justify-start px-4 pt-8 sm:justify-center sm:px-6 sm:pt-16">
+        <div className="mx-auto max-w-4xl text-center">
+          {/* Pill badge */}
+          <div className="animate-fade-in-up stagger-1 mb-8 inline-flex items-center gap-2 rounded-full border border-primary/20 bg-primary/[0.06] px-4 py-1.5 text-sm text-primary">
+            <Sparkles className="h-3.5 w-3.5" />
+            <span className="font-medium">Career Command Center</span>
+          </div>
+
+          {/* Headline — each line staggers in, neon glow */}
+          <h1
+            className="font-heading text-5xl font-bold tracking-tight sm:text-6xl lg:text-7xl"
+            style={{ textShadow: '0 0 80px oklch(0.89 0.29 128 / 0.15), 0 0 40px oklch(0.89 0.29 128 / 0.08)' }}
+          >
+            <span className="animate-fade-in-up stagger-2 block">
+              Your CV.
+            </span>
+            <span className="animate-fade-in-up stagger-3 block mt-1">
+              Every Application.
+            </span>
+            <span className="animate-fade-in-up stagger-4 block mt-1">
+              One{" "}
+              <span className="bg-gradient-to-r from-primary via-lime-300 to-primary bg-clip-text text-transparent">
+                Record
+              </span>
+              .
+            </span>
+          </h1>
+
+          {/* Subtitle */}
+          <p className="animate-fade-in-up stagger-5 mx-auto mt-6 max-w-2xl text-lg leading-relaxed text-muted-foreground sm:text-xl">
+            Upload your CV and let Job
+            <span className="bg-gradient-to-r from-primary via-lime-300 to-primary bg-clip-text text-transparent font-semibold">
+              360
+            </span>
+            &apos;s 8-dimensional scoring engine judge the fit, tailor your
+            documents, and remember every version — forever.
+          </p>
+
+          {/* CTAs */}
+          <div className="animate-fade-in-up stagger-6 mt-10 flex flex-col items-center gap-4 sm:flex-row sm:justify-center">
+            <Link
+              href="/profile"
+              className="group inline-flex h-12 items-center gap-2 rounded-xl bg-primary px-8 text-sm font-semibold text-primary-foreground shadow-[0_0_30px_oklch(0.89_0.29_128/0.4)] transition-all hover:shadow-[0_0_50px_oklch(0.89_0.29_128/0.6)] hover:brightness-110 hover:scale-105"
+            >
+              <Upload className="h-4 w-4" />
+              Get Started
+              <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
+            </Link>
+          </div>
+        </div>
+
+        {/* Scroll indicator — below CTAs with spacing */}
+        <div className="animate-fade-in-up stagger-7 mt-16 hidden sm:flex flex-col items-center gap-2 text-muted-foreground/30">
+          <span className="text-[10px] tracking-[0.2em] uppercase">Scroll</span>
+          <div className="h-6 w-[1px] bg-gradient-to-b from-muted-foreground/20 to-transparent" />
+        </div>
+      </section>
+
+      {/* ═══════════════════════════════════════════════════
+          STATS BAR
+          ═══════════════════════════════════════════════════ */}
+      <section className="relative px-4 py-16 sm:px-6">
+        <div className="mx-auto max-w-5xl">
+          <div className="glass-card rounded-2xl p-2">
+            <div className="grid grid-cols-2 gap-2 lg:grid-cols-4">
+              {STATS.map(({ icon: Icon, value, label, description }, i) => (
+                <div
+                  key={label}
+                  className={`animate-fade-in-up stagger-${i + 1} flex flex-col items-center gap-3 rounded-xl px-4 py-6 text-center transition-colors hover:bg-primary/[0.04]`}
+                >
+                  <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10 ring-1 ring-primary/20">
+                    <Icon className="h-5 w-5 text-primary" />
+                  </div>
+                  <div>
+                    <p className="font-mono text-2xl font-bold tracking-tight text-foreground">
+                      {value}
+                    </p>
+                    <p className="text-sm font-semibold text-foreground/90">
+                      {label}
+                    </p>
+                    <p className="mt-0.5 text-xs text-muted-foreground">
+                      {description}
+                    </p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* ═══════════════════════════════════════════════════
+          FEATURE GRID
+          ═══════════════════════════════════════════════════ */}
+      <section className="relative px-4 py-16 sm:px-6 lg:py-24">
+        <div className="mx-auto max-w-7xl">
+          {/* Section header */}
+          <div className="animate-fade-in-up stagger-1 mx-auto max-w-2xl text-center mb-12 lg:mb-16">
+            <p className="text-sm font-semibold uppercase tracking-widest text-primary">
+              Everything you need
+            </p>
+            <h2 className="font-heading mt-3 text-3xl font-bold tracking-tight sm:text-4xl">
+              Built for serious job seekers
+            </h2>
+            <p className="mt-4 text-muted-foreground text-lg">
+              Not another job board. A professional-grade search engine that
+              understands your career and finds roles you&apos;d actually want.
+            </p>
+          </div>
+
+          {/* Cards grid */}
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {FEATURES.map(
+              ({ icon: Icon, title, description, stagger }) => (
+                <div
+                  key={title}
+                  className={`animate-fade-in-up stagger-${stagger} glass-card group rounded-xl p-6`}
+                >
+                  <div className="mb-4 flex h-11 w-11 items-center justify-center rounded-lg bg-primary/10 ring-1 ring-primary/20 transition-all group-hover:bg-primary/15 group-hover:ring-primary/40">
+                    <Icon className="h-5 w-5 text-primary" />
+                  </div>
+                  <h3 className="font-heading text-lg font-semibold tracking-tight">
+                    {title}
+                  </h3>
+                  <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+                    {description}
+                  </p>
+                </div>
+              )
+            )}
+          </div>
+        </div>
+      </section>
+
+      {/* ═══════════════════════════════════════════════════
+          HOW IT WORKS — 3-step flow
+          ═══════════════════════════════════════════════════ */}
+      <section className="relative px-4 py-16 sm:px-6 lg:py-24">
+        <div className="mx-auto max-w-5xl">
+          <div className="animate-fade-in-up stagger-1 mx-auto max-w-2xl text-center mb-12">
+            <p className="text-sm font-semibold uppercase tracking-widest text-primary">
+              How it works
+            </p>
+            <h2 className="font-heading mt-3 text-3xl font-bold tracking-tight sm:text-4xl">
+              Three steps to your next role
+            </h2>
+          </div>
+
+          <div className="grid gap-8 md:grid-cols-3">
+            {[
+              {
+                step: "01",
+                title: "Upload your CV",
+                description:
+                  "Drop your PDF or DOCX. Our parser extracts skills, titles, experience, education, and certifications automatically.",
+                icon: Upload,
+              },
+              {
+                step: "02",
+                title: "Bring the job you found",
+                description:
+                  "Paste a job you found anywhere. Job360 scores it against your profile in 8 dimensions and keeps the ad even after the listing disappears.",
+                icon: Zap,
+              },
+              {
+                step: "03",
+                title: "Review top matches",
+                description:
+                  "Deduplicated, reranked, and sorted. See exactly why each job matched with evidence-backed scoring breakdowns.",
+                icon: Target,
+              },
+            ].map(({ step, title, description, icon: Icon }, i) => (
+              <div
+                key={step}
+                className={`animate-fade-in-up stagger-${i + 2} relative`}
+              >
+                {/* Connector line (hidden on last card and mobile) */}
+                {i < 2 && (
+                  <div
+                    aria-hidden
+                    className="absolute right-0 top-10 hidden h-[1px] w-8 translate-x-full bg-gradient-to-r from-primary/30 to-transparent md:block"
+                  />
+                )}
+                <div className="glass-card rounded-xl p-6 h-full flex flex-col">
+                  <div className="mb-4 flex items-center gap-3">
+                    <span className="font-mono text-3xl font-bold text-primary/30">
+                      {step}
+                    </span>
+                    <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10 ring-1 ring-primary/20">
+                      <Icon className="h-5 w-5 text-primary" />
+                    </div>
+                  </div>
+                  <h3 className="font-heading text-lg font-semibold">
+                    {title}
+                  </h3>
+                  <p className="mt-2 text-sm leading-relaxed text-muted-foreground flex-1">
+                    {description}
+                  </p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ═══════════════════════════════════════════════════
+          BOTTOM CTA
+          ═══════════════════════════════════════════════════ */}
+      <section className="relative px-4 py-20 sm:px-6 lg:py-28">
+        <div className="mx-auto max-w-3xl text-center">
+          {/* Ambient glow behind CTA */}
+          <div
+            aria-hidden
+            className="pointer-events-none absolute inset-0 flex items-center justify-center"
+          >
+            <div className="h-[500px] w-[800px] rounded-full bg-primary/[0.12] blur-[120px]" />
+          </div>
+
+          <div className="relative">
+            <h2 className="animate-fade-in-up stagger-1 font-heading text-3xl font-bold tracking-tight sm:text-4xl lg:text-5xl">
+              Ready to find your{" "}
+              <span className="bg-gradient-to-r from-primary via-lime-300 to-primary bg-clip-text text-transparent">
+                next role
+              </span>
+              ?
+            </h2>
+            <p className="animate-fade-in-up stagger-2 mx-auto mt-4 max-w-xl text-lg text-muted-foreground">
+              Upload your CV and let the engine do the heavy lifting. No
+              accounts, no spam, no fluff — just relevant matches.
+            </p>
+            <div className="animate-fade-in-up stagger-3 mt-8 flex flex-col items-center gap-4 sm:flex-row sm:justify-center">
+              <Link
+                href="/profile"
+                className="group inline-flex h-14 items-center gap-3 rounded-xl bg-primary px-10 text-base font-semibold text-primary-foreground shadow-[0_0_30px_oklch(0.89_0.29_128/0.4)] transition-all hover:shadow-[0_0_50px_oklch(0.89_0.29_128/0.6)] hover:brightness-110 hover:scale-105"
+              >
+                <Upload className="h-5 w-5" />
+                Upload Your CV
+                <ArrowRight className="h-5 w-5 transition-transform group-hover:translate-x-1" />
+              </Link>
+            </div>
+            <p className="animate-fade-in-up stagger-4 mt-6 text-xs text-muted-foreground/60">
+              Free and open source. Your data stays on your machine.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* ── Footer spacer ─────────────────────────────── */}
+      <div className="h-12" />
+    </div>
+  );
+}

--- a/frontend/src/app/__tests__/landing-sources-count.test.tsx
+++ b/frontend/src/app/__tests__/landing-sources-count.test.tsx
@@ -1,28 +1,26 @@
 /**
- * Regression guard: every source count on the landing page agrees with the ONE
- * constant, and no stale literal survives anywhere in the copy.
+ * Regression guard: the landing page never advertises a job-source count.
  *
- * WHY THIS TEST WAS REWRITTEN
+ * WHY THIS TEST WAS REWRITTEN (spec 2026-09-04-application-spine, R14)
  *
- * The previous version said in its docstring that it guarded "the live
- * SOURCE_REGISTRY size", then hardcoded `47` and asserted only that the page
- * did not say `46`. Six sources were pruned on 2026-08-17, the registry became
- * 41, and this test went on passing — its passing is exactly what kept the
- * landing page telling every visitor a number that was wrong by six.
+ * This file used to assert the landing page's FIVE mentions of `SOURCE_COUNT`
+ * were all internally consistent. R14 removed sourcing from the pitch
+ * entirely — "Job360 never sources or ranks jobs" (VISION rule 4) — so the
+ * previous assertions (checking a number that must no longer appear) would
+ * now be asserting the wrong thing. This test now asserts the OPPOSITE: no
+ * "<N> source(s)" copy survives anywhere on the landing page.
  *
- * A test that names a literal freezes that literal. So this one names none.
- * It asserts the rendered numbers are CONSISTENT with `SOURCE_COUNT`, and that
- * no other 2-digit count is lurking next to the word "source".
- *
- * The tie back to the backend registry is not this test's job and cannot be —
- * jsdom cannot read Python. `scripts/doc_sync_check.py` (guard
- * `landing-source-count`) compares `SOURCE_COUNT` against `SOURCE_REGISTRY`
- * and is mutation-tested, so it is known to be able to fail.
+ * `src/app/page.tsx` is now an async Server Component (it reads the session
+ * cookie via `next/headers` to decide Landing vs. the applications home) and
+ * can no longer be rendered synchronously by React Testing Library, so this
+ * test renders `Landing` (the extracted marketing page) directly.
  */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
-import Home from "../page";
-import { SOURCE_COUNT } from "@/lib/catalog";
+import { render } from "@testing-library/react";
+import Landing from "../Landing";
+import { Footer } from "@/components/layout/Footer";
 
 // Mock next/link — not available in jsdom
 vi.mock("next/link", () => ({
@@ -33,39 +31,45 @@ vi.mock("next/link", () => ({
   ),
 }));
 
-describe("Landing page — source count copy", () => {
-  it("stats bar shows the constant for Sources", () => {
-    render(<Home />);
-    expect(screen.getByText(String(SOURCE_COUNT))).toBeInTheDocument();
-  });
+const SOURCE_COUNT_RE = /\d{1,3}\s+(?:job\s+)?sources?\b/gi;
 
-  it("feature card title uses the constant", () => {
-    render(<Home />);
-    expect(screen.getByText(`${SOURCE_COUNT} Job Sources`)).toBeInTheDocument();
-  });
-
-  it("hero heading uses the constant", () => {
-    render(<Home />);
-    expect(screen.getByText(`${SOURCE_COUNT} Sources.`)).toBeInTheDocument();
-  });
-
-  it("hero paragraph uses the constant", () => {
-    render(<Home />);
-    expect(
-      screen.getByText(new RegExp(`${SOURCE_COUNT} job sources\\.`, "i")),
-    ).toBeInTheDocument();
-  });
-
-  it("no OTHER two-digit count appears beside the word 'source'", () => {
-    // The real failure was five copies of one number, only some of which any
-    // single assertion looked at. This sweeps the whole rendered document, so
-    // a sixth mention added later cannot quietly disagree with the other five.
-    const { container } = render(<Home />);
+describe("Landing page — no source-count copy (R14)", () => {
+  it("never mentions a job-source count", () => {
+    const { container } = render(<Landing />);
     const text = container.textContent ?? "";
-    const mentions = [...text.matchAll(/(\d{1,3})\s+(?:job\s+)?sources?\b/gi)];
-    expect(mentions.length).toBeGreaterThan(0);
-    for (const m of mentions) {
-      expect(Number(m[1])).toBe(SOURCE_COUNT);
-    }
+    const mentions = [...text.matchAll(SOURCE_COUNT_RE)];
+    expect(mentions).toHaveLength(0);
+  });
+
+  it("still renders the hero headline", () => {
+    const { getByText } = render(<Landing />);
+    expect(getByText("Your CV.")).toBeInTheDocument();
+  });
+});
+
+// C2 (application-spine review) — the Footer sits on EVERY page (mounted
+// once in layout.tsx), so a source-count claim there reaches a signed-in
+// user Landing.tsx never renders for. Same for the exported <head> metadata
+// (title/description/OpenGraph/Twitter) — a crawler or a share-card reads
+// that text, never the rendered DOM.
+describe("Footer — no source-count copy (R14, C2)", () => {
+  it("never mentions a job-source count", () => {
+    const { container } = render(<Footer />);
+    const text = container.textContent ?? "";
+    expect([...text.matchAll(SOURCE_COUNT_RE)]).toHaveLength(0);
+  });
+});
+
+describe("Root layout metadata — no source-count copy (R14, C2)", () => {
+  it("never mentions a job-source count in title/description/OpenGraph/Twitter", () => {
+    // Read the source text rather than `import { metadata } from "../layout"`:
+    // layout.tsx also pulls in `next/font/google`, which needs the Next.js
+    // compiler and cannot be imported directly under plain Vite/vitest.
+    // vitest runs with cwd = the frontend package root (vitest.config.ts).
+    const layoutPath = join(process.cwd(), "src/app/layout.tsx");
+    const source = readFileSync(layoutPath, "utf-8");
+    const metadataBlock = source.slice(source.indexOf("export const metadata"));
+    expect([...metadataBlock.matchAll(SOURCE_COUNT_RE)]).toHaveLength(0);
+    expect(metadataBlock).not.toMatch(/\d+D scoring/i);
   });
 });

--- a/frontend/src/app/applications/[id]/ApplicationClient.tsx
+++ b/frontend/src/app/applications/[id]/ApplicationClient.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import Link from "next/link";
+import { useCallback, useEffect, useState } from "react";
+import { ArrowLeft } from "lucide-react";
+import { toast } from "sonner";
+import { getApplication, recordApplicationReceipt } from "@/lib/api";
+import type { ApplicationDetail } from "@/lib/api";
+import { Timeline } from "@/components/applications/Timeline";
+import { ArtifactVersions } from "@/components/applications/ArtifactVersions";
+import { FitPanel } from "@/components/applications/FitPanel";
+
+const STATUS_LABEL: Record<string, string> = {
+  considering: "Considering",
+  applied: "Applied",
+  replied: "Replied",
+  interview_requested: "Interview requested",
+  interview_scheduled: "Interview scheduled",
+  interview_done: "Interview done",
+  offer: "Offer",
+  rejected: "Rejected",
+  withdrawn: "Withdrawn",
+  ghosted: "Ghosted",
+};
+
+/** The application record: status, the durable job snapshot (spec R2 —
+ * survives the catalog purging the live row), every artifact version, the
+ * event timeline, receipts, and the fit verdict. */
+export function ApplicationClient({ applicationId }: { applicationId: number }) {
+  const [detail, setDetail] = useState<ApplicationDetail | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [marking, setMarking] = useState(false);
+
+  const load = useCallback(async () => {
+    try {
+      const res = await getApplication(applicationId);
+      setDetail(res);
+      setError(null);
+    } catch {
+      setError("Could not load this application.");
+    }
+  }, [applicationId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const markApplied = useCallback(async () => {
+    setMarking(true);
+    try {
+      await recordApplicationReceipt(applicationId, {});
+      await load();
+    } catch (err) {
+      // C10 (application-spine review) — see ApplicationList.tsx's identical
+      // fix: without this the button just went quiet on failure.
+      const msg = err instanceof Error ? err.message : "Could not mark this application applied.";
+      toast.error(msg);
+    } finally {
+      setMarking(false);
+    }
+  }, [applicationId, load]);
+
+  if (error) {
+    return <p className="text-sm text-destructive">{error}</p>;
+  }
+  if (!detail) {
+    return <p className="text-sm text-muted-foreground">Loading…</p>;
+  }
+
+  return (
+    <div className="mx-auto flex max-w-3xl flex-col gap-6 px-4 py-8">
+      <Link href="/applications" className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground">
+        <ArrowLeft className="h-4 w-4" /> All applications
+      </Link>
+
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h1 className="font-heading text-2xl font-bold">{detail.job.job_title || "Untitled role"}</h1>
+          <p className="text-muted-foreground">{detail.job.job_company}</p>
+          {!detail.job.catalog_present && (
+            <p className="mt-1 text-xs text-muted-foreground/70">
+              This listing is no longer in the catalog — the snapshot above is what it read when you brought it.
+            </p>
+          )}
+        </div>
+        <div className="flex items-center gap-3">
+          <span className="rounded-full bg-primary/10 px-3 py-1 text-sm font-medium text-primary">
+            {STATUS_LABEL[detail.status] ?? detail.status}
+          </span>
+          {detail.status === "considering" && (
+            <button
+              type="button"
+              onClick={() => void markApplied()}
+              disabled={marking}
+              className="rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition-opacity hover:opacity-90 disabled:opacity-50"
+            >
+              {marking ? "Marking…" : "Mark Applied"}
+            </button>
+          )}
+          {detail.job.job_url && (
+            <a
+              href={detail.job.job_url}
+              target="_blank"
+              rel="noreferrer"
+              className="rounded-lg border border-border px-4 py-2 text-sm font-medium text-muted-foreground hover:text-foreground"
+            >
+              View ad
+            </a>
+          )}
+          <Link
+            href={`/jobs/${detail.job_id}`}
+            className="rounded-lg border border-border px-4 py-2 text-sm font-medium text-muted-foreground hover:text-foreground"
+          >
+            Tailor CV
+          </Link>
+        </div>
+      </div>
+
+      <section>
+        <h2 className="mb-2 text-sm font-semibold uppercase tracking-wide text-muted-foreground">Fit</h2>
+        <FitPanel fit={detail.fit} />
+      </section>
+
+      <section>
+        <h2 className="mb-2 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+          Artifacts
+        </h2>
+        <ArtifactVersions applicationId={detail.id} artifacts={detail.artifacts} />
+      </section>
+
+      <section>
+        <h2 className="mb-2 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+          Timeline
+        </h2>
+        <Timeline events={detail.events} />
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/app/applications/[id]/page.tsx
+++ b/frontend/src/app/applications/[id]/page.tsx
@@ -1,0 +1,22 @@
+import { ApplicationClient } from "./ApplicationClient";
+
+// ---------------------------------------------------------------------------
+// The application record (spec R11, R14).
+//
+// Server component shell: awaits `params` (Next.js 16 — sync access to
+// `params` was removed, see frontend/AGENTS.md) and hands the plain numeric
+// id to a client child, which does the actual fetch/render. Same
+// server-page + client-child split as src/app/oauth/consent/[rid]/page.tsx.
+//
+// Protected by middleware.ts (`/applications` is in PROTECTED_PATHS).
+// ---------------------------------------------------------------------------
+
+export default async function ApplicationPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+
+  return <ApplicationClient applicationId={Number(id)} />;
+}

--- a/frontend/src/app/applications/page.tsx
+++ b/frontend/src/app/applications/page.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { ApplicationList } from "@/components/applications/ApplicationList";
+
+// spec R14 — the applications list. Protected by middleware.ts
+// (`/applications` is in PROTECTED_PATHS). No metadata/SSR needs here, so a
+// plain client page (same pattern as src/app/pipeline/page.tsx).
+export default function ApplicationsPage() {
+  return (
+    <div className="mx-auto flex max-w-3xl flex-col gap-6 px-4 py-8">
+      <div>
+        <h1 className="font-heading text-2xl font-bold">Your applications</h1>
+        <p className="text-muted-foreground">
+          Every job you&apos;ve brought, its status, and its whole history.
+        </p>
+      </div>
+      <ApplicationList />
+    </div>
+  );
+}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,7 +1,4 @@
 import type { Metadata } from "next";
-// Catalog numbers shown to users live in one place; the copy said 47 for a
-// week after the registry dropped to 41. See src/lib/catalog.ts.
-import { SOURCE_COUNT, SCORING_DIMENSIONS } from "@/lib/catalog";
 import { Sora, Plus_Jakarta_Sans, JetBrains_Mono } from "next/font/google";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { Navbar } from "@/components/layout/Navbar";
@@ -34,20 +31,24 @@ const jetbrainsMono = JetBrains_Mono({
   display: "swap",
 });
 
+// C2 (application-spine review, VISION rule 4) — Job360 never sources or
+// ranks jobs; the meta/OpenGraph/Twitter copy used to advertise a source
+// count and scoring dimensions on every page. Mission copy instead.
+const TAGLINE = "Your career memory. Your agent's context.";
+
 export const metadata: Metadata = {
   title: "Job360 — Your Career Command Center",
-  description:
-    `${SOURCE_COUNT} sources. ${SCORING_DIMENSIONS}D scoring. One dashboard. Upload your CV and let Job360 find your perfect match.`,
+  description: `${TAGLINE} Job360 remembers every application, every version, every outcome for the AI agent doing your job search.`,
   openGraph: {
     title: "Job360 — Your Career Command Center",
-    description: `${SOURCE_COUNT} sources. ${SCORING_DIMENSIONS}D scoring. One dashboard.`,
+    description: TAGLINE,
     type: "website",
     siteName: "Job360",
   },
   twitter: {
     card: "summary_large_image",
     title: "Job360 — Your Career Command Center",
-    description: `${SOURCE_COUNT} sources. ${SCORING_DIMENSIONS}D scoring. One dashboard.`,
+    description: TAGLINE,
   },
 };
 

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,386 +1,46 @@
+import { cookies } from "next/headers";
 import Link from "next/link";
-// One place for the catalog numbers shown to users. The copy said 47 for a
-// week after the registry dropped to 41; see src/lib/catalog.ts.
-import { SOURCE_COUNT, SCORING_DIMENSIONS } from "@/lib/catalog";
-import {
-  Radar,
-  Globe,
-  Target,
-  Layers,
-  Kanban,
-  Brain,
-  ArrowRight,
-  Upload,
-  Zap,
-  Clock,
-  Shield,
-  Sparkles,
-} from "lucide-react";
+import Landing from "./Landing";
+import { ApplicationList } from "@/components/applications/ApplicationList";
 
-const FEATURES = [
-  {
-    icon: Radar,
-    title: "8-Dimensional Scoring",
-    description:
-      "Role, Skill, Seniority, Experience, Credentials, Location, Recency, and Semantic similarity — every job scored 0-100 with evidence-backed reasons.",
-    stagger: 1,
-  },
-  {
-    icon: Globe,
-    title: `${SOURCE_COUNT} Job Sources`,
-    description:
-      "APIs, ATS boards, RSS feeds, and intelligent scrapers. From Greenhouse to HackerNews, Reed to RemoteOK — all aggregated in real time.",
-    stagger: 2,
-  },
-  {
-    icon: Target,
-    title: "Skill Gap Analysis",
-    description:
-      "Instantly see matched, missing, and transferable skills for every listing. Know exactly where you stand before you apply.",
-    stagger: 3,
-  },
-  {
-    icon: Layers,
-    title: "Smart Deduplication",
-    description:
-      "Two-pass dedup with normalized keys and semantic similarity. No more seeing the same role posted across five boards.",
-    stagger: 4,
-  },
-  {
-    icon: Kanban,
-    title: "Application Pipeline",
-    description:
-      "Track every opportunity from discovery to offer. Bookmarks, applications, interviews, and outcomes — all in one view.",
-    stagger: 5,
-  },
-  {
-    icon: Brain,
-    title: "Career Intelligence",
-    description:
-      "AI-powered matching with 424 synonym groups, a 563-edge skill graph, and cross-encoder reranking. It understands your career, not just keywords.",
-    stagger: 6,
-  },
-] as const;
+// ---------------------------------------------------------------------------
+// R14 (docs/plans/2026-09-04-application-spine/spec.md) — the web home is
+// YOUR APPLICATIONS. A signed-in visitor sees their applications home; a
+// signed-out visitor keeps the existing marketing landing page.
+//
+// `/` is deliberately NOT in middleware.ts's PROTECTED_PATHS (unfurl bots
+// and landing-cta-auth.spec.ts depend on the public landing staying public)
+// — so the split happens HERE, by reading the session cookie's PRESENCE
+// (same signal middleware.ts itself checks; the actual auth/authorization
+// check for every API call this page's children make is the backend's
+// `require_user`, not this cookie peek).
+// ---------------------------------------------------------------------------
 
-const STATS = [
-  {
-    icon: Globe,
-    value: String(SOURCE_COUNT),
-    label: "Sources",
-    description: "APIs, ATS, RSS & scrapers",
-  },
-  {
-    icon: Radar,
-    value: "8D",
-    label: "Scoring",
-    description: "Multi-dimensional match engine",
-  },
-  {
-    icon: Clock,
-    value: "Real-time",
-    label: "Updates",
-    description: "Fresh jobs every run",
-  },
-  {
-    icon: Shield,
-    value: "Any",
-    label: "Domain",
-    description: "Tech, finance, health & more",
-  },
-] as const;
+export default async function Home() {
+  const cookieStore = await cookies();
+  const signedIn = Boolean(cookieStore.get("job360_session")?.value);
 
-export default function Home() {
+  if (!signedIn) {
+    return <Landing />;
+  }
+
   return (
-    <div className="relative">
-      {/* ── Hero ambient glow — dramatic multi-layer aurora ── */}
-      <div
-        aria-hidden
-        className="pointer-events-none absolute inset-0 overflow-hidden"
-      >
-        {/* Primary top beam — strong, animated */}
-        <div
-          className="absolute -top-[20%] left-1/2 h-[900px] w-[1200px] -translate-x-1/2 rounded-full bg-primary/[0.15] blur-[140px]"
-          style={{ animation: 'aurora-drift 8s ease-in-out infinite' }}
-        />
-        {/* Secondary top-right accent */}
-        <div
-          className="absolute -top-[10%] right-[5%] h-[500px] w-[500px] rounded-full bg-primary/[0.08] blur-[100px]"
-          style={{ animation: 'aurora-drift 12s ease-in-out infinite reverse' }}
-        />
-        {/* Left side beam */}
-        <div className="absolute top-[20%] -left-[15%] h-[600px] w-[400px] rounded-full bg-primary/[0.10] blur-[100px]" />
-        {/* Right side beam */}
-        <div className="absolute top-[40%] -right-[10%] h-[500px] w-[400px] rounded-full bg-primary/[0.06] blur-[80px]" />
-        {/* Bottom center glow */}
-        <div className="absolute -bottom-[15%] left-1/2 -translate-x-1/2 h-[400px] w-[800px] rounded-full bg-primary/[0.08] blur-[120px]" />
-        {/* Horizontal scan line effect */}
-        <div
-          className="absolute inset-0 opacity-[0.03]"
-          style={{
-            backgroundImage: 'repeating-linear-gradient(0deg, transparent, transparent 2px, oklch(0.89 0.29 128 / 0.15) 2px, transparent 4px)',
-            backgroundSize: '100% 4px',
-          }}
-        />
-      </div>
-
-      {/* ═══════════════════════════════════════════════════
-          HERO SECTION
-          ═══════════════════════════════════════════════════ */}
-      {/* Vertical centring is right on a desktop viewport and wrong on a phone.
-          At 390x844 it left ~210px of empty background above the badge and
-          pushed "Get Started" down into the consent banner's ~200px, so the
-          landing page's only call to action was unreadable and untappable on a
-          first visit. Start the content near the top on small screens; keep the
-          centred composition from `sm` up, where there is room for it. */}
-      <section className="relative flex min-h-[calc(100vh-3.5rem)] flex-col items-center justify-start px-4 pt-8 sm:justify-center sm:px-6 sm:pt-16">
-        <div className="mx-auto max-w-4xl text-center">
-          {/* Pill badge */}
-          <div className="animate-fade-in-up stagger-1 mb-8 inline-flex items-center gap-2 rounded-full border border-primary/20 bg-primary/[0.06] px-4 py-1.5 text-sm text-primary">
-            <Sparkles className="h-3.5 w-3.5" />
-            <span className="font-medium">Career Command Center</span>
-          </div>
-
-          {/* Headline — each line staggers in, neon glow */}
-          <h1
-            className="font-heading text-5xl font-bold tracking-tight sm:text-6xl lg:text-7xl"
-            style={{ textShadow: '0 0 80px oklch(0.89 0.29 128 / 0.15), 0 0 40px oklch(0.89 0.29 128 / 0.08)' }}
-          >
-            <span className="animate-fade-in-up stagger-2 block">
-              Your CV.
-            </span>
-            <span className="animate-fade-in-up stagger-3 block mt-1">
-              {SOURCE_COUNT} Sources.
-            </span>
-            <span className="animate-fade-in-up stagger-4 block mt-1">
-              One{" "}
-              <span className="bg-gradient-to-r from-primary via-lime-300 to-primary bg-clip-text text-transparent">
-                Dashboard
-              </span>
-              .
-            </span>
-          </h1>
-
-          {/* Subtitle */}
-          <p className="animate-fade-in-up stagger-5 mx-auto mt-6 max-w-2xl text-lg leading-relaxed text-muted-foreground sm:text-xl">
-            Upload your CV and let Job
-            <span className="bg-gradient-to-r from-primary via-lime-300 to-primary bg-clip-text text-transparent font-semibold">
-              360
-            </span>
-            &apos;s 8-dimensional scoring engine find your perfect match across
-            {SOURCE_COUNT} job sources.
+    <div className="mx-auto flex max-w-3xl flex-col gap-6 px-4 py-8 sm:py-12">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="font-heading text-2xl font-bold sm:text-3xl">Your applications</h1>
+          <p className="text-muted-foreground">
+            Every job you&apos;ve brought, its status, and its whole history.
           </p>
-
-          {/* CTAs */}
-          <div className="animate-fade-in-up stagger-6 mt-10 flex flex-col items-center gap-4 sm:flex-row sm:justify-center">
-            <Link
-              href="/profile"
-              className="group inline-flex h-12 items-center gap-2 rounded-xl bg-primary px-8 text-sm font-semibold text-primary-foreground shadow-[0_0_30px_oklch(0.89_0.29_128/0.4)] transition-all hover:shadow-[0_0_50px_oklch(0.89_0.29_128/0.6)] hover:brightness-110 hover:scale-105"
-            >
-              <Upload className="h-4 w-4" />
-              Get Started
-              <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
-            </Link>
-          </div>
         </div>
-
-        {/* Scroll indicator — below CTAs with spacing */}
-        <div className="animate-fade-in-up stagger-7 mt-16 hidden sm:flex flex-col items-center gap-2 text-muted-foreground/30">
-          <span className="text-[10px] tracking-[0.2em] uppercase">Scroll</span>
-          <div className="h-6 w-[1px] bg-gradient-to-b from-muted-foreground/20 to-transparent" />
-        </div>
-      </section>
-
-      {/* ═══════════════════════════════════════════════════
-          STATS BAR
-          ═══════════════════════════════════════════════════ */}
-      <section className="relative px-4 py-16 sm:px-6">
-        <div className="mx-auto max-w-5xl">
-          <div className="glass-card rounded-2xl p-2">
-            <div className="grid grid-cols-2 gap-2 lg:grid-cols-4">
-              {STATS.map(({ icon: Icon, value, label, description }, i) => (
-                <div
-                  key={label}
-                  className={`animate-fade-in-up stagger-${i + 1} flex flex-col items-center gap-3 rounded-xl px-4 py-6 text-center transition-colors hover:bg-primary/[0.04]`}
-                >
-                  <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10 ring-1 ring-primary/20">
-                    <Icon className="h-5 w-5 text-primary" />
-                  </div>
-                  <div>
-                    <p className="font-mono text-2xl font-bold tracking-tight text-foreground">
-                      {value}
-                    </p>
-                    <p className="text-sm font-semibold text-foreground/90">
-                      {label}
-                    </p>
-                    <p className="mt-0.5 text-xs text-muted-foreground">
-                      {description}
-                    </p>
-                  </div>
-                </div>
-              ))}
-            </div>
-          </div>
-        </div>
-      </section>
-
-      {/* ═══════════════════════════════════════════════════
-          FEATURE GRID
-          ═══════════════════════════════════════════════════ */}
-      <section className="relative px-4 py-16 sm:px-6 lg:py-24">
-        <div className="mx-auto max-w-7xl">
-          {/* Section header */}
-          <div className="animate-fade-in-up stagger-1 mx-auto max-w-2xl text-center mb-12 lg:mb-16">
-            <p className="text-sm font-semibold uppercase tracking-widest text-primary">
-              Everything you need
-            </p>
-            <h2 className="font-heading mt-3 text-3xl font-bold tracking-tight sm:text-4xl">
-              Built for serious job seekers
-            </h2>
-            <p className="mt-4 text-muted-foreground text-lg">
-              Not another job board. A professional-grade search engine that
-              understands your career and finds roles you&apos;d actually want.
-            </p>
-          </div>
-
-          {/* Cards grid */}
-          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-            {FEATURES.map(
-              ({ icon: Icon, title, description, stagger }) => (
-                <div
-                  key={title}
-                  className={`animate-fade-in-up stagger-${stagger} glass-card group rounded-xl p-6`}
-                >
-                  <div className="mb-4 flex h-11 w-11 items-center justify-center rounded-lg bg-primary/10 ring-1 ring-primary/20 transition-all group-hover:bg-primary/15 group-hover:ring-primary/40">
-                    <Icon className="h-5 w-5 text-primary" />
-                  </div>
-                  <h3 className="font-heading text-lg font-semibold tracking-tight">
-                    {title}
-                  </h3>
-                  <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
-                    {description}
-                  </p>
-                </div>
-              )
-            )}
-          </div>
-        </div>
-      </section>
-
-      {/* ═══════════════════════════════════════════════════
-          HOW IT WORKS — 3-step flow
-          ═══════════════════════════════════════════════════ */}
-      <section className="relative px-4 py-16 sm:px-6 lg:py-24">
-        <div className="mx-auto max-w-5xl">
-          <div className="animate-fade-in-up stagger-1 mx-auto max-w-2xl text-center mb-12">
-            <p className="text-sm font-semibold uppercase tracking-widest text-primary">
-              How it works
-            </p>
-            <h2 className="font-heading mt-3 text-3xl font-bold tracking-tight sm:text-4xl">
-              Three steps to your next role
-            </h2>
-          </div>
-
-          <div className="grid gap-8 md:grid-cols-3">
-            {[
-              {
-                step: "01",
-                title: "Upload your CV",
-                description:
-                  "Drop your PDF or DOCX. Our parser extracts skills, titles, experience, education, and certifications automatically.",
-                icon: Upload,
-              },
-              {
-                step: "02",
-                title: "We search everywhere",
-                description:
-                  `${SOURCE_COUNT} sources queried in parallel — APIs, ATS boards, RSS feeds. Every job scored against your profile in ${SCORING_DIMENSIONS} dimensions.`,
-                icon: Zap,
-              },
-              {
-                step: "03",
-                title: "Review top matches",
-                description:
-                  "Deduplicated, reranked, and sorted. See exactly why each job matched with evidence-backed scoring breakdowns.",
-                icon: Target,
-              },
-            ].map(({ step, title, description, icon: Icon }, i) => (
-              <div
-                key={step}
-                className={`animate-fade-in-up stagger-${i + 2} relative`}
-              >
-                {/* Connector line (hidden on last card and mobile) */}
-                {i < 2 && (
-                  <div
-                    aria-hidden
-                    className="absolute right-0 top-10 hidden h-[1px] w-8 translate-x-full bg-gradient-to-r from-primary/30 to-transparent md:block"
-                  />
-                )}
-                <div className="glass-card rounded-xl p-6 h-full flex flex-col">
-                  <div className="mb-4 flex items-center gap-3">
-                    <span className="font-mono text-3xl font-bold text-primary/30">
-                      {step}
-                    </span>
-                    <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10 ring-1 ring-primary/20">
-                      <Icon className="h-5 w-5 text-primary" />
-                    </div>
-                  </div>
-                  <h3 className="font-heading text-lg font-semibold">
-                    {title}
-                  </h3>
-                  <p className="mt-2 text-sm leading-relaxed text-muted-foreground flex-1">
-                    {description}
-                  </p>
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      {/* ═══════════════════════════════════════════════════
-          BOTTOM CTA
-          ═══════════════════════════════════════════════════ */}
-      <section className="relative px-4 py-20 sm:px-6 lg:py-28">
-        <div className="mx-auto max-w-3xl text-center">
-          {/* Ambient glow behind CTA */}
-          <div
-            aria-hidden
-            className="pointer-events-none absolute inset-0 flex items-center justify-center"
-          >
-            <div className="h-[500px] w-[800px] rounded-full bg-primary/[0.12] blur-[120px]" />
-          </div>
-
-          <div className="relative">
-            <h2 className="animate-fade-in-up stagger-1 font-heading text-3xl font-bold tracking-tight sm:text-4xl lg:text-5xl">
-              Ready to find your{" "}
-              <span className="bg-gradient-to-r from-primary via-lime-300 to-primary bg-clip-text text-transparent">
-                next role
-              </span>
-              ?
-            </h2>
-            <p className="animate-fade-in-up stagger-2 mx-auto mt-4 max-w-xl text-lg text-muted-foreground">
-              Upload your CV and let the engine do the heavy lifting. No
-              accounts, no spam, no fluff — just relevant matches.
-            </p>
-            <div className="animate-fade-in-up stagger-3 mt-8 flex flex-col items-center gap-4 sm:flex-row sm:justify-center">
-              <Link
-                href="/profile"
-                className="group inline-flex h-14 items-center gap-3 rounded-xl bg-primary px-10 text-base font-semibold text-primary-foreground shadow-[0_0_30px_oklch(0.89_0.29_128/0.4)] transition-all hover:shadow-[0_0_50px_oklch(0.89_0.29_128/0.6)] hover:brightness-110 hover:scale-105"
-              >
-                <Upload className="h-5 w-5" />
-                Upload Your CV
-                <ArrowRight className="h-5 w-5 transition-transform group-hover:translate-x-1" />
-              </Link>
-            </div>
-            <p className="animate-fade-in-up stagger-4 mt-6 text-xs text-muted-foreground/60">
-              Free and open source. Your data stays on your machine.
-            </p>
-          </div>
-        </div>
-      </section>
-
-      {/* ── Footer spacer ─────────────────────────────── */}
-      <div className="h-12" />
+        <Link
+          href="/bring"
+          className="rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition-opacity hover:opacity-90"
+        >
+          Bring a job
+        </Link>
+      </div>
+      <ApplicationList />
     </div>
   );
 }

--- a/frontend/src/app/pipeline/page.tsx
+++ b/frontend/src/app/pipeline/page.tsx
@@ -95,8 +95,19 @@ export default function PipelinePage() {
         getPipelineCounts(),
         getPipelineReminders(),
       ]);
-      setApplications(appsRes.applications);
-      setCounts(countsRes);
+      // B2 (application-spine review) — a freshly-brought job now lands at
+      // stage "considering" (birth_application writes it explicitly, see
+      // backend/src/services/applications/spine.py::birth_application). That
+      // is not one of this board's six columns (STAGE_META/KanbanBoard), so a
+      // "considering" row would silently vanish from the Kanban while still
+      // padding the applications array and the stats-row total. Filter it out
+      // here — the legacy board stays exactly as it read before this slice.
+      setApplications(
+        appsRes.applications.filter((a) => a.stage !== "considering")
+      );
+      const visibleCounts = { ...countsRes };
+      delete visibleCounts.considering;
+      setCounts(visibleCounts);
       setReminders(
         (remindersRes.reminders ?? []) as PipelineApplication[]
       );

--- a/frontend/src/components/applications/ApplicationList.tsx
+++ b/frontend/src/components/applications/ApplicationList.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import Link from "next/link";
+import { useCallback, useEffect, useState } from "react";
+import { toast } from "sonner";
+import { listApplications, recordApplicationReceipt } from "@/lib/api";
+import type { ApplicationSummary } from "@/lib/api";
+
+// The status vocabulary is closed in the backend (src/core/settings.py
+// APPLICATION_STATUS_EVENT_TYPES) — this is display copy only, never a
+// second source of truth for which statuses exist.
+const STATUS_LABEL: Record<string, string> = {
+  considering: "Considering",
+  applied: "Applied",
+  replied: "Replied",
+  interview_requested: "Interview requested",
+  interview_scheduled: "Interview scheduled",
+  interview_done: "Interview done",
+  offer: "Offer",
+  rejected: "Rejected",
+  withdrawn: "Withdrawn",
+  ghosted: "Ghosted",
+};
+
+/**
+ * The applications home + the `/applications` list page share this list —
+ * both render the same summary rows (spec R11 `GET /applications`).
+ *
+ * "Mark Applied" is the fastest path from "considering" to a receipt: it
+ * calls `record_application` (spec R8) with no artifact named, so it freezes
+ * whatever the newest CV/cover-letter version already is (or none).
+ */
+export function ApplicationList({ limit = 50 }: { limit?: number }) {
+  const [applications, setApplications] = useState<ApplicationSummary[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [markingId, setMarkingId] = useState<number | null>(null);
+
+  const load = useCallback(async () => {
+    try {
+      const res = await listApplications({ limit });
+      setApplications(res.applications);
+      setError(null);
+    } catch {
+      setError("Could not load your applications.");
+    }
+  }, [limit]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const markApplied = useCallback(
+    async (id: number) => {
+      setMarkingId(id);
+      try {
+        await recordApplicationReceipt(id, {});
+        await load();
+      } catch (err) {
+        // C10 (application-spine review) — an unhandled rejection here left
+        // the button stuck on "Marking…" forever with no feedback: the
+        // `finally` below always clears `markingId`, but nothing ever told
+        // the user the call actually failed.
+        const msg = err instanceof Error ? err.message : "Could not mark this application applied.";
+        toast.error(msg);
+      } finally {
+        setMarkingId(null);
+      }
+    },
+    [load]
+  );
+
+  if (error) {
+    return <p className="text-sm text-destructive">{error}</p>;
+  }
+
+  if (applications === null) {
+    return <p className="text-sm text-muted-foreground">Loading your applications…</p>;
+  }
+
+  if (applications.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        Nothing yet. Bring a job from your agent, or the{" "}
+        <Link href="/bring" className="text-primary underline">
+          Bring a job
+        </Link>{" "}
+        page, to start your record.
+      </p>
+    );
+  }
+
+  return (
+    <ul className="flex flex-col gap-3">
+      {applications.map((app) => (
+        <li
+          key={app.id}
+          className="glass-card flex items-center justify-between gap-4 rounded-xl p-4"
+        >
+          <Link href={`/applications/${app.id}`} className="min-w-0 flex-1">
+            <p className="truncate font-semibold">{app.job_title || "Untitled role"}</p>
+            <p className="truncate text-sm text-muted-foreground">{app.job_company}</p>
+          </Link>
+          <div className="flex shrink-0 items-center gap-3">
+            <span className="rounded-full bg-primary/10 px-3 py-1 text-xs font-medium text-primary">
+              {STATUS_LABEL[app.status] ?? app.status}
+            </span>
+            {app.status === "considering" && (
+              <button
+                type="button"
+                onClick={() => void markApplied(app.id)}
+                disabled={markingId === app.id}
+                className="rounded-lg bg-primary px-3 py-1.5 text-xs font-semibold text-primary-foreground transition-opacity hover:opacity-90 disabled:opacity-50"
+              >
+                {markingId === app.id ? "Marking…" : "Mark Applied"}
+              </button>
+            )}
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/frontend/src/components/applications/ArtifactVersions.tsx
+++ b/frontend/src/components/applications/ArtifactVersions.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { getApplicationArtifact } from "@/lib/api";
+import type { ApplicationArtifact } from "@/lib/api";
+
+/**
+ * Every version of every artifact, grouped by kind — "every version still
+ * readable" (spec's done-when). Artifact TEXT is off by default on
+ * `GET /applications/{id}` (R11); clicking a version fetches its full text
+ * from `GET /applications/{id}/artifacts/{artifact_id}` on demand.
+ */
+export function ArtifactVersions({
+  applicationId,
+  artifacts,
+}: {
+  applicationId: number;
+  artifacts: ApplicationArtifact[];
+}) {
+  const [openId, setOpenId] = useState<number | null>(null);
+  const [texts, setTexts] = useState<Record<number, string>>({});
+  const [loadingId, setLoadingId] = useState<number | null>(null);
+
+  const open = useCallback(
+    async (artifact: ApplicationArtifact) => {
+      if (openId === artifact.id) {
+        setOpenId(null);
+        return;
+      }
+      setOpenId(artifact.id);
+      if (artifact.text != null) {
+        setTexts((prev) => ({ ...prev, [artifact.id]: artifact.text as string }));
+        return;
+      }
+      if (texts[artifact.id] != null) return;
+      setLoadingId(artifact.id);
+      try {
+        const full = await getApplicationArtifact(applicationId, artifact.id);
+        setTexts((prev) => ({ ...prev, [artifact.id]: full.text ?? "" }));
+      } finally {
+        setLoadingId(null);
+      }
+    },
+    [applicationId, openId, texts]
+  );
+
+  if (artifacts.length === 0) {
+    return <p className="text-sm text-muted-foreground">No CV or cover letter versions saved yet.</p>;
+  }
+
+  const byKind = new Map<string, ApplicationArtifact[]>();
+  for (const a of artifacts) {
+    const list = byKind.get(a.kind) ?? [];
+    list.push(a);
+    byKind.set(a.kind, list);
+  }
+  for (const list of byKind.values()) list.sort((a, b) => a.version_no - b.version_no);
+
+  return (
+    <div className="flex flex-col gap-4">
+      {[...byKind.entries()].map(([kind, versions]) => (
+        <div key={kind}>
+          <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            {kind.replace("_", " ")}
+          </p>
+          <div className="flex flex-col gap-2">
+            {versions.map((artifact) => (
+              <div key={artifact.id} className="glass-card rounded-lg p-3">
+                <button
+                  type="button"
+                  onClick={() => void open(artifact)}
+                  className="flex w-full items-center justify-between gap-2 text-left text-sm font-medium"
+                >
+                  <span>
+                    <span data-testid="artifact-version-label">v{artifact.version_no}</span>{" "}
+                    <span className="ml-2 text-xs font-normal text-muted-foreground">
+                      {artifact.made_by} · {artifact.chars} chars
+                    </span>
+                  </span>
+                  <span className="text-xs text-muted-foreground">
+                    {new Date(artifact.created_at).toLocaleDateString()}
+                  </span>
+                </button>
+                {openId === artifact.id && (
+                  <div className="mt-2 whitespace-pre-wrap rounded-md bg-muted/30 p-3 text-sm">
+                    {loadingId === artifact.id ? "Loading…" : texts[artifact.id]}
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/applications/FitPanel.tsx
+++ b/frontend/src/components/applications/FitPanel.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import type { ApplicationFit } from "@/lib/api";
+
+/**
+ * The fit verdict — STORED, never computed by Job360 (VISION rule 4). This
+ * panel only ever displays what an agent already saved via `save_fit`; it
+ * makes no scoring call of its own.
+ */
+export function FitPanel({ fit }: { fit: ApplicationFit | null }) {
+  if (!fit) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        No fit judgement recorded yet — your agent can save one with `save_fit`.
+      </p>
+    );
+  }
+
+  return (
+    <div className="glass-card rounded-xl p-4">
+      <div className="flex items-center justify-between gap-3">
+        <p className="font-semibold">{fit.verdict ?? "No verdict text"}</p>
+        {fit.score != null && (
+          <span className="rounded-full bg-primary/10 px-3 py-1 text-sm font-semibold text-primary">
+            {fit.score}/100
+          </span>
+        )}
+      </div>
+      {fit.reasoning && <p className="mt-2 text-sm text-muted-foreground">{fit.reasoning}</p>}
+      {fit.gaps.length > 0 && (
+        <ul className="mt-2 flex flex-wrap gap-1.5">
+          {fit.gaps.map((gap) => (
+            <li
+              key={gap}
+              className="rounded-full bg-destructive/10 px-2.5 py-0.5 text-xs text-destructive"
+            >
+              {gap}
+            </li>
+          ))}
+        </ul>
+      )}
+      <p className="mt-2 text-xs text-muted-foreground/70">
+        recorded by {fit.recorded_by} · {new Date(fit.recorded_at).toLocaleString()}
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/components/applications/Timeline.tsx
+++ b/frontend/src/components/applications/Timeline.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import type { ApplicationEvent } from "@/lib/api";
+
+/** The whole append-only event log, in `occurred_at` order (spec R3/R11). A
+ * superseded event (retired by a correcting event, spec R3) is shown struck
+ * through rather than hidden — the log itself never drops a row. */
+export function Timeline({ events }: { events: ApplicationEvent[] }) {
+  if (events.length === 0) {
+    return <p className="text-sm text-muted-foreground">No events yet.</p>;
+  }
+
+  return (
+    <ol className="flex flex-col gap-3">
+      {events.map((event) => (
+        <li
+          key={event.id}
+          className={`glass-card rounded-lg p-3 text-sm ${event.superseded ? "opacity-50" : ""}`}
+        >
+          <div className="flex items-center justify-between gap-2">
+            <span className={`font-medium ${event.superseded ? "line-through" : ""}`}>
+              {event.event_type}
+            </span>
+            <span className="text-xs text-muted-foreground">
+              {new Date(event.occurred_at).toLocaleString()}
+            </span>
+          </div>
+          {event.detail && <p className="mt-1 text-muted-foreground">{event.detail}</p>}
+          <p className="mt-1 text-xs text-muted-foreground/70">
+            recorded by {event.recorded_by}
+            {event.superseded && " · superseded"}
+          </p>
+        </li>
+      ))}
+    </ol>
+  );
+}

--- a/frontend/src/components/layout/Footer.tsx
+++ b/frontend/src/components/layout/Footer.tsx
@@ -1,8 +1,5 @@
 import Link from "next/link";
 import { Activity, ExternalLink } from "lucide-react";
-// This strapline sits on every page. It said "47 sources" for a week after the
-// registry dropped to 41. See src/lib/catalog.ts.
-import { SOURCE_COUNT, SCORING_DIMENSIONS } from "@/lib/catalog";
 
 // Legal link slots — content (privacy policy, terms) populated in Batch 4 launch readiness
 const LEGAL_LINKS: { label: string; href: string }[] = [
@@ -49,7 +46,10 @@ export function Footer() {
         </nav>
 
         <p className="text-xs text-muted-foreground/60">
-          {SOURCE_COUNT} sources. {SCORING_DIMENSIONS}D scoring. One dashboard.
+          {/* C2 (application-spine review) — VISION rule 4: Job360 never
+              sources or ranks jobs. This footer advertised a source count on
+              every page; replaced with the mission line. */}
+          Your career memory. Your agent&apos;s context.
         </p>
       </div>
     </footer>

--- a/frontend/src/components/layout/Navbar.signed-out.test.tsx
+++ b/frontend/src/components/layout/Navbar.signed-out.test.tsx
@@ -33,7 +33,12 @@ vi.mock("@/components/layout/AuthProvider", () => ({
   useAuth: () => ({ ...mockAuth, logout: vi.fn() }),
 }));
 
-const APP_LINKS = ["Profile", "Dashboard", "Pipeline", "Channels"];
+// R12/R14 (docs/plans/2026-09-04-application-spine) — Dashboard is gated
+// behind NEXT_PUBLIC_SEARCH_UI_ENABLED (unset/false in this test env, so it
+// does not render); Applications is the new spine-home nav item. Pipeline
+// (and Receipts) LEFT the nav under R14 — both URLs still work, just not
+// linked from here (C3, application-spine review).
+const APP_LINKS = ["Profile", "Applications", "Channels"];
 
 beforeEach(() => {
   mockPathname = "/";

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -6,12 +6,11 @@ import { useState } from "react";
 import {
   LayoutDashboard,
   User,
-  Kanban,
   Menu,
   Activity,
   Send,
   ClipboardPaste,
-  FileCheck2,
+  FolderClock,
   Settings,
   LogOut,
 } from "lucide-react";
@@ -19,12 +18,21 @@ import { Button } from "@/components/ui/button";
 import { Sheet, SheetContent, SheetTrigger, SheetTitle } from "@/components/ui/sheet";
 import { useAuth } from "@/components/layout/AuthProvider";
 
+// R12/R14 (docs/plans/2026-09-04-application-spine) — the legacy search UI
+// (Dashboard) is gated behind the same build-time flag as the backend
+// routes and the /dashboard 404 in middleware.ts. NEXT_PUBLIC_* is inlined
+// at build time, same convention as src/lib/api.ts:47.
+const SEARCH_UI_ENABLED = process.env.NEXT_PUBLIC_SEARCH_UI_ENABLED === "true";
+
+// R14 (docs/plans/2026-09-04-application-spine) — /pipeline and /receipts
+// leave the nav here; both URLs keep working (slice 5 removes the routes).
 const NAV_LINKS = [
   { href: "/profile", label: "Profile", icon: User },
   { href: "/bring", label: "Bring a job", icon: ClipboardPaste },
-  { href: "/dashboard", label: "Dashboard", icon: LayoutDashboard },
-  { href: "/pipeline", label: "Pipeline", icon: Kanban },
-  { href: "/receipts", label: "Receipts", icon: FileCheck2 },
+  { href: "/applications", label: "Applications", icon: FolderClock },
+  ...(SEARCH_UI_ENABLED
+    ? [{ href: "/dashboard", label: "Dashboard", icon: LayoutDashboard }]
+    : []),
   { href: "/channels", label: "Channels", icon: Send },
 ] as const;
 

--- a/frontend/src/lib/api-types.ts
+++ b/frontend/src/lib/api-types.ts
@@ -89,6 +89,142 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/applications": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List Applications */
+        get: operations["list_applications_api_applications_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/applications/export": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Export History */
+        get: operations["export_history_api_applications_export_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/applications/{application_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Application */
+        get: operations["get_application_api_applications__application_id__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/applications/{application_id}/artifacts": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Save Artifact */
+        post: operations["save_artifact_api_applications__application_id__artifacts_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/applications/{application_id}/artifacts/{artifact_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Application Artifact */
+        get: operations["get_application_artifact_api_applications__application_id__artifacts__artifact_id__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/applications/{application_id}/events": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Record Event */
+        post: operations["record_event_api_applications__application_id__events_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/applications/{application_id}/fit": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /** Save Fit */
+        put: operations["save_fit_api_applications__application_id__fit_put"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/applications/{application_id}/receipt": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Record Application Receipt */
+        post: operations["record_application_receipt_api_applications__application_id__receipt_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/auth/login": {
         parameters: {
             query?: never;
@@ -1691,6 +1827,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/whats-new": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Whats New */
+        get: operations["whats_new_api_whats_new_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -1723,6 +1876,213 @@ export interface components {
         ActionsListResponse: {
             /** Actions */
             actions: components["schemas"]["ActionResponse"][];
+        };
+        /**
+         * ApplicationArtifactOut
+         * @description The ``get_application`` artifacts-list shape: ``text`` is ALWAYS a key
+         *     (null unless ``with_artifact_text=true`` and under the byte cap).
+         */
+        ApplicationArtifactOut: {
+            /** Chars */
+            chars: number;
+            /** Created At */
+            created_at: string;
+            /** Id */
+            id: number;
+            /** Kind */
+            kind: string;
+            /** Label */
+            label: string;
+            /** Made By */
+            made_by: string;
+            /** Model */
+            model: string | null;
+            /** Profile Version */
+            profile_version: number | null;
+            /** Text */
+            text: string | null;
+            /** Truncated */
+            truncated: boolean;
+            /** Version No */
+            version_no: number;
+        };
+        /**
+         * ApplicationArtifactRowOut
+         * @description ``get_application_artifact`` — one version in full. No ``truncated``:
+         *     this route always returns the real row, never a capped read.
+         */
+        ApplicationArtifactRowOut: {
+            /** Chars */
+            chars: number;
+            /** Created At */
+            created_at: string;
+            /** Id */
+            id: number;
+            /** Kind */
+            kind: string;
+            /** Label */
+            label: string;
+            /** Made By */
+            made_by: string;
+            /** Model */
+            model: string | null;
+            /** Profile Version */
+            profile_version: number | null;
+            /** Text */
+            text: string;
+            /** Version No */
+            version_no: number;
+        };
+        /** ApplicationDetailOut */
+        ApplicationDetailOut: {
+            /** Artifacts */
+            artifacts: components["schemas"]["ApplicationArtifactOut"][];
+            /** Created At */
+            created_at: string;
+            /** Events */
+            events: components["schemas"]["ApplicationEventOut"][];
+            fit: components["schemas"]["ApplicationFitOut"] | null;
+            /** Id */
+            id: number;
+            job: components["schemas"]["ApplicationJobOut"];
+            /** Job Id */
+            job_id: number;
+            /** Last Event At */
+            last_event_at: string | null;
+            /** Receipts */
+            receipts: components["schemas"]["ApplicationReceiptOut"][];
+            /** Status */
+            status: string;
+            /** Updated At */
+            updated_at: string;
+        };
+        /**
+         * ApplicationEventOut
+         * @description The timeline shape (``list_events_for_display``) — used by
+         *     ``get_application`` and ``export_history``. Carries ``superseded``;
+         *     ``whats_new``'s events do not (see ``WhatsNewEventOut``).
+         */
+        ApplicationEventOut: {
+            /** Corrects Event Id */
+            corrects_event_id: number | null;
+            /** Detail */
+            detail: string;
+            /** Event Type */
+            event_type: string;
+            /** Id */
+            id: number;
+            /** Occurred At */
+            occurred_at: string;
+            /** Payload */
+            payload: {
+                [key: string]: unknown;
+            };
+            /** Recorded At */
+            recorded_at: string;
+            /** Recorded By */
+            recorded_by: string;
+            /** Superseded */
+            superseded: boolean;
+        };
+        /** ApplicationFitOut */
+        ApplicationFitOut: {
+            /** Gaps */
+            gaps: string[];
+            /** Reasoning */
+            reasoning: string | null;
+            /** Recorded At */
+            recorded_at: string;
+            /** Recorded By */
+            recorded_by: string;
+            /** Score */
+            score: number | null;
+            /** Verdict */
+            verdict: string | null;
+        };
+        /** ApplicationJobOut */
+        ApplicationJobOut: {
+            /** Catalog Present */
+            catalog_present: boolean;
+            /** Job Company */
+            job_company: string;
+            /** Job Description Snapshot */
+            job_description_snapshot: string;
+            /** Job Location */
+            job_location: string;
+            /** Job Source */
+            job_source: string;
+            /** Job Title */
+            job_title: string;
+            /** Job Url */
+            job_url: string;
+            /** Snapshot At */
+            snapshot_at: string | null;
+        };
+        /** ApplicationReceiptExportOut */
+        ApplicationReceiptExportOut: {
+            /** Channel */
+            channel: string;
+            /** Confirmation */
+            confirmation: string;
+            /** Cover Letter Artifact Id */
+            cover_letter_artifact_id: number | null;
+            /** Cover Letter Text */
+            cover_letter_text?: string | null;
+            /** Cv Artifact Id */
+            cv_artifact_id: number | null;
+            /** Cv Text */
+            cv_text?: string | null;
+            /** Id */
+            id: number;
+            /** Note */
+            note: string;
+            /** Sent At */
+            sent_at: string;
+        };
+        /**
+         * ApplicationReceiptOut
+         * @description ``get_application``'s receipts list — never carries the receipt text
+         *     (that call site never passes ``include_text``; see
+         *     ``ApplicationReceiptExportOut`` for the ``export_history`` shape).
+         */
+        ApplicationReceiptOut: {
+            /** Channel */
+            channel: string;
+            /** Confirmation */
+            confirmation: string;
+            /** Cover Letter Artifact Id */
+            cover_letter_artifact_id: number | null;
+            /** Cv Artifact Id */
+            cv_artifact_id: number | null;
+            /** Id */
+            id: number;
+            /** Note */
+            note: string;
+            /** Sent At */
+            sent_at: string;
+        };
+        /** ApplicationSummaryOut */
+        ApplicationSummaryOut: {
+            /** Artifacts */
+            artifacts: {
+                [key: string]: number;
+            };
+            /** Events */
+            events: number;
+            /** Id */
+            id: number;
+            /** Job Company */
+            job_company: string;
+            /** Job Id */
+            job_id: number;
+            /** Job Title */
+            job_title: string;
+            /** Last Event At */
+            last_event_at: string | null;
+            /** Receipts */
+            receipts: number;
+            /** Status */
+            status: string;
         };
         /** ApplicationTimelineResponse */
         ApplicationTimelineResponse: {
@@ -1793,11 +2153,15 @@ export interface components {
         };
         /** BringJobResponse */
         BringJobResponse: {
+            /** Application Id */
+            application_id: number;
             /** Existing */
             existing: boolean;
             job: components["schemas"]["JobResponse"];
             /** Scored */
             scored: boolean;
+            /** Status */
+            status: string;
         };
         /**
          * CVDetail
@@ -2006,6 +2370,69 @@ export interface components {
         EmailVerificationConfirmRequest: {
             /** Token */
             token: string;
+        };
+        /** ExportApplicationOut */
+        ExportApplicationOut: {
+            /** Artifacts */
+            artifacts: components["schemas"]["ExportArtifactOut"][];
+            /** Created At */
+            created_at: string;
+            /** Events */
+            events: components["schemas"]["ApplicationEventOut"][];
+            /** Id */
+            id: number;
+            /** Job Company */
+            job_company: string;
+            /** Job Id */
+            job_id: number;
+            /** Job Title */
+            job_title: string;
+            /** Last Event At */
+            last_event_at: string | null;
+            /** Receipts */
+            receipts: components["schemas"]["ApplicationReceiptExportOut"][];
+            /** Status */
+            status: string;
+            /** Updated At */
+            updated_at: string;
+        };
+        /**
+         * ExportArtifactOut
+         * @description ``export_history``'s artifact METADATA (not the full row): ``text`` is
+         *     only a key at all when ``include_text=true`` — hence the default.
+         */
+        ExportArtifactOut: {
+            /** Chars */
+            chars: number;
+            /** Created At */
+            created_at: string;
+            /** Id */
+            id: number;
+            /** Kind */
+            kind: string;
+            /** Label */
+            label: string;
+            /** Made By */
+            made_by: string;
+            /** Model */
+            model: string | null;
+            /** Profile Version */
+            profile_version: number | null;
+            /** Text */
+            text?: string | null;
+            /** Version No */
+            version_no: number;
+        };
+        /** ExportHistoryResponse */
+        ExportHistoryResponse: {
+            /** Applications */
+            applications: components["schemas"]["ExportApplicationOut"][];
+            /** Bytes */
+            bytes: number;
+            /** Next Since */
+            next_since?: string | null;
+            /** Truncated */
+            truncated: boolean;
         };
         /** GitHubResponse */
         GitHubResponse: {
@@ -2240,6 +2667,13 @@ export interface components {
             merged: boolean;
             /** Ok */
             ok: boolean;
+        };
+        /** ListApplicationsResponse */
+        ListApplicationsResponse: {
+            /** Applications */
+            applications: components["schemas"]["ApplicationSummaryOut"][];
+            /** Total */
+            total: number;
         };
         /** LivezResponse */
         LivezResponse: {
@@ -2657,6 +3091,13 @@ export interface components {
             /** Sent At */
             sent_at: string;
         };
+        /** ReceiptAnswer */
+        ReceiptAnswer: {
+            /** Answer */
+            answer: string;
+            /** Question */
+            question: string;
+        };
         /** ReceiptListResponse */
         ReceiptListResponse: {
             /** Receipts */
@@ -2691,6 +3132,90 @@ export interface components {
             note: string;
             /** Sent At */
             sent_at: string;
+        };
+        /** RecordApplicationReceiptRequest */
+        RecordApplicationReceiptRequest: {
+            /** Answers */
+            answers?: components["schemas"]["ReceiptAnswer"][];
+            /** Applied At */
+            applied_at?: string | null;
+            /**
+             * Channel
+             * @default
+             */
+            channel: string;
+            /**
+             * Confirmation
+             * @default
+             */
+            confirmation: string;
+            /** Cover Letter Artifact Id */
+            cover_letter_artifact_id?: number | null;
+            /** Cv Artifact Id */
+            cv_artifact_id?: number | null;
+            /** Fields Filled */
+            fields_filled?: {
+                [key: string]: unknown;
+            };
+            /**
+             * Note
+             * @default
+             */
+            note: string;
+        };
+        /** RecordApplicationReceiptResponse */
+        RecordApplicationReceiptResponse: {
+            /** Channel */
+            channel: string;
+            /** Confirmation */
+            confirmation: string;
+            /** Cover Letter Artifact Id */
+            cover_letter_artifact_id: number | null;
+            /** Cv Artifact Id */
+            cv_artifact_id: number | null;
+            /** Cv Version No */
+            cv_version_no: number | null;
+            /** Event Id */
+            event_id: number;
+            /** Receipt Id */
+            receipt_id: number;
+            /** Sent At */
+            sent_at: string;
+            /** Url */
+            url: string;
+        };
+        /** RecordEventRequest */
+        RecordEventRequest: {
+            /** Corrects Event Id */
+            corrects_event_id?: number | null;
+            /**
+             * Detail
+             * @default
+             */
+            detail: string;
+            /** Event Type */
+            event_type: string;
+            /** Occurred At */
+            occurred_at?: string | null;
+            /** Payload */
+            payload?: {
+                [key: string]: unknown;
+            };
+        };
+        /** RecordEventResponse */
+        RecordEventResponse: {
+            /** Event Id */
+            event_id: number;
+            /** Event Type */
+            event_type: string;
+            /** Occurred At */
+            occurred_at: string;
+            /** Recorded At */
+            recorded_at: string;
+            /** Recorded By */
+            recorded_by: string;
+            /** Status */
+            status: string;
         };
         /** RegisterRequest */
         RegisterRequest: {
@@ -2757,6 +3282,60 @@ export interface components {
             runs: components["schemas"]["RunEntry"][];
             /** Total */
             total: number;
+        };
+        /** SaveArtifactRequest */
+        SaveArtifactRequest: {
+            /** Kind */
+            kind: string;
+            /**
+             * Label
+             * @default
+             */
+            label: string;
+            /** Model */
+            model?: string | null;
+            /** Text */
+            text: string;
+        };
+        /** SaveArtifactResponse */
+        SaveArtifactResponse: {
+            /** Artifact Id */
+            artifact_id: number;
+            /** Chars */
+            chars: number;
+            /** Created At */
+            created_at: string;
+            /** Event Id */
+            event_id: number;
+            /** Kind */
+            kind: string;
+            /** Made By */
+            made_by: string;
+            /** Model */
+            model: string | null;
+            /** Profile Version */
+            profile_version: number | null;
+            /** Version No */
+            version_no: number;
+        };
+        /** SaveFitRequest */
+        SaveFitRequest: {
+            /** Gaps */
+            gaps?: string[] | null;
+            /** Reasoning */
+            reasoning?: string | null;
+            /** Score */
+            score?: number | null;
+            /** Verdict */
+            verdict?: string | null;
+        };
+        /** SaveFitResponse */
+        SaveFitResponse: {
+            /** Application Id */
+            application_id: number;
+            /** Event Id */
+            event_id: number;
+            fit: components["schemas"]["ApplicationFitOut"];
         };
         /** SearchStartResponse */
         SearchStartResponse: {
@@ -2954,6 +3533,63 @@ export interface components {
             /** Error Type */
             type: string;
         };
+        /** WhatsNewApplicationOut */
+        WhatsNewApplicationOut: {
+            /** Id */
+            id: number;
+            /** Job Company */
+            job_company: string;
+            /** Job Title */
+            job_title: string;
+            /** Last Event At */
+            last_event_at: string | null;
+            /** Status */
+            status: string;
+        };
+        /**
+         * WhatsNewEventOut
+         * @description ``whats_new``'s raw event rows — no ``superseded`` (unlike
+         *     ``ApplicationEventOut``); carries ``application_id`` instead.
+         */
+        WhatsNewEventOut: {
+            /** Application Id */
+            application_id: number;
+            /** Corrects Event Id */
+            corrects_event_id: number | null;
+            /** Detail */
+            detail: string;
+            /** Event Type */
+            event_type: string;
+            /** Id */
+            id: number;
+            /** Occurred At */
+            occurred_at: string;
+            /** Payload */
+            payload: {
+                [key: string]: unknown;
+            };
+            /** Recorded At */
+            recorded_at: string;
+            /** Recorded By */
+            recorded_by: string;
+        };
+        /** WhatsNewResponse */
+        WhatsNewResponse: {
+            /** Applications */
+            applications: components["schemas"]["WhatsNewApplicationOut"][];
+            /** Events */
+            events: components["schemas"]["WhatsNewEventOut"][];
+            /** Next After Id */
+            next_after_id: number | null;
+            /** Next Since */
+            next_since: string;
+            /** Now */
+            now: string;
+            /** Since */
+            since: string;
+            /** Truncated */
+            truncated: boolean;
+        };
     };
     responses: never;
     parameters: never;
@@ -3078,6 +3714,309 @@ export interface operations {
                     "application/json": {
                         [key: string]: number;
                     };
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_applications_api_applications_get: {
+        parameters: {
+            query?: {
+                status?: string | null;
+                updated_since?: string | null;
+                limit?: number;
+                offset?: number;
+            };
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: {
+                job360_session?: string | null;
+            };
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ListApplicationsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    export_history_api_applications_export_get: {
+        parameters: {
+            query?: {
+                since?: string | null;
+                include_text?: boolean;
+            };
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: {
+                job360_session?: string | null;
+            };
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ExportHistoryResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_application_api_applications__application_id__get: {
+        parameters: {
+            query?: {
+                with_artifact_text?: boolean;
+            };
+            header?: {
+                authorization?: string | null;
+            };
+            path: {
+                application_id: number;
+            };
+            cookie?: {
+                job360_session?: string | null;
+            };
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApplicationDetailOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    save_artifact_api_applications__application_id__artifacts_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path: {
+                application_id: number;
+            };
+            cookie?: {
+                job360_session?: string | null;
+            };
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SaveArtifactRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SaveArtifactResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_application_artifact_api_applications__application_id__artifacts__artifact_id__get: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path: {
+                application_id: number;
+                artifact_id: number;
+            };
+            cookie?: {
+                job360_session?: string | null;
+            };
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApplicationArtifactRowOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    record_event_api_applications__application_id__events_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path: {
+                application_id: number;
+            };
+            cookie?: {
+                job360_session?: string | null;
+            };
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["RecordEventRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RecordEventResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    save_fit_api_applications__application_id__fit_put: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path: {
+                application_id: number;
+            };
+            cookie?: {
+                job360_session?: string | null;
+            };
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SaveFitRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SaveFitResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    record_application_receipt_api_applications__application_id__receipt_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                authorization?: string | null;
+            };
+            path: {
+                application_id: number;
+            };
+            cookie?: {
+                job360_session?: string | null;
+            };
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["RecordApplicationReceiptRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RecordApplicationReceiptResponse"];
                 };
             };
             /** @description Validation Error */
@@ -5700,6 +6639,43 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    whats_new_api_whats_new_get: {
+        parameters: {
+            query?: {
+                since?: string | null;
+                after_id?: number | null;
+                limit?: number;
+            };
+            header?: {
+                authorization?: string | null;
+            };
+            path?: never;
+            cookie?: {
+                job360_session?: string | null;
+            };
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WhatsNewResponse"];
+                };
             };
             /** @description Validation Error */
             422: {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -868,3 +868,103 @@ export async function listGrants(): Promise<OAuthGrant[]> {
 export async function revokeGrant(id: number): Promise<void> {
   await request<void>(`/api/oauth/grants/${id}`, { method: "DELETE" });
 }
+
+// ---------------------------------------------------------------------------
+// The application spine (docs/plans/2026-09-04-application-spine/spec.md)
+// ---------------------------------------------------------------------------
+//
+// Shapes come straight from the generated `_Schemas` (backend `response_model`
+// on `src/api/routes/applications.py` — same pattern as the OAuth helpers
+// above). Run `npm run gen:types` after any change to those response models.
+
+export type ApplicationSummary = _Schemas["ApplicationSummaryOut"];
+export type ApplicationEvent = _Schemas["ApplicationEventOut"];
+export type ApplicationArtifact = _Schemas["ApplicationArtifactOut"];
+export type ApplicationArtifactRow = _Schemas["ApplicationArtifactRowOut"];
+export type ApplicationReceiptEntry = _Schemas["ApplicationReceiptOut"];
+export type ApplicationJobSnapshot = _Schemas["ApplicationJobOut"];
+export type ApplicationFit = _Schemas["ApplicationFitOut"];
+export type ApplicationDetail = _Schemas["ApplicationDetailOut"];
+
+export async function listApplications(
+  params: { status?: string; updated_since?: string; limit?: number; offset?: number } = {}
+): Promise<_Schemas["ListApplicationsResponse"]> {
+  const query = { limit: 20, ...params };
+  return request(`/api/applications${qs(query as Record<string, unknown>)}`);
+}
+
+export async function getApplication(id: number, withArtifactText = false): Promise<ApplicationDetail> {
+  // Query string omitted entirely in the (default) false case — not just an
+  // empty value — so the URL is a bare `/api/applications/{id}` when no
+  // artifact text is requested (matches the hermetic e2e mock's route
+  // pattern, which has no query-string wildcard on this endpoint).
+  const query = withArtifactText ? qs({ with_artifact_text: true }) : "";
+  return request(`/api/applications/${id}${query}`);
+}
+
+export async function getApplicationArtifact(
+  applicationId: number,
+  artifactId: number
+): Promise<ApplicationArtifactRow> {
+  return request(`/api/applications/${applicationId}/artifacts/${artifactId}`);
+}
+
+export async function saveApplicationArtifact(
+  applicationId: number,
+  body: { kind: string; text: string; label?: string; model?: string }
+): Promise<_Schemas["SaveArtifactResponse"]> {
+  return request(`/api/applications/${applicationId}/artifacts`, {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+export async function saveApplicationFit(
+  applicationId: number,
+  body: { score?: number; verdict?: string; gaps?: string[]; reasoning?: string }
+): Promise<_Schemas["SaveFitResponse"]> {
+  return request(`/api/applications/${applicationId}/fit`, {
+    method: "PUT",
+    body: JSON.stringify(body),
+  });
+}
+
+export async function recordApplicationEvent(
+  applicationId: number,
+  body: {
+    event_type: string;
+    detail?: string;
+    payload?: Record<string, unknown>;
+    occurred_at?: string;
+    corrects_event_id?: number;
+  }
+): Promise<_Schemas["RecordEventResponse"]> {
+  return request(`/api/applications/${applicationId}/events`, {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+/** "I applied" (or any receipt) — the rich record. Body fields all optional. */
+export async function recordApplicationReceipt(
+  applicationId: number,
+  body: {
+    channel?: string;
+    note?: string;
+    confirmation?: string;
+    cv_artifact_id?: number;
+    cover_letter_artifact_id?: number;
+    applied_at?: string;
+  } = {}
+): Promise<_Schemas["RecordApplicationReceiptResponse"]> {
+  return request(`/api/applications/${applicationId}/receipt`, {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+export async function getWhatsNew(
+  params: { since?: string; after_id?: number; limit?: number } = {}
+): Promise<_Schemas["WhatsNewResponse"]> {
+  return request(`/api/whats-new${qs(params as Record<string, unknown>)}`);
+}

--- a/frontend/src/middleware.test.ts
+++ b/frontend/src/middleware.test.ts
@@ -12,8 +12,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { middleware } from "./middleware";
 
+// R12 (docs/plans/2026-09-04-application-spine) — /dashboard now 404s ahead
+// of the auth check when NEXT_PUBLIC_SEARCH_UI_ENABLED is off (unset here),
+// which would short-circuit every test below before it reached the outage/
+// bypass logic these tests actually exercise. /profile is protected the same
+// way (PROTECTED_PATHS) without the search-flag gate, so it stands in as
+// "any protected route" here.
 function protectedRequest(): NextRequest {
-  return new NextRequest("http://localhost:3000/dashboard", {
+  return new NextRequest("http://localhost:3000/profile", {
     headers: { cookie: "job360_session=some-session-value" },
   });
 }
@@ -37,7 +43,7 @@ describe("middleware — backend outage (F4)", () => {
     expect(res.status).toBe(307);
     const location = new URL(res.headers.get("location")!);
     expect(location.pathname).toBe("/login");
-    expect(location.searchParams.get("next")).toBe("/dashboard");
+    expect(location.searchParams.get("next")).toBe("/profile");
     expect(location.searchParams.get("error")).toBe("service_unavailable");
   });
 
@@ -76,7 +82,7 @@ describe("middleware — backend outage (F4)", () => {
     const fetchMock = vi.fn();
     vi.stubGlobal("fetch", fetchMock);
     const res = await middleware(
-      new NextRequest("http://localhost:3000/dashboard")
+      new NextRequest("http://localhost:3000/profile")
     );
     expect(res.status).toBe(307);
     expect(new URL(res.headers.get("location")!).pathname).toBe("/login");

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -10,6 +10,7 @@ const PROTECTED_PATHS = [
   "/pipeline",
   "/bring",
   "/receipts",
+  "/applications",
   "/channels",
   "/settings",
   "/notifications",
@@ -17,11 +18,31 @@ const PROTECTED_PATHS = [
   "/oauth",
 ];
 
+// R12 (docs/plans/2026-09-04-application-spine) — the legacy search UI goes
+// behind a flag, off by default. Not a security control (spec S10): these
+// routes keep their normal auth gate below regardless of the flag: the flag
+// only decides whether the FEATURE exists. NEXT_PUBLIC_* is inlined at build
+// time — flipping it is a redeploy, not a restart (spec C2).
+const SEARCH_UI_ENABLED = process.env.NEXT_PUBLIC_SEARCH_UI_ENABLED === "true";
+// `/dashboard` (the whole search UI) and bare `/jobs` (the redirect page —
+// see src/app/jobs/page.tsx) 404 when the flag is off. `/jobs/[id]` is
+// DELIBERATELY exempt: job detail pages are shared-catalog and public
+// (unfurl bots, existing links — same reasoning as PROTECTED_PATHS above).
+const SEARCH_UI_EXACT_PATHS = new Set(["/dashboard", "/jobs"]);
+
 // Backend origin used to VERIFY the session (same value the /api proxy forwards to).
 const BACKEND_ORIGIN = process.env.BACKEND_ORIGIN || "http://localhost:8000";
 
 export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
+
+  if (
+    !SEARCH_UI_ENABLED &&
+    (SEARCH_UI_EXACT_PATHS.has(pathname) || pathname.startsWith("/dashboard/"))
+  ) {
+    return new NextResponse("Not Found", { status: 404 });
+  }
+
   const isProtected = PROTECTED_PATHS.some((p) => pathname.startsWith(p));
 
   if (!isProtected) return NextResponse.next();

--- a/frontend/tests/e2e/applications-home.spec.ts
+++ b/frontend/tests/e2e/applications-home.spec.ts
@@ -1,0 +1,217 @@
+import { test, expect, type Page } from "@playwright/test";
+
+/**
+ * The application spine — the owner's done-when, walked hermetically
+ * (docs/plans/2026-09-04-application-spine/spec.md §Frozen tests, item 38).
+ *
+ * "The owner brings a job, saves two CV versions, records 'applied' with the
+ * second... and the web home show exactly that, every version still readable."
+ *
+ * Neither `/applications` nor `/applications/[id]` exist on this branch yet —
+ * this spec is expected to FAIL (timeouts waiting for content that is never
+ * rendered) until slice 2 ships those pages. That is the intended RED state.
+ *
+ * Hermetic (frontend-only), same pattern as feed-visibility.spec.ts: fake the
+ * session cookie (middleware only checks presence) and mock every API call
+ * with `page.route`. `NEXT_PUBLIC_SEARCH_UI_ENABLED` defaults to false, so the
+ * Dashboard nav link must be gone (R12/R14).
+ */
+
+const SESSION_COOKIE = {
+  name: "job360_session",
+  value: "e2e-token",
+  domain: "localhost",
+  path: "/",
+};
+
+const APPLICATION_ID = 4242;
+const JOB_ID = 777;
+
+const CV_TEXT: Record<number, string> = {
+  1: "CV VERSION ONE — the first draft",
+  2: "CV VERSION TWO — the one actually sent",
+};
+
+function applicationSummary(status: string) {
+  return {
+    id: APPLICATION_ID,
+    job_id: JOB_ID,
+    job_title: "Data Engineer",
+    job_company: "Northwind",
+    status,
+    last_event_at: "2026-09-04T00:00:00Z",
+    events: status === "considering" ? 1 : 2,
+    artifacts: { cv: 2 },
+    receipts: status === "considering" ? 0 : 1,
+  };
+}
+
+function applicationDetail(status: string) {
+  const events = [
+    {
+      id: 1,
+      event_type: "brought",
+      detail: "",
+      payload: {},
+      occurred_at: "2026-09-01T00:00:00Z",
+      recorded_at: "2026-09-01T00:00:00Z",
+      recorded_by: "web",
+      corrects_event_id: null,
+      superseded: false,
+    },
+  ];
+  if (status === "applied") {
+    events.push({
+      id: 2,
+      event_type: "applied",
+      detail: "",
+      payload: {},
+      occurred_at: "2026-09-02T00:00:00Z",
+      recorded_at: "2026-09-02T00:00:00Z",
+      recorded_by: "web",
+      corrects_event_id: null,
+      superseded: false,
+    });
+  }
+  return {
+    id: APPLICATION_ID,
+    job_id: JOB_ID,
+    status,
+    created_at: "2026-09-01T00:00:00Z",
+    updated_at: "2026-09-02T00:00:00Z",
+    last_event_at: "2026-09-02T00:00:00Z",
+    job: {
+      job_title: "Data Engineer",
+      job_company: "Northwind",
+      job_location: "Remote",
+      job_url: "https://northwind.example/careers/7",
+      job_source: "user_brought",
+      job_description_snapshot: "Build the pipelines. Python, dbt, Snowflake.",
+      snapshot_at: "2026-09-01T00:00:00Z",
+      catalog_present: true,
+    },
+    fit: null,
+    artifacts: [
+      {
+        id: 1, kind: "cv", version_no: 1, made_by: "web", model: null,
+        profile_version: 1, label: "", chars: CV_TEXT[1].length, created_at: "2026-09-01T00:05:00Z",
+      },
+      {
+        id: 2, kind: "cv", version_no: 2, made_by: "web", model: null,
+        profile_version: 1, label: "", chars: CV_TEXT[2].length, created_at: "2026-09-02T00:00:00Z",
+      },
+    ],
+    events,
+    receipts:
+      status === "applied"
+        ? [
+            {
+              id: 1, sent_at: "2026-09-02T00:00:00Z", channel: "company site",
+              confirmation: "", cv_artifact_id: 2, cover_letter_artifact_id: null, note: "",
+            },
+          ]
+        : [],
+  };
+}
+
+/** A mutable-status backend double: everything the home + record pages need,
+ * with `status` flipping in place the moment the receipt route is hit — so a
+ * SINGLE page session sees "considering" then "applied" without a reload. */
+async function mockBackend(page: Page) {
+  let status: "considering" | "applied" = "considering";
+
+  await page.route("**/api/auth/me**", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ id: "e2e-user", email: "e2e@example.com" }),
+    })
+  );
+
+  await page.route("**/api/applications?**", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ applications: [applicationSummary(status)], total: 1 }),
+    })
+  );
+
+  await page.route(`**/api/applications/${APPLICATION_ID}`, (route) => {
+    if (route.request().method() !== "GET") return route.fallback();
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(applicationDetail(status)),
+    });
+  });
+
+  await page.route(`**/api/applications/${APPLICATION_ID}/receipt`, (route) => {
+    status = "applied";
+    route.fulfill({
+      status: 201,
+      contentType: "application/json",
+      body: JSON.stringify({
+        receipt_id: 1, sent_at: "2026-09-02T00:00:00Z", cv_artifact_id: 2, cv_version_no: 2,
+        cover_letter_artifact_id: null, channel: "company site", confirmation: "",
+        url: `/applications/${APPLICATION_ID}`, event_id: 2,
+      }),
+    });
+  });
+
+  for (const [idStr, text] of Object.entries(CV_TEXT)) {
+    const id = Number(idStr);
+    await page.route(`**/api/applications/${APPLICATION_ID}/artifacts/${id}`, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          id, kind: "cv", version_no: id, text, made_by: "web", model: null,
+          profile_version: 1, label: "", chars: text.length, created_at: "2026-09-01T00:00:00Z",
+        }),
+      })
+    );
+  }
+}
+
+test.describe("Applications home — the spine, end to end (hermetic)", () => {
+  test("brought -> applied shows on the home; the record lists both CV versions, both readable", async ({
+    page,
+    context,
+  }) => {
+    await context.addCookies([SESSION_COOKIE]);
+    await mockBackend(page);
+
+    await page.goto("/");
+
+    // The brought application is on the signed-in home, status "considering".
+    await expect(page.getByText(/data engineer/i).first()).toBeVisible({ timeout: 20_000 });
+    await expect(page.getByText(/considering/i).first()).toBeVisible();
+
+    // R12/R14 — the search flag is off by default, so the old Dashboard link
+    // must not exist on a page a signed-in user can navigate.
+    await expect(page.getByRole("link", { name: /^dashboard$/i })).toHaveCount(0);
+
+    // Record "applied" with CV v2 — whichever control the home/record page
+    // exposes for it, it must call the receipt endpoint (mocked above).
+    await page
+      .getByRole("button", { name: /mark.*applied|i applied|record application|applied/i })
+      .first()
+      .click();
+    await expect(page.getByText(/^applied$/i).first()).toBeVisible({ timeout: 20_000 });
+
+    // Open the application record: two CV versions listed, both open with
+    // their own text — "every version still readable" (done-when).
+    await page.goto(`/applications/${APPLICATION_ID}`);
+    await expect(page.getByText(/data engineer/i).first()).toBeVisible({ timeout: 20_000 });
+
+    const v1 = page.getByText(/v(ersion)?\.?\s*1\b/i).first();
+    const v2 = page.getByText(/v(ersion)?\.?\s*2\b/i).first();
+    await expect(v1).toBeVisible();
+    await expect(v2).toBeVisible();
+
+    await v1.click();
+    await expect(page.getByText(CV_TEXT[1])).toBeVisible({ timeout: 10_000 });
+    await v2.click();
+    await expect(page.getByText(CV_TEXT[2])).toBeVisible({ timeout: 10_000 });
+  });
+});

--- a/frontend/tests/e2e/auth-flow.spec.ts
+++ b/frontend/tests/e2e/auth-flow.spec.ts
@@ -5,9 +5,27 @@ import { test, expect } from "@playwright/test";
  * Runs against the Next.js dev server at http://localhost:3000.
  */
 test.describe("Auth middleware", () => {
-  test("anonymous visit to /dashboard redirects to /login", async ({ page }) => {
-    // Navigate without cookies — middleware should redirect
-    await page.goto("/dashboard");
+  // R12 (docs/plans/2026-09-04-application-spine) — the legacy search UI
+  // (Dashboard) is behind NEXT_PUBLIC_SEARCH_UI_ENABLED, default OFF, and
+  // this project does not set it — so /dashboard 404s regardless of auth
+  // state. Unlike the backend flag (settings.py, monkeypatchable per test),
+  // NEXT_PUBLIC_* is inlined at BUILD TIME (spec C2), so this project cannot
+  // exercise both flag positions in one dev-server run — the OFF position
+  // (this test) is what a default production build actually serves;
+  // backend/tests/test_search_flag.py pins BOTH positions where it can.
+  // KNOWN CONSEQUENCE, not a bug introduced here: dashboard-sort.spec.ts,
+  // feed-visibility.spec.ts, job-render.spec.ts and
+  // two-account-isolation.spec.ts all navigate to /dashboard and will now
+  // fail against a default build — the dashboard they exercise is the exact
+  // feature R12 hides (and slice 5 deletes). Flagged in the build report,
+  // not silently fixed by flipping the default back on.
+  test("anonymous visit to /dashboard 404s (search UI flag is off by default)", async ({ page }) => {
+    const response = await page.goto("/dashboard");
+    expect(response?.status()).toBe(404);
+  });
+
+  test("anonymous visit to /applications redirects to /login", async ({ page }) => {
+    await page.goto("/applications");
     await expect(page).toHaveURL(/\/login/);
   });
 

--- a/frontend/tests/e2e/dashboard-sort.spec.ts
+++ b/frontend/tests/e2e/dashboard-sort.spec.ts
@@ -100,6 +100,11 @@ function isDescending(arr: number[]): boolean {
 }
 
 test.describe("Dashboard job sort order", () => {
+  test.skip(
+    process.env.NEXT_PUBLIC_SEARCH_UI_ENABLED !== "true",
+    "legacy search UI is off by default (slice 2, R12); dies with slice 5"
+  );
+
   const TABS = ["All", "24h", "48h", "3d", "5d", "7d"];
 
   test("jobs render highest-score-first regardless of server order", async ({

--- a/frontend/tests/e2e/feed-visibility.spec.ts
+++ b/frontend/tests/e2e/feed-visibility.spec.ts
@@ -108,6 +108,11 @@ function renderedCount(page: Page): Promise<number> {
 }
 
 test.describe("Feed visibility", () => {
+  test.skip(
+    process.env.NEXT_PUBLIC_SEARCH_UI_ENABLED !== "true",
+    "legacy search UI is off by default (slice 2, R12); dies with slice 5"
+  );
+
   test("shows EVERY job by default — the floor no longer hides the product", async ({
     page,
     context,

--- a/frontend/tests/e2e/job-render.spec.ts
+++ b/frontend/tests/e2e/job-render.spec.ts
@@ -48,6 +48,11 @@ const MOCK_JOB = {
 };
 
 test.describe("Dashboard job render", () => {
+  test.skip(
+    process.env.NEXT_PUBLIC_SEARCH_UI_ENABLED !== "true",
+    "legacy search UI is off by default (slice 2, R12); dies with slice 5"
+  );
+
   test.beforeEach(async ({ context }) => {
     // Bypass middleware by providing a session cookie
     await context.addCookies([

--- a/frontend/tests/e2e/landing-cta-auth.spec.ts
+++ b/frontend/tests/e2e/landing-cta-auth.spec.ts
@@ -73,20 +73,46 @@ test.describe("Landing CTA → profile journeys", () => {
   });
 
   // ── Journey 3: already signed in → straight to /profile ───────────────────
+  //
+  // R14 (docs/plans/2026-09-04-application-spine) — a signed-in visitor's "/"
+  // is now the applications home, not the marketing landing page, so there is
+  // no more "Get Started" CTA to click for this journey. The behaviour this
+  // journey actually protects — a real session reaches a protected page with
+  // no sign-in detour — is asserted directly against /profile instead.
 
-  test("signed-in 'Get Started' goes straight to /profile (no sign-in detour)", async ({
+  test("a signed-in visitor reaches /profile with no sign-in detour", async ({
     page,
     context,
   }) => {
     await signedIn(context);
     await mockAuthedApis(page);
 
-    await page.goto("/");
-    await page.getByRole("link", { name: /get started/i }).click();
-
     // Generous timeout: /profile may cold-compile on the first navigation.
-    await expect(page).toHaveURL(/\/profile/, { timeout: 40_000 });
+    await page.goto("/profile", { timeout: 40_000 });
+    await expect(page).toHaveURL(/\/profile/);
     await expect(page).not.toHaveURL(/\/login/);
+  });
+
+  // R14 — the signed-in home is now applications, not the marketing landing.
+  test("a signed-in visitor's '/' shows the applications home, not the landing hero", async ({
+    page,
+    context,
+  }) => {
+    await signedIn(context);
+    await mockAuthedApis(page);
+    await page.route("**/api/applications?**", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ applications: [], total: 0 }),
+      })
+    );
+
+    await page.goto("/");
+    await expect(page.getByRole("heading", { name: /your applications/i })).toBeVisible({
+      timeout: 20_000,
+    });
+    await expect(page.getByRole("link", { name: /get started/i })).toHaveCount(0);
   });
 
   // ── Journey 2: returning user → sign in → /profile ────────────────────────

--- a/frontend/tests/e2e/two-account-isolation.spec.ts
+++ b/frontend/tests/e2e/two-account-isolation.spec.ts
@@ -81,6 +81,11 @@ async function serveAccount(
 }
 
 test.describe("two accounts in one browser", () => {
+  test.skip(
+    process.env.NEXT_PUBLIC_SEARCH_UI_ENABLED !== "true",
+    "legacy search UI is off by default (slice 2, R12); dies with slice 5"
+  );
+
   test("side-by-side sessions never see each other's jobs", async ({ browser }) => {
     const ctxA = await browser.newContext();
     const ctxB = await browser.newContext();


### PR DESCRIPTION
Slice 2 of the pivot (#480): one Application object per (user, job), an append-only typed event log, versioned artifacts, stored fit, and the 8 store tools — exposed identically over REST and MCP. Built with the SDLC playbook: Opus design → frozen tests (46, red first) → Sonnet build → two Opus review passes → fix batch → real-browser verifier walk.

## What this builds (issue #480)

- **`Application` born at `bring_job`**, status `considering`; folds `applications` + `application_receipts` + `application_stage_history` + `tailored_documents` into one model (migration 0037, copy-don't-delete, no row lost — pinned by `test_migration_0037.py`).
- **Append-only typed events** with `recorded_by` derived from the credential (a body-supplied value is a 422). No UPDATE/DELETE path exists; a wrong event is superseded by a correcting event.
- **Versioned artifacts** (`cv` / `cover_letter` / `answers` / `outreach`), kept forever, stamped with model + profile version; caps are env parameters.
- **Fit is stored, never computed** (VISION rule 4) — `save_fit` writes the agent's verdict; a test poisons `skill_matcher` to prove nothing scores.
- **Tools** (REST + MCP, gate-parity-tested): `get_application`, `list_applications`, `save_artifact`, `save_fit`, `record_event`, `record_application` (enriched receipt), `whats_new`, `export_history`.
- **Web home = your applications**; legacy search UI behind `SEARCH_UI_ENABLED` (default off, backend routes 404 too); `refresh_catalog` + `enrichment_sweep` crons behind `CATALOG_CRONS_ENABLED` (default off); tailoring stays as a web fallback and now mirrors into artifact versions.
- **Prod bug fixed on the way**: `purge_old_jobs` had no `user_brought` exemption — a brought job's catalog row (title/company/description) silently vanished after 30 days. Now exempt on both the direct DELETE and the cascade subquery, plus a snapshot on the application.

## Review findings (all fixed + pinned in `test_application_spine_fixes.py`)

Bugs pass (Opus): **P1** migration backfilled `status` but wrote no event, so the next event replayed an `offer` back to `considering`; **P1** `bring_job` rows inherited the column default `stage='applied'`, so the legacy pipeline showed never-applied jobs as applied (now `considering`, excluded from reminders); **Important** `occurred_at` kept the caller's UTC offset, breaking TEXT-ordered timelines; **P2** `whats_new` cursor used two independent predicates and could skip a concurrently-committed event (now a real keyset); 2 nits (dangling `corrects_event_id` → 422; receipt now stamps `profile_version`).

Conventions pass (Opus): MCP `record_application` rewired onto the same rich-receipt route the web uses (M5 parity); "41 sources / 8D scoring" removed from the footer and site metadata (VISION rule 4); `/pipeline` + `/receipts` left the nav (URLs still work, slice 5 deletes them); 8 nits (typed `db: JobDatabase`, `pg.IntegrityError` over string-sniffing, env-param for the last hardcoded cap, docstrings, toast on failed mutations, ARCHITECTURE env rows, conftest fixture hygiene).

Note for the owner: `.claude/skills/hard-rules/SKILL.md` gets two small edits consistent with what rules M3/#3 already pre-authorized (purge exemption, spine tables in the per-user lists) — flagged here rather than folded in silently.

## Verifier walk — 12/12 PASS (real backend + Postgres + headless Chromium)

| # | Step | Result |
|---|------|--------|
| 1 | `POST /jobs/bring` → application `considering` | PASS |
| 2-3 | CV artifact v1, v2 saved | PASS |
| 4 | Rich receipt, `cv_artifact_id` = v2 | PASS |
| 5-6 | `replied`, `interview_requested` events | PASS |
| 7 | `whats_new`: all events in order, status `interview_requested` | PASS |
| 8 | Both artifact versions readable, distinct | PASS |
| 9 | `export_history` complete (events + artifacts + receipt) | PASS |
| 10 | Browser: home lists the application; detail page timeline + versions + receipt | PASS |
| 11 | Second user: 404 on detail, empty list | PASS |
| 12 | Flag off: search API 404, `/dashboard` 404, no nav link | PASS |

Environment findings from the walk (not this PR's code): the shared dev Postgres `public` schema is drifted (`applications`/`user_actions` missing `user_id` despite 0002 recorded as applied) — any backend boot against it crashes until the owner repairs it; and `frontend/.env.local.example` documented a footgun (`NEXT_PUBLIC_API_URL` set → CSP blocks everything) — example file now says leave it unset for local dev.

## Checks

- Frozen: `test_application_spine.py` 31, `test_migration_0037.py` 7, `test_search_flag.py` 4, gate-parity extended, Playwright `applications-home.spec.ts` 1 — all green; fixes file adds 6.
- Backend targeted suite (incl. route-auth coverage, MCP server, receipts, pipeline): green. `ruff` clean, mypy ratchet 0/0.
- Frontend: type-check clean, lint 0 errors, unit 363/363. Legacy `/dashboard` Playwright specs gated behind `NEXT_PUBLIC_SEARCH_UI_ENABLED` (they die with slice 5).
- Docs: ARCHITECTURE regenerated + env rows, `docs/README.md` row, STATUS head, `.env.example` block; `gen_doc_blocks` current.

## Done-when (owner closes)

Bring a job from Claude Code via MCP, save two CV versions, record applied with v2, later record replied + interview_requested — `whats_new` and the web home must show exactly that. The verifier walk proved this end-to-end locally; the MCP-client (Claude.ai/ChatGPT) round trip needs prod after merge.

Closes #480.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011wAduRqokWdPEByUkcVbvc
