### PR TITLE
feat(frontend): show what the agent did — timeline first, human labels, who-chips, receipts, what's-new (agentic UX audit, fixes 3-5)

### DIFF
--- a/frontend/src/app/applications/[id]/ApplicationClient.tsx
+++ b/frontend/src/app/applications/[id]/ApplicationClient.tsx
@@ -11,19 +11,9 @@ import { ArtifactVersions } from "@/components/applications/ArtifactVersions";
 import { FitPanel } from "@/components/applications/FitPanel";
 import { TailorSection } from "@/components/tailor/TailorSection";
 import { Contacts } from "@/components/applications/Contacts";
-
-const STATUS_LABEL: Record<string, string> = {
-  considering: "Considering",
-  applied: "Applied",
-  replied: "Replied",
-  interview_requested: "Interview requested",
-  interview_scheduled: "Interview scheduled",
-  interview_done: "Interview done",
-  offer: "Offer",
-  rejected: "Rejected",
-  withdrawn: "Withdrawn",
-  ghosted: "Ghosted",
-};
+import { Receipts } from "@/components/applications/Receipts";
+import { NoteForm } from "@/components/applications/NoteForm";
+import { STATUS_LABEL } from "@/lib/event-labels";
 
 /** The application record: status, the durable job snapshot (spec R2 —
  * survives the catalog purging the live row), every artifact version, the
@@ -117,7 +107,15 @@ export function ApplicationClient({ applicationId }: { applicationId: number }) 
         </div>
       </div>
 
-      <section>
+      <section data-testid="section-timeline">
+        <h2 className="mb-2 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+          Timeline
+        </h2>
+        <Timeline events={detail.events} />
+        <NoteForm applicationId={detail.id} onRecorded={load} />
+      </section>
+
+      <section data-testid="section-fit">
         <h2 className="mb-2 text-sm font-semibold uppercase tracking-wide text-muted-foreground">Fit</h2>
         <FitPanel fit={detail.fit} />
       </section>
@@ -140,12 +138,14 @@ export function ApplicationClient({ applicationId }: { applicationId: number }) 
         <ArtifactVersions applicationId={detail.id} artifacts={detail.artifacts} />
       </section>
 
-      <section>
-        <h2 className="mb-2 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
-          Timeline
-        </h2>
-        <Timeline events={detail.events} />
-      </section>
+      {detail.receipts.length > 0 && (
+        <section>
+          <h2 className="mb-2 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+            Receipts
+          </h2>
+          <Receipts receipts={detail.receipts} />
+        </section>
+      )}
     </div>
   );
 }

--- a/frontend/src/app/applications/page.tsx
+++ b/frontend/src/app/applications/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { ApplicationList } from "@/components/applications/ApplicationList";
+import { WhatsNewStrip } from "@/components/applications/WhatsNewStrip";
 
 // spec R14 — the applications list. Protected by middleware.ts
 // (`/applications` is in PROTECTED_PATHS). No metadata/SSR needs here, so a
@@ -14,6 +15,7 @@ export default function ApplicationsPage() {
           Every job you&apos;ve brought, its status, and its whole history.
         </p>
       </div>
+      <WhatsNewStrip />
       <ApplicationList />
     </div>
   );

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -2,6 +2,7 @@ import { cookies } from "next/headers";
 import Link from "next/link";
 import Landing from "./Landing";
 import { ApplicationList } from "@/components/applications/ApplicationList";
+import { WhatsNewStrip } from "@/components/applications/WhatsNewStrip";
 
 // ---------------------------------------------------------------------------
 // R14 (docs/plans/2026-09-04-application-spine/spec.md) — the web home is
@@ -40,6 +41,7 @@ export default async function Home() {
           Bring a job
         </Link>
       </div>
+      <WhatsNewStrip />
       <ApplicationList />
     </div>
   );

--- a/frontend/src/components/applications/ApplicationList.tsx
+++ b/frontend/src/components/applications/ApplicationList.tsx
@@ -5,22 +5,13 @@ import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
 import { listApplications, recordApplicationReceipt } from "@/lib/api";
 import type { ApplicationSummary } from "@/lib/api";
+import { STATUS_LABEL } from "@/lib/event-labels";
+import { relativeTime } from "@/lib/utils";
 
 // The status vocabulary is closed in the backend (src/core/settings.py
-// APPLICATION_STATUS_EVENT_TYPES) — this is display copy only, never a
-// second source of truth for which statuses exist.
-const STATUS_LABEL: Record<string, string> = {
-  considering: "Considering",
-  applied: "Applied",
-  replied: "Replied",
-  interview_requested: "Interview requested",
-  interview_scheduled: "Interview scheduled",
-  interview_done: "Interview done",
-  offer: "Offer",
-  rejected: "Rejected",
-  withdrawn: "Withdrawn",
-  ghosted: "Ghosted",
-};
+// APPLICATION_STATUS_EVENT_TYPES) — STATUS_LABEL (src/lib/event-labels.ts)
+// is display copy only, never a second source of truth for which statuses
+// exist.
 
 /**
  * The applications home + the `/applications` list page share this list —
@@ -91,7 +82,16 @@ export function ApplicationList({ limit = 50 }: { limit?: number }) {
 
   return (
     <ul className="flex flex-col gap-3">
-      {applications.map((app) => (
+      {applications.map((app) => {
+        const artifactCount = Object.values(app.artifacts ?? {}).reduce((a, b) => a + b, 0);
+        const activityParts = [
+          relativeTime(app.last_event_at),
+          app.events > 0 ? `${app.events} event${app.events === 1 ? "" : "s"}` : "",
+          artifactCount > 0 ? `${artifactCount} artifact${artifactCount === 1 ? "" : "s"}` : "",
+          app.receipts > 0 ? `${app.receipts} receipt${app.receipts === 1 ? "" : "s"}` : "",
+        ].filter(Boolean);
+
+        return (
         <li
           key={app.id}
           className="glass-card flex items-center justify-between gap-4 rounded-xl p-4"
@@ -99,6 +99,11 @@ export function ApplicationList({ limit = 50 }: { limit?: number }) {
           <Link href={`/applications/${app.id}`} className="min-w-0 flex-1">
             <p className="truncate font-semibold">{app.job_title || "Untitled role"}</p>
             <p className="truncate text-sm text-muted-foreground">{app.job_company}</p>
+            {activityParts.length > 0 && (
+              <p data-testid="row-activity" className="mt-0.5 truncate text-xs text-muted-foreground/70">
+                {activityParts.join(" · ")}
+              </p>
+            )}
           </Link>
           <div className="flex shrink-0 items-center gap-3">
             <span className="rounded-full bg-primary/10 px-3 py-1 text-xs font-medium text-primary">
@@ -116,7 +121,8 @@ export function ApplicationList({ limit = 50 }: { limit?: number }) {
             )}
           </div>
         </li>
-      ))}
+        );
+      })}
     </ul>
   );
 }

--- a/frontend/src/components/applications/NoteForm.tsx
+++ b/frontend/src/components/applications/NoteForm.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { toast } from "sonner";
+import { recordApplicationEvent } from "@/lib/api";
+import { apiErrorMessage } from "@/lib/api-error";
+import { Textarea } from "@/components/ui/textarea";
+import { Button } from "@/components/ui/button";
+
+// APPLICATION_EVENT_DETAIL_MAX_CHARS (backend/src/core/settings.py) — the
+// same cap `RecordEventRequest.clamp_detail` enforces server-side.
+const NOTE_MAX_CHARS = 2000;
+
+/** "Add a note" under the Timeline (fix 3, agentic UX audit) — the fastest
+ * way for the seeker themself to leave a plain note on the record, the same
+ * `note` event type an agent can also record via MCP. */
+export function NoteForm({
+  applicationId,
+  onRecorded,
+}: {
+  applicationId: number;
+  onRecorded: () => Promise<void>;
+}) {
+  const [text, setText] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  const submit = useCallback(async () => {
+    const detail = text.trim();
+    if (!detail) return;
+    setSubmitting(true);
+    try {
+      await recordApplicationEvent(applicationId, { event_type: "note", detail });
+      setText("");
+      await onRecorded();
+    } catch (err) {
+      toast.error(apiErrorMessage(err, "Could not add this note."));
+    } finally {
+      setSubmitting(false);
+    }
+  }, [applicationId, text, onRecorded]);
+
+  return (
+    <div className="mt-3 flex flex-col gap-2">
+      <Textarea
+        data-testid="note-input"
+        value={text}
+        onChange={(e) => setText(e.target.value.slice(0, NOTE_MAX_CHARS))}
+        placeholder="Add a note…"
+        rows={2}
+        maxLength={NOTE_MAX_CHARS}
+      />
+      <Button
+        type="button"
+        size="sm"
+        data-testid="note-submit"
+        disabled={submitting || !text.trim()}
+        onClick={() => void submit()}
+        className="self-start"
+      >
+        {submitting ? "Adding…" : "Add note"}
+      </Button>
+    </div>
+  );
+}

