### PR TITLE
feat(spine): #513 email evidence on events + interview datetime

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -16,8 +16,8 @@
 
 | Fact | Value | Where the code says it |
 | --- | --- | --- |
-| Migration head | **0040** | `backend/migrations/` |
-| Migration files | **41** | `backend/migrations/*.up.sql` |
+| Migration head | **0041** | `backend/migrations/` |
+| Migration files | **42** | `backend/migrations/*.up.sql` |
 | `test_*.py` files | **135** | `backend/tests/` |
 | GitHub Actions workflows | **23** | `.github/workflows/` |
 | Hard rules | **14** | `.claude/skills/hard-rules/SKILL.md` |
@@ -412,7 +412,12 @@ routers — a wrong endpoint reads like a contract and 404s whoever trusts it.
 | `APPLICATION_ARTIFACT_MAX_VERSIONS` | No (default `200`) | Per-`(application_id, kind)` version-count cap — over the cap is a 429 naming this variable, never a silent drop |
 | `APPLICATION_EVENT_DETAIL_MAX_CHARS` | No (default `2000`) | S5 — `detail` char cap on `POST /applications/{id}/events`; over the cap is a 422 naming this variable |
 | `APPLICATION_EVENT_PAYLOAD_MAX_BYTES` | No (default `8192`) | S5 — event `payload` cap, checked on the SERIALISED (`json.dumps`) size, because that is what the column costs; the payload must also be a JSON object, never a list/scalar |
-| `APPLICATION_EVENT_MAX_FUTURE_SECONDS` | No (default `300`) | S6 — how far into the future `occurred_at` may claim to be before it is refused as implausible. No lower bound: backdating is the normal case |
+| `APPLICATION_EVENT_MAX_FUTURE_SECONDS` | No (default `300`) | S6 — how far into the future `occurred_at` may claim to be before it is refused as implausible. No lower bound: backdating is the normal case. Slice 6 reuses it for an email source's `received_at` |
+| `APPLICATION_EVENT_SOURCE_KINDS` | No (default `email`) | Slice 6 — the closed set of `source.kind` values an event may cite; anything else is a 422 naming this variable |
+| `APPLICATION_EVENT_SOURCE_MESSAGE_ID_MAX_CHARS` | No (default `256`) | Slice 6 (S2) — char cap on `source.message_id`, the identity the same-message dedupe keys on |
+| `APPLICATION_EVENT_SOURCE_SENDER_MAX_CHARS` | No (default `320`) | Slice 6 (S2) — char cap on `source.sender` |
+| `APPLICATION_EVENT_SOURCE_SUBJECT_MAX_CHARS` | No (default `500`) | Slice 6 (S2) — char cap on `source.subject` |
+| `APPLICATION_SCHEDULED_AT_MAX_FUTURE_SECONDS` | No (default `31622400` = 366 days) | Slice 6 (S8) — how far ahead `scheduled_at` (an interview datetime) may be; past values are allowed |
 | `APPLICATION_RECEIPT_ANSWERS_MAX` | No (default `50`) | S5 — max `answers` items on `POST /applications/{id}/receipt` |
 | `APPLICATION_RECEIPT_ANSWER_MAX_CHARS` | No (default `2000`) | S5 — max chars per receipt answer |
 | `APPLICATION_RECEIPT_FIELDS_MAX_BYTES` | No (default `8192`) | S5 — `fields_filled` cap on the receipt, checked on the serialised size |

--- a/backend/migrations/0041_event_source_and_schedule.down.sql
+++ b/backend/migrations/0041_event_source_and_schedule.down.sql
@@ -1,0 +1,21 @@
+-- 0041 down: reverses the DDL only. No pre-existing `application_events` row
+-- or column is touched beyond the six added by the up file.
+--
+-- WHAT THIS COSTS, STATED PLAINLY: every stored email source and every
+-- stored interview datetime — including any recorded AFTER this migration by
+-- real product usage — is dropped with its columns and is NOT recoverable
+-- except from a backup. The events themselves survive: `application_events`
+-- keeps every row, `event_type`/`detail`/`payload`/`occurred_at` untouched;
+-- only the six slice-6 columns and their unique index are gone. A rejection,
+-- an interview request or a plain reply recorded through `record_event`
+-- after this rollback goes back to carrying its email source as prose in
+-- `detail`, same as before slice 6.
+
+DROP INDEX IF EXISTS uq_application_events_app_source_msg;
+
+ALTER TABLE application_events DROP COLUMN IF EXISTS scheduled_at;
+ALTER TABLE application_events DROP COLUMN IF EXISTS source_received_at;
+ALTER TABLE application_events DROP COLUMN IF EXISTS source_subject;
+ALTER TABLE application_events DROP COLUMN IF EXISTS source_sender;
+ALTER TABLE application_events DROP COLUMN IF EXISTS source_message_id;
+ALTER TABLE application_events DROP COLUMN IF EXISTS source_kind;

--- a/backend/migrations/0041_event_source_and_schedule.up.sql
+++ b/backend/migrations/0041_event_source_and_schedule.up.sql
@@ -1,0 +1,24 @@
+-- 0041_event_source_and_schedule: slice 6 of the mission roadmap
+-- (docs/plans/2026-09-07-email-evidence/spec.md §Data model).
+--
+-- WHY. An event can now name the email it came from (R1) so a re-read inbox
+-- adds zero rows (R2), and an interview event can carry a real datetime (R3)
+-- instead of prose in `detail`. Six columns on `application_events` — never a
+-- new table, since a source/schedule is a property of the ONE event that
+-- named it, not a fact worth its own history.
+--
+-- DDL ONLY. No existing row is read, copied or changed. Conventions copied
+-- from 0038: TEXT NOT NULL DEFAULT '' ('' = none, no NULL branch needed
+-- anywhere), IF NOT EXISTS, partial UNIQUE index for the idempotency rule —
+-- the same non-empty `source_message_id` on the same application is the same
+-- event; a message id with no source (`''`) never collides with another.
+
+ALTER TABLE application_events ADD COLUMN IF NOT EXISTS source_kind        TEXT NOT NULL DEFAULT '';
+ALTER TABLE application_events ADD COLUMN IF NOT EXISTS source_message_id  TEXT NOT NULL DEFAULT '';  -- '' = no source
+ALTER TABLE application_events ADD COLUMN IF NOT EXISTS source_sender      TEXT NOT NULL DEFAULT '';
+ALTER TABLE application_events ADD COLUMN IF NOT EXISTS source_subject     TEXT NOT NULL DEFAULT '';
+ALTER TABLE application_events ADD COLUMN IF NOT EXISTS source_received_at TEXT NOT NULL DEFAULT '';  -- ISO +00:00 or ''
+ALTER TABLE application_events ADD COLUMN IF NOT EXISTS scheduled_at       TEXT NOT NULL DEFAULT '';  -- ISO +00:00 or ''
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_application_events_app_source_msg
+    ON application_events(application_id, source_message_id) WHERE source_message_id <> '';

--- a/backend/src/api/mcp_server.py
+++ b/backend/src/api/mcp_server.py
@@ -512,17 +512,29 @@ def build_server() -> MCPServer:
         payload: Optional[dict[str, Any]] = None,
         occurred_at: Optional[str] = None,
         corrects_event_id: Optional[int] = None,
+        source: Optional[dict[str, Any]] = None,
+        scheduled_at: Optional[str] = None,
     ) -> dict[str, Any]:
         """Append one event to this application's history — replied, an
         interview stage, a note, a lesson learned. `occurred_at` may be in the
         past (backdating a reply you just found is normal); it may not be
         implausibly in the future. A status event (applied/replied/interview_*/
         offer/rejected/withdrawn/ghosted) moves the application's status; a
-        note-family event never does."""
+        note-family event never does.
+
+        `source` names the email an event came from (kind/message_id/sender/
+        subject/received_at) — the same message_id on the same application is
+        the same event, so you get the first one back with
+        already_existed=true and nothing is written; re-reading an inbox is
+        safe. `scheduled_at` is the real interview datetime (ISO-8601 with a
+        timezone) and is only accepted on interview_requested/
+        interview_scheduled."""
         try:
             body = applications_route.RecordEventRequest(
                 event_type=event_type, detail=detail, payload=payload or {},
                 occurred_at=occurred_at, corrects_event_id=corrects_event_id,
+                source=applications_route.EventSource(**source) if source else None,
+                scheduled_at=scheduled_at,
             )
         except ValidationError as exc:
             raise _validation_error(exc) from None

--- a/backend/src/api/routes/applications.py
+++ b/backend/src/api/routes/applications.py
@@ -72,6 +72,21 @@ class SaveFitRequest(BaseModel):
         return self.reasoning
 
 
+class EventSource(BaseModel):
+    """Slice 6 (docs/plans/2026-09-07-email-evidence/spec.md §Tool contracts)
+    — the email an event came from. No length caps declared here: every cap
+    is a live ``settings`` value ``spine.validate_source`` checks at call
+    time, the same reasoning ``AddContactRequest``'s docstring gives."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    kind: str = "email"
+    message_id: str
+    sender: str = ""
+    subject: str = ""
+    received_at: Optional[str] = None
+
+
 class RecordEventRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -80,6 +95,8 @@ class RecordEventRequest(BaseModel):
     payload: dict[str, Any] = Field(default_factory=dict)
     occurred_at: Optional[str] = None
     corrects_event_id: Optional[int] = None
+    source: Optional[EventSource] = None
+    scheduled_at: Optional[str] = None
 
     def clamp_detail(self) -> str:
         cap = settings.APPLICATION_EVENT_DETAIL_MAX_CHARS
@@ -166,6 +183,17 @@ class ApplicationFitOut(BaseModel):
     recorded_at: str
 
 
