### PR TITLE
docs: daily truth check

### DIFF
--- a/.claude/skills/verify-job360/SKILL.md
+++ b/.claude/skills/verify-job360/SKILL.md
@@ -3,12 +3,12 @@ name: verify-job360
 description: >-
   Verify Job360 changes by actually running the app and watching the behavior — not by
   assuming tests or a clean compile prove it works. Use this AGGRESSIVELY: any time you
-  touch backend (FastAPI, scoring, sources, DB, scheduler) or frontend (Next.js pages,
+  touch backend (FastAPI, the application spine, DB, migrations) or frontend (Next.js pages,
   API calls, auth) code, before saying something is "done" or "fixed", before opening a
   PR, and whenever the user asks to verify / test / confirm / "does it actually work" /
   "prove it". Drives a real browser with Playwright for UX, hits routes with curl and
-  queries the Postgres DB for backend, and walks the full register→CV→search→jobs journey
-  for end-to-end. If you changed Job360 code and haven't run it, this skill applies.
+  queries the Postgres DB for backend, and walks the full register→CV→bring→tailor→receipt
+  journey for end-to-end. If you changed Job360 code and haven't run it, this skill applies.
 ---
 <!-- doc: LIVING -->
 
@@ -35,8 +35,8 @@ that landed, a log line that proves the code path ran. "It should work now" is n
 Choose based on what you touched. When unsure, do the broader one.
 
 - **Frontend / UX** — you changed a page, component, API call, or auth flow → drive a real browser, screenshot.
-- **Backend** — you changed a route, scorer, source, DB, scheduler, worker → run the service, hit the route, query the DB, read the logs.
-- **End-to-end** — you changed something that spans both, or the user wants the whole journey proven → walk register → CV → search → jobs.
+- **Backend** — you changed a route, the spine, the DB, or a migration → run the service, hit the route, query the DB, read the logs.
+- **End-to-end** — you changed something that spans both, or the user wants the whole journey proven → walk register → CV → bring → tailor → receipt.
 
 `$ARGUMENTS` may name a flavor (`backend`, `frontend`, `e2e`) or a specific feature to focus on. If given, scope to that.
 
@@ -124,8 +124,7 @@ For per-user routes you need a session cookie — register via `POST /api/auth/r
 > buttons + the LinkedIn/GitHub gates). Report its PASS/FAIL/GATED table.
 
 Run **both** servers, then walk the real journey with the browser and watch the DB/logs in parallel.
-**The journey is the product path (`docs/product/VISION.md`): bring → tailor → receipt → MCP. The old
-search journey is legacy — verify it only when the change touched `src/sources/` or the scorer.**
+**The journey is the product path (`docs/product/VISION.md`): bring → tailor → receipt → MCP.**
 
 1. **Register** a fresh account (UI: `/register`, or `POST /api/auth/register`).
 2. **Upload a CV** on `/profile` — use `test-artifacts/sample_cv.pdf` (a realistic ML-engineer CV).

--- a/docs/product/DEPLOY.md
+++ b/docs/product/DEPLOY.md
@@ -5,7 +5,8 @@
 
 **Railway is GitHub-linked to `Ranjith36963/job360`, branch `main`. Every merge ships to real users.** There is no manual deploy step and no staging gate. Merging is a release — never merge "to tidy up".
 
-Live at **job360.uk**. Five services: `backend`, `frontend`, `worker`, `Postgres`, `Redis`.
+Live at **job360.uk**. The service list changes without a commit, so read it rather than
+trust a doc: `railway status --json`. (No `worker` — `backend/src/workers/` went in slice 5.)
 
 ### How to check what is actually deployed
 
@@ -23,12 +24,10 @@ The manual `railway up` recipe further down still works, but it is the fallback 
 
 ---
 
-> **Status: ✅ LIVE since 2026-07-02.** Railway Hobby active. Project `job360`, 5 services all Online.
+> **Status: ✅ LIVE since 2026-07-02.** Railway Hobby active, project `job360`.
 > - **Custom domain:** https://job360.uk
 > - **Frontend:** https://frontend-production-c608f.up.railway.app
 > - **Backend API:** https://backend-production-80e8e.up.railway.app
-> - Verified live: `/readyz` → `{db:ok, redis:ok}`, security headers, full register→login→/me auth flow.
-> - Worker running 10 ARQ functions + 2 crons. Managed Postgres + Redis attached.
 
 ## 🟢 What's already done (no action needed)
 - Backend + frontend **Dockerfiles**, **`docker-compose.prod.yml`** (5 services) — validated.
@@ -74,6 +73,6 @@ railway domain --service frontend    # → public site URL
 ```
 
 ## Verify after deploy
-- `curl https://<backend-url>/livez` → 200; `/readyz` → `{db:ok, redis:ok}`
+- `curl https://<backend-url>/livez` → 200; `/readyz` → 200 with `redis` `"skipped"` (not `"ok"`) while `REDIS_URL` is unset — `backend/tests/test_health_probes.py::test_readyz_redis_skipped_when_url_unset`
 - Register + upload CV on the live frontend; confirm a row in the managed Postgres.
 - Sentry receives a test error; PostHog receives a pageview.


### PR DESCRIPTION
Scout pass over LIVING docs against `main` @ `8f30a4e`. Supersedes **#497** — please close that one.

**LIVING surface: 3,771 → 3,769 lines (39 docs).** Two files, 10 insertions / 12 deletions.

> **Rebuilt 2026-09-06 17:2x.** This branch was first cut against `962d88e` and carried five findings. The cleanup audit (#503, −114k lines) then landed and closed three of them, so the branch was re-cut from `8f30a4e` and force-pushed (single commit, mine, nobody else had pushed to it). Only claims still false against the code survive below. See "What the cleanup audit closed".

Slice 5 (#483) and the cleanup audit (#503) deleted large parts of the codebase. Two LIVING claims outlived the code they describe. **One of them is an instruction agents execute.**

## Findings

`file — doc said X, code says Y — closed by DELETE / POINTER / TEST`

1. **`.claude/skills/verify-job360/SKILL.md`** — still routes agents through deleted code:
   - flavor list: *"you changed a route, **scorer, source**, DB, **scheduler, worker**"*
   - E2E journey: *"walk register → CV → **search → jobs**"*
   - journey note: *"verify it only when the change touched **`src/sources/`** or the scorer"*

   `src/sources/`, the scorer, the scheduler and `src/workers/` are all gone. **Two of these sit in the frontmatter `description:`** — the text that loads the skill into a session, so the stale wording is what every session actually reads. — **DELETE**; journey is now `register → CV → bring → tailor → receipt`.

2. **`docs/product/DEPLOY.md`** — inventoried *"Five services: `backend`, `frontend`, `worker`, `Postgres`, `Redis`"*, *"5 services all Online"*, *"Worker running 10 ARQ functions + 2 crons"*. `backend/src/workers/` does not exist. — **DELETE** rather than correct: no code can verify a Railway service list, so it is prose that can only rot; `railway status --json` is the pointer. Its post-deploy step also promised `/readyz` → `{db:ok, redis:ok}`; `api/routes/health.readyz` reports `redis: "skipped"` when `REDIS_URL` is unset, so the runbook made a healthy system read as broken. — **TEST**: `backend/tests/test_health_probes.py::test_readyz_redis_skipped_when_url_unset`.

## What the cleanup audit closed (no longer in this PR)

- **`CLAUDE.md` "15 tools"** → `main` now says **18**, which matches `grep -c "@mcp.tool()"`. It is true today, so it is not drift and I did not touch it. Worth noting the pattern anyway: that number has read 8 → 15 → 18 in three days, each time written as a literal beside the instruction to measure it.
- **`.claude/skills/health/SKILL.md`** — file deleted by #503. Its "Dashboard loads / verdict badges render" instruction went with it.
- **`docs/product/MONETIZATION_GAPS.md`** — file deleted by #503.
- **`ARCHITECTURE.md` generated block** — `gen_doc_blocks.py` reports current on `8f30a4e`; #503 regenerated it, so `drift-check` is no longer red on `main` and this PR no longer needs to carry that fix.

## Deliberately not duplicated

`doc_sync_check.py` reports one finding on `main` — `ARCHITECTURE.md` `backend/data` tree-dead-path. That is its job, not mine; untouched.

## Verification

- `python scripts/doc_sync_check.py` — **1 finding before, the same 1 after.** No regressions.
- `python scripts/doc_sync_check.py --budget-only` — OK.
- `python scripts/gen_doc_blocks.py` — *generated doc blocks are current*.
- `python scripts/doc_sync_mutation_test.py` — **all 10 guards still provably red-able.**
- Docs-only. `pytest` and Postgres are both absent from this runner, so no suite was executed; the test named above was confirmed to exist by name in its file.

## Two harness notes, no action taken

- **`scripts/agent-gate.sh` does not run**: `command substitution: line 104: syntax error near unexpected token '||'` — the `LOCK_OUT="$(cd backend && python - <<'PYLOCK' … || true` construct. `bash -n` passes (the substitution is only re-parsed at runtime), so a syntax check cannot see it. Combined with no `pytest` and no Postgres here, **no commit touching `backend/` or `frontend/` can be stamped from a session like this one** — which is also why this branch was re-cut rather than merged: `.claude/hooks/commit-gate.sh` exempts a tree only when `git status --porcelain -- backend frontend` is empty, and merging `main` brings its backend deletions into that check.
- **`.claude/hooks/commit-gate.sh` blocks `git merge --abort`**: its `_creates_commit` parser matches the verb `merge`, but `--abort` destroys a merge rather than creating one, leaving a conflicted worktree with no supported exit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HYErbh9gw9tqhoi5tivsm3