### PR TITLE
fix(ci): post-#503 — sync frontend lock, skip numpy test without extra, add lock-sync guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,6 +234,13 @@ jobs:
           cache: npm
           cache-dependency-path: frontend/package-lock.json
 
+      # Lock ⇄ package.json sync, on the JSON, before npm ci. npm ci catches the
+      # same drift itself, but with 40 lines of usage text; this names the edge.
+      # It exists mainly for the local commit gate (scripts/agent-gate.sh), which
+      # runs against installed node_modules and cannot see a pruned lock (#503).
+      - name: Lockfile sync (scripts/check_lock_sync.py)
+        run: python scripts/check_lock_sync.py frontend
+
       - name: Install frontend deps
         working-directory: frontend
         run: npm ci

--- a/.gitignore
+++ b/.gitignore
@@ -55,8 +55,9 @@ test-*.png
 # Claude Code schedule skill runtime lock
 .claude/scheduled_tasks.lock
 
-# Python build artifacts
+# Python build artifacts (`pip install .` in backend/ leaves build/lib/ behind)
 *.egg-info/
+backend/build/
 # E2E verification artifacts: ignore everything under test-artifacts/ EXCEPT the
 # two committed fixtures (README + sample CV). The old `test-artifacts/*.png`
 # glob only caught top-level PNGs, letting nested screenshot dirs (design/,

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -275,6 +275,12 @@ mypy_path = "backend"
 module = [
     "sentence_transformers.*",
     "sentence_transformers",
+    # numpy is only in the optional `semantic`/`esco` extras and is lazy-imported
+    # behind an ImportError guard (skill_normalizer._load). CI's `.[dev]` install
+    # has none, so mypy there reports import-not-found (#508, after #503 removed
+    # the scikit-learn path that used to drag it in).
+    "numpy.*",
+    "numpy",
     "rapidfuzz.*",
     "rapidfuzz",
     "apprise.*",

--- a/backend/tests/test_skill_normalizer.py
+++ b/backend/tests/test_skill_normalizer.py
@@ -11,11 +11,17 @@ import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import numpy as np
 import pytest
 
-from src.services.profile import skill_normalizer
-from src.services.profile.skill_normalizer import (
+# numpy lives only in the optional `semantic` extra (pyproject). It used to
+# arrive transitively via scikit-learn; the cleanup audit (#503) removed that,
+# so a plain `pip install .[dev]` — what CI does — has no numpy. The normalizer
+# itself is disabled without it (skill_normalizer._load), so skipping is the
+# honest verdict, not a hidden failure.
+np = pytest.importorskip("numpy")
+
+from src.services.profile import skill_normalizer  # noqa: E402
+from src.services.profile.skill_normalizer import (  # noqa: E402
     ESCOMatch,
     index_status,
     normalize_skill,
@@ -81,7 +87,7 @@ def test_normalize_returns_none_when_encoder_unavailable(fake_esco_dir):
 # ── matching paths ──────────────────────────────────────────────────
 
 
-def _fake_encoder(query_vec: np.ndarray):
+def _fake_encoder(query_vec: list[float]):
     """Return a fake encoder whose ``.encode`` returns ``query_vec``."""
     enc = MagicMock()
     enc.encode = MagicMock(return_value=np.array([query_vec], dtype="float32"))

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -948,6 +948,28 @@
         "@noble/ciphers": "^1.0.0"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.3.tgz",
+      "integrity": "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.3",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",
@@ -11524,8 +11546,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/recast": {
       "version": "0.23.11",

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -242,6 +242,10 @@ fi
 
 if [ "$FRONTEND_CHANGED" -gt 0 ]; then
   echo "[gate] frontend gates..."
+  # Lock-sync FIRST: every check below runs against the already-installed
+  # node_modules and cannot see a lock that Linux `npm ci` will refuse (#503
+  # shipped one; Railway + CI both died at `npm ci` while this gate was green).
+  python scripts/check_lock_sync.py frontend
   (cd frontend && npm run -s test:unit && npm run -s type-check && npm run -s lint)
 fi
 

--- a/scripts/check_lock_sync.py
+++ b/scripts/check_lock_sync.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""LOCKFILE SYNC GUARD — say "Missing: X from lock file" before Linux does.
+
+`npm ci` on Linux refuses a package-lock.json in which some package's
+`dependencies` cannot be resolved to a lock entry. The cleanup audit (#503)
+shipped exactly that: npm on Windows pruned the platform-optional `@emnapi/*`
+entries (deps of `@img/sharp-wasm32`), every local check passed against the
+already-installed node_modules, and Railway + CI both died at `npm ci` while
+the commit gate was green.
+
+Neither npm command is a usable guard on Windows (both measured 2026-09-06):
+  * `npm ci --dry-run` returned 0 for that broken lock;
+  * `npm install --package-lock-only` REMOVES the entries when node_modules
+    is absent and ADDS them when it is present — the answer depends on state.
+
+So this is the platform-independent half of npm's own check, done on the JSON:
+  1. every dependency in package.json has a lock entry, and
+  2. every `dependencies` / `optionalDependencies` / non-optional
+     `peerDependencies` of every lock entry resolves — walking up the
+     node_modules nesting the way Node's resolver does.
+
+Exit 0 = in sync · 1 = drift (each missing edge printed) · 2 = cannot read.
+Usage: python scripts/check_lock_sync.py [frontend] | --drill
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parent.parent
+
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+
+
+def _resolves(packages: dict[str, dict[str, Any]], from_loc: str, name: str) -> bool:
+    """True if `name`, required from lock path `from_loc`, has a lock entry.
+
+    Mirrors Node resolution: look in the requirer's own node_modules, then
+    each ancestor's, then the root's.
+    """
+    base = from_loc
+    while True:
+        candidate = f"{base}/node_modules/{name}" if base else f"node_modules/{name}"
+        if candidate in packages:
+            return True
+        if not base:
+            return False
+        idx = base.rfind("/node_modules/")
+        base = "" if idx == -1 else base[:idx]
+
+
+def check(pkg_dir: Path) -> list[str]:
+    """Return every unresolved edge; an empty list means the lock is in sync.
+
+    Raises OSError / ValueError when the files cannot be read or parsed —
+    the caller turns that into exit 2, never into a green verdict.
+    """
+    pkg = json.loads((pkg_dir / "package.json").read_text(encoding="utf-8"))
+    lock = json.loads((pkg_dir / "package-lock.json").read_text(encoding="utf-8"))
+    packages = lock.get("packages")
+    if not isinstance(packages, dict):
+        raise ValueError("lockfileVersion 2/3 `packages` map missing — unsupported lock")
+
+    problems: list[str] = []
+
+    # 1. root package.json ⇄ lock root entry
+    root = packages.get("", {})
+    for field in ("dependencies", "devDependencies", "optionalDependencies"):
+        for name in pkg.get(field, {}):
+            if name not in root.get(field, {}):
+                problems.append(f'package.json {field} "{name}" is not in the lock root')
+            if not _resolves(packages, "", name):
+                problems.append(f'package.json {field} "{name}" has no node_modules/{name} lock entry')
+
+    # 2. every edge inside the lock resolves
+    for loc, entry in packages.items():
+        if loc == "" or entry.get("link"):
+            continue
+        meta = entry.get("peerDependenciesMeta", {})
+        edges = set(entry.get("dependencies", {})) | set(entry.get("optionalDependencies", {}))
+        edges |= {n for n in entry.get("peerDependencies", {}) if not meta.get(n, {}).get("optional")}
+        for name in sorted(edges):
+            if not _resolves(packages, loc, name):
+                problems.append(f"Missing: {name} (required by {loc}) from lock file")
+    return problems
+
+
+def run(pkg_dir: Path) -> int:
+    """Check one package directory and print the verdict."""
+    try:
+        problems = check(pkg_dir)
+    except (OSError, ValueError) as exc:
+        print(f"check_lock_sync: cannot read {pkg_dir}: {exc}")
+        return 2
+    if problems:
+        print(f"check_lock_sync: {pkg_dir}/package-lock.json is OUT OF SYNC — npm ci on Linux will refuse it:")
+        for p in problems:
+            print(f"  - {p}")
+        print(
+            "Fix: regenerate the lock (`npm install --package-lock-only` WITH node_modules "
+            "present, or on Linux) and commit it."
+        )
+        return 1
+    print(f"check_lock_sync: {pkg_dir.name}/package-lock.json in sync — every edge resolves.")
+    return 0
+
+
+def drill() -> int:
+    """Prove the guard can go RED: break a copy of the real lock the way #503 did.
+
+    Removes the lock entry of a package that something else depends on, then
+    demands the guard reports exactly that edge. Also the negative control:
+    the untouched lock must stay green.
+    """
+    src = ROOT / "frontend"
+    fails = 0
+    if check(src):
+        print("[drill] negative control FAILED: the real lock is reported out of sync")
+        fails += 1
+    with tempfile.TemporaryDirectory() as tmp:
+        dst = Path(tmp) / "frontend"
+        dst.mkdir()
+        shutil.copy(src / "package.json", dst / "package.json")
+        lock = json.loads((src / "package-lock.json").read_text(encoding="utf-8"))
+        packages = lock["packages"]
+        # Pick a dependency edge that exists, then delete its target — the
+        # exact shape npm on Windows produced (dependant kept, dependency gone).
+        victim = next(
+            (n for loc, e in packages.items() if loc for n in e.get("dependencies", {})
+             if f"node_modules/{n}" in packages),
+            None,
+        )
+        if victim is None:
+            print("[drill] cannot find a resolvable edge to break — lock too small?")
+            return 1
+        del packages[f"node_modules/{victim}"]
+        (dst / "package-lock.json").write_text(json.dumps(lock), encoding="utf-8")
+        problems = check(dst)
+        hit = [p for p in problems if p.startswith(f"Missing: {victim} ")]
+        if hit:
+            print(f"[drill] RED as required: deleting node_modules/{victim} -> {len(hit)} missing edge(s)")
+        else:
+            print(f"[drill] FAILED: deleted node_modules/{victim} and the guard stayed green")
+            fails += 1
+    print(f"[drill] {2 - fails}/2 checks passed")
+    return 1 if fails else 0
+
+
+def main(argv: list[str]) -> int:
+    if "--drill" in argv:
+        return drill()
+    target = Path(argv[1]) if len(argv) > 1 else ROOT / "frontend"
+    return run(target)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/drill_registry.py
+++ b/scripts/drill_registry.py
@@ -262,6 +262,16 @@ REGISTRY: dict[str, Guard] = {
         # known-bad string, so a NEW way of writing the same bug is still caught.
         drill=[sys.executable, "scripts/check_alert_paths.py", "--drill"],
     ),
+    "scripts/check_lock_sync.py": Guard(
+        status="drilled",
+        # Says "Missing: X from lock file" before Linux `npm ci` does. #503
+        # shipped a lock npm-on-Windows had pruned; every local check ran
+        # against installed node_modules and stayed green while Railway + CI
+        # died at `npm ci`. Drill deletes a depended-on lock entry from a copy
+        # of the real lock and demands that exact edge is reported; the
+        # untouched lock is the negative control.
+        drill=[sys.executable, "scripts/check_lock_sync.py", "--drill"],
+    ),
     "scripts/check_workflow_slack_wiring.py": Guard(
         status="drilled",
         # Checks the CALLERS, not the sender: every slack step passes a token, a


### PR DESCRIPTION
## Why

#503 merged with CI red. Backend deployed fine (`8f30a4e`, migration 0040 applied, 6 tables gone). **Frontend Railway deploy FAILED** — the site is still serving the previous build (`962d88e`). Two root causes, both invisible to the local gate.

## What broke

| | Root cause | Fix |
|---|---|---|
| Frontend (Railway + CI) | `package-lock.json` missing `@emnapi/runtime` + `@emnapi/core` 1.11.3 — optional deps of the wasm sharp/tailwind packages. Windows npm prunes them when `node_modules` is absent; Linux `npm ci` refuses the lock. | Lock regenerated. Proven: `npm ci` exit 0 in `node:20-alpine` (same base as `frontend/Dockerfile`). |
| Backend CI | `tests/test_skill_normalizer.py` imported numpy at module level. numpy is only in the optional `semantic`/`esco` extras; it used to arrive via scikit-learn, removed in #503. CI's `pip install .[dev]` has none. | `pytest.importorskip("numpy")` — the normalizer itself is disabled without numpy, so skip is the honest verdict. 10 pass locally. |

| Backend CI (mypy) — 2nd commit | Same missing numpy: mypy in CI reports `skill_normalizer.py … Cannot find … "numpy" [import-not-found]`. The import is lazy + guarded (`_load`, ImportError → disabled). | `numpy` added to the existing `ignore_missing_imports` override next to `sentence_transformers` (same extra). A `# type: ignore` was rejected: `warn_unused_ignores` under strict makes it red wherever numpy IS installed. Proven in a throwaway venv with only `.[dev]`: ratchet 0 errors, test skips. |

## Guard so it can't recur

`scripts/check_lock_sync.py` — walks `package.json` → lock root → every lock entry's `dependencies` / `optionalDependencies` / non-optional `peerDependencies` and fails on any unresolvable edge. Runs **first** in `agent-gate.sh`'s frontend section and as a CI step before `npm ci`. Registered `drilled` in `drill_registry.py` (`--drill` deletes a depended-on entry from a lock copy and demands RED; 2/2).

Rejected as guards (measured): `npm ci --dry-run` returns 0 on the broken lock on Windows; `npm install --package-lock-only` rewrites the lock differently with vs without `node_modules`.

## Files (8, 2 commits)

- `frontend/package-lock.json` (+23/−2)
- `backend/tests/test_skill_normalizer.py`, `backend/pyproject.toml`
- `.gitignore` (+`backend/build/` — `pip install .` leaves it behind and it nearly got staged)
- `scripts/check_lock_sync.py` (new, mypy --strict + ruff clean)
- `scripts/agent-gate.sh`, `scripts/drill_registry.py`, `.github/workflows/ci.yml`

## Owner

Merge this → frontend redeploys on the cleaned-up code. Nothing else to do for this PR. (Still owed from #503: delete the dead Railway backend vars, read the rewritten privacy/terms copy.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011wAduRqokWdPEByUkcVbvc