--- a/frontend/src/components/applications/Receipts.tsx
+++ b/frontend/src/components/applications/Receipts.tsx
@@ -1,0 +1,33 @@
+import type { ApplicationReceiptEntry } from "@/lib/api";
+
+/** The Receipts section on an application's record page (fix 3, agentic UX
+ * audit): every "I applied" receipt, in the order the backend returns them.
+ * Only rendered by the caller when there is at least one. */
+export function Receipts({ receipts }: { receipts: ApplicationReceiptEntry[] }) {
+  return (
+    <ul className="flex flex-col gap-2">
+      {receipts.map((receipt) => (
+        <li key={receipt.id} data-testid="receipt-row" className="glass-card rounded-lg p-3 text-sm">
+          <div className="flex items-center justify-between gap-2">
+            <span className="font-medium">{receipt.channel || "Applied"}</span>
+            <span className="text-xs text-muted-foreground">
+              {new Date(receipt.sent_at).toLocaleDateString()}
+            </span>
+          </div>
+          {(receipt.cv_artifact_id != null || receipt.cover_letter_artifact_id != null) && (
+            <p className="mt-1 text-xs text-muted-foreground">
+              {receipt.cv_artifact_id != null && `CV #${receipt.cv_artifact_id}`}
+              {receipt.cv_artifact_id != null && receipt.cover_letter_artifact_id != null && " · "}
+              {receipt.cover_letter_artifact_id != null &&
+                `Cover letter #${receipt.cover_letter_artifact_id}`}
+            </p>
+          )}
+          {receipt.confirmation && (
+            <p className="mt-1 text-xs text-muted-foreground">Confirmation: {receipt.confirmation}</p>
+          )}
+          {receipt.note && <p className="mt-1 text-muted-foreground">{receipt.note}</p>}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/frontend/src/components/applications/Timeline.tsx
+++ b/frontend/src/components/applications/Timeline.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import type { ApplicationEvent } from "@/lib/api";
+import { eventLabel } from "@/lib/event-labels";
+import { WhoChip } from "@/components/applications/WhoChip";
 
 /** The whole append-only event log, in `occurred_at` order (spec R3/R11). A
  * superseded event (retired by a correcting event, spec R3) is shown struck
@@ -15,11 +17,12 @@ export function Timeline({ events }: { events: ApplicationEvent[] }) {
       {events.map((event) => (
         <li
           key={event.id}
+          data-testid="timeline-event"
           className={`glass-card rounded-lg p-3 text-sm ${event.superseded ? "opacity-50" : ""}`}
         >
           <div className="flex items-center justify-between gap-2">
             <span className={`font-medium ${event.superseded ? "line-through" : ""}`}>
-              {event.event_type}
+              {eventLabel(event)}
             </span>
             <span className="text-xs text-muted-foreground">
               {new Date(event.occurred_at).toLocaleString()}
@@ -40,10 +43,12 @@ export function Timeline({ events }: { events: ApplicationEvent[] }) {
               Scheduled for {new Date(event.scheduled_at).toLocaleString()}
             </p>
           )}
-          <p className="mt-1 text-xs text-muted-foreground/70">
-            recorded by {event.recorded_by}
-            {event.superseded && " · superseded"}
-          </p>
+          <div className="mt-1 flex items-center gap-1.5">
+            <WhoChip recordedBy={event.recorded_by} />
+            {event.superseded && (
+              <span className="text-xs text-muted-foreground/70">superseded</span>
+            )}
+          </div>
         </li>
       ))}
     </ol>

--- a/frontend/src/components/applications/WhatsNewStrip.tsx
+++ b/frontend/src/components/applications/WhatsNewStrip.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import Link from "next/link";
+import { useQuery } from "@tanstack/react-query";
+import { getWhatsNew } from "@/lib/api";
+import type { WhatsNewApplication, WhatsNewEvent } from "@/lib/api";
+import { eventLabel } from "@/lib/event-labels";
+import { relativeTime } from "@/lib/utils";
+import { WhoChip } from "@/components/applications/WhoChip";
+
+/** "What's new" — a strip of the caller's most recent activity across every
+ * application, mounted above the list on the signed-in home and on
+ * `/applications` (fix 4/5, agentic UX audit). Fails SILENTLY: on error or
+ * an empty window it renders nothing, since the hermetic e2e specs mock only
+ * the routes they need and a missing `/api/whats-new` mock must not break
+ * them. */
+export function WhatsNewStrip() {
+  const { data, isError } = useQuery({
+    queryKey: ["whats-new", 10],
+    queryFn: () => getWhatsNew({ limit: 10 }),
+  });
+
+  if (isError || !data || data.events.length === 0) {
+    return null;
+  }
+
+  const appById = new Map<number, WhatsNewApplication>(data.applications.map((a) => [a.id, a]));
+
+  // The backend pages `whats_new` forward in RECORDED order (oldest first —
+  // that's the correct cursor semantics for polling), so the strip reverses
+  // it to show newest-first, the way a human reads "what's new".
+  const events: WhatsNewEvent[] = [...data.events].reverse();
+
+  return (
+    <section data-testid="whats-new">
+      <h2 className="mb-2 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+        What&apos;s new
+      </h2>
+      <ul className="flex flex-col gap-2">
+        {events.map((event) => {
+          const app = appById.get(event.application_id);
+          return (
+            <li
+              key={event.id}
+              className="glass-card flex flex-wrap items-center gap-x-2 gap-y-1 rounded-lg p-3 text-sm"
+            >
+              <span className="font-medium">{eventLabel(event)}</span>
+              <WhoChip recordedBy={event.recorded_by} />
+              {app && (
+                <Link
+                  href={`/applications/${app.id}`}
+                  className="min-w-0 truncate text-primary hover:underline"
+                >
+                  {app.job_title || "Untitled role"}
+                </Link>
+              )}
+              <span className="ml-auto shrink-0 text-xs text-muted-foreground">
+                {relativeTime(event.occurred_at)}
+              </span>
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}

--- a/frontend/src/components/applications/WhoChip.tsx
+++ b/frontend/src/components/applications/WhoChip.tsx
@@ -1,0 +1,30 @@
+import { Bot } from "lucide-react";
+import { whoLabel } from "@/lib/event-labels";
+
+/** The "recorded by" chip — **You** (neutral) or **Agent · name** (accent).
+ * One component for every feed surface (Timeline, What's-new) so the two
+ * never drift apart visually. `name` is attacker-supplied (an OAuth client's
+ * registered name, or a personal-token name) — rendered as a plain React
+ * text node only, never markup, never a URL, never a className. */
+export function WhoChip({ recordedBy }: { recordedBy: string }) {
+  const { who, name } = whoLabel(recordedBy);
+  if (who === "you") {
+    return (
+      <span
+        data-testid="event-who"
+        className="inline-flex items-center rounded-full bg-muted px-2 py-0.5 text-[11px] font-medium text-muted-foreground"
+      >
+        {name}
+      </span>
+    );
+  }
+  return (
+    <span
+      data-testid="event-who"
+      className="inline-flex items-center gap-1 rounded-full bg-accent/20 px-2 py-0.5 text-[11px] font-medium text-accent-foreground"
+    >
+      <Bot className="h-3 w-3" />
+      Agent · {name}
+    </span>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -705,9 +705,13 @@ export async function recordApplicationReceipt(
   });
 }
 
+export type WhatsNewResponse = _Schemas["WhatsNewResponse"];
+export type WhatsNewEvent = _Schemas["WhatsNewEventOut"];
+export type WhatsNewApplication = _Schemas["WhatsNewApplicationOut"];
+
 export async function getWhatsNew(
   params: { since?: string; after_id?: number; limit?: number } = {}
-): Promise<_Schemas["WhatsNewResponse"]> {
+): Promise<WhatsNewResponse> {
   return request(`/api/whats-new${qs(params as Record<string, unknown>)}`);
 }
 

--- a/frontend/src/lib/event-labels.test.ts
+++ b/frontend/src/lib/event-labels.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from "vitest";
+import { STATUS_LABEL, EVENT_LABEL, eventLabel, whoLabel } from "./event-labels";
+
+// The closed sets from backend/src/core/settings.py — kept in sync by hand
+// (there is no shared schema to import across the language boundary); a
+// vocabulary edit there should also edit these two lists.
+const APPLICATION_STATUS_EVENT_TYPES = [
+  "brought",
+  "applied",
+  "replied",
+  "interview_requested",
+  "interview_scheduled",
+  "interview_done",
+  "offer",
+  "rejected",
+  "withdrawn",
+  "ghosted",
+];
+
+const APPLICATION_NOTE_EVENT_TYPES = [
+  "fit_judged",
+  "artifact_saved",
+  "contact_added",
+  "outreach_sent",
+  "note",
+  "lesson",
+];
+
+describe("STATUS_LABEL", () => {
+  it("has a label for every status a status event can produce", () => {
+    // `brought` maps to `considering`, not itself.
+    const statuses = APPLICATION_STATUS_EVENT_TYPES.map((t) => (t === "brought" ? "considering" : t));
+    for (const status of statuses) {
+      expect(STATUS_LABEL[status]).toBeTruthy();
+    }
+  });
+});
+
+describe("EVENT_LABEL", () => {
+  it("has a label for every note-family event type", () => {
+    for (const type of APPLICATION_NOTE_EVENT_TYPES) {
+      expect(EVENT_LABEL[type]).toBeTruthy();
+    }
+  });
+});
+
+describe("eventLabel", () => {
+  it("labels every status event as 'Status → <label>'", () => {
+    expect(eventLabel({ event_type: "brought" })).toBe("Status → Considering");
+    expect(eventLabel({ event_type: "applied" })).toBe("Status → Applied");
+    expect(eventLabel({ event_type: "replied" })).toBe("Status → Replied");
+    expect(eventLabel({ event_type: "interview_requested" })).toBe("Status → Interview requested");
+    expect(eventLabel({ event_type: "interview_scheduled" })).toBe("Status → Interview scheduled");
+    expect(eventLabel({ event_type: "interview_done" })).toBe("Status → Interview done");
+    expect(eventLabel({ event_type: "offer" })).toBe("Status → Offer");
+    expect(eventLabel({ event_type: "rejected" })).toBe("Status → Rejected");
+    expect(eventLabel({ event_type: "withdrawn" })).toBe("Status → Withdrawn");
+    expect(eventLabel({ event_type: "ghosted" })).toBe("Status → Ghosted");
+  });
+
+  it("labels every note-family event type", () => {
+    expect(eventLabel({ event_type: "fit_judged" })).toBe("Fit judged");
+    expect(eventLabel({ event_type: "artifact_saved" })).toBe("Artifact saved");
+    expect(eventLabel({ event_type: "contact_added" })).toBe("Contact added");
+    expect(eventLabel({ event_type: "outreach_sent" })).toBe("Outreach sent");
+    expect(eventLabel({ event_type: "note" })).toBe("Note");
+    expect(eventLabel({ event_type: "lesson" })).toBe("Lesson");
+  });
+
+  it("falls back to the raw event_type string for an unknown type", () => {
+    expect(eventLabel({ event_type: "some_future_type" })).toBe("some_future_type");
+  });
+});
+
+describe("whoLabel", () => {
+  it("'web' -> {you, You}", () => {
+    expect(whoLabel("web")).toEqual({ who: "you", name: "You" });
+  });
+
+  it("'token:foo' -> {agent, foo}", () => {
+    expect(whoLabel("token:foo")).toEqual({ who: "agent", name: "foo" });
+  });
+
+  it("'token:claude-code' -> {agent, claude-code}", () => {
+    expect(whoLabel("token:claude-code")).toEqual({ who: "agent", name: "claude-code" });
+  });
+
+  it("'agent:bar' -> {agent, bar}", () => {
+    expect(whoLabel("agent:bar")).toEqual({ who: "agent", name: "bar" });
+  });
+
+  it("anything else -> {agent, recordedBy}", () => {
+    expect(whoLabel("something-weird")).toEqual({ who: "agent", name: "something-weird" });
+  });
+});

--- a/frontend/src/lib/event-labels.ts
+++ b/frontend/src/lib/event-labels.ts
@@ -1,0 +1,97 @@
+// ---------------------------------------------------------------------------
+// One label module for the application event feed (agentic UX audit, fix 3).
+//
+// The event-type vocabulary is closed in the BACKEND, not here
+// (backend/src/core/settings.py: APPLICATION_STATUS_EVENT_TYPES,
+// APPLICATION_NOTE_EVENT_TYPES). This file is display copy only — it must
+// cover every member of both tuples, never invent a third vocabulary.
+//
+// A status event's underlying application status is the event_type ITSELF —
+// there is no `new_status` field in the payload. The one exception is
+// `brought`, which maps to `considering`
+// (backend/src/services/applications/status.py: `_EVENT_TO_STATUS`). Every
+// other status event's name IS the status.
+// ---------------------------------------------------------------------------
+
+/** APPLICATION_STATUS_EVENT_TYPES (settings.py) — the closed set of
+ * status-bearing event types, in the application's own status vocabulary. */
+const STATUS_EVENT_TYPES = new Set([
+  "brought",
+  "applied",
+  "replied",
+  "interview_requested",
+  "interview_scheduled",
+  "interview_done",
+  "offer",
+  "rejected",
+  "withdrawn",
+  "ghosted",
+]);
+
+/** `status.py`'s `_EVENT_TO_STATUS` — the one status event whose name is NOT
+ * the status. Every other status event's name IS the status. */
+const EVENT_TYPE_TO_STATUS: Record<string, string> = {
+  brought: "considering",
+};
+
+/** Display copy for the application's `status` column (ApplicationSummaryOut
+ * / ApplicationDetailOut.status), keyed by every value `status_for_event` can
+ * ever produce. */
+export const STATUS_LABEL: Record<string, string> = {
+  considering: "Considering",
+  applied: "Applied",
+  replied: "Replied",
+  interview_requested: "Interview requested",
+  interview_scheduled: "Interview scheduled",
+  interview_done: "Interview done",
+  offer: "Offer",
+  rejected: "Rejected",
+  withdrawn: "Withdrawn",
+  ghosted: "Ghosted",
+};
+
+/** Display copy for APPLICATION_NOTE_EVENT_TYPES (settings.py) — the
+ * non-status ("note-family") event types. */
+export const EVENT_LABEL: Record<string, string> = {
+  fit_judged: "Fit judged",
+  artifact_saved: "Artifact saved",
+  contact_added: "Contact added",
+  outreach_sent: "Outreach sent",
+  note: "Note",
+  lesson: "Lesson",
+};
+
+/** The label for one timeline row. A status event reads "Status → <label>";
+ * a note-family event reads its own label; anything unrecognised (a future
+ * `APPLICATION_EXTRA_EVENT_TYPES` addition, or drift) falls back to the raw
+ * `event_type` string rather than hiding the row. */
+export function eventLabel(e: { event_type: string; payload?: unknown }): string {
+  if (STATUS_EVENT_TYPES.has(e.event_type)) {
+    const status = EVENT_TYPE_TO_STATUS[e.event_type] ?? e.event_type;
+    return `Status → ${STATUS_LABEL[status] ?? status}`;
+  }
+  return EVENT_LABEL[e.event_type] ?? e.event_type;
+}
+
+/** Who did this — for the Timeline's "recorded by" chip.
+ *
+ * `recorded_by` has exactly three shapes (backend
+ * `src/services/applications/authorship.py::actor_for`):
+ * `"web"` (the seeker, in the browser), `"token:<name>"` (a personal-token
+ * MCP client), `"agent:<client>"` (an OAuth-grant MCP client). Both token and
+ * agent forms are an autonomous caller acting on the user's behalf, so both
+ * render as "Agent" — the distinction is internal auth plumbing, not
+ * something the seeker needs to see.
+ */
+export function whoLabel(recordedBy: string): { who: "you" | "agent"; name: string } {
+  if (recordedBy === "web") {
+    return { who: "you", name: "You" };
+  }
+  if (recordedBy.startsWith("token:")) {
+    return { who: "agent", name: recordedBy.slice("token:".length) };
+  }
+  if (recordedBy.startsWith("agent:")) {
+    return { who: "agent", name: recordedBy.slice("agent:".length) };
+  }
+  return { who: "agent", name: recordedBy };
+}

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -16,3 +16,30 @@ export function safeUrl(url: string | null | undefined): string {
     return "#";
   }
 }
+
+/** "2 h ago" / "just now" — a short, human relative time for an ISO
+ * timestamp. Never throws on a bad/empty input: falls back to "". A future
+ * timestamp (clock skew) reads as "just now" rather than a negative duration. */
+export function relativeTime(iso: string | null | undefined): string {
+  if (!iso) return "";
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return "";
+
+  const seconds = Math.round((Date.now() - then) / 1000);
+  if (seconds < 60) return "just now";
+
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return `${minutes} m ago`;
+
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `${hours} h ago`;
+
+  const days = Math.round(hours / 24);
+  if (days < 30) return `${days} d ago`;
+
+  const months = Math.round(days / 30);
+  if (months < 12) return `${months} mo ago`;
+
+  const years = Math.round(months / 12);
+  return `${years} y ago`;
+}

--- a/frontend/tests/e2e/applications-home.spec.ts
+++ b/frontend/tests/e2e/applications-home.spec.ts
@@ -124,6 +124,48 @@ async function mockBackend(page: Page) {
     })
   );
 
+  // fix 4/5 (agentic UX audit) — the What's-new strip. One event, recorded by
+  // an MCP personal-token client ("Agent · claude-code" — event-labels.ts's
+  // `whoLabel`), so the strip has something to show without depending on the
+  // spine's own event fixtures below.
+  await page.route("**/api/whats-new**", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        now: "2026-09-04T00:00:00Z",
+        since: "2026-08-28T00:00:00Z",
+        next_since: "2026-09-01T00:00:00Z",
+        next_after_id: 1,
+        truncated: false,
+        applications: [
+          {
+            id: APPLICATION_ID,
+            job_title: "Data Engineer",
+            job_company: "Northwind",
+            status: "considering",
+            last_event_at: "2026-09-01T00:00:00Z",
+          },
+        ],
+        events: [
+          {
+            id: 1,
+            application_id: APPLICATION_ID,
+            event_type: "artifact_saved",
+            detail: "",
+            payload: {},
+            occurred_at: "2026-09-01T00:00:00Z",
+            recorded_at: "2026-09-01T00:00:00Z",
+            recorded_by: "token:claude-code",
+            corrects_event_id: null,
+            scheduled_at: null,
+            source: null,
+          },
+        ],
+      }),
+    })
+  );
+
   await page.route("**/api/applications?**", (route) =>
     route.fulfill({
       status: 200,
@@ -183,6 +225,11 @@ test.describe("Applications home — the spine, end to end (hermetic)", () => {
     await expect(page.getByText(/data engineer/i).first()).toBeVisible({ timeout: 20_000 });
     await expect(page.getByText(/considering/i).first()).toBeVisible();
 
+    // fix 5 (agentic UX audit) — the What's-new strip shows the mocked
+    // agent-recorded event: its label and the "Agent · claude-code" chip.
+    await expect(page.getByText(/artifact saved/i).first()).toBeVisible({ timeout: 20_000 });
+    await expect(page.getByText(/agent\s*·\s*claude-code/i).first()).toBeVisible();
+
     // R12/R14 — the search flag is off by default, so the old Dashboard link
     // must not exist on a page a signed-in user can navigate.
     await expect(page.getByRole("link", { name: /^dashboard$/i })).toHaveCount(0);
@@ -209,5 +256,19 @@ test.describe("Applications home — the spine, end to end (hermetic)", () => {
     await expect(page.getByText(CV_TEXT[1])).toBeVisible({ timeout: 10_000 });
     await v2.click();
     await expect(page.getByText(CV_TEXT[2])).toBeVisible({ timeout: 10_000 });
+
+    // fix 3 (agentic UX audit) — Timeline is now the first section, ahead of
+    // Fit (`data-testid` order), and the one receipt in the mock renders.
+    const timelineSection = page.getByTestId("section-timeline");
+    const fitSection = page.getByTestId("section-fit");
+    await expect(timelineSection).toBeVisible();
+    await expect(fitSection).toBeVisible();
+    const timelineBox = await timelineSection.boundingBox();
+    const fitBox = await fitSection.boundingBox();
+    expect(timelineBox).not.toBeNull();
+    expect(fitBox).not.toBeNull();
+    expect(timelineBox!.y).toBeLessThan(fitBox!.y);
+
+    await expect(page.getByTestId("receipt-row")).toHaveCount(1);
   });
 });


### PR DESCRIPTION
## What

Fixes 3–5 of the agentic-era frontend UX audit: the web app finally shows **what your agent did**, in plain words, with who-did-it on every row.

| Where | Change |
|---|---|
| `lib/event-labels.ts` (new) | One label module. `STATUS_LABEL` moved here (two identical copies deleted). `EVENT_LABEL` covers `APPLICATION_NOTE_EVENT_TYPES` exactly. `eventLabel()` → "Status → Applied" / "Fit judged". `whoLabel()` maps `web` / `token:<n>` / `agent:<n>` → You / Agent · name. |
| `components/applications/WhoChip.tsx` (new) | **You** (neutral) or **Agent · name** (accent, Bot icon). Shared by Timeline + What's-new. |
| `Timeline.tsx` | human labels + WhoChip instead of `fit_judged` / `recorded by token:…` |
| `applications/[id]/ApplicationClient.tsx` | **Timeline is the first section.** Inline "Add a note" (note event, 2000-char cap matches the backend). **Receipts** section rendered for the first time. |
| `ApplicationList.tsx` | rows show "2 h ago · 3 events · 2 artifacts · 1 receipt"; zeros stay silent |
| `components/applications/WhatsNewStrip.tsx` (new) | "What's new": last 10 events across all applications, newest first, on the signed-in home and `/applications`. Fails silently (no error UI) so hermetic specs without a `/api/whats-new` mock keep passing. |
| `lib/utils.ts` | `relativeTime()` helper, no new dependency |
| tests | `event-labels.test.ts` (10 unit); `applications-home.spec.ts` asserts the strip, Timeline-before-Fit, receipt row |

## Why

Audit finding: the agent-user's #1 question is "what did my agent just do?" — the answer was last on the page, in raw enums, with no way to tell agent from human. `detail.receipts` and `/api/whats-new` existed in the API but no screen used them.

Audit report: https://claude.ai/code/artifact/1cf19d2c-25be-4aa8-8ac9-f9c1bd3df31b

## Security

- `recorded_by` names (OAuth client name / personal-token name) are attacker-supplied → React text nodes only; never in `href`, `className`, or HTML.
- Label maps are display copy; the vocabulary stays closed in `backend/src/core/settings.py`. Unknown types fall back to the raw string rather than hiding the row.
- Note input capped client-side at `APPLICATION_EVENT_DETAIL_MAX_CHARS` (2000); the server still enforces it.

## Verified

- `npm run lint` 0 · `npm run type-check` 0 · `npm run test:unit` 268/268 (37 files)
- `applications-home.spec.ts` 1/1 locally against the dev server (hermetic mocks)
- commit gate green

## Series

- A: #523 copy/visual cleanup
- B: #524 Connect-an-agent path
- C: this

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011wAduRqokWdPEByUkcVbvc
