### PR TITLE
fix(frontend): delete the sourcing-era copy and visuals (agentic UX audit, fix 1)

### DIFF
--- a/frontend/src/app/(auth)/register/page.tsx
+++ b/frontend/src/app/(auth)/register/page.tsx
@@ -124,7 +124,7 @@ export default function RegisterPage() {
         <CardHeader>
           <CardTitle>Create your Job360 account</CardTitle>
           <CardDescription>
-            Upload your CV next — matches start flowing within minutes.
+            Upload your CV next — it becomes the memory your agent works from.
           </CardDescription>
         </CardHeader>
         <CardContent>

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -47,11 +47,10 @@
   --radius-3xl: calc(var(--radius) * 2.2);
   --radius-4xl: calc(var(--radius) * 2.6);
 
-  /* Custom score colors */
+  /* Custom score colors — score-high still used (text-score-high /
+     bg-score-high in CVUpload.tsx, PreferencesForm.tsx, profile/page.tsx).
+     score-good/mid/low removed 2026-09 (cleanup audit): zero usages. */
   --color-score-high: oklch(0.89 0.29 128);
-  --color-score-good: oklch(0.78 0.25 130);
-  --color-score-mid: oklch(0.75 0.15 85);
-  --color-score-low: oklch(0.65 0.2 25);
 }
 
 /* ═══════════════════════════════════════════
@@ -242,44 +241,6 @@ body {
 }
 
 /* ═══════════════════════════════════════════
-   SCORE BADGES — the signature glow element
-   ═══════════════════════════════════════════ */
-
-.score-badge {
-  font-family: var(--font-jetbrains);
-  font-variant-numeric: tabular-nums;
-  letter-spacing: -0.02em;
-}
-
-.score-high {
-  color: oklch(0.89 0.29 128);
-  background: oklch(0.89 0.29 128 / 0.1);
-  box-shadow: 0 0 12px oklch(0.89 0.29 128 / 0.2);
-  border: 1px solid oklch(0.89 0.29 128 / 0.25);
-}
-
-.score-good {
-  color: oklch(0.78 0.25 130);
-  background: oklch(0.78 0.25 130 / 0.1);
-  box-shadow: 0 0 10px oklch(0.78 0.25 130 / 0.15);
-  border: 1px solid oklch(0.78 0.25 130 / 0.2);
-}
-
-.score-mid {
-  color: oklch(0.75 0.15 85);
-  background: oklch(0.75 0.15 85 / 0.1);
-  box-shadow: 0 0 8px oklch(0.75 0.15 85 / 0.15);
-  border: 1px solid oklch(0.75 0.15 85 / 0.2);
-}
-
-.score-low {
-  color: oklch(0.65 0.2 25);
-  background: oklch(0.65 0.2 25 / 0.1);
-  box-shadow: 0 0 6px oklch(0.65 0.2 25 / 0.1);
-  border: 1px solid oklch(0.65 0.2 25 / 0.2);
-}
-
-/* ═══════════════════════════════════════════
    SKILL PILLS
    ═══════════════════════════════════════════ */
 
@@ -287,18 +248,6 @@ body {
   color: oklch(0.89 0.29 128);
   background: oklch(0.89 0.29 128 / 0.08);
   border: 1px solid oklch(0.89 0.29 128 / 0.15);
-}
-
-.skill-missing {
-  color: oklch(0.65 0.2 25);
-  background: oklch(0.65 0.2 25 / 0.1);
-  border: 1px solid oklch(0.65 0.2 25 / 0.2);
-}
-
-.skill-transferable {
-  color: oklch(0.75 0.15 85);
-  background: oklch(0.75 0.15 85 / 0.1);
-  border: 1px solid oklch(0.75 0.15 85 / 0.2);
 }
 
 /* ═══════════════════════════════════════════

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -37,17 +37,17 @@ const jetbrainsMono = JetBrains_Mono({
 const TAGLINE = "Your career memory. Your agent's context.";
 
 export const metadata: Metadata = {
-  title: "Job360 — Your Career Command Center",
+  title: "Job360 — Your agent's memory",
   description: `${TAGLINE} Job360 remembers every application, every version, every outcome for the AI agent doing your job search.`,
   openGraph: {
-    title: "Job360 — Your Career Command Center",
+    title: "Job360 — Your agent's memory",
     description: TAGLINE,
     type: "website",
     siteName: "Job360",
   },
   twitter: {
     card: "summary_large_image",
-    title: "Job360 — Your Career Command Center",
+    title: "Job360 — Your agent's memory",
     description: TAGLINE,
   },
 };

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -311,7 +311,7 @@ export default function ProfilePage() {
                 </h1>
                 <p className="text-sm text-muted-foreground">
                   {profile?.summary.is_complete
-                    ? "Your profile is ready for job matching"
+                    ? "Your profile is ready for your agent"
                     : "Upload your CV and set preferences to get started"}
                 </p>
               </div>
@@ -573,40 +573,6 @@ export default function ProfilePage() {
                 </div>
               );
             })()}
-
-            {/* ── Skill ESCO Mappings ───────────────────── */}
-            {profile?.skill_esco &&
-              Object.keys(profile.skill_esco).length > 0 && (
-                <div className="animate-fade-in-up glass-card rounded-xl p-6">
-                  <h2 className="font-heading text-base font-semibold mb-1 text-foreground">
-                    Skill Mappings
-                  </h2>
-                  <p className="mb-4 text-xs text-muted-foreground">
-                    Raw skills extracted from your CV mapped to canonical ESCO
-                    identifiers.
-                  </p>
-                  <ul className="grid gap-1.5 sm:grid-cols-2 lg:grid-cols-3">
-                    {Object.entries(profile.skill_esco).map(
-                      ([raw, canonical]) => (
-                        <li
-                          key={raw}
-                          className="flex items-center gap-2 rounded-lg border border-border bg-muted/20 px-3 py-2 text-xs"
-                        >
-                          <span className="min-w-0 flex-1 truncate text-muted-foreground">
-                            {raw}
-                          </span>
-                          <span className="shrink-0 text-muted-foreground/50">
-                            →
-                          </span>
-                          <span className="min-w-0 flex-1 truncate font-medium text-foreground">
-                            {canonical}
-                          </span>
-                        </li>
-                      )
-                    )}
-                  </ul>
-                </div>
-              )}
 
           </div>
         )}