+class EventSourceOut(BaseModel):
+    """Slice 6 — the ``source`` shape every reader emits (or ``null``, when
+    the event carries none)."""
+
+    kind: str
+    message_id: str
+    sender: str
+    subject: str
+    received_at: Optional[str]
+
+
 class ApplicationEventOut(BaseModel):
     """The timeline shape (``list_events_for_display``) — used by
     ``get_application`` and ``export_history``. Carries ``superseded``;
@@ -180,6 +208,8 @@ class ApplicationEventOut(BaseModel):
     recorded_by: str
     corrects_event_id: Optional[int]
     superseded: bool
+    source: Optional[EventSourceOut]
+    scheduled_at: Optional[str]
 
 
 class ApplicationArtifactOut(BaseModel):
@@ -260,6 +290,7 @@ class ApplicationDetailOut(BaseModel):
     fit: Optional[ApplicationFitOut]
     artifacts: list[ApplicationArtifactOut]
     events: list[ApplicationEventOut]
+    interview_at: Optional[str]
     receipts: list[ApplicationReceiptOut]
     contacts: list[ContactOut]
 
@@ -306,6 +337,8 @@ class RecordEventResponse(BaseModel):
     recorded_at: str
     recorded_by: str
     status: str
+    already_existed: bool
+    scheduled_at: Optional[str]
 
 
 class RecordApplicationReceiptResponse(BaseModel):
@@ -333,6 +366,8 @@ class WhatsNewEventOut(BaseModel):
     recorded_at: str
     recorded_by: str
     corrects_event_id: Optional[int]
+    source: Optional[EventSourceOut]
+    scheduled_at: Optional[str]
 
 
 class WhatsNewApplicationOut(BaseModel):
@@ -654,13 +689,15 @@ async def record_event(
         detail = body.clamp_detail()
         payload = spine.validate_payload(body.payload)
         occurred_at = spine.parse_occurred_at(body.occurred_at)
+        source = spine.validate_source(body.source.model_dump() if body.source else None)
+        scheduled_at = spine.parse_scheduled_at(body.scheduled_at, body.event_type)
         app_row = await spine.get_owned_application(db, user.id, application_id)
         if app_row is None:
             raise SpineError(404, "application not found")
         return await spine.append_event(
             db, user_id=user.id, application_id=application_id, event_type=body.event_type,
             detail=detail, payload=payload, occurred_at=occurred_at, recorded_by=actor_for(user),
-            corrects_event_id=body.corrects_event_id,
+            corrects_event_id=body.corrects_event_id, source=source, scheduled_at=scheduled_at,
         )
     except SpineError as exc:
         _raise(exc)

--- a/backend/src/core/settings.py
+++ b/backend/src/core/settings.py
@@ -284,6 +284,37 @@ APPLICATION_EVENT_PAYLOAD_MAX_BYTES = int(os.getenv("APPLICATION_EVENT_PAYLOAD_M
 # refused as implausible. No lower bound: backdating is the normal case.
 APPLICATION_EVENT_MAX_FUTURE_SECONDS = int(os.getenv("APPLICATION_EVENT_MAX_FUTURE_SECONDS", "300"))
 
+# ── Slice 6 (docs/plans/2026-09-07-email-evidence/spec.md) — an event may
+# carry the email it came from, and an interview may carry a real datetime
+# instead of prose in `detail`. Every cap a parameter; a breach is 422 naming
+# the setting (S2).
+APPLICATION_EVENT_SOURCE_KINDS = _env_list("APPLICATION_EVENT_SOURCE_KINDS", ("email",))
+APPLICATION_EVENT_SOURCE_MESSAGE_ID_MAX_CHARS = int(
+    os.getenv("APPLICATION_EVENT_SOURCE_MESSAGE_ID_MAX_CHARS", "256")
+)
+APPLICATION_EVENT_SOURCE_SENDER_MAX_CHARS = int(os.getenv("APPLICATION_EVENT_SOURCE_SENDER_MAX_CHARS", "320"))
+APPLICATION_EVENT_SOURCE_SUBJECT_MAX_CHARS = int(os.getenv("APPLICATION_EVENT_SOURCE_SUBJECT_MAX_CHARS", "500"))
+
+# R3 — which status event types accept a `scheduled_at`. Derived from
+# APPLICATION_STATUS_EVENT_TYPES the way STATS_INTERVIEW_EVENT_TYPES (below)
+# is, so a vocabulary rename cannot leave a stale name behind here.
+_SCHEDULABLE_NAMES = {"interview_requested", "interview_scheduled"}
+APPLICATION_SCHEDULABLE_EVENT_TYPES = tuple(
+    t for t in APPLICATION_STATUS_EVENT_TYPES if t in _SCHEDULABLE_NAMES
+)
+_schedulable_mismatch = set(APPLICATION_SCHEDULABLE_EVENT_TYPES) != _SCHEDULABLE_NAMES
+if _schedulable_mismatch:  # pragma: no cover — a vocabulary edit would trip this
+    raise RuntimeError(
+        f"APPLICATION_SCHEDULABLE_EVENT_TYPES expected {sorted(_SCHEDULABLE_NAMES)} inside "
+        f"APPLICATION_STATUS_EVENT_TYPES {APPLICATION_STATUS_EVENT_TYPES}, got {APPLICATION_SCHEDULABLE_EVENT_TYPES}"
+    )
+# S8 — the mirror of `occurred_at`'s future bound: an interview can be
+# scheduled far ahead (an email cannot arrive in the future — `received_at`
+# reuses APPLICATION_EVENT_MAX_FUTURE_SECONDS instead).
+APPLICATION_SCHEDULED_AT_MAX_FUTURE_SECONDS = int(
+    os.getenv("APPLICATION_SCHEDULED_AT_MAX_FUTURE_SECONDS", str(366 * 86400))
+)
+
 # R5 — artifact versions. Storage decision: TEXT in Postgres, not a file store
 # (spec §Data model) — a tailored CV measured on this codebase is 2-8 KB.
 APPLICATION_ARTIFACT_KINDS = ("cv", "cover_letter", "answers", "outreach")

--- a/backend/src/services/applications/spine.py
+++ b/backend/src/services/applications/spine.py
@@ -17,6 +17,7 @@ update of the slot is explicitly not history) and, once, a legacy
 from __future__ import annotations
 
 import json
+import unicodedata
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, Mapping, Optional
 
@@ -80,32 +81,182 @@ def validate_payload(payload: Any) -> dict[str, Any]:
     return payload
 
 
-def parse_occurred_at(raw: Optional[str]) -> str:
-    """S6 — ISO-8601 with a timezone, bounded on the future side only."""
+def _parse_bounded_iso(
+    raw: str,
+    *,
+    field: str,
+    max_future_seconds: int,
+    max_future_setting: str,
+) -> str:
+    """Slice 6 — the shared guts of ``parse_occurred_at`` (S6), reused by
+    ``validate_source``'s ``received_at`` and ``parse_scheduled_at``'s
+    ``scheduled_at`` (S8): ISO-8601, timezone required, bounded on the future
+    side only. ``field`` and ``max_future_setting`` name themselves in the
+    error so a 422 always points at the right input and the right knob.
+
+    B3 fix — normalise to the canonical +00:00 offset (pg.py:178-184's own
+    convention) before storing. Every one of these columns is a TEXT column
+    that some caller sorts lexically (``list_events_for_display``'s ORDER BY
+    ``occurred_at`` ASC); two instants recorded under different offsets (e.g.
+    "+05:30" vs "+00:00") do NOT compare correctly as strings even though they
+    compare correctly as instants, so every caller's offset must collapse to
+    the same one before it ever reaches SQL.
+    """
     now = datetime.now(timezone.utc)
-    if raw is None:
-        return now.isoformat()
     try:
         parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
     except ValueError:
-        raise SpineError(422, "occurred_at must be ISO-8601 (e.g. 2026-09-04T12:00:00+00:00)") from None
+        raise SpineError(422, f"{field} must be ISO-8601 (e.g. 2026-09-04T12:00:00+00:00)") from None
     if parsed.tzinfo is None:
-        raise SpineError(422, "occurred_at must include a timezone offset")
-    max_future = timedelta(seconds=settings.APPLICATION_EVENT_MAX_FUTURE_SECONDS)
+        raise SpineError(422, f"{field} must include a timezone offset")
+    max_future = timedelta(seconds=max_future_seconds)
     if parsed > now + max_future:
         raise SpineError(
             422,
-            f"occurred_at is more than APPLICATION_EVENT_MAX_FUTURE_SECONDS "
-            f"({settings.APPLICATION_EVENT_MAX_FUTURE_SECONDS}s) in the future",
+            f"{field} is more than {max_future_setting} ({max_future_seconds}s) in the future",
         )
-    # B3 fix — normalise to the canonical +00:00 offset (pg.py:178-184's own
-    # convention) before storing. `application_events.occurred_at` is a TEXT
-    # column ordered lexically (list_events_for_display's ORDER BY occurred_at
-    # ASC); two instants recorded under different offsets (e.g. "+05:30" vs
-    # "+00:00") do NOT compare correctly as strings even though they compare
-    # correctly as instants, so every caller's offset must collapse to the
-    # same one before it ever reaches SQL.
     return parsed.astimezone(timezone.utc).isoformat()
+
+
+def parse_occurred_at(raw: Optional[str]) -> str:
+    """S6 — ISO-8601 with a timezone, bounded on the future side only."""
+    if raw is None:
+        return datetime.now(timezone.utc).isoformat()
+    return _parse_bounded_iso(
+        raw,
+        field="occurred_at",
+        max_future_seconds=settings.APPLICATION_EVENT_MAX_FUTURE_SECONDS,
+        max_future_setting="APPLICATION_EVENT_MAX_FUTURE_SECONDS",
+    )
+
+
+# ── Slice 6 (docs/plans/2026-09-07-email-evidence/spec.md) — an event's
+# optional email source and interview datetime ──────────────────────────────
+
+
+_SOURCE_CONTROL_CHAR_FIELDS = ("message_id", "sender", "subject")
+
+# S3 — what "control character" means for a source field. Unicode category
+# Cc is C0 + DEL + C1; Zl/Zp are U+2028/U+2029, real line terminators in
+# JSON/JS contexts, so they poison exports exactly like "\n" does; the bidi
+# embeddings/overrides/isolates flip how the REST of a timeline line renders.
+# Deliberately NOT all of Cf: emoji ZWJ sequences (U+200D) are legal subjects.
+_SOURCE_BANNED_CATEGORIES = frozenset({"Cc", "Zl", "Zp"})
+_SOURCE_BANNED_CHARS = frozenset(
+    chr(cp) for cp in (
+        0x202A, 0x202B, 0x202C, 0x202D, 0x202E,  # LRE RLE PDF LRO RLO
+        0x2066, 0x2067, 0x2068, 0x2069,  # LRI RLI FSI PDI
+    )
+)
+
+
+def _has_control_chars(value: str) -> bool:
+    return any(
+        ch in _SOURCE_BANNED_CHARS or unicodedata.category(ch) in _SOURCE_BANNED_CATEGORIES
+        for ch in value
+    )
+
+
+def validate_source(raw: Optional[dict[str, Any]]) -> Optional[dict[str, Any]]:
+    """R1/S2/S3 — normalise-and-validate an event's optional email source.
+
+    ``None`` in, ``None`` out (an event with no source). Otherwise: trim the
+    three text fields, reject an empty ``message_id`` (that is the identity
+    R2 dedupes on — it cannot be blank), reject any control character (S3 —
+    a subject cannot legally carry a newline), cap each field's length
+    (S2, naming the setting), and check ``kind`` against the closed set.
+    ``received_at`` is parsed with ``occurred_at``'s rules (S8: ISO-8601,
+    timezone required, normalised to +00:00, same tight future bound — an
+    email cannot arrive in the future).
+    """
+    if raw is None:
+        return None
+
+    kind = raw.get("kind", "email")
+    message_id = str(raw.get("message_id") or "").strip()
+    sender = str(raw.get("sender") or "").strip()
+    subject = str(raw.get("subject") or "").strip()
+    received_at_raw = raw.get("received_at")
+
+    if not message_id:
+        raise SpineError(422, "message_id must not be empty")
+
+    fields = {"message_id": message_id, "sender": sender, "subject": subject}
+    for name in _SOURCE_CONTROL_CHAR_FIELDS:
+        value = fields[name]
+        if _has_control_chars(value):
+            raise SpineError(422, f"{name} must not contain control characters")
+
+    caps = (
+        ("message_id", message_id, settings.APPLICATION_EVENT_SOURCE_MESSAGE_ID_MAX_CHARS,
+         "APPLICATION_EVENT_SOURCE_MESSAGE_ID_MAX_CHARS"),
+        ("sender", sender, settings.APPLICATION_EVENT_SOURCE_SENDER_MAX_CHARS,
+         "APPLICATION_EVENT_SOURCE_SENDER_MAX_CHARS"),
+        ("subject", subject, settings.APPLICATION_EVENT_SOURCE_SUBJECT_MAX_CHARS,
+         "APPLICATION_EVENT_SOURCE_SUBJECT_MAX_CHARS"),
+    )
+    for name, value, cap, setting_name in caps:
+        if len(value) > cap:
+            raise SpineError(422, f"{name} exceeds {setting_name} ({cap} chars)")
+
+    if kind not in settings.APPLICATION_EVENT_SOURCE_KINDS:
+        raise SpineError(
+            422,
+            f"kind must be one of APPLICATION_EVENT_SOURCE_KINDS {settings.APPLICATION_EVENT_SOURCE_KINDS}",
+        )
+
+    received_at = ""
+    if received_at_raw is not None:
+        received_at = _parse_bounded_iso(
+            str(received_at_raw),
+            field="received_at",
+            max_future_seconds=settings.APPLICATION_EVENT_MAX_FUTURE_SECONDS,
+            max_future_setting="APPLICATION_EVENT_MAX_FUTURE_SECONDS",
+        )
+
+    return {
+        "kind": kind,
+        "message_id": message_id,
+        "sender": sender,
+        "subject": subject,
+        "received_at": received_at,
+    }
+
+
+def parse_scheduled_at(raw: Optional[str], event_type: str) -> str:
+    """R3/S8 — an interview datetime, allowed only on
+    ``settings.APPLICATION_SCHEDULABLE_EVENT_TYPES``. Its own, longer future
+    bound (an interview can be scheduled far ahead; an email cannot arrive in
+    the future)."""
+    if raw is None:
+        return ""
+    if event_type not in settings.APPLICATION_SCHEDULABLE_EVENT_TYPES:
+        raise SpineError(
+            422,
+            f"scheduled_at is only allowed on APPLICATION_SCHEDULABLE_EVENT_TYPES "
+            f"{settings.APPLICATION_SCHEDULABLE_EVENT_TYPES}; got event_type {event_type!r}",
+        )
+    return _parse_bounded_iso(
+        raw,
+        field="scheduled_at",
+        max_future_seconds=settings.APPLICATION_SCHEDULED_AT_MAX_FUTURE_SECONDS,
+        max_future_setting="APPLICATION_SCHEDULED_AT_MAX_FUTURE_SECONDS",
+    )
+
+
+def _event_source(row: Mapping[str, Any]) -> Optional[dict[str, Any]]:
+    """R4 — build the ``source`` object a reader emits from the six raw
+    columns; ``None`` when the event carries no source (the 0038/0041
+    convention: ``source_message_id == ''`` means none, never NULL)."""
+    if not row.get("source_message_id"):
+        return None
+    return {
+        "kind": row["source_kind"],
+        "message_id": row["source_message_id"],
+        "sender": row["source_sender"],
+        "subject": row["source_subject"],
+        "received_at": row["source_received_at"] or None,
+    }
 
 
 # ── Ownership lookups ───────────────────────────────────────────────────────
@@ -149,7 +300,8 @@ async def list_events_for_display(db: JobDatabase, application_id: int) -> list[
     """Timeline order — ``occurred_at`` (backdated events included), NOT the
     ``recorded_at`` order the status recompute uses."""
     cur = await db._db.execute(
-        "SELECT id, event_type, detail, payload, occurred_at, recorded_at, recorded_by, corrects_event_id "
+        "SELECT id, event_type, detail, payload, occurred_at, recorded_at, recorded_by, corrects_event_id, "
+        "source_kind, source_message_id, source_sender, source_subject, source_received_at, scheduled_at "
         "FROM application_events WHERE application_id = ? ORDER BY occurred_at ASC, id ASC",
         (application_id,),
     )
@@ -168,9 +320,56 @@ async def list_events_for_display(db: JobDatabase, application_id: int) -> list[
                 "recorded_by": r["recorded_by"],
                 "corrects_event_id": r["corrects_event_id"],
                 "superseded": r["id"] in superseded_ids,
+                "source": _event_source(r),
+                "scheduled_at": r["scheduled_at"] or None,
             }
         )
     return out
+
+
+async def _event_by_source_message_id(
+    db: JobDatabase, application_id: int, message_id: str
+) -> Optional[dict[str, Any]]:
+    """R2 — the identity a duplicate `record_event` call resolves against:
+    ``(application_id, source_message_id)``, backed by the partial UNIQUE
+    index `migrations/0041...up.sql`."""
+    cur = await db._db.execute(
+        "SELECT id, event_type, occurred_at, recorded_at, recorded_by, scheduled_at "
+        "FROM application_events WHERE application_id = ? AND source_message_id = ?",
+        (application_id, message_id),
+    )
+    row = await cur.fetchone()
+    return dict(row) if row else None
+
+
+async def _duplicate_event_result(
+    db: JobDatabase, application_id: int, recorded_by: str, existing: dict[str, Any]
+) -> dict[str, Any]:
+    """R2/S4 — the same message id has already been recorded: audit ids ONLY
+    (never subject/sender/message_id — S4), write nothing, and hand back the
+    EXISTING event plus the application's current status."""
+    get_audit_logger().info(
+        "application_event_duplicate",
+        extra={
+            "event": "application_event_duplicate",
+            "application_id": application_id,
+            "event_id": existing["id"],
+            "event_type": existing["event_type"],
+            "recorded_by": recorded_by,
+        },
+    )
+    cur = await db._db.execute("SELECT status FROM applications WHERE id = ?", (application_id,))
+    app_row = await cur.fetchone()
+    return {
+        "event_id": existing["id"],
+        "event_type": existing["event_type"],
+        "occurred_at": existing["occurred_at"],
+        "recorded_at": existing["recorded_at"],
+        "recorded_by": existing["recorded_by"],
+        "status": app_row["status"] if app_row else None,
+        "already_existed": True,
+        "scheduled_at": existing["scheduled_at"] or None,
+    }
 
 
 async def append_event(
@@ -184,6 +383,8 @@ async def append_event(
     detail: str = "",
     payload: Optional[dict[str, Any]] = None,
     corrects_event_id: Optional[int] = None,
+    source: Optional[dict[str, Any]] = None,
+    scheduled_at: str = "",
 ) -> dict[str, Any]:
     """R3/R4 — append one event, then recompute + write-through the status
     cache (and its legacy `stage` projection) in the SAME logical operation.
@@ -196,6 +397,14 @@ async def append_event(
     event (or a typo'd id that never existed) and ``list_events_for_display``
     would mark the wrong thing (or nothing) as superseded. 422, not 404 — this
     is a body-field validation error, not a missing resource.
+
+    Slice 6 R2 — ``source`` (already normalised by ``validate_source``) makes
+    ``(application_id, source_message_id)`` the identity: a second call
+    naming a message id already on THIS application returns the existing row
+    untouched (``already_existed: True``) — no insert, no replay, no status
+    change. The UNIQUE index still backstops a race between two concurrent
+    callers (``pg.IntegrityError``): re-read and return the existing row the
+    same way ``save_artifact``'s version race does.
     """
     if corrects_event_id is not None:
         cur = await db._db.execute(
@@ -208,14 +417,46 @@ async def append_event(
                 f"corrects_event_id {corrects_event_id} does not exist on this application",
             )
 
+    if source is not None:
+        existing = await _event_by_source_message_id(db, application_id, source["message_id"])
+        if existing is not None:
+            return await _duplicate_event_result(db, application_id, recorded_by, existing)
+
     now = datetime.now(timezone.utc).isoformat()
     payload_json = json.dumps(payload or {})
-    cur = await db._db.execute(
-        "INSERT INTO application_events "
-        "(user_id, application_id, event_type, detail, payload, occurred_at, recorded_at, "
-        " recorded_by, corrects_event_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
-        (user_id, application_id, event_type, detail, payload_json, occurred_at, now, recorded_by, corrects_event_id),
-    )
+    source_kind = source["kind"] if source else ""
+    source_message_id = source["message_id"] if source else ""
+    source_sender = source["sender"] if source else ""
+    source_subject = source["subject"] if source else ""
+    source_received_at = source["received_at"] if source else ""
+    try:
+        # Scoped like contacts.add_contact's INSERT: a bare ``rollback()`` is
+        # forbidden by psycopg inside an outer ``transaction()`` block (and
+        # add_contact calls append_event inside one), which would leave the
+        # transaction ABORTED for the re-read below. The block rolls the
+        # failed INSERT back correctly either way — SAVEPOINT when nested.
+        async with db._db.transaction():
+            cur = await db._db.execute(
+                "INSERT INTO application_events "
+                "(user_id, application_id, event_type, detail, payload, occurred_at, recorded_at, "
+                " recorded_by, corrects_event_id, source_kind, source_message_id, source_sender, "
+                " source_subject, source_received_at, scheduled_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    user_id, application_id, event_type, detail, payload_json, occurred_at, now,
+                    recorded_by, corrects_event_id, source_kind, source_message_id, source_sender,
+                    source_subject, source_received_at, scheduled_at,
+                ),
+            )
+    except pg.IntegrityError:
+        # A race: two callers recorded the same message id at once (same
+        # reasoning as save_artifact's version race — see spine.py). The
+        # UNIQUE index caught it; re-read and return the row that won.
+        if source is not None:
+            existing = await _event_by_source_message_id(db, application_id, source["message_id"])
+            if existing is not None:
+                return await _duplicate_event_result(db, application_id, recorded_by, existing)
+        raise
     event_id = cur.lastrowid
 
     new_status = replay_status(await _events_for_replay(db, application_id))
@@ -248,6 +489,8 @@ async def append_event(
         "recorded_at": now,
         "recorded_by": recorded_by,
         "status": new_status,
+        "already_existed": False,
+        "scheduled_at": scheduled_at or None,
     }
 
 
@@ -657,6 +900,17 @@ async def get_application_detail(
             "recorded_at": app_row.get("fit_recorded_at"),
         }
 
+    events = await list_events_for_display(db, application_id)
+    # R4 — the newest NON-superseded event that carries a scheduled_at (a
+    # rescheduled interview is a correcting event, which is what makes the
+    # old value drop out — see spec §Flagged concerns). `events` is already
+    # ordered oldest-first (occurred_at ASC, id ASC), so the last match IS
+    # the newest one; no extra query.
+    interview_at: Optional[str] = None
+    for ev in events:
+        if ev["scheduled_at"] and not ev["superseded"]:
+            interview_at = ev["scheduled_at"]
+
     return {
         "id": app_row["id"],
         "job_id": job_id,
@@ -676,7 +930,8 @@ async def get_application_detail(
         },
         "fit": fit,
         "artifacts": await _list_artifacts(db, application_id, with_text=with_artifact_text),
-        "events": await list_events_for_display(db, application_id),
+        "events": events,
+        "interview_at": interview_at,
         "receipts": await _list_receipts_for_application(db, user_id, application_id),
         "contacts": await list_contacts(db, user_id, application_id),
     }
@@ -793,7 +1048,8 @@ async def whats_new(
 
     cur = await db._db.execute(
         f"SELECT id, application_id, event_type, detail, payload, occurred_at, recorded_at, "  # noqa: S608
-        f"recorded_by, corrects_event_id FROM application_events WHERE {where_sql} "
+        f"recorded_by, corrects_event_id, source_kind, source_message_id, source_sender, "
+        f"source_subject, source_received_at, scheduled_at FROM application_events WHERE {where_sql} "
         f"ORDER BY recorded_at ASC, id ASC LIMIT ?",
         [*params, limit + 1],
     )
@@ -811,6 +1067,7 @@ async def whats_new(
                 "detail": r["detail"], "payload": json.loads(r["payload"] or "{}"),
                 "occurred_at": r["occurred_at"], "recorded_at": r["recorded_at"],
                 "recorded_by": r["recorded_by"], "corrects_event_id": r["corrects_event_id"],
+                "source": _event_source(r), "scheduled_at": r["scheduled_at"] or None,
             }
         )
         if r["application_id"] not in seen:

--- a/backend/tests/test_application_spine.py
+++ b/backend/tests/test_application_spine.py
@@ -763,3 +763,248 @@ async def test_audit_log_never_carries_a_body(authenticated_async_context, audit
         blob = " ".join(f"{k}={v!r}" for k, v in record.items())
         for marker in markers:
             assert marker not in blob, f"audit log leaked a body field: {marker} in {blob[:300]}"
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# ── Slice 6 (#513): email evidence + interview datetime ─────────────────────
+#
+# docs/plans/2026-09-07-email-evidence/spec.md — written RED first against
+# that doc's §Frozen tests list (every case 422'd on "extra_forbidden" until
+# `source` / `scheduled_at` existed), green since R1-R6 landed. Dates in the
+# fixtures are deliberately in the PAST: `received_at` shares `occurred_at`'s
+# tight future bound (S8), so a fixed future date would rot.
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_event_with_email_source_is_stored_and_shown(authenticated_async_context):
+    async with authenticated_async_context() as client:
+        app_id = (await _bring(client))["application_id"]
+        source = {
+            "kind": "email",
+            "message_id": "msg-001@mail.example",
+            "sender": "recruiter@northwind.example",
+            "subject": "Re: Data Engineer application",
+            "received_at": "2026-09-01T08:30:00+01:00",
+        }
+        resp = await _record_event(client, app_id, "replied", source=source)
+        assert resp.status_code == 201, resp.text
+        assert resp.json()["already_existed"] is False
+
+        detail = await _get_application(client, app_id)
+        whats_new = await client.get("/api/whats-new")
+
+    expected_source = {**source, "received_at": "2026-09-01T07:30:00+00:00"}
+    replied = next(e for e in detail.json()["events"] if e["event_type"] == "replied")
+    assert replied["source"] == expected_source, replied
+
+    wn_replied = next(e for e in whats_new.json()["events"] if e["event_type"] == "replied")
+    assert wn_replied["source"] == expected_source
+
+
+@pytest.mark.asyncio
+async def test_same_message_id_twice_adds_zero_rows(authenticated_async_context):
+    from src.api import dependencies as api_deps
+
+    async with authenticated_async_context() as client:
+        app_id = (await _bring(client))["application_id"]
+        first = await _record_event(client, app_id, "replied", source={"message_id": "dup-1"})
+        assert first.status_code == 201, first.text
+        first_body = first.json()
+
+        db = await api_deps.get_db()
+        cur = await db._conn.execute(
+            "SELECT COUNT(*) FROM application_events WHERE application_id = ?", (app_id,)
+        )
+        count_before = (await cur.fetchone())[0]
+
+        second = await _record_event(
+            client, app_id, "interview_requested", source={"message_id": "dup-1"}
+        )
+        assert second.status_code == 201, second.text
+        second_body = second.json()
+
+    assert second_body["already_existed"] is True
+    assert second_body["event_id"] == first_body["event_id"]
+    assert second_body["event_type"] == first_body["event_type"] == "replied"
+    assert second_body["status"] == first_body["status"], "a duplicate must not replay status"
+
+    cur = await db._conn.execute(
+        "SELECT COUNT(*) FROM application_events WHERE application_id = ?", (app_id,)
+    )
+    count_after = (await cur.fetchone())[0]
+    assert count_after == count_before, "the second call must add zero rows"
+
+
+@pytest.mark.asyncio
+async def test_same_message_id_on_another_application_is_a_new_row(authenticated_async_context):
+    async with authenticated_async_context() as client:
+        app_1 = (await _bring(client))["application_id"]
+        app_2 = (await _bring(client, _AD_2))["application_id"]
+
+        r1 = await _record_event(client, app_1, "replied", source={"message_id": "shared-msg-1"})
+        r2 = await _record_event(client, app_2, "replied", source={"message_id": "shared-msg-1"})
+
+    assert r1.status_code == 201, r1.text
+    assert r2.status_code == 201, r2.text
+    assert r1.json()["event_id"] != r2.json()["event_id"]
+    assert r1.json()["already_existed"] is False
+    assert r2.json()["already_existed"] is False
+
+
+@pytest.mark.asyncio
+async def test_event_without_source_has_null_source(authenticated_async_context):
+    async with authenticated_async_context() as client:
+        app_id = (await _bring(client))["application_id"]
+        resp = await _record_event(client, app_id, "note", detail="plain note")
+        assert resp.status_code == 201, resp.text
+        assert resp.json()["already_existed"] is False
+
+        detail = await _get_application(client, app_id)
+
+    note_evt = next(e for e in detail.json()["events"] if e["event_type"] == "note")
+    assert note_evt["source"] is None
+    assert note_evt["scheduled_at"] is None
+
+
+@pytest.mark.asyncio
+async def test_scheduled_at_is_normalised_and_becomes_interview_at(authenticated_async_context):
+    async with authenticated_async_context() as client:
+        app_id = (await _bring(client))["application_id"]
+
+        first = await _record_event(
+            client, app_id, "interview_scheduled", scheduled_at="2026-09-15T10:00:00+01:00"
+        )
+        assert first.status_code == 201, first.text
+        assert first.json()["scheduled_at"] == "2026-09-15T09:00:00+00:00"
+        first_id = first.json()["event_id"]
+
+        detail_1 = await _get_application(client, app_id)
+        assert detail_1.json()["interview_at"] == "2026-09-15T09:00:00+00:00"
+
+        # The interview got rescheduled: a correcting event supersedes the
+        # first and carries its OWN, newer scheduled_at.
+        second = await _record_event(
+            client, app_id, "interview_scheduled",
+            scheduled_at="2026-09-20T14:00:00+00:00", corrects_event_id=first_id,
+        )
+        assert second.status_code == 201, second.text
+
+        detail_2 = await _get_application(client, app_id)
+
+    assert detail_2.json()["interview_at"] == "2026-09-20T14:00:00+00:00", (
+        "interview_at must move to the CORRECTING event's scheduled_at, not stay on the superseded one"
+    )
+
+
+@pytest.mark.asyncio
+async def test_scheduled_at_on_a_non_interview_event_is_422(authenticated_async_context):
+    async with authenticated_async_context() as client:
+        app_id = (await _bring(client))["application_id"]
+        resp = await _record_event(
+            client, app_id, "note", scheduled_at="2026-09-15T10:00:00+00:00"
+        )
+        assert resp.status_code == 422, resp.text
+        assert "APPLICATION_SCHEDULABLE_EVENT_TYPES" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_scheduled_at_without_timezone_is_422(authenticated_async_context):
+    async with authenticated_async_context() as client:
+        app_id = (await _bring(client))["application_id"]
+        resp = await _record_event(
+            client, app_id, "interview_requested", scheduled_at="2026-09-15T10:00:00"
+        )
+        assert resp.status_code == 422, resp.text
+
+
+@pytest.mark.asyncio
+async def test_source_caps_and_control_chars_are_422(authenticated_async_context):
+    from src.core import settings
+
+    async with authenticated_async_context() as client:
+        app_id = (await _bring(client))["application_id"]
+
+        too_long_subject = "x" * (settings.APPLICATION_EVENT_SOURCE_SUBJECT_MAX_CHARS + 1)
+        over_cap = await _record_event(
+            client, app_id, "note", source={"message_id": "cap-1", "subject": too_long_subject}
+        )
+        assert over_cap.status_code == 422, over_cap.text
+        assert "APPLICATION_EVENT_SOURCE_SUBJECT_MAX_CHARS" in over_cap.text
+
+        bad_kind = await _record_event(
+            client, app_id, "note", source={"kind": "sms", "message_id": "cap-2"}
+        )
+        assert bad_kind.status_code == 422, bad_kind.text
+
+        control_char = await _record_event(
+            client, app_id, "note", source={"message_id": "cap-3", "subject": "line1\nline2"}
+        )
+        assert control_char.status_code == 422, control_char.text
+
+        # S3 widened after review: U+2028 is a line terminator in JSON/JS
+        # exports and U+202E flips how the rest of the timeline line renders;
+        # both slip past a bare `< 0x20` check. An emoji ZWJ sequence is a
+        # legal subject and must NOT be refused.
+        for bad in ("line1\u2028line2", "\u202eevil", "c1\x85ctrl"):
+            resp = await _record_event(client, app_id, "note", source={"message_id": "cap-3b", "subject": bad})
+            assert resp.status_code == 422, (bad, resp.text)
+        zwj_ok = await _record_event(
+            client, app_id, "note", source={"message_id": "cap-3c", "subject": "\U0001F468\u200d\U0001F4BB hi"}
+        )
+        assert zwj_ok.status_code == 201, zwj_ok.text
+
+        blank_message_id = await _record_event(
+            client, app_id, "note", source={"message_id": "   "}
+        )
+        assert blank_message_id.status_code == 422, blank_message_id.text
+
+        unknown_key = await _record_event(
+            client, app_id, "note", source={"message_id": "cap-4", "bogus": "x"}
+        )
+        assert unknown_key.status_code == 422, unknown_key.text
+
+
+@pytest.mark.asyncio
+async def test_source_never_reaches_the_audit_log(authenticated_async_context, audit_capture):
+    async with authenticated_async_context() as client:
+        app_id = (await _bring(client))["application_id"]
+        source = {
+            "message_id": "audit-msg-1",
+            "sender": "SECRET_SENDER_MARKER@example.com",
+            "subject": "SECRET_SUBJECT_MARKER",
+        }
+        await _record_event(client, app_id, "replied", source=source)
+        # Same message id again -> exercises the duplicate/audit path too.
+        await _record_event(client, app_id, "note", source=source)
+
+    markers = ("SECRET_SENDER_MARKER", "SECRET_SUBJECT_MARKER", "audit-msg-1")
+    for record in audit_capture.records:
+        blob = " ".join(f"{k}={v!r}" for k, v in record.items())
+        for marker in markers:
+            assert marker not in blob, f"audit log leaked a source field: {marker} in {blob[:300]}"
+
+
+@pytest.mark.asyncio
+async def test_a_foreign_application_id_is_404_before_the_duplicate_lookup(authenticated_async_context):
+    from src.api import dependencies as api_deps
+
+    async with authenticated_async_context() as owner:
+        app_id = (await _bring(owner))["application_id"]
+
+    db = await api_deps.get_db()
+    cur = await db._conn.execute(
+        "SELECT COUNT(*) FROM application_events WHERE application_id = ?", (app_id,)
+    )
+    count_before = (await cur.fetchone())[0]
+
+    cookie = await _second_user_session_cookie("intruder-email-evidence@example.com")
+    async with _session_client(cookie) as intruder:
+        resp = await _record_event(intruder, app_id, "replied", source={"message_id": "steal-1"})
+        assert resp.status_code == 404, resp.text
+
+    cur = await db._conn.execute(
+        "SELECT COUNT(*) FROM application_events WHERE application_id = ?", (app_id,)
+    )
+    count_after = (await cur.fetchone())[0]
+    assert count_after == count_before, "a foreign application_id must 404 before any duplicate lookup runs"

--- a/backend/tests/test_mcp_server.py
+++ b/backend/tests/test_mcp_server.py
@@ -298,3 +298,65 @@ async def test_record_application_writes_a_rich_receipt_through_the_new_route(au
         # The event log recorded it too — not just the receipts table.
         statuses = [e["event_type"] for e in detail.json()["events"]]
         assert "applied" in statuses
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Slice 6 (#513): email evidence + interview datetime
+# docs/plans/2026-09-07-email-evidence/spec.md — test 11 of §Frozen tests.
+# Written RED first (the tool had neither parameter, so the call failed
+# MCP-side input validation), green since the tool grew `source` and
+# `scheduled_at`. `received_at` is a past date on purpose — it shares
+# `occurred_at`'s tight future bound (S8).
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_record_event_tool_passes_source_and_scheduled_at(authenticated_async_context):
+    from src.api.mcp_server import mcp_runtime
+
+    token = await _mint_token(authenticated_async_context)
+    async with mcp_runtime():
+        async with _mcp_client(token) as mcp:
+            brought = _payload(await mcp.call_tool("bring_job", JOB))
+            application_id = brought["application_id"]
+            source = {
+                "kind": "email",
+                "message_id": "mcp-msg-1",
+                "sender": "recruiter@acme.example",
+                "subject": "Interview invite",
+                "received_at": "2026-09-01T08:00:00+00:00",
+            }
+
+            recorded = _payload(
+                await mcp.call_tool(
+                    "record_event",
+                    {
+                        "application_id": application_id,
+                        "event_type": "interview_scheduled",
+                        "source": source,
+                        "scheduled_at": "2026-09-15T10:00:00+01:00",
+                    },
+                )
+            )
+            assert recorded["already_existed"] is False
+
+            again = _payload(
+                await mcp.call_tool(
+                    "record_event",
+                    {
+                        "application_id": application_id,
+                        "event_type": "interview_scheduled",
+                        "source": source,
+                        "scheduled_at": "2026-09-15T10:00:00+01:00",
+                    },
+                )
+            )
+            assert again["already_existed"] is True
+            assert again["event_id"] == recorded["event_id"]
+
+            detail = _payload(
+                await mcp.call_tool("get_application", {"application_id": application_id})
+            )
+            evt = next(e for e in detail["events"] if e["id"] == recorded["event_id"])
+            assert evt["source"]["message_id"] == "mcp-msg-1"
+            assert evt["scheduled_at"] == "2026-09-15T09:00:00+00:00"

--- a/docs/README.md
+++ b/docs/README.md
@@ -42,6 +42,7 @@ every link below resolves; nothing is left out.
 | 3 — URL fetch on the web | [`plans/2026-09-04-url-fetch/spec.md`](plans/2026-09-04-url-fetch/spec.md) | PR #496 |
 | 4 — Contacts, stats, `update_profile` | [`plans/2026-09-05-contacts-stats/spec.md`](plans/2026-09-05-contacts-stats/spec.md) | PR #498 |
 | 5 — Delete the sourcing era | [`plans/2026-09-05-delete-sourcing-era/spec.md`](plans/2026-09-05-delete-sourcing-era/spec.md) | #483 |
+| 6 — Email evidence on events + interview datetime | [`plans/2026-09-07-email-evidence/spec.md`](plans/2026-09-07-email-evidence/spec.md) | #513 |
 | — Bring a job, keep the receipt | [`plans/2026-09-02-bring-a-job/spec.md`](plans/2026-09-02-bring-a-job/spec.md) | PR #469 |
 | — Personal tokens + MCP server | [`plans/2026-09-03-mcp-server/spec.md`](plans/2026-09-03-mcp-server/spec.md) | PR #473 |
 

--- a/docs/plans/2026-09-07-email-evidence/spec.md
+++ b/docs/plans/2026-09-07-email-evidence/spec.md
@@ -1,0 +1,210 @@
+<!-- doc: PLAN | status: ACTIVE | pr: — -->
+# Spec: email evidence on events + interview datetime (slice 6, #513)
+
+Builds on the spine spec (`docs/plans/2026-09-04-application-spine/spec.md`, R1–R10,
+S1–S12) and the contacts spec (`2026-09-05-contacts-stats/spec.md`). Every rule there
+still holds; this document only adds. Line numbers are as of `e0dde31`.
+
+Owner decisions this implements (VISION.md decisions 19–20, 2026-09-07): the agent's own
+Gmail connector reads the inbox — we never do (decision 8, hard rule M2). What we add is
+the **store** side: an event can name the email it came from, a re-read inbox adds zero
+rows, and an interview has a real datetime instead of prose in `detail`.
+
+## Measured starting point
+
+| Thing | Where | State |
+|---|---|---|
+| `application_events` columns | `migrations/0037_application_spine.up.sql:66-83` | `id, user_id, application_id, event_type, detail, payload, occurred_at, recorded_at, recorded_by, corrects_event_id` — nothing names a source |
+| write door | `services/applications/spine.py:176 append_event` | one INSERT, then `replay_status` → `applications` slot |
+| route | `api/routes/applications.py:646 record_event` → `RecordEventRequest :75` (`extra="forbid"`) → `RecordEventResponse :302` | no `source`, no `scheduled_at` |
+| MCP tool | `api/mcp_server.py:508 record_event` | builds the same request model; parity table `tests/test_mcp_gate_parity.py:49-82` |
+| read shapes | `ApplicationEventOut :169` (detail + export) · `WhatsNewEventOut :323` | both emit the raw event dict; nothing formats "interview at …" server-side |
+| idempotency idiom to copy | `0038_contacts_and_profile_edits.up.sql:39-40` + `services/applications/contacts.py:134 add_contact` | partial UNIQUE `WHERE email <> ''`, read-before-insert, `already_existed: true` |
+| timestamp idiom to copy | `spine.py:83 parse_occurred_at` | ISO-8601, tz required, bounded future, stored as `+00:00` (TEXT sorts lexically) |
+| append-only guard | `tests/test_application_spine.py:366 test_events_are_append_only` | greps `backend/src/` for `UPDATE|DELETE FROM application_events` |
+| timeline | `frontend/src/components/applications/Timeline.tsx` · header `app/applications/[id]/ApplicationClient.tsx:78-113` | shows `event_type`, `detail`, `occurred_at`, `recorded_by` |
+| api types | `frontend/src/lib/api-types.ts` (generated; `npm run gen:types`; gate runs `check:types-drift`) | must be regenerated with any response-model change |
+
+## Requirements
+
+- **R1 — an event may carry its source.** `record_event` accepts an optional `source`
+  object: `{kind, message_id, sender, subject, received_at}`. `kind` is one of
+  `settings.APPLICATION_EVENT_SOURCE_KINDS` (today `("email",)`). It is stored on the
+  event row itself (six new columns, see Data model) — not in `payload`, so the
+  idempotency key can be indexed and the shape is typed on every read.
+- **R2 — same message, zero new rows.** `(application_id, source.message_id)` is the
+  identity. A second `record_event` naming a message id already on this application
+  returns the **existing** event (`already_existed: true`, its `event_id`, its
+  `event_type`, the application's current `status`) and writes nothing — no row, no
+  status replay. No UPDATE, ever (M3): if the agent classified the email wrongly the
+  first time, it records a correcting event with `corrects_event_id`, as today. The same
+  message id on a *different* application is a new row (an email can concern two roles).
+  An event without `source` behaves exactly as before.
+- **R3 — interview datetime is a field.** `record_event` accepts an optional
+  `scheduled_at` (ISO-8601 with timezone, stored normalised to `+00:00`). Allowed only on
+  `settings.APPLICATION_SCHEDULABLE_EVENT_TYPES` (today `("interview_requested",
+  "interview_scheduled")`) — 422 elsewhere. May be up to
+  `APPLICATION_SCHEDULED_AT_MAX_FUTURE_SECONDS` (default 366 days) in the future; may be
+  in the past (recording an interview that already happened is normal).
+- **R4 — every reader shows both.** `ApplicationEventOut` and `WhatsNewEventOut` gain
+  `source` (object or `null`) and `scheduled_at` (string or `null`). `export_history`
+  inherits it (same function). `GET /applications/{id}` gains `interview_at`: the
+  `scheduled_at` of the newest **non-superseded** event that carries one, else `null`.
+- **R5 — the web shows it.** `Timeline.tsx` renders a source line under an event
+  (`✉ sender — "subject"`, plus received time when present) and a `Scheduled for <local
+  datetime>` line when `scheduled_at` is set. The detail header shows an
+  `Interview <local datetime>` pill when `interview_at` is set. Text only — React escapes
+  it; no HTML, no links built from email content.
+- **R6 — MCP parity (M5).** The `record_event` tool gains `source` and `scheduled_at`
+  parameters and calls the same route function. The docstring tells the agent the
+  idempotency rule in one sentence so it can re-read an inbox without bookkeeping.
+
+## Data model — migration `0041_event_source_and_schedule`
+
+`up.sql` (DDL only, no row read or changed; conventions from 0038):
+
+```sql
+ALTER TABLE application_events ADD COLUMN IF NOT EXISTS source_kind        TEXT NOT NULL DEFAULT '';
+ALTER TABLE application_events ADD COLUMN IF NOT EXISTS source_message_id  TEXT NOT NULL DEFAULT '';  -- '' = no source
+ALTER TABLE application_events ADD COLUMN IF NOT EXISTS source_sender      TEXT NOT NULL DEFAULT '';
+ALTER TABLE application_events ADD COLUMN IF NOT EXISTS source_subject     TEXT NOT NULL DEFAULT '';
+ALTER TABLE application_events ADD COLUMN IF NOT EXISTS source_received_at TEXT NOT NULL DEFAULT '';  -- ISO +00:00 or ''
+ALTER TABLE application_events ADD COLUMN IF NOT EXISTS scheduled_at       TEXT NOT NULL DEFAULT '';  -- ISO +00:00 or ''
+CREATE UNIQUE INDEX IF NOT EXISTS uq_application_events_app_source_msg
+    ON application_events(application_id, source_message_id) WHERE source_message_id <> '';
+```
+
+`down.sql`: `DROP INDEX IF EXISTS …;` then six `ALTER TABLE … DROP COLUMN IF EXISTS …;`
+with the 0037-style "what this costs" header (every stored source and datetime is lost;
+the events themselves survive).
+
+`''` means "none" (the 0038 convention) so the partial index and the readers need no
+NULL branch; the API still emits `null` for none (R4).
+
+## Tool contracts
+
+### `record_event` — `POST /applications/{id}/events` (additions)
+
+Request (`RecordEventRequest`, still `extra="forbid"`):
+
+```
+source:       EventSource | null = null
+scheduled_at: str | null = null
+EventSource (extra="forbid"):
+  kind: str = "email"          # ∈ APPLICATION_EVENT_SOURCE_KINDS
+  message_id: str              # required, trimmed, 1..APPLICATION_EVENT_SOURCE_MESSAGE_ID_MAX_CHARS (256)
+  sender: str = ""             # trimmed, ≤ APPLICATION_EVENT_SOURCE_SENDER_MAX_CHARS (320)
+  subject: str = ""            # trimmed, ≤ APPLICATION_EVENT_SOURCE_SUBJECT_MAX_CHARS (500)
+  received_at: str | null      # ISO-8601 with tz → normalised +00:00 (parse_occurred_at rules, no future beyond its bound)
+```
+
+Response (`RecordEventResponse`): existing six fields **plus `already_existed: bool`**.
+On a duplicate: `event_id`/`event_type`/`occurred_at`/`recorded_at`/`recorded_by` are
+the existing row's, `status` is the application's current status.
+
+Order of checks in the route (unchanged order, new ones slotted in):
+`validate_event_type` → `clamp_detail` → `validate_payload` → `parse_occurred_at` →
+**`validate_source`** → **`parse_scheduled_at(raw, event_type)`** → ownership 404 →
+`append_event`.
+
+`append_event(…, source: Optional[dict] = None, scheduled_at: str = "")`:
+
+```
+if source: existing = SELECT … WHERE application_id=? AND source_message_id=?
+           if existing: audit "application_event_duplicate" (ids only); return existing + already_existed=True
+INSERT (… six new columns …)
+  except pg.IntegrityError:        # two agents raced the same message id
+      rollback; re-read; return existing + already_existed=True
+replay_status → UPDATE applications slot (as today)
+```
+
+### Read shapes (additions)
+
+```
+EventSourceOut: {kind: str, message_id: str, sender: str, subject: str, received_at: str | null}
+ApplicationEventOut  += source: EventSourceOut | null, scheduled_at: str | null
+WhatsNewEventOut     += source: EventSourceOut | null, scheduled_at: str | null
+ApplicationDetailOut += interview_at: str | null
+```
+
+`list_events_for_display` and `whats_new` build `source` from the six columns
+(`None` when `source_message_id == ''`).
+
+## Security guardrails
+
+- **S1 — ownership first.** The duplicate lookup runs only after `get_owned_application`
+  returned a row, so a foreign caller gets 404 before any message-id probe (rule #12/#25).
+  The UNIQUE index is per `application_id`, and the application is per `user_id`.
+- **S2 — caps are settings, breaches are 422 naming the setting** (S5 of the spine
+  spec): message id 256, sender 320, subject 500 chars; `kind` outside the tuple;
+  `scheduled_at` on a non-schedulable type; missing timezone. Never clipped silently.
+- **S3 — no control characters.** `message_id`, `sender`, `subject` reject Unicode
+  category `Cc` (C0, DEL, C1), `Zl`/`Zp` (U+2028/U+2029 — line terminators in JSON/JS
+  exports) and the bidi embeddings/overrides/isolates U+202A–U+202E, U+2066–U+2069
+  (they flip how the rest of a timeline line renders). NOT all of `Cf`: emoji ZWJ
+  sequences are legal subjects. (Widened from `< 0x20 or == 0x7f` at review.) Trim
+  first, then check, then cap.
+- **S4 — the audit log carries no body.** The duplicate/record audit records carry
+  `application_id`, `event_id`, `event_type`, `recorded_by`, `already_existed` — never
+  `subject`, `sender` or `message_id` (extends `test_audit_log_never_carries_a_body`).
+- **S5 — append-only stays provable.** No `UPDATE`/`DELETE` on `application_events`
+  is added; `test_events_are_append_only` must still pass unchanged. The race path
+  re-reads, it never upserts.
+- **S6 — text stays text on the web.** Rendered through React text nodes only; no
+  `dangerouslySetInnerHTML`, no `href` built from `sender`/`subject`.
+- **S7 — no new fetch, no new token, no background job.** The agent's connector reads
+  the inbox; Job360 never touches Gmail (M2, decision 8).
+- **S8 — the mirror of `occurred_at`'s future bound.** `received_at` uses the
+  `occurred_at` bound (an email cannot arrive in the future); `scheduled_at` has its own,
+  longer bound (an interview can).
+
+## Frozen tests (red before the build) — `backend/tests/test_application_spine.py`
+
+1. `test_event_with_email_source_is_stored_and_shown` — record `replied` with a full
+   source → `GET /applications/{id}` event carries the same `source` (received_at
+   normalised to `+00:00`); `whats_new` shows it too; `already_existed` is `false`.
+2. `test_same_message_id_twice_adds_zero_rows` — second call (even with a different
+   `event_type`) returns the first `event_id`, `already_existed: true`, the first
+   `event_type`; `SELECT COUNT(*)` on the application's events is unchanged; status
+   unchanged.
+3. `test_same_message_id_on_another_application_is_a_new_row` — two applications, same
+   message id → two rows, two ids.
+4. `test_event_without_source_has_null_source` — plain `note` → `source: null`,
+   `scheduled_at: null`, `already_existed: false`.
+5. `test_scheduled_at_is_normalised_and_becomes_interview_at` — `interview_scheduled`
+   with `2026-09-15T10:00:00+01:00` → event `scheduled_at == "2026-09-15T09:00:00+00:00"`,
+   detail `interview_at` equals it; a later correcting event that supersedes it makes
+   `interview_at` fall back to the correcting event's value (or `null`).
+6. `test_scheduled_at_on_a_non_interview_event_is_422` — `note` + `scheduled_at` → 422
+   naming `APPLICATION_SCHEDULABLE_EVENT_TYPES`.
+7. `test_scheduled_at_without_timezone_is_422`.
+8. `test_source_caps_and_control_chars_are_422` — subject of 501 chars → 422 naming
+   `APPLICATION_EVENT_SOURCE_SUBJECT_MAX_CHARS`; `kind: "sms"` → 422; subject with `\n`
+   → 422; `message_id: "  "` → 422; unknown key inside `source` → 422 (forbid).
+9. `test_source_never_reaches_the_audit_log` — record with source twice; no audit
+   record contains the subject, sender or message id.
+10. `test_a_foreign_application_id_is_404_before_the_duplicate_lookup` — user B posts
+    user A's application id with A's message id → 404, and A's row count is unchanged.
+11. `tests/test_mcp_server.py::test_record_event_tool_passes_source_and_scheduled_at` —
+    the tool call lands both fields on the stored event and returns `already_existed`.
+12. `test_events_are_append_only` and `test_the_parity_table_covers_every_tool` stay
+    green unchanged.
+
+## Done when
+
+- Migration 0041 pair applied by `init_db()` on boot; up→down→up round-trips locally.
+- All twelve above green; full gate green; api-types regenerated (drift check green).
+- Draft PR; owner merges; then the live proof: the owner's Claude.ai + Gmail connector
+  against prod records a rejection, an invite with a date, and a plain reply — and a
+  second read of the same inbox adds zero rows (`stats`/`whats_new` unchanged).
+
+## Flagged concerns
+
+- The **applications list card** does not show `interview_at` — that needs a per-row
+  subquery or a cached slot on `applications`; deferred until the detail page proves the
+  field earns it.
+- `source.kind` is a tuple today with one member; adding `"whatsapp"` later is a settings
+  change, not a schema change (decision 22).
+- `interview_at` is "newest non-superseded event with a `scheduled_at`", not "next in the
+  future" — a rescheduled interview is a correcting event, which is what makes the old
+  value drop out.

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -288,6 +288,17 @@
             "title": "Id",
             "type": "integer"
           },
+          "interview_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Interview At"
+          },
           "job": {
             "$ref": "#/components/schemas/ApplicationJobOut"
           },
@@ -333,6 +344,7 @@
           "fit",
           "artifacts",
           "events",
+          "interview_at",
           "receipts",
           "contacts"
         ],
@@ -382,6 +394,27 @@
             "title": "Recorded By",
             "type": "string"
           },
+          "scheduled_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Scheduled At"
+          },
+          "source": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/EventSourceOut"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "superseded": {
             "title": "Superseded",
             "type": "boolean"
@@ -396,7 +429,9 @@
           "recorded_at",
           "recorded_by",
           "corrects_event_id",
-          "superseded"
+          "superseded",
+          "source",
+          "scheduled_at"
         ],
         "title": "ApplicationEventOut",
         "type": "object"
