### PR TITLE
fix(reaper): the hook read the script from a checkout that may not have it

### DIFF
--- a/.claude/hooks/worktree-reaper.sh
+++ b/.claude/hooks/worktree-reaper.sh
@@ -52,7 +52,24 @@ ROOT="$(dirname "$COMMON")"
 [ -d "$ROOT" ] || exit 0
 
 [ -f "$ROOT/docs/maintenance/REAPER-OFF" ] && exit 0
-[ -f "$ROOT/scripts/worktree_reaper.py" ] || exit 0
+
+# THE SCRIPT SHIPS BESIDE THIS HOOK — take it from here, not from $ROOT.
+#
+# $ROOT is the MAIN repo's WORKING TREE, and that tree is checked out on whatever
+# branch its own session left it on. Measured 2026-09-05: D:/dev/job360 sat on
+# `chore/repo-hygiene`, a branch predating the reaper, so
+# $ROOT/scripts/worktree_reaper.py did not exist and this hook exited 0 —
+# silently, on every session, forever. The feature was live on `main` and could
+# never run.
+#
+# The hook and the script land in the SAME commit, so if this file is executing,
+# its sibling is right there. $ROOT is still where the reaper OPERATES (the
+# script recomputes that itself from --git-common-dir); it is just not where the
+# code is read from.
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)" || exit 0
+REAPER="$HERE/../../scripts/worktree_reaper.py"
+[ -f "$REAPER" ] || REAPER="$ROOT/scripts/worktree_reaper.py"
+[ -f "$REAPER" ] || exit 0
 
 STATE="$COMMON/reaper"
 mkdir -p "$STATE" 2>/dev/null || exit 0
@@ -61,7 +78,7 @@ mkdir -p "$STATE" 2>/dev/null || exit 0
 # anyone ever learns it ran) and tells us whether another run is due.
 # The `if !` matters: a bare call returning 3 would trip the ERR trap above and
 # exit before this line ever read it. Same outcome by luck is not the same thing.
-if ! python "$ROOT/scripts/worktree_reaper.py" \
+if ! python "$REAPER" \
      --hook-tick "$STATE" --throttle-hours "$THROTTLE_HOURS" 2>/dev/null; then
   exit 0   # exit 3 = throttled; anything else = something is wrong, do nothing
 fi
@@ -74,7 +91,7 @@ touch "$STATE/last-run" 2>/dev/null || true
 # session is simply sitting in without typing.
 (
   cd "$ROOT" || exit 0
-  nohup python scripts/worktree_reaper.py \
+  nohup python "$REAPER" \
     --apply --json \
     --max "$MAX_PER_RUN" \
     --max-branches "$MAX_BRANCHES" \

--- a/scripts/worktree_reaper.py
+++ b/scripts/worktree_reaper.py
@@ -490,6 +490,42 @@ def _drill_hook_tick() -> list[tuple[str, bool, str]]:
     return rows
 
 
+def _drill_hook_finds_its_script() -> list[tuple[str, bool, str]]:
+    """The hook must read the reaper from BESIDE ITSELF, never from $ROOT.
+
+    Measured 2026-09-05, after this shipped to main: the hook exited 0 on every
+    session and reaped nothing, because it tested
+    `[ -f "$ROOT/scripts/worktree_reaper.py" ]` — and $ROOT is the MAIN repo's
+    WORKING TREE, which sat on `chore/repo-hygiene`, a branch predating the
+    reaper. The file was on `main` but not in that checkout, so the guard was
+    false and the hook bailed. Live feature, could never run, exit code 0.
+
+    A hook is not covered by drill_registry.py, so nothing else watches this.
+    """
+    hook = Path(__file__).resolve().parent.parent / ".claude" / "hooks" / "worktree-reaper.sh"
+    if not hook.is_file():
+        return [("hook_exists", False, f"no hook at {hook}")]
+    src = hook.read_text(encoding="utf-8")
+
+    # Strip comments: this file's own post-mortem quotes the bad pattern.
+    code = "\n".join(ln for ln in src.splitlines() if not ln.lstrip().startswith("#"))
+
+    return [
+        (
+            "hook_resolves_script_beside_itself",
+            "BASH_SOURCE" in code,
+            "hook must locate the reaper relative to its own path",
+        ),
+        (
+            "hook_never_runs_ROOT_copy_directly",
+            'python "$ROOT/scripts/worktree_reaper.py"' not in code
+            and "python scripts/worktree_reaper.py" not in code,
+            "invoking $ROOT's copy silently no-ops when that checkout is on an "
+            "older branch",
+        ),
+    ]
+
+
 def _drill_delegation() -> list[tuple[str, bool, str]]:
     """This file must never grow a second opinion about what is SAFE.
 
@@ -560,6 +596,7 @@ def drill() -> int:
         + _drill_prune_before_remove()
         + _drill_hook_tick()
         + _drill_remote()
+        + _drill_hook_finds_its_script()
         + _drill_delegation()
     )
     width = max(len(n) for n, _, _ in rows)


### PR DESCRIPTION
The reaper shipped in #501, went green in CI, and **could never run.**

## What happened

The hook gated on this:

```bash
[ -f "$ROOT/scripts/worktree_reaper.py" ] || exit 0
```

`$ROOT` is the **main repo's working tree** — and that tree is checked out on whatever branch its own session last left it on.

Measured 2026-09-07: `D:/dev/job360` was sitting on `chore/repo-hygiene`, a branch that predates the reaper. The file was on `main` but **not in that checkout**, so the guard was false and the hook exited 0.

Silently. On every session. Forever.

**Exit 0 is also what a healthy run returns**, so nothing anywhere could tell the difference — the exact failure class `drill_registry.py` exists to end, sitting in the one file `drill_registry.py` cannot see (`.claude/hooks/` is not scanned).

Found only because the owner asked me to run it by hand.

## The fix

Read the script from **beside the hook**, not from `$ROOT`. They land in the same commit, so if the hook is executing, its sibling is right there.

`$ROOT` is still where the reaper *operates* — the script recomputes that itself from `--git-common-dir` — it is just no longer where the code is *read from*. Both call sites move to `"$REAPER"`; the `$ROOT` copy stays as a fallback.

## Two new drill cases (22 total)

`hook_resolves_script_beside_itself` and `hook_never_runs_ROOT_copy_directly` read the hook's source, strip comments (this file's own post-mortem quotes the bad pattern), and fail if either regression returns.

A hook is not covered by the registry, so without these **nothing watches it**.

## Verified, not assumed

**Before:** hook exits 0, no state dir, nothing launched.

**After:** state dir created, child launched detached, survives the hook exiting, runs the census, writes its result:

```json
{"pruned": 0, "worktrees_removed": [], "branches_deleted": [], "skipped": [], "applied": true}
```

Zero is the **correct** answer — the 184-branch backlog was already reaped by hand, and every remaining worktree is genuinely held (unshipped commits, uncommitted files, or gitignored `.env`/`data`).

The full path `hook → detached child → census → result` is proven end to end for the first time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6DsQH5EUxJc3Vnqz9YHgQ