--- a/frontend/src/app/settings/account/page.tsx
+++ b/frontend/src/app/settings/account/page.tsx
@@ -370,7 +370,7 @@ function VerifyEmailCard() {
       <CardHeader>
         <CardTitle>Verify your email</CardTitle>
         <CardDescription>
-          Some features (like running a job search) need a verified email. Resend the
+          Some features (like connecting an agent) need a verified email. Resend the
           verification link if you didn&apos;t get it.
         </CardDescription>
       </CardHeader>

--- a/frontend/src/components/layout/FloatingIcons.tsx
+++ b/frontend/src/components/layout/FloatingIcons.tsx
@@ -2,20 +2,15 @@
 
 import {
   Briefcase,
-  Search,
   FileText,
   GraduationCap,
-  Target,
-  BarChart3,
   Users,
   Globe,
   Star,
   Award,
-  TrendingUp,
   Handshake,
   Building2,
   MapPin,
-  Radar,
   Layers,
   Mail,
   Clock,
@@ -35,9 +30,8 @@ import {
 } from "lucide-react";
 
 const ICON_SET: LucideIcon[] = [
-  Briefcase, Search, FileText, GraduationCap, Target,
-  BarChart3, Users, Globe, Star, Award,
-  TrendingUp, Handshake, Building2, MapPin, Radar,
+  Briefcase, FileText, GraduationCap, Users, Globe,
+  Star, Award, Handshake, Building2, MapPin,
   Layers, Mail, Clock, CheckCircle, Shield,
   Zap, BookOpen, PenTool, Laptop, Coffee,
   Lightbulb, Rocket, Heart, Send, UserCheck,

--- a/frontend/src/components/profile/CVUpload.tsx
+++ b/frontend/src/components/profile/CVUpload.tsx
@@ -326,7 +326,7 @@ export function CVUpload({
             </h3>
             <p className="text-xs text-muted-foreground">
               {hasCV
-                ? "Your CV has been parsed — highlighted text drives your job matching"
+                ? "Your CV has been parsed — this is what your agent reads"
                 : "PDF or DOCX — we extract skills, titles, and more"}
             </p>
           </div>
@@ -526,7 +526,7 @@ export function CVUpload({
               return (
                 <div className="flex flex-wrap items-center gap-x-3 gap-y-1.5 text-[11px] text-muted-foreground">
                   <span className="font-medium">
-                    Highlighted = extracted for job matching:
+                    Highlighted = what your agent reads:
                   </span>
                   {present.map((l) => (
                     <span key={l.category} className="flex items-center gap-1">


### PR DESCRIPTION
## What

Fix 1 of the agentic-era frontend UX audit: delete every word and picture left over from the job-matching era. Pure deletion / copy swap — no behaviour change.

| Where | Before | After |
|---|---|---|
| `(auth)/register/page.tsx` | "matches start flowing within minutes" | "it becomes the memory your agent works from" |
| `profile/page.tsx` | "ready for job matching" | "ready for your agent" |
| `components/profile/CVUpload.tsx` ×2 | "drives your job matching" / "extracted for job matching" | "what your agent reads" |
| `settings/account/page.tsx` | "running a job search" | "connecting an agent" |
| `layout.tsx` `<title>` ×3 | "Your Career Command Center" | "Your agent's memory" |
| `profile/page.tsx` | Skill ESCO Mappings panel | deleted |
| `FloatingIcons.tsx` | Search / Target / BarChart3 / Radar / TrendingUp | removed |
| `globals.css` | score-good/mid/low, .score-badge, .skill-missing, .skill-transferable | deleted (zero usages) — `score-high` kept, still used |

## Why

Product rule 4: we never source, rank or recommend jobs. A new user reading "matches start flowing" waits for something that never comes.

Audit report: https://claude.ai/code/artifact/1cf19d2c-25be-4aa8-8ac9-f9c1bd3df31b

## Verified

- `npm run lint` 0 · `npm run type-check` 0 · `npm run test:unit` 258/258
- commit gate green

## Next PRs in this series

- B: "Connect an agent" in the nav + landing CTA + Claude.ai/ChatGPT steps
- C: Timeline first with human labels + provenance chips, list activity, what's-new strip

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011wAduRqokWdPEByUkcVbvc