@@ -1250,6 +1285,88 @@
           "token"
         ],
         "title": "EmailVerificationConfirmRequest",
+        "type": "object"
+      },
+      "EventSource": {
+        "additionalProperties": false,
+        "description": "Slice 6 (docs/plans/2026-09-07-email-evidence/spec.md \u00a7Tool contracts)\n\u2014 the email an event came from. No length caps declared here: every cap\nis a live ``settings`` value ``spine.validate_source`` checks at call\ntime, the same reasoning ``AddContactRequest``'s docstring gives.",
+        "properties": {
+          "kind": {
+            "default": "email",
+            "title": "Kind",
+            "type": "string"
+          },
+          "message_id": {
+            "title": "Message Id",
+            "type": "string"
+          },
+          "received_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Received At"
+          },
+          "sender": {
+            "default": "",
+            "title": "Sender",
+            "type": "string"
+          },
+          "subject": {
+            "default": "",
+            "title": "Subject",
+            "type": "string"
+          }
+        },
+        "required": [
+          "message_id"
+        ],
+        "title": "EventSource",
+        "type": "object"
+      },
+      "EventSourceOut": {
+        "description": "Slice 6 \u2014 the ``source`` shape every reader emits (or ``null``, when\nthe event carries none).",
+        "properties": {
+          "kind": {
+            "title": "Kind",
+            "type": "string"
+          },
+          "message_id": {
+            "title": "Message Id",
+            "type": "string"
+          },
+          "received_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Received At"
+          },
+          "sender": {
+            "title": "Sender",
+            "type": "string"
+          },
+          "subject": {
+            "title": "Subject",
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "message_id",
+          "sender",
+          "subject",
+          "received_at"
+        ],
+        "title": "EventSourceOut",
         "type": "object"
       },
       "ExportApplicationOut": {
@@ -2787,6 +2904,27 @@
             "additionalProperties": true,
             "title": "Payload",
             "type": "object"
+          },
+          "scheduled_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Scheduled At"
+          },
+          "source": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/EventSource"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "required": [
@@ -2797,6 +2935,10 @@
       },
       "RecordEventResponse": {
         "properties": {
+          "already_existed": {
+            "title": "Already Existed",
+            "type": "boolean"
+          },
           "event_id": {
             "title": "Event Id",
             "type": "integer"
@@ -2817,6 +2959,17 @@
             "title": "Recorded By",
             "type": "string"
           },
+          "scheduled_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Scheduled At"
+          },
           "status": {
             "title": "Status",
             "type": "string"
@@ -2828,7 +2981,9 @@
           "occurred_at",
           "recorded_at",
           "recorded_by",
-          "status"
+          "status",
+          "already_existed",
+          "scheduled_at"
         ],
         "title": "RecordEventResponse",
         "type": "object"
@@ -3798,6 +3953,27 @@
           "recorded_by": {
             "title": "Recorded By",
             "type": "string"
+          },
+          "scheduled_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Scheduled At"
+          },
+          "source": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/EventSourceOut"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "required": [
@@ -3809,7 +3985,9 @@
           "occurred_at",
           "recorded_at",
           "recorded_by",
