### PR TITLE
fix(auto-merge): the arm has never once judged a PR — its probe could not start

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -87,6 +87,31 @@ jobs:
       - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
+
+      # THE DEPENDENCY THE CAPABILITY QUESTION NEEDS TO BE ANSWERABLE AT ALL.
+      # `merge_cage.py` is described as having no dependencies, and its JUDGEMENT
+      # does not — but `_load_lists()` (merge_cage.py:389) does `import yaml` at
+      # IMPORT time, deliberately, so a broken policy fails as a sentence instead
+      # of a traceback. That import runs before argparse, so even `--help` needs
+      # PyYAML. The `arm` job below installs it; this job did not, so on a fresh
+      # `setup-python` the probe below died with ModuleNotFoundError, printed no
+      # `--queue`, and `ready` was false.
+      #
+      # MEASURED, not reasoned: every auto-merge run from the arm landing on the
+      # default branch through 2026-09-08 stood down. Run 34215804514 emitted
+      # "auto-merge stood down — the default branch's cage cannot queue yet, so
+      # NO PR was judged" while main's cage did have `--queue`. Reproduced in a
+      # venv with CI's dependency set: `--help` exits on `import yaml`.
+      #
+      # This is the failure the step below was built to prevent, arriving through
+      # the door it left open: it correctly stopped asking "is the file here?"
+      # and started asking "can it do the thing?" — but a probe that cannot START
+      # answers "no" for both a missing capability and a missing import, and the
+      # stand-down text only names the first. Hence the dependency here, and the
+      # split message below.
+      - name: The probe's one dependency
+        run: python -m pip install --quiet pyyaml
+
       - id: look
         run: |
           set -euo pipefail
@@ -104,29 +129,74 @@ jobs:
           # it — a capability you have not confirmed you possess is not one you
           # can build a lane on, which is the same rule the policy applies to
           # `canRollback` before it lets the product lane merge at all.
+          #
+          # AND A PROBE THAT CANNOT START IS NOT A PROBE THAT SAID NO. The two
+          # were folded into one `if`, so `ModuleNotFoundError` and "this cage
+          # genuinely has no --queue" produced the same stand-down sentence —
+          # which is why the real cause survived unread for every run. The probe
+          # output is captured and its exit code kept, so the message below can
+          # name which of the two actually happened.
+          # THE FILE TESTS KEEP THEIR ORIGINAL SHAPE ON PURPOSE.
+          # `gate_wiring_check.py` scans this file as text for places the cage is
+          # invoked, and exempts exactly two harmless shapes: a `[ -f ... ]` test
+          # and an `echo`. A first attempt here tracked WHICH file was missing by
+          # putting the paths into a message variable — neither shape — and G1
+          # failed the build: "job `precheck` judges a PR ... but never passes
+          # --baseline". Measured, exit 1.
+          #
+          # The tempting fix is to spell the paths differently so the guard stops
+          # recognising them. That is the one thing `_CAGE_EXISTENCE_TEST`'s own
+          # comment forbids ("making the test unrecognisable to its own guard
+          # would be gaming it"), and the next REAL invocation written that way
+          # would slip past too. So the per-file detail is dropped instead: it was
+          # the least useful half. Which file is missing is one `ls` away; whether
+          # the cage COULD NOT START versus HAS NO `--queue` is the distinction
+          # that hid this bug for every run, and that one is kept below.
+          set +e
+          probe=$(python scripts/merge_cage.py --help 2>&1)
+          probe_rc=$?
+          set -e
+
           if [ -f scripts/merge_cage.py ] && [ -f scripts/lane.py ] && [ -f .github/merge-policy.yml ] \
-             && python scripts/merge_cage.py --help 2>&1 | grep -q -- "--queue"; then
+             && [ "$probe_rc" -eq 0 ] && printf '%s' "$probe" | grep -q -- "--queue"; then
             echo "ready=true" >> "$GITHUB_OUTPUT"
           else
             echo "ready=false" >> "$GITHUB_OUTPUT"
