### PR TITLE
feat(frontend): make "Connect an agent" a first-class path (agentic UX audit, fix 2)

### DIFF
--- a/frontend/src/app/Landing.tsx
+++ b/frontend/src/app/Landing.tsx
@@ -11,6 +11,7 @@ import {
   Clock,
   Shield,
   Sparkles,
+  Plug,
 } from "lucide-react";
 
 // R14 (docs/plans/2026-09-04-application-spine/spec.md) — the landing copy
@@ -180,6 +181,18 @@ export default function Landing() {
               <Upload className="h-4 w-4" />
               Get Started
               <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
+            </Link>
+            {/* Second, secondary path — the whole product depends on the user
+                connecting their own agent, so it belongs beside the primary
+                CTA, not buried behind a gear icon. A signed-out visitor is
+                bounced to /login?next=/settings/connect by middleware.ts,
+                same as any other protected route. */}
+            <Link
+              href="/settings/connect"
+              className="inline-flex h-12 items-center gap-2 rounded-xl border border-border/60 bg-transparent px-8 text-sm font-semibold text-foreground transition-colors hover:border-primary/60 hover:text-primary"
+            >
+              <Plug className="h-4 w-4" />
+              Connect an agent
             </Link>
           </div>
         </div>
@@ -372,6 +385,13 @@ export default function Landing() {
                 <Upload className="h-5 w-5" />
                 Upload Your CV
                 <ArrowRight className="h-5 w-5 transition-transform group-hover:translate-x-1" />
+              </Link>
+              <Link
+                href="/settings/connect"
+                className="inline-flex h-14 items-center gap-3 rounded-xl border border-border/60 bg-transparent px-10 text-base font-semibold text-foreground transition-colors hover:border-primary/60 hover:text-primary"
+              >
+                <Plug className="h-5 w-5" />
+                Connect an agent
               </Link>
             </div>
             <p className="animate-fade-in-up stagger-4 mt-6 text-xs text-muted-foreground/60">

--- a/frontend/src/app/settings/connect/page.tsx
+++ b/frontend/src/app/settings/connect/page.tsx
@@ -145,6 +145,71 @@ function NewTokenReveal({
 }
 
 // ---------------------------------------------------------------------------
+// Connect Claude.ai / ChatGPT — these apps sign in through the OAuth consent
+// screen (/oauth/consent/[rid]), not a pasted token, so the only thing the
+// user needs from this page is the address to paste into the app's own
+// "add connector" flow. Agentic UX audit (2026-09-08) — this is the address
+// step; token minting below is for MCP clients that take a bearer token
+// (Claude Code) instead of doing OAuth.
+// ---------------------------------------------------------------------------
+
+function ConnectAppCard() {
+  const url = mcpUrl();
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Connect Claude.ai or ChatGPT</CardTitle>
+        <CardDescription>
+          These apps connect with a sign-in, not a token. Paste this address
+          as a custom connector; when the app asks, sign in with your Job360
+          email.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="space-y-1">
+          <Label htmlFor="mcp-url">Address</Label>
+          <div className="flex gap-2">
+            <Input
+              id="mcp-url"
+              readOnly
+              value={url}
+              className="font-mono text-xs"
+              data-testid="mcp-url"
+              onFocus={(e) => e.currentTarget.select()}
+            />
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => copyText(url, "Address")}
+            >
+              Copy
+            </Button>
+          </div>
+        </div>
+        <div className="space-y-3 text-xs text-muted-foreground">
+          <p>
+            <span className="font-medium text-foreground">Claude.ai</span> —
+            Settings → Connectors → Add custom connector → paste the address →
+            Connect.
+          </p>
+          <p>
+            <span className="font-medium text-foreground">
+              ChatGPT (Plus/Pro)
+            </span>{" "}
+            — Settings → turn on Developer mode → Connectors → Create → paste
+            the address → Create.
+          </p>
+          <p>
+            Claude Code and other MCP clients use a personal token instead —
+            create one below.
+          </p>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Connected apps — OAuth grants (ChatGPT, Claude.ai, any spec-following MCP
 // client that signed in through the consent screen at /oauth/consent/[rid]).
 // One active grant per (user, client); Revoke kills every token under it on
@@ -454,6 +519,7 @@ export default function ConnectAgentPage() {
           applied. A personal token is the key; you can revoke it any time.
         </p>
       </div>
+      <ConnectAppCard />
       <ConnectedAppsCard
         grants={grants}
         loading={grantsLoading}

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -10,6 +10,7 @@ import {
   ClipboardPaste,
   FolderClock,
   Settings,
+  Plug,
   LogOut,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -22,10 +23,15 @@ import { useAuth } from "@/components/layout/AuthProvider";
 // Channels/notifications outright (VISION:133 — notifications are pull-not-
 // push) — Job360 never sources or ranks jobs (VISION rule 4), so there is no
 // catalog left to browse either.
+//
+// Agentic UX audit (2026-09-08) — the whole product depends on the user
+// connecting their own agent, but /settings/connect was reachable only via
+// the gear icon. It is a first-class destination now, not a settings tab.
 const NAV_LINKS = [
   { href: "/profile", label: "Profile", icon: User },
   { href: "/bring", label: "Bring a job", icon: ClipboardPaste },
   { href: "/applications", label: "Applications", icon: FolderClock },
+  { href: "/settings/connect", label: "Connect an agent", icon: Plug },
 ] as const;
 
 export function Navbar() {
@@ -43,6 +49,12 @@ export function Navbar() {
   // the session resolves. While unknown, the header shows the logo only.
   const signedIn = Boolean(user);
   const signedOut = !loading && !user;
+
+  // /settings/connect is now its own NAV_LINKS entry (see above), so the gear
+  // must not also light up for it — otherwise two nav controls look active
+  // at once on that page.
+  const settingsActive =
+    pathname.startsWith("/settings") && !pathname.startsWith("/settings/connect");
 
   return (
     <header className="sticky top-0 z-50 border-b border-border/30 bg-background/60 backdrop-blur-md">
@@ -85,10 +97,10 @@ export function Navbar() {
           {signedIn && (
             <Link
               href="/settings"
-              aria-current={pathname.startsWith("/settings") ? "page" : undefined}
+              aria-current={settingsActive ? "page" : undefined}
               aria-label="Settings"
               className={`flex h-9 w-9 items-center justify-center rounded-lg transition-colors ${
-                pathname.startsWith("/settings")
+                settingsActive
                   ? "bg-primary/10 text-primary"
                   : "text-muted-foreground hover:text-foreground hover:bg-muted/50"
               }`}
@@ -188,9 +200,9 @@ export function Navbar() {
                 <Link
                   href="/settings"
                   onClick={() => setMobileOpen(false)}
-                  aria-current={pathname.startsWith("/settings") ? "page" : undefined}
+                  aria-current={settingsActive ? "page" : undefined}
                   className={`flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium transition-colors ${
-                    pathname.startsWith("/settings")
+                    settingsActive
                       ? "bg-primary/10 text-primary"
                       : "text-muted-foreground hover:text-foreground hover:bg-muted/50"
                   }`}

--- a/frontend/tests/e2e/connect-agent.spec.ts
+++ b/frontend/tests/e2e/connect-agent.spec.ts
@@ -73,6 +73,7 @@ test.describe("Connect an agent", () => {
     await page.goto("/settings/connect");
     await expect(page).not.toHaveURL(/\/login/);
     await expect(page.getByRole("heading", { name: "Connect an agent" })).toBeVisible();
+    await expect(page.getByTestId("mcp-url")).toHaveValue(/\/api\/mcp$/);
     await expect(page.getByTestId("tokens-empty")).toBeVisible({ timeout: 10_000 });
 
     // --- 1. Create -------------------------------------------------------

--- a/frontend/tests/e2e/landing-cta-auth.spec.ts
+++ b/frontend/tests/e2e/landing-cta-auth.spec.ts
@@ -72,6 +72,18 @@ test.describe("Landing CTA → profile journeys", () => {
     await expect(page).toHaveURL(/\/login\?next=%2Fprofile/, { timeout: 40_000 });
   });
 
+  // Agentic UX audit (2026-09-08) — the hero's secondary CTA links straight
+  // to /settings/connect; href check only, no navigation needed here since
+  // the middleware redirect for a protected route is already covered above.
+  test("hero 'Connect an agent' link points at /settings/connect", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await expect(
+      page.getByRole("link", { name: /connect an agent/i }).first()
+    ).toHaveAttribute("href", "/settings/connect");
+  });
+
   // ── Journey 3: already signed in → straight to /profile ───────────────────
   //
   // R14 (docs/plans/2026-09-04-application-spine) — a signed-in visitor's "/"


### PR DESCRIPTION
## What

Fix 2 of the agentic-era frontend UX audit: "Connect an agent" becomes a first-class path instead of a hidden settings tab.

| Where | Change |
|---|---|
| `components/layout/Navbar.tsx` | 4th nav link **Connect an agent** (Plug icon). Gear icon no longer also lights up on `/settings/connect`. |
| `app/Landing.tsx` | Secondary **Connect an agent** button beside "Get Started" (hero) and beside "Upload Your CV" (bottom). Signed-out → `/login?next=/settings/connect` via middleware, as today. |
| `app/settings/connect/page.tsx` | New top card **Connect Claude.ai or ChatGPT**: read-only MCP address + Copy, then the menu path for each app. Token minting below is now framed as the Claude Code / bearer path. |
| `tests/e2e/connect-agent.spec.ts` | asserts the address ends in `/api/mcp` |
| `tests/e2e/landing-cta-auth.spec.ts` | asserts the hero link href |

Menu paths were verified against the current Claude.ai / ChatGPT help pages (2026-09-08): Claude.ai → Settings → Connectors → Add custom connector; ChatGPT Plus/Pro → Settings → Developer mode → Connectors → Create.

## Why

Audit finding: the product's one required step (connect your agent) was reachable only via the gear icon, and the page never said *how* Claude.ai / ChatGPT connect (they use the OAuth consent screen, not a pasted token).

Audit report: https://claude.ai/code/artifact/1cf19d2c-25be-4aa8-8ac9-f9c1bd3df31b

## ⚠️ Owner action needed before this is true in prod

Claude.ai and ChatGPT only complete the OAuth flow once their callback URLs are in `OAUTH_REDIRECT_ALLOWLIST` on the Railway `backend` service (env var, never code — see PR #488). Until then the card is accurate about the steps but the final "Connect" will be refused by our server.

## Verified

- `npm run lint` 0 · `npm run type-check` 0 · `npm run test:unit` 258/258
- commit gate green

## Series

- A: #523 copy/visual cleanup
- B: this
- C: Timeline first with human labels + provenance chips, list activity, what's-new strip

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011wAduRqokWdPEByUkcVbvc