-          "corrects_event_id"
+          "corrects_event_id",
+          "source",
+          "scheduled_at"
         ],
         "title": "WhatsNewEventOut",
         "type": "object"

--- a/frontend/src/app/applications/[id]/ApplicationClient.tsx
+++ b/frontend/src/app/applications/[id]/ApplicationClient.tsx
@@ -89,6 +89,11 @@ export function ApplicationClient({ applicationId }: { applicationId: number }) 
           <span className="rounded-full bg-primary/10 px-3 py-1 text-sm font-medium text-primary">
             {STATUS_LABEL[detail.status] ?? detail.status}
           </span>
+          {detail.interview_at && (
+            <span className="rounded-full bg-accent/20 px-3 py-1 text-sm font-medium text-accent-foreground">
+              Interview {new Date(detail.interview_at).toLocaleString()}
+            </span>
+          )}
           {detail.status === "considering" && (
             <button
               type="button"

--- a/frontend/src/components/applications/Timeline.test.tsx
+++ b/frontend/src/components/applications/Timeline.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { Timeline } from "./Timeline";
+import type { ApplicationEvent } from "@/lib/api";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeEvent(overrides: Partial<ApplicationEvent> = {}): ApplicationEvent {
+  return {
+    id: 1,
+    event_type: "replied",
+    detail: "",
+    payload: {},
+    occurred_at: "2026-09-07T10:00:00+00:00",
+    recorded_at: "2026-09-07T10:00:00+00:00",
+    recorded_by: "agent",
+    corrects_event_id: null,
+    superseded: false,
+    source: null,
+    scheduled_at: null,
+    ...overrides,
+  };
+}
+
+describe("Timeline", () => {
+  it("renders the sender and subject for an event with a source, and no anchor", () => {
+    render(
+      <Timeline
+        events={[
+          makeEvent({
+            source: {
+              kind: "email",
+              message_id: "abc",
+              sender: "recruiter@acme.example",
+              subject: "Your application",
+              received_at: "2026-09-07T09:00:00+00:00",
+            },
+          }),
+        ]}
+      />
+    );
+
+    expect(screen.getByText(/recruiter@acme\.example/)).toBeInTheDocument();
+    expect(screen.getByText(/your application/i)).toBeInTheDocument();
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+  });
+
+  it("shows 'Scheduled for' when the event carries scheduled_at", () => {
+    render(
+      <Timeline
+        events={[
+          makeEvent({
+            event_type: "interview_scheduled",
+            scheduled_at: "2026-09-15T09:00:00+00:00",
+          }),
+        ]}
+      />
+    );
+
+    expect(screen.getByText(/scheduled for/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/applications/Timeline.tsx
+++ b/frontend/src/components/applications/Timeline.tsx
@@ -26,6 +26,20 @@ export function Timeline({ events }: { events: ApplicationEvent[] }) {
             </span>
           </div>
           {event.detail && <p className="mt-1 text-muted-foreground">{event.detail}</p>}
+          {event.source && (
+            <p className="mt-1 text-xs text-muted-foreground">
+              {"✉ "}
+              {event.source.sender}
+              {event.source.subject && ` — “${event.source.subject}”`}
+              {event.source.received_at &&
+                ` · received ${new Date(event.source.received_at).toLocaleString()}`}
+            </p>
+          )}
+          {event.scheduled_at && (
+            <p className="mt-1 text-xs font-medium text-foreground">
+              Scheduled for {new Date(event.scheduled_at).toLocaleString()}
+            </p>
+          )}
           <p className="mt-1 text-xs text-muted-foreground/70">
             recorded by {event.recorded_by}
             {event.superseded && " · superseded"}

--- a/frontend/src/lib/api-types.ts
+++ b/frontend/src/lib/api-types.ts
@@ -1572,6 +1572,8 @@ export interface components {
             fit: components["schemas"]["ApplicationFitOut"] | null;
             /** Id */
             id: number;
+            /** Interview At */
+            interview_at: string | null;
             job: components["schemas"]["ApplicationJobOut"];
             /** Job Id */
             job_id: number;
@@ -1609,6 +1611,9 @@ export interface components {
             recorded_at: string;
             /** Recorded By */
             recorded_by: string;
+            /** Scheduled At */
+            scheduled_at: string | null;
+            source: components["schemas"]["EventSourceOut"] | null;
             /** Superseded */
             superseded: boolean;
         };
@@ -1992,6 +1997,51 @@ export interface components {
         EmailVerificationConfirmRequest: {
             /** Token */
             token: string;
+        };
+        /**
+         * EventSource
+         * @description Slice 6 (docs/plans/2026-09-07-email-evidence/spec.md §Tool contracts)
+         *     — the email an event came from. No length caps declared here: every cap
+         *     is a live ``settings`` value ``spine.validate_source`` checks at call
+         *     time, the same reasoning ``AddContactRequest``'s docstring gives.
+         */
+        EventSource: {
+            /**
+             * Kind
+             * @default email
+             */
+            kind: string;
+            /** Message Id */
+            message_id: string;
+            /** Received At */
+            received_at?: string | null;
+            /**
+             * Sender
+             * @default
+             */
+            sender: string;
+            /**
+             * Subject
+             * @default
+             */
+            subject: string;
+        };
+        /**
+         * EventSourceOut
+         * @description Slice 6 — the ``source`` shape every reader emits (or ``null``, when
+         *     the event carries none).
+         */
+        EventSourceOut: {
+            /** Kind */
+            kind: string;
+            /** Message Id */
+            message_id: string;
+            /** Received At */
+            received_at: string | null;
+            /** Sender */
+            sender: string;
+            /** Subject */
+            subject: string;
         };
         /** ExportApplicationOut */
         ExportApplicationOut: {
@@ -2660,9 +2710,14 @@ export interface components {
             payload?: {
                 [key: string]: unknown;
             };
+            /** Scheduled At */
+            scheduled_at?: string | null;
+            source?: components["schemas"]["EventSource"] | null;
         };
         /** RecordEventResponse */
         RecordEventResponse: {
+            /** Already Existed */
+            already_existed: boolean;
             /** Event Id */
             event_id: number;
             /** Event Type */
@@ -2673,6 +2728,8 @@ export interface components {
             recorded_at: string;
             /** Recorded By */
             recorded_by: string;
+            /** Scheduled At */
+            scheduled_at: string | null;
             /** Status */
             status: string;
         };
@@ -3000,6 +3057,9 @@ export interface components {
             recorded_at: string;
             /** Recorded By */
             recorded_by: string;
+            /** Scheduled At */
+            scheduled_at: string | null;
+            source: components["schemas"]["EventSourceOut"] | null;
         };
         /** WhatsNewResponse */
         WhatsNewResponse: {


### PR DESCRIPTION
Closes #513 — slice 6 of the mission roadmap (`docs/plans/2026-09-03-mission-roadmap.md`).

## What

The agent reads Gmail; Job360 stores the receipt (VISION #8 — Gmail stays agent-side). Two additive fields on application events:

| Field | Meaning |
|---|---|
| `source` `{kind, message_id, sender, subject, received_at}` | Email evidence attached to the event that records it. Idempotent per `(application_id, source_message_id)` — a replayed message returns the existing event with `already_existed: true`, zero new rows. |
| `scheduled_at` | Interview datetime as a real column. Application detail exposes `interview_at` = last non-superseded event carrying a schedule, in display order. |

Spec with security section: `docs/plans/2026-09-07-email-evidence/spec.md`.

## Where

- **Migration 0041** (`up`/`down`): 6 nullable columns + partial UNIQUE index on `(application_id, source_message_id) WHERE source_message_id <> ''`.
- **Spine** (`backend/src/services/applications/spine.py`): `validate_source` — settings-named caps (`APPLICATION_EVENT_SOURCE_*_MAX_CHARS`, `APPLICATION_EVENT_SOURCE_KINDS`), control-char guard (Unicode `Cc`/`Zl`/`Zp` + bidi U+202A–202E / U+2066–2069, emoji ZWJ stays legal), `received_at` shares `occurred_at`'s tight future bound, `scheduled_at` gets its own 366-day bound. Duplicate race path is inside `db._db.transaction()` (SAVEPOINT-safe under an outer transaction).
- **Route + MCP tool** `record_application_event` grow the same params; parity test still green. M3 append-only untouched (no UPDATE/DELETE on `application_events`).
- **Frontend**: `Timeline.tsx` shows `✉ sender — “subject” · received …` and `Scheduled for …`; `ApplicationClient.tsx` shows the `Interview …` pill. Text nodes only — no links rendered from email content. New `Timeline.test.tsx`.
- **Docs**: ARCHITECTURE env-table rows (5 new settings), gen-block regenerated (head 0041), `docs/README.md` slice row, regenerated `openapi.json` + `api-types.ts`.

## Verified

- Backend: `tests/test_application_spine.py tests/test_mcp_server.py tests/test_mcp_gate_parity.py tests/test_pg_translate.py` → 74 passed; ruff clean; gate #10 green.
- Frontend: `type-check` 0, `lint` 0, `test:unit` 36 files / 258 tests passed.
- Reviews: conventions (Opus) 3 findings fixed; bugs (Opus) no P0/P1, both P2s fixed (bare rollback → transaction; control-char widening).

## Not in this PR / owner-owned

- **Living-surface ratchet is red on `main` already** (3844 lines vs ceiling 3797 at `e0dde31`; nightly doc-sync has been red 4 days; the fixer refuses to touch `scripts/living_surface_ceiling.txt`). This PR adds +6 lines. Non-blocking on PRs; needs a separate ceiling fix.
- Live proof: owner runs Claude.ai + Gmail against prod after merge (`record_application_event` with `source` + `scheduled_at`).
- Next slices in order: #514 visa → #515 CV diff → #516 flag UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011wAduRqokWdPEByUkcVbvc