+            # ORDER MATTERS: ask "could it run?" before "what did it say?".
+            # A non-zero exit means the probe never reached argparse, so its
+            # output is silent about `--queue` — reporting "no --queue" there
+            # would be inventing a finding out of a crash, which is precisely
+            # the confusion that kept this lane asleep.
+            if [ "$probe_rc" -ne 0 ]; then
+              why="the cage would not start (exit $probe_rc) — it is present but cannot run here, so this says nothing about \`--queue\`"
+            else
+              why="the cage ran but offers no \`--queue\`"
+            fi
+            echo "stand_down_reason=$why"
+            printf '%s\n' "--- probe output (last 20 lines) ---" >> "$GITHUB_STEP_SUMMARY"
+            printf '%s\n' '```' >> "$GITHUB_STEP_SUMMARY"
+            printf '%s\n' "$probe" | tail -20 >> "$GITHUB_STEP_SUMMARY"
+            printf '%s\n' '```' >> "$GITHUB_STEP_SUMMARY"
             # A GREEN RUN THAT QUEUED NOTHING AND A GREEN RUN THAT HAD NOTHING
             # TO QUEUE MUST NOT LOOK THE SAME IN THE RUN LIST. The stand-down is
             # correct behaviour, so this is not a failure — but a step summary
             # inside a green run is invisible to anyone not already reading it,
             # and a silent skip in an alerting path IS the bug. The annotation
             # puts it on the run's own face. (CodeRabbit, PR #380.)
-            echo "::warning::auto-merge stood down — the default branch's cage cannot queue yet, so NO PR was judged"
+            echo "::warning::auto-merge stood down — $why — so NO PR was judged"
             {
               echo "### Auto-merge stood down — nothing was queued"
               echo
-              echo "The default branch either lacks the cage, the lane map and the policy, or"
-              echo "has a copy of \`merge_cage.py\` with no \`--queue\`. Either way the rules a PR"
-              echo "cannot edit cannot do the job, and falling back to the PR's own copy is"
-              echo "exactly what rule G5 forbids — so this lane declines to act."
+              echo "**Why:** $why"
               echo
-              echo "**Expected until the arm lands on the default branch.** Reported as a"
-              echo "stand-down and not a failure: the PR is not at fault, and a red X here made"
-              echo "six PRs look broken when none were."
+              echo "The rules a PR cannot edit could not do the job, and falling back to the"
+              echo "PR's own copy is exactly what rule G5 forbids — so this lane declines to act."
+              echo
+              echo "Reported as a stand-down and not a failure: the PR is not at fault, and a"
+              echo "red X here made six PRs look broken when none were. But note that a"
+              echo "stand-down every run is NOT the expected steady state once the arm is on"
+              echo "the default branch — if you are reading this repeatedly, the reason above"
+              echo "is the bug, not the weather."
             } >> "$GITHUB_STEP_SUMMARY"
           fi
 


### PR DESCRIPTION
## What is wrong

`auto-merge.yml`'s `precheck` job gates the entire lane. It asks the cage what it can do:

```
python scripts/merge_cage.py --help 2>&1 | grep -q -- "--queue"
```

Right question. It could not be answered.

`merge_cage.py` is described as dependency-free, and its judgement is — but `_load_lists()` (`scripts/merge_cage.py:389`) does `import yaml` at **import time**, deliberately, so a malformed policy fails as a sentence instead of a traceback. That runs before argparse, so even `--help` needs PyYAML. The `arm` job installs it; `precheck` never did.

## Evidence, not reasoning

Run **34215804514** (2026-09-08) emitted:

> `auto-merge stood down — the default branch's cage cannot queue yet, so NO PR was judged`

…while main's cage **does** have `--queue` (`scripts/merge_cage.py:2486+`). All three files are on main. So the stated reason was false.

Reproduced in a venv with CI's dependency set:

| environment | result |
|---|---|
| no PyYAML (what CI had) | `ready=false` — `--help` exits 1 on `import yaml` |
| PyYAML installed (this PR) | `ready=true` |

**Every auto-merge run since the arm landed has stood down.** The lane has never judged a single PR.

## Why it stayed hidden

Every run was **green**. A stand-down is correct behaviour, so it is deliberately not a failure — and a lane that is always correctly doing nothing looks identical to a lane that is working. The one warning it printed named the wrong cause.

## The change

- `precheck` installs pyyaml, matching `arm`. **One line — that is the whole bug.**
- The stand-down now distinguishes *the cage would not start* from *the cage has no `--queue`*, checking the exit code before reading the output. Folding those together is what hid this.

## Deliberately not changed

The three `[ -f ... ]` tests keep their exact shape. A first attempt tracked *which* file was missing via a message variable and `gate_wiring_check.py` failed with **G1** — that variable is neither shape it exempts. Respelling paths to dodge the guard is what `_CAGE_EXISTENCE_TEST`'s own comment forbids, so the per-file detail was dropped instead.

## Verified

- `gate_wiring_check.py` → 0 findings, **real** exit 0 (first attempt was exit 1; caught by reading the true code, not `tail`'s)
- `merge_cage.py --drill`, `lane.py --drill`, `gate_wiring_check.py --drill` → all exit 0
- workflow YAML parses; all three jobs intact

Draft: `.github/workflows/auto-merge.yml` is `harness_owner` lane — your hand, always.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6DsQH5EUxJc3Vnqz9YHgQ