### PR TITLE
docs: daily truth check

### DIFF
--- a/.claude/skills/hard-rules/SKILL.md
+++ b/.claude/skills/hard-rules/SKILL.md
@@ -26,10 +26,8 @@ Nothing here is weaker for being a skill. It loads when the work touches it.
 
 The sourcing-era pipeline (search, scoring, dedup, enrichment, embeddings) was
 deleted 2026-09-05 (slice 5, #483) along with the rules that only guarded it.
-Two of those rules guarded facts that outlived the deletion and moved up into
-the index below unchanged: dedup-key normalization (still used by a brought
-job) and the digest notification path (dead code, kept only so nobody
-resurrects it by accident).
+One of those rules guarded a fact that outlived the deletion and moved up into
+the index below unchanged: dedup-key normalization, still used by a brought job.
 
 ## Still binding
 
@@ -37,7 +35,7 @@ An index of the 14 hard rules, one line each. Where a test guards a rule, the te
 
 ### Schema + data integrity
 1. **`normalized_key()` in `models.py`** — never change without re-verifying the DB UNIQUE constraint. Wrong normalization = duplicate rows. Still bites `bring_job`: two users pasting the same ad share one row.
-10. **Never INSERT into `jobs` with `user_id`/`tenant_id`** — `jobs` is the shared catalog (a brought job is a catalog row too). Per-user state lives in `user_feed`, `user_actions`, `applications`, `application_receipts`.
+10. **Never INSERT into `jobs` with `user_id`/`tenant_id`** — `jobs` is the shared catalog (a brought job is a catalog row too). Per-user state lives in the tables that carry a `user_id` column; `backend/src/repositories/database.py` is the list (`user_feed` was dropped in migration 0040).
 
 ### Auth + multi-tenant routes
 12. **Every per-user FastAPI route MUST `Depends(require_user)`** and scope queries by `user.id`. Never accept `user_id` from URL/body — trivial IDOR.

--- a/.claude/skills/sync/SKILL.md
+++ b/.claude/skills/sync/SKILL.md
@@ -15,7 +15,7 @@ Read the actual code and extract current facts. **The mission is `docs/product/V
 - **Roadmap state**: which slices in `docs/plans/2026-09-03-mission-roadmap.md` have merged (check the issue #479–#483 state with `gh issue view`)
 - **Test count**: Run (from `backend/`) `python -m pytest tests/ --collect-only -q 2>&1 | tail -3` to get exact test count
 - **DB schema**: Read `backend/src/repositories/database.py` + `backend/migrations/` for table definitions (jobs, applications, application_receipts, tailored_documents, user_actions), column names, UNIQUE constraints, indexes
-- **Features**: Check what modules exist in `backend/src/services/`, `backend/src/services/profile/`, `backend/src/services/notifications/`, `backend/src/api/` — what's actually implemented
+- **Features**: Check what modules exist in `backend/src/services/` and `backend/src/api/` — what's actually implemented
 - **Commands**: Read `backend/src/cli.py` for actual CLI commands and flags
 - **Dependencies**: Read `backend/pyproject.toml` for actual packages
 
@@ -56,14 +56,10 @@ For each mismatch found in Step 2:
 
 **Then stamp every LIVING doc you verified** (even ones needing no fix):
 add or update `<!-- doc: LIVING | last-verified: YYYY-MM-DD by /sync -->` near
-the top of each file. **Do not type the list from memory — read it from the
-`LIVING_DOCS` constant in `scripts/doc_sync_check.py`**, which is the only
-authority and has grown from 6 files to 15 (it now covers CONTRIBUTING.md,
-frontend/CLAUDE.md, backend/README.md and every file in
-`docs/product/pillars/`). The Loop-3 PR-time gate (`scripts/doc_sync_check.py`,
-run by `.github/workflows/doc-sync.yml` on every pull request) reads both the
-type tag and the date, and flags any doc not verified within 45 days — so
-stamping a hardcoded subset leaves the rest to go red on freshness at the next PR.
+the top of each file. **Do not type the list from memory — a doc is LIVING
+because it stamps itself so.** `scripts/doc_sync_check.py::living_stamped_docs`
+enumerates them; `python scripts/doc_sync_check.py` prints the count and which
+stamps have gone stale.
 
 **If a doc claims something the code does NOT do** (code is behind the doc —
 an "AHEAD" doc): **leave that doc completely untouched** (user's rule —

--- a/.claude/skills/verify-job360/CHECKLIST.md
+++ b/.claude/skills/verify-job360/CHECKLIST.md
@@ -5,7 +5,7 @@
 feature, page, button, and route, from landing on the site to closing it. A "full sweep"
 is not done until every item below is exercised (or explicitly marked gated, with the reason).
 
-**How to use:** start the full stack (backend + frontend + Redis/ARQ worker when present),
+**How to use:** start the full stack (backend + frontend),
 register a fresh user, then walk the list top to bottom. Prove each with evidence
 (HTTP code, DB row, screenshot, log line). Report a PASS / FAIL / GATED table.
 
@@ -26,7 +26,7 @@ not fired (needs external service or sample data) · `GATED` = needs infra not p
 
 ## B. Auth (full lifecycle)
 - [ ] 3. Register → `POST /api/auth/register` 201, `users` row lands, cookie issued
-- [ ] 4. Email verify — `POST /verify-email/request`, `/verify-email/confirm`, `GET /me/email-verified` (confirm whether enforcement is on/off — currently `email_verified_at` stays NULL = not enforced)
+- [ ] 4. Email verify — `POST /verify-email/request`, `/verify-email/confirm`, `GET /me/email-verified`; which routes the gate holds is pinned by `tests/test_email_enforcement.py` and `tests/test_token_mint_is_session_only.py`
 - [ ] 5. Login + session — `GET /api/auth/me` resolves the exact user from the cookie
 - [ ] 6. Password reset **request** → 204 (send is SMTP-conditional)
 - [ ] 7. Password reset **confirm** → `/password-reset/confirm` with a token
@@ -77,4 +77,4 @@ not fired (needs external service or sample data) · `GATED` = needs infra not p
 Produce a table: `# | item | LIVE/CODE/GATED/FAIL | evidence`. End with:
 - counts (e.g. "30 LIVE, 3 CODE, 1 GATED, 1 FAIL")
 - the FIRST real FAIL with exact file:line + error (if any)
-- what's needed to close the gates (install Redis; add LinkedIn sample; set OAuth creds)
+- what's needed to close the gates (add LinkedIn sample; set OAuth creds)

--- a/.claude/skills/verify-job360/SKILL.md
+++ b/.claude/skills/verify-job360/SKILL.md
@@ -3,12 +3,12 @@ name: verify-job360
 description: >-
   Verify Job360 changes by actually running the app and watching the behavior — not by
   assuming tests or a clean compile prove it works. Use this AGGRESSIVELY: any time you
-  touch backend (FastAPI, scoring, sources, DB, scheduler) or frontend (Next.js pages,
+  touch backend (FastAPI, MCP, DB) or frontend (Next.js pages,
   API calls, auth) code, before saying something is "done" or "fixed", before opening a
   PR, and whenever the user asks to verify / test / confirm / "does it actually work" /
   "prove it". Drives a real browser with Playwright for UX, hits routes with curl and
-  queries the Postgres DB for backend, and walks the full register→CV→search→jobs journey
-  for end-to-end. If you changed Job360 code and haven't run it, this skill applies.
+  queries the Postgres DB for backend, and walks the full register→CV→bring→tailor→receipt
+  journey for end-to-end. If you changed Job360 code and haven't run it, this skill applies.
 ---
 <!-- doc: LIVING -->
 
@@ -35,8 +35,8 @@ that landed, a log line that proves the code path ran. "It should work now" is n
 Choose based on what you touched. When unsure, do the broader one.
 
 - **Frontend / UX** — you changed a page, component, API call, or auth flow → drive a real browser, screenshot.
-- **Backend** — you changed a route, scorer, source, DB, scheduler, worker → run the service, hit the route, query the DB, read the logs.
-- **End-to-end** — you changed something that spans both, or the user wants the whole journey proven → walk register → CV → search → jobs.
+- **Backend** — you changed a route, a service, the DB or MCP → run the service, hit the route, query the DB, read the logs.
+- **End-to-end** — you changed something that spans both, or the user wants the whole journey proven → walk the 5 steps below.
 
 `$ARGUMENTS` may name a flavor (`backend`, `frontend`, `e2e`) or a specific feature to focus on. If given, scope to that.
 
@@ -94,11 +94,11 @@ For per-user routes you need a session cookie — register via `POST /api/auth/r
   storage layer is psycopg3; `src/repositories/pg.py` only *shapes* itself like
   aiosqlite):
   ```
-  cd backend && python -c "import os,psycopg; dsn=os.getenv('DATABASE_URL','postgresql://job360:job360dev@localhost:5433/job360'); c=psycopg.connect(dsn); print(c.execute('SELECT COUNT(*) FROM jobs').fetchone()); [print(r) for r in c.execute('SELECT match_score,title FROM jobs ORDER BY match_score DESC LIMIT 5')]"
+  cd backend && python -c "import os,psycopg; dsn=os.getenv('DATABASE_URL','postgresql://job360:job360dev@localhost:5433/job360'); c=psycopg.connect(dsn); print(c.execute('SELECT COUNT(*) FROM jobs').fetchone())"
   ```
   Against PROD instead of local dev: `railway run -s Postgres python <script>`
   (never print the DSN).
-  Useful tables: `jobs` (shared catalog), `user_feed`, `user_profiles`, `users`, `sessions`, `applications`, `run_log`.
+  For the table list, read `backend/src/repositories/database.py` — it is the schema.
 - **Did the path run?** Read the server's stdout/log. When you launched it as a background
   Bash task, its output goes to a task file — `tail` that file and grep for your route,
   for `ERROR`/`WARNING`, and for the run UUID. If a code path's execution is ambiguous,
@@ -124,8 +124,7 @@ For per-user routes you need a session cookie — register via `POST /api/auth/r
 > buttons + the LinkedIn/GitHub gates). Report its PASS/FAIL/GATED table.
 
 Run **both** servers, then walk the real journey with the browser and watch the DB/logs in parallel.
-**The journey is the product path (`docs/product/VISION.md`): bring → tailor → receipt → MCP. The old
-search journey is legacy — verify it only when the change touched `src/sources/` or the scorer.**
+**The journey is the product path (`docs/product/VISION.md`): bring → tailor → receipt → MCP.**
 
 1. **Register** a fresh account (UI: `/register`, or `POST /api/auth/register`).
 2. **Upload a CV** on `/profile` — use `test-artifacts/sample_cv.pdf` (a realistic ML-engineer CV).
@@ -140,8 +139,7 @@ search journey is legacy — verify it only when the change touched `src/sources
    receipt-listing tool return the same data the web showed.
 
 A good E2E run produces a short report: what works, what's broken (with the exact file:line
-and the DB/log evidence), severity, and the fix. See `E2E_TEST_REPORT.md` at the repo root
-for the format and the two real bugs this methodology already caught.
+and the DB/log evidence), severity, and the fix.
 
 ---
 
@@ -186,7 +184,7 @@ These cost real time the first time. Reading them here saves the next run.
 - **CV extraction is ASYNC (~60–90 s).** The upload returns **200 immediately**, then the two-pass LLM extraction runs in the background and saves the profile ~1 min later. Reading `/api/profile` right after the 200 shows **empty skills/titles** — that's timing, NOT a bug. Poll the profile (or the DB `user_profiles.cv_data` blob) until skills appear before asserting populated.
 - **`user_profiles` stores the CV under the `cv_data` JSON column** (siblings: `preferences`, `linkedin_data`, `github_data`) — there is NO `profile_json` column. Use `cv_data` for direct DB skill/title checks.
 - **Login is now brute-force-locked.** 5 failed logins for one email → **HTTP 429** (Retry-After) for ~15 min, even with the correct password. When sweeping: use a **throwaway email** for the lockout test, and never reuse an email you've intentionally failed — the lock turns a later legit login into a false 429.
-- **Minting an agent token is gated on a verified email.** A fresh registered user is unverified, so `POST /api/tokens` returns **403 `email_not_verified`** (`require_verified_user`). To exercise the MCP surface, first verify: walk the verify-email token, or `UPDATE users SET email_verified_at = now() WHERE email = ?`.
+- **Which routes the email gate holds is pinned, not prose** — `tests/test_token_mint_is_session_only.py` (minting needs only a session) and `tests/test_email_enforcement.py::test_a_gated_route_blocks_an_unverified_user` (the LLM-spending routes 403). Read those two before assuming a 403.
 - **Gemini free tier returns 429 (quota 0); the Groq/Cerebras fallback handles it.** Don't flag the Gemini 429 as a failure — the fallback chain saving the profile ("Profile saved for user …") is the success signal.
 
 ## Tools this skill uses

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -18,7 +18,7 @@
 | --- | --- | --- |
 | Migration head | **0041** | `backend/migrations/` |
 | Migration files | **42** | `backend/migrations/*.up.sql` |
-| `test_*.py` files | **135** | `backend/tests/` |
+| `test_*.py` files | **136** | `backend/tests/` |
 | GitHub Actions workflows | **23** | `.github/workflows/` |
 | Hard rules | **14** | `.claude/skills/hard-rules/SKILL.md` |
 <!-- /generated -->

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -58,7 +58,7 @@ job360/
 │   │       ├── logger.py             # Rotating file + console logging
 │   │       ├── audit_trail.py        # who-did-what rows for account changes
 │   │       └── loop_guard.py         # refuses blocking work on the event loop
-│   └── tests/                        # across 135 `test_*.py` files (collected-test count: measure it, never quote it)
+│   └── tests/                        # across 136 `test_*.py` files (collected-test count: measure it, never quote it)
 ├── frontend/                         # Next.js 16 + React 19 + Tailwind 4 + shadcn
 │   ├── src/app/                      # App Router pages (server/client split; params is Promise<...> per Next.js 16)
 │   ├── src/components/{ui,applications,tailor,profile,layout}/
@@ -98,8 +98,9 @@ def normalized_key(self) -> tuple[str, str]:
 
 This key is used for:
 - **Database uniqueness** — `UNIQUE(normalized_company, normalized_title)` constraint
-- **Seen-check** — `is_job_seen()` queries by these columns, so two users pasting
-  the same ad share one `jobs` row
+- **Seen-check** — `bring.py` looks the key up before inserting, so two users
+  pasting the same ad share one `jobs` row
+  (`tests/test_bring_a_job.py::test_bring_twice_lands_on_same_row`)
 
 ---
 
@@ -272,9 +273,9 @@ CREATE INDEX IF NOT EXISTS idx_jobs_date_found ON jobs(date_found);
 CREATE INDEX IF NOT EXISTS idx_jobs_first_seen ON jobs(first_seen);
 ```
 
-**Pragmas:** none. This was a SQLite-era line (`journal_mode=WAL`, `busy_timeout=5000`); the store has been Postgres since 2026-07-02 and sets neither — `database.py:94` says so in as many words, `db_retry.open_db()` accepts `busy_timeout_ms` only for signature compatibility and ignores it (`db_retry.py:30-31`), and the `pg.py` shim turns any remaining `PRAGMA` into a no-op (`pg.py:316-317`).
+**Pragmas:** none. This was a SQLite-era line (`journal_mode=WAL`, `busy_timeout=5000`); the store has been Postgres since 2026-07-02 and sets neither — `db_retry.open_db` accepts `busy_timeout_ms` only for signature compatibility and ignores it, and the `pg.py` shim turns any remaining `PRAGMA` into a no-op.
 
-**Auto-purge:** `purge_old_jobs(days=30)` deletes jobs by **liveness, not ingestion** — `DELETE FROM jobs WHERE COALESCE(last_seen_at, first_seen) < cutoff` (`repositories/database.py:688,723`), skipping any row whose `source` is the user-brought marker (hard rule 3) — a brought job (and its application snapshot) survives the purge. It also deletes the catalog-derived child rows itself because the shim strips every FK clause, including `ON DELETE CASCADE`.
+**Auto-purge:** none. `purge_old_jobs` went with the sourcing era (`backend/tests/test_sourcing_era_deleted.py`); nothing deletes a `jobs` row on age, and there is no scheduler left to call it if it came back.
 
 **first_seen:** Set in Python via `datetime.now(timezone.utc).isoformat()` at insert time (not a database DEFAULT).
 

--- a/backend/tests/test_token_mint_is_session_only.py
+++ b/backend/tests/test_token_mint_is_session_only.py
@@ -1,0 +1,68 @@
+"""Minting a personal token needs a SESSION, not a verified email.
+
+`.claude/skills/verify-job360/SKILL.md` told the nightly verifier that a fresh
+registered user gets **403 `email_not_verified`** from `POST /api/tokens`, and
+therefore to run `UPDATE users SET email_verified_at = now()` before touching
+the MCP surface. `src/api/routes/tokens.py` depends on ``require_session_user``
+only — the verification gate guards the routes that SPEND an LLM call
+(`test_email_enforcement.py::test_a_gated_route_blocks_an_unverified_user`),
+and minting a credential spends nothing. A verifier following the doc would
+have reported a false failure the first time the 201 arrived.
+
+The doc now cites this file instead of restating the gate.
+"""
+from __future__ import annotations
+
+import pytest
+
+import src.core.settings as settings_mod
+from src.repositories import pgsync
+
+
+def _unverify(user_id: str) -> None:
+    conn = pgsync.connect(str(settings_mod.DB_PATH))
+    conn.execute("UPDATE users SET email_verified_at = NULL WHERE id = ?", (user_id,))
+    conn.commit()
+    conn.close()
+
+
+@pytest.mark.asyncio
+async def test_an_unverified_user_can_mint_a_token(authenticated_async_context):
+    """The claim under test: no email verification is required to mint."""
+    _unverify(authenticated_async_context.fixture_user_id)
+
+    async with authenticated_async_context() as client:
+        resp = await client.post("/api/tokens", json={"name": "agent"})
+
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["token"].startswith("j360_")
+
+
+@pytest.mark.asyncio
+async def test_an_unverified_user_can_list_and_revoke_tokens(authenticated_async_context):
+    """The whole router is session-gated, not just the mint route."""
+    _unverify(authenticated_async_context.fixture_user_id)
+
+    async with authenticated_async_context() as client:
+        made = await client.post("/api/tokens", json={"name": "agent"})
+        assert made.status_code == 201, made.text
+
+        listed = await client.get("/api/tokens")
+        assert listed.status_code == 200, listed.text
+
+        revoked = await client.delete(f"/api/tokens/{made.json()['id']}")
+        assert revoked.status_code == 204, revoked.text
+
+
+@pytest.mark.asyncio
+async def test_minting_still_needs_a_session(authenticated_async_context):
+    """Session-gated is not ungated: no cookie → 401, never 201."""
+    from httpx import ASGITransport, AsyncClient
+
+    from src.api.main import app
+
+    async with authenticated_async_context():
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as anon:
+            resp = await anon.post("/api/tokens", json={"name": "agent"})
+
+    assert resp.status_code == 401, resp.text

--- a/docs/harness/maintenance/DOC-MAINTENANCE.md
+++ b/docs/harness/maintenance/DOC-MAINTENANCE.md
@@ -12,7 +12,7 @@
 > git history is the copy for merged work, a pushed tag/branch is the copy for
 > unmerged work; (2) ground truth (`CLAUDE.md`, `ARCHITECTURE.md`, `README`,
 > `STATUS.md`, `CONTRIBUTING`, `SECURITY`) and permanent records
-> (`IMPLEMENTATION_LOG.md`, decision records, reviews) are never auto-touched;
+> (`docs/decisions/`, reviews) are never auto-touched;
 > (3) an unshipped plan is never silently deleted — park it, don't ticket-and-
 > forget; (4) any loop may read freely, but a loop that **writes** lands only
 > through a PR a human merges — never a direct push to `main` — the Loop-1
@@ -21,12 +21,15 @@
 
 ## 1. Doc taxonomy — every doc gets exactly ONE type
 
-| Type | Examples | Rule |
-|------|----------|------|
-| **LIVING** | `CLAUDE.md`, `ARCHITECTURE.md`, `README.md`, `STATUS.md`, `backend/CLAUDE.md`, `frontend/README.md` | Must always match the code. Any drift is a bug, same severity as a failing test. |
-| **PLAN** | `docs/plans/*`, `docs/step_*_plan.md`, design docs for unbuilt features | Has a lifecycle (below). Never silently edited after execution starts — plans are promises, and history must stay honest. |
-| **LOG** | `docs/harness/IMPLEMENTATION_LOG.md`, `docs/harness/maintenance/JOURNAL.md` | Append-only. Never rewritten, so never stale by definition. |
-| **REFERENCE** | decision records (`docs/product/plans/batch-2-decisions.md`), research notes | Updated only when the decision itself changes; superseded ones get a banner pointing to the successor, content stays. |
+Which doc is which is not listed here — each doc stamps itself, and
+`python scripts/doc_sync_check.py` prints the roll call.
+
+| Type | Rule |
+|------|------|
+| **LIVING** | Must always match the code. Any drift is a bug, same severity as a failing test. |
+| **PLAN** | Has a lifecycle (below). Never silently edited after execution starts — plans are promises, and history must stay honest. |
+| **LOG** | Append-only. Never rewritten, so never stale by definition. |
+| **REFERENCE** | Updated only when the decision itself changes; superseded ones get a banner pointing to the successor, content stays. |
 
 ### Every doc carries its type on line 2 (machine + human readable)
 
@@ -65,15 +68,12 @@ DRAFT ──► ACTIVE ──► IMPLEMENTED ──► ARCHIVED
 
   "Never deleted" was amended by the owner on 2026-08-25. Scaffolding whose
   output has merged — step plans, prompt batches — may be deleted, because git
-  history holds the content and `IMPLEMENTATION_LOG.md` holds the narrative.
-  Five scaffolding docs went that day, alongside four superseded audit
-  records — nine files, 3,123 lines in total.
+  history holds the content.
 
-  What may NOT be deleted is anything still cited: `CurrentStatus.md` is
-  hardcoded in `merge_cage.py`, and the two `*_progress.md` logs are cited from
-  backend test docstrings. Before deleting any doc, grep the repo for its
-  filename and repoint every hit to a `git show <sha>:<path>` reference first —
-  a deletion that leaves dangling citations costs more than it saves.
+  What may NOT be deleted is anything still cited. Before deleting any doc,
+  grep the repo for its filename and repoint every hit to a
+  `git show <sha>:<path>` reference first — a deletion that leaves dangling
+  citations costs more than it saves.
 - A plan that was abandoned or replaced gets a `> **SUPERSEDED by <doc>**` banner.
 - A plan not yet built stays where it is — it is the backlog.
 
@@ -135,16 +135,15 @@ report, but never edits them — memory hygiene is the session's own job.
 | Docs-as-code: in repo, PR-reviewed, versioned | Already true — keep it |
 | Dedicated technical writers | Loop 3 tooling is the writer; you are the editor who merges |
 | Freshness SLAs + staleness dashboards | Tier-1 PR gate + `DOC-HEALTH.md` scorecard |
-| ADRs (architecture decision records) | `docs/product/plans/batch-2-decisions.md` pattern — keep appending |
+| ADRs (architecture decision records) | `docs/decisions/` — keep appending |
 | Archive-over-delete retention | An archive location under `docs/` + stamps (none exists today — see §2). Nothing deleted EXCEPT merged scaffolding, per the 2026-08-25 amendment in §2 |
 | Doc impact required in code review | Rule 5 above |
 
 ## 6. Outputs this framework maintains
 
 - `docs/harness/maintenance/DOC-HEALTH.md` — **written by the first Tier-3 audit; absent
-  until one runs**, so an unresolved link here is expected, not rot. This is the
-  destination `.claude/skills/doc-audit/SKILL.md:89` writes to. Scorecard from each audit:
-  docs checked, drifts fixed, plans archived, gaps parked, modules undocumented.
+  until one runs**, so an unresolved link here is expected, not rot. Its contents
+  are specified in `.claude/skills/doc-audit/SKILL.md` ("Health report + one PR").
 - `docs/harness/maintenance/PARKED.md` — the "code is behind the doc" list: intentions
   found in docs that are not yet implemented, each with source doc + date.
 - Archived plans, when this framework is active again, live under `docs/`

--- a/docs/product/DEPLOY.md
+++ b/docs/product/DEPLOY.md
@@ -5,7 +5,7 @@
 
 **Railway is GitHub-linked to `Ranjith36963/job360`, branch `main`. Every merge ships to real users.** There is no manual deploy step and no staging gate. Merging is a release — never merge "to tidy up".
 
-Live at **job360.uk**. Five services: `backend`, `frontend`, `worker`, `Postgres`, `Redis`.
+Live at **job360.uk**. `railway status` lists the services that actually exist.
 
 ### How to check what is actually deployed
 
@@ -23,28 +23,18 @@ The manual `railway up` recipe further down still works, but it is the fallback 
 
 ---
 
-> **Status: ✅ LIVE since 2026-07-02.** Railway Hobby active. Project `job360`, 5 services all Online.
+> **Status: ✅ LIVE since 2026-07-02.** Railway Hobby active, project `job360`.
 > - **Custom domain:** https://job360.uk
-> - **Frontend:** https://frontend-production-c608f.up.railway.app
-> - **Backend API:** https://backend-production-80e8e.up.railway.app
-> - Verified live: `/readyz` → `{db:ok, redis:ok}`, security headers, full register→login→/me auth flow.
-> - Worker running 10 ARQ functions + 2 crons. Managed Postgres + Redis attached.
 
-## 🟢 What's already done (no action needed)
-- Backend + frontend **Dockerfiles**, **`docker-compose.prod.yml`** (5 services) — validated.
-- App runs on **Postgres**. (Test count deliberately not quoted here — measure it:
-  `cd backend && python -m pytest --collect-only -q | tail -1`. The
-  merge-gate floor lives in one place, `CONTRIBUTING.md`, and only there.)
-- **`/health`, `/livez`, `/readyz`** + **env validation at boot** (fail-fast on missing prod secrets).
-- **DB backup script** (`backend/scripts/backup_db.py`).
-- All prod env values staged in the local `.env` (LLM keys, `SESSION_SECRET`, `CHANNEL_ENCRYPTION_KEY`, `SENTRY_DSN`, `NEXT_PUBLIC_POSTHOG_KEY`).
+Which env vars prod needs is the table in `ARCHITECTURE.md`; nightly backups are
+`.github/workflows/db-backup.yml` and restoring them is `RUNBOOK-backups.md`.
 
 ## First-time provisioning (HISTORICAL — already done 2026-07-02)
 
-> These commands **created** the project, databases and services. They are kept as a
-> record of how prod was built, and as the recipe if it ever has to be rebuilt from
-> scratch. **They are NOT how you deploy a code change** — merging to `main` does
-> that automatically (see the banner at the top).
+> These commands **created** the project, databases and services as they stood on
+> 2026-07-02, `worker` and `Redis` included; both were deleted 2026-09-02, so this
+> is a record, not a rebuild recipe. **They are NOT how you deploy a code change** —
+> merging to `main` does that automatically (see the banner at the top).
 
 ```bash
 # From repo root, logged in as rahulranjith369@gmail.com
@@ -74,6 +64,7 @@ railway domain --service frontend    # → public site URL
 ```
 
 ## Verify after deploy
-- `curl https://<backend-url>/livez` → 200; `/readyz` → `{db:ok, redis:ok}`
+- `curl https://<backend-url>/livez` → 200; `/readyz` → 200 (what it checks, and what
+  each check answers when a dependency is absent, is `api/routes/health.readyz`).
 - Register + upload CV on the live frontend; confirm a row in the managed Postgres.
 - Sentry receives a test error; PostHog receives a pageview.

--- a/docs/product/RUNBOOK-backups.md
+++ b/docs/product/RUNBOOK-backups.md
@@ -64,5 +64,5 @@ rm -f "job360-${TS}.sql.gz.gpg"
 - **Restore into a fresh DB first**, verify, then repoint the app — never blind-restore over live prod.
 - The dump is `--no-owner --no-privileges`, so it restores cleanly into a DB with a different role/owner than prod.
 - The pg client must be **≥ the prod server major version** (prod Postgres is 18.x — use psql 18).
-- **Retention is ~30 newest** (nightly ⇒ ~30 days). If you need older, it's already gone — there is no long-term archive. (Gap flagged in `docs/harness/fable/04-OPS-AND-RELIABILITY.md`: consider a second region + a monthly cold copy.)
+- **Retention is ~30 newest** (nightly ⇒ ~30 days). If you need older, it's already gone — there is no long-term archive, no second region and no cold copy.
 - **Do a restore drill quarterly** into a scratch DB so this procedure stays true and you stay practiced.

--- a/docs/product/VISION.md
+++ b/docs/product/VISION.md
@@ -157,7 +157,7 @@ consent-first; everything free; no auto-submit at volume; global from day one.
 | 21 | "Review before submit" | **Side-by-side diff + one Keep button**, web only. Agents already hold both texts. |
 | 22 | What first | **Email evidence (#513)**, then visa (#514), CV diff (#515), flag-for-next-time (#516). |
 | 23 | WhatsApp | **Wait for a paying signal.** If ever: inbound-only Twilio webhook first, no worker. |
-| 24 | ChatGPT / Grok connectors | **Proved live in prod by a session in a real browser**, findings in `docs/operations/`. Never assumed from the OAuth code. |
+| 24 | ChatGPT / Grok connectors | **Proved live in prod by a session in a real browser.** Never assumed from the OAuth code. |
 | 25 | The eight pre-pivot `wiring/*` draft PRs | **Closed** (#447–#454). They targeted the deleted notification stack. |
 
 ## Older docs this supersedes

--- a/docs/product/product_design_rules.md
+++ b/docs/product/product_design_rules.md
@@ -24,19 +24,15 @@ does not punish jobs for missing a salary the user never stated. It matches
 on the title alone. Job360 behaves the same for salary range, preferred
 locations, remote/hybrid/office, experience level, and about_me.
 
-**What this means in code:**
+**What this means in code.** Every layer that consumed a preference — the dim
+scorers, the prefilter, the LLM judge, the embeddings — was deleted with the
+sourcing era (`backend/tests/test_sourcing_era_deleted.py::test_modules_gone`).
+What survives the rule is the input side: preference inputs are **optional and
+say so**, nothing blocks on an unfilled one, and no default is silently written
+(a written default is indistinguishable from a choice). Extraction obeys the
+mirror rule — extract everything offered, invent nothing.
 
-| Layer | Compliant behaviour |
-|---|---|
-| Dim scorers (`scoring_dimensions.py`) | Empty user side → a **constant** for every job (neutral half-weight or 0). A constant cannot change ranking order — that is what "silent" means. Never a per-job penalty for a preference that was never stated. |
-| Prefilter (`prefilter.py`) | Empty `preferred_locations` / `work_arrangement` / `experience_level` → the stage **passes everything**. A filter you didn't fill is a filter that doesn't exist. |
-| LLM judge (`llm_matcher.profile_to_matcher_text`) | Empty prefs are **not mentioned** in the prompt at all — the judge cannot penalise what it never sees. |
-| Embeddings (`embeddings.py`) | Empty fields contribute no text. |
-| Frontend | Preference inputs are **optional and say so**. Never block a search on unfilled preferences; never silently write a default value the user didn't choose (a written default is indistinguishable from a choice — see the contradiction below). |
-| Extraction (Pillar 1) | The mirror rule: extract everything offered, invent nothing. An input the user didn't provide (no LinkedIn, no GitHub) produces empty fields, not guesses. |
-
-**Audited 2026-08-07:** prefilter, judge, embeddings, and all four dim scorers
-comply. One contradiction found and reported:
+One contradiction found on the 2026-08-07 audit and still open:
 
 - **`needs_visa: bool` cannot say "unset".** `False` conflates "I don't need
   sponsorship" with "I never answered". Every other preference has an empty
@@ -45,18 +41,14 @@ comply. One contradiction found and reported:
   answered. Schema fix (`Optional[bool]`, default `None`) awaiting owner
   decision.
 
-**The exception this doc used to carve out is GONE (2026-08-12).** The legacy
-scorer's foreign-location penalty (−15) was deleted along with the hand-typed
-`FOREIGN_INDICATORS` list behind it — Rule 2 says UK-only is a door, and a
-second, rotting copy of that decision in the scorer is not a backstop. Measured
-on the live catalog the day it was removed: 379 of 9,196 rows were paying the
-−15, and 9 of them were UK jobs docked by accident ("Belfast, Northern
-Ireland" matched "ireland"). If a foreign job is found scoring well, that is a
-gate bug to fix, never a penalty to reinstate.
+**The lesson the 2026-08-12 deletion paid for.** A second, hand-typed copy of a
+decision (the scorer's own foreign-location penalty, beside Rule 2's gate) is
+not a backstop — it is a thing that rots separately. Measured the day it went:
+379 of 9,196 rows were paying that penalty and 9 of them were UK jobs docked by
+accident ("Belfast, Northern Ireland" matched "ireland").
 
-**The test for new code:** take any scoring/filter change, empty ONE user
-field, and re-rank. If any job's position changes *relative to another job*
-because of the emptiness alone, the rule is broken.
+**The test for new code:** empty ONE user field. If what the user is shown
+changes *because of the emptiness alone*, the rule is broken.
 
 ---
 
@@ -66,26 +58,19 @@ because of the emptiness alone, the rule is broken.
 country, that is a product fault. How can we solve it rather than penalty?"*
 
 **The rule.** Job360 is a UK-market product. A job the user cannot take
-because it is in another country is a **catalog defect**, not a low-ranking
-job. It is refused at ingestion; it never reaches storage, a feed, an
-enrichment budget, an embedding, or a candidate-shelf slot.
+because it is in another country is a **defect**, not a low-ranking job — it is
+refused, never admitted-then-demoted.
 
-**Why not the penalty.** The legacy scorer applied −15 for a foreign location
-(deleted 2026-08-12). That admits the job and then argues about its rank — so it still consumes
-every downstream budget and can still surface when the other dimensions score
-well. Measured 2026-08-07: 156 clearly foreign jobs were live in prod
-(Shanghai, São Paulo, Lima, Ottawa, München) despite the penalty existing.
+**Why not the penalty.** A penalty admits the job and then argues about its
+rank, so it still consumes every downstream budget and can still surface when
+the other dimensions score well. Measured 2026-08-07: 156 clearly foreign jobs
+were live in prod (Shanghai, São Paulo, Lima, Ottawa, München) despite the
+penalty existing.
 
-**How the gate decides** (`src/services/uk_gate.py`, one chokepoint in
-`main.py` — never per-source). Order is load-bearing:
-
-1. A named foreign **country or admin division** → **blocked**, whoever listed it.
-2. Remote fenced to another region ("Remote — US only") → **blocked**.
-3. An explicit UK country name or a **full UK postcode** → allowed.
-4. A hit in the **UK gazetteer** (~52k places) → allowed.
-5. Genuine remote → allowed.
-6. Otherwise **who said it decides**: a UK-native source keeps it; a global
-   source needs evidence (£, right-to-work language, a UK city in the body).
+**The gate that enforced this is gone** — it was an ingestion chokepoint on a
+catalog we no longer build (rule 4), deleted with the sourcing era
+(`backend/tests/test_sourcing_era_deleted.py::test_modules_gone`). What is kept
+below is the design lesson it paid for, which applies to any future list.
 
 ### THE RULE THIS ENCODES: never hand-enumerate an UNBOUNDED set
 
@@ -95,9 +80,9 @@ this list? Then you missed that."* He is right — foreign cities are unbounded,
 so a hand-written **sample** of them rots silently and misses forever.
 
 So the polarity is inverted. **UK places are FINITE** (~52k populated places,
-published; settlements do not churn), compiled from GeoNames by
-`scripts/build_uk_gazetteer.py` into `src/data/uk_gazetteer/`. Every future miss is
-a data refresh, never a code edit.
+published; settlements do not churn), so the list was compiled from GeoNames at
+build time rather than typed. Every future miss is a data refresh, never a code
+edit.
 
 **The distinction that matters:** countries (~250) and first-level admin
 divisions (~4.5k — US states, Canadian provinces) stay enumerated *on purpose*,
@@ -109,61 +94,20 @@ fatal hole — `"Cambridge (USA)"` contains "cambridge", a real UK town, so a
 pure gazetteer lookup would **admit** it. The country override runs first.
 
 **Ambiguity is COMPUTED, not typed.** Boston, Cambridge and Perth name real
-places here and abroad. `ambiguous.txt` is derived at build time by comparing
-UK populations against **world cities *and* the closed country / first-level
-admin-division sets** — London survives (London, Ontario is ~4% the size);
-Boston does not. Hand-listing collisions would repeat the original sin.
-
-The country/admin1 half was added for issue #330 (2026-08-19) and it is the
-whole reason the escape below finally holds. The first version compared against
-`cities500` alone — world *city* primary names — and the UK has hamlets called
-New York (pop 0), California (830) and Canada (0). None of those three is a
-cities500 primary name (GeoNames calls NYC "New York City"; California is a US
-state; Canada is a country), so all three scored as *trusted, unambiguous* UK
-places and carried 153 of the 190 live foreign rows straight through the
-dual-site escape. Countries and admin1 divisions were already downloaded and
-already closed sets, so they now feed the same computation at a flat weight —
-`FOREIGN_ADMIN_WEIGHT = 20_000` (`backend/scripts/build_uk_gazetteer.py:95,181-186`).
-The weight is measured, not chosen by taste: the 84 UK names colliding with a
-foreign country or admin1 have exactly one population gap, between Warwick
-(37,267) and Portsmouth (47,350), so a 40,000-effective cut-off keeps
-Manchester, Southampton and Canterbury while dropping the hamlets. **Those
-figures are a dated measurement, not something you can re-derive from this
-repo:** they were taken on 2026-08-19 and are recorded in the builder's own
-comment (`backend/scripts/build_uk_gazetteer.py:90-95`); the GeoNames snapshot
-they came from is fetched at build time and never checked in, so `--check`
-validates file counts and canaries, not these populations. Treat them as the
-recorded basis for the threshold, and re-measure rather than re-cite if the
-gazetteer is ever rebuilt against newer GeoNames data. No branch
-was added to `check_uk` and no city was typed — the fix is DATA, which is the
-rule. Still admitted on purpose: `"London, Ontario"` — a big UK city beside a
-foreign region is how both a foreign address and a genuine two-site ad get
-written, and `london` never enters `ambiguous.txt`, so the escape still speaks
-for it (`backend/src/services/uk_gate.py:367-382`; root `CLAUDE.md:57` rule #30
-records this as the remaining gap). **No test pins that exact input** —
-`backend/tests/test_uk_gate.py:161` asserts only bare `check_uk("London", …)`,
-and `backend/tests/test_scorer.py:673-679` names "London, Ontario" expressly to say it is
-*not* asserted there. The behaviour above is read off the gate logic and the
-shipped gazetteer data (`ontario` in `foreign_admin.txt`, absent from
-`uk_places.txt`; `london` in neither ambiguity list), so treat it as
-documented-and-unguarded until a test claims it.
-
-**Traps found by dry-running over the live catalog** (do this before shipping
-any location rule):
-- The naive "no UK token → reject" blocked **48%**, including Telford and
-  Northampton — `UK_TERMS` only held 26 cities.
-- **devitjobs** was misclassified as global; its endpoint is devitjobs.**uk**.
-  That alone was 1,409 wrongly blocked jobs.
-- `"Sydney, Australia"` was **allowed**: the UK has a hamlet called Sydney, so
-  a bare gazetteer hit triggered the dual-site escape. Dual-site now demands an
-  *unambiguous* UK signal.
-- `"Indianapolis, IN, USA"` was not blocked — the country data holds "United
-  States", not "USA"/"US". ISO2 + ISO3 codes are now included.
-
-Measured after: 799 blocked of 4,544 (18%), **2 potential false drops**.
+places here and abroad. The collision list was derived at build time by
+comparing UK populations against world cities *and* the closed country /
+admin-division sets — London survives (London, Ontario is ~4% the size); Boston
+does not. Hand-listing collisions would repeat the original sin.
 
 **Ambiguity favours the user:** a dual-site posting ("London / New York") is
 kept — the user can take the UK half.
+
+**Dry-run any location rule over real data before shipping it.** Every trap
+this rule cost was found that way and none of them by reading the code: a naive
+"no UK token → reject" blocked 48% of the catalog; a UK-native source was
+misclassified as global on its own domain; "Sydney, Australia" was admitted
+because the UK has a hamlet called Sydney; "Indianapolis, IN, USA" survived
+because the country data spelled it "United States".
 
 ---
 
@@ -178,7 +122,7 @@ do not. Turning visa ON must never shrink the catalog:
 | Toggle | Behaviour |
 |---|---|
 | **OFF** | every job shows; visa affects nothing |
-| **ON** | every job *still* shows — but sponsors are **guaranteed into the feed**, **ranked up**, and every card carries a badge |
+| **ON** | every job *still* shows — sponsorship is emphasised, never used to hide a job |
 
 **Why never a hard filter.** Visa status is a three-state fact —
 **sponsors / no sponsorship / unknown** — and *unknown dominates*. Measured
@@ -190,19 +134,19 @@ failed to detect. The badge gives the user the fact without the deletion.
 **Three states, never a boolean.** `jobs.visa_flag` is a bool, so "this ad says
 it will not sponsor" and "this ad never mentions visas" are the same value.
 Those are opposite facts for a candidate: a dead end versus a question worth
-asking. Use `services/visa_signal.detect_visa_status()`.
+asking. The detector that gave the third state was deleted with the sourcing era
+(`backend/tests/test_sourcing_era_deleted.py::test_modules_gone`); the agent now
+supplies the signal on `bring_job` (VISION decision 20) and the column keeps its
+old two-state shape until it is replaced.
 
-**Precedence is load-bearing:** "we cannot offer visa sponsorship" *contains*
-"visa sponsorship", so refusal must be tested before offer. And a signal that
-fires on the wrong sentence is worse than no signal — `tier 2` was removed
-from the pattern after it matched "Tier 1 and Tier 2 support representatives".
+**If a detector is ever written again, precedence is load-bearing:** "we cannot
+offer visa sponsorship" *contains* "visa sponsorship", so refusal must be tested
+before offer. A signal that fires on the wrong sentence is worse than no signal
+— `tier 2` had to leave the pattern after it matched "Tier 1 and Tier 2 support
+representatives".
 
-**Detection is deterministic first, LLM second.** The phrases are formulaic UK
-recruitment boilerplate. Reading stored text took visa coverage from **3% to
-42% (14×) at zero LLM cost**; enrichment's verdict still wins where it exists.
-
-**This is Rule 1 applied to a filter:** what the user turns on *sharpens the
-ranking*; it never silently deletes the catalog.
+**This is Rule 1 applied to a filter:** what the user turns on *sharpens* what
+they see; it never silently deletes it.
 
 ---
 
@@ -214,12 +158,12 @@ ranking*; it never silently deletes the catalog.
 it — a pasted ad, a link, or an MCP call. There is no feed, no ranking, no
 "jobs for you". Job boards and the user's own AI agent find jobs; we do not.
 
-**What this means in code:** the search pipeline, the 41 sources and the batch
-scorer/judge/enrichment are hidden behind a flag (off) and will be deleted
-(VISION.md build order, step 5). Rules 1–3 above still govern the one place
-matching-like logic survives: the *fit context* we hand the agent for a job
-the user brought. An empty preference is still silent; UK/visa are still
-spotlights, never walls — applied to one job, not to a catalog.
+**What this means in code:** the search pipeline, its sources and the batch
+scorer/judge/enrichment were deleted in slice 5 (#483), and
+`backend/tests/test_sourcing_era_deleted.py` keeps them deleted. Rules 1–3 above
+survive as principles, not as code: they govern the *fit context* we hand the
+agent for a job the user brought — an empty preference is still silent, UK and
+visa are still spotlights and never walls, applied to one job, not a catalog.
 
 ---
 

--- a/docs/product/troubleshooting.md
+++ b/docs/product/troubleshooting.md
@@ -3,7 +3,7 @@
 
 Common **developer-environment** issues and fixes (ports, locks, env-var gotchas, install hiccups). Each entry: **Symptom → Cause → Fix**.
 
-> **For production issues** read prod directly — Sentry, `railway logs`, the Postgres service — as root `CLAUDE.md` describes. The sourcing-era runbook and glossary were archived FROZEN in `docs/_archive/sourcing-era/` (slice 5, #483); their SQL targets tables that no longer exist.
+> **For production issues** read prod directly — Sentry, `railway logs`, the Postgres service — as root `CLAUDE.md` describes. The sourcing-era runbook and glossary were deleted, not archived (`backend/tests/test_sourcing_era_deleted.py::test_archive_deleted`); git history is the only copy.
 
 ---
 
@@ -44,14 +44,11 @@ one test writes to schema A while another reads schema B.
 **Fix:**
 
 ```bash
-# From the repo root. `make redis-up` starts the redis service ONLY
-# (Makefile:238 → `docker compose ... up -d redis`), so it does NOT fix this
-# symptom — postgres is a separate service in docker-compose.dev.yml:37.
-# `--wait` is load-bearing: plain `up -d` returns as soon as the container is
-# RUNNING, so pytest can start before postgres accepts connections and you get
-# this exact symptom back. `--wait` blocks on the pg_isready healthcheck at
-# docker-compose.dev.yml:50-54.
-docker compose -f docker-compose.dev.yml up -d --wait   # both: postgres + redis
+# From the repo root. `--wait` is load-bearing: plain `up -d` returns as soon as
+# the container is RUNNING, so pytest can start before postgres accepts
+# connections and you get this exact symptom back. `--wait` blocks on the
+# pg_isready healthcheck the compose file declares.
+docker compose -f docker-compose.dev.yml up -d --wait postgres
 cd backend && python -m pytest -q -p no:randomly
 ```
 
@@ -98,29 +95,13 @@ Look for `[llm_provider]` lines — they log which provider was tried and why ea
 
 ---
 
-## 4. Redis missing on Windows
+## 4. `Redis unreachable` in the logs
 
-**Symptom:** `ConnectionRefusedError: [WinError 10061]` or `check_worker.py` reports `tcp localhost:6379 unreachable`.
+**Symptom:** `ConnectionRefusedError` against `localhost:6379`, or a Redis warning at boot.
 
-**Cause:** Redis has no native Windows build. The ARQ worker needs a Redis instance.
-
-**Fix — pick one:**
-
-- **A. WSL2 + Ubuntu** (recommended for dev)
-  ```bash
-  wsl --install -d Ubuntu
-  # inside WSL:
-  sudo apt-get install redis-server && sudo service redis-server start
-  ```
-
-- **B. Docker Desktop**
-  ```bash
-  docker run -d -p 6379:6379 --name redis redis:7-alpine
-  ```
-
-- **C. Memurai** (Redis-compatible native Windows fork) — https://www.memurai.com/
-
-- **D. Skip the worker.** The CLI (`python -m src.cli run`), the read-only API, the frontend, and the full test suite all work without ARQ / Redis. Only the live notification dispatcher needs it.
+**Cause:** Nothing. The `worker` and `Redis` services were deleted 2026-09-02 and
+no background work is left; the auth rate limiter falls back to an in-process
+window when Redis is absent. Do not install Redis to silence it.
 
 ---
 


### PR DESCRIPTION
Scout pass over the 40 LIVING docs for the drift `scripts/doc_sync_check.py` cannot see. Both guards were green before this PR and are green after; nothing here duplicates them.

**LIVING surface: 3,860 lines before → 3,768 after (−92).**

`docs: updated ARCHITECTURE.md, docs/product/*, docs/harness/maintenance/DOC-MAINTENANCE.md, .claude/skills/*` (+ one new test file)

## Findings

| # | File | Doc said | Code says | Closed by |
|---|---|---|---|---|
| 1 | `.claude/skills/verify-job360/SKILL.md` + `CHECKLIST.md` | Minting a token is "gated on a verified email" — `POST /api/tokens` returns **403 `email_not_verified`**, so `UPDATE users SET email_verified_at = now()` first. `CHECKLIST.md` item 4 said the *opposite*: "not enforced". | `src/api/routes/tokens.py` depends on `require_session_user` only; its own docstring says "every route here uses `require_session_user`". An unverified user gets **201**. The gate holds the routes that spend an LLM call. | **TEST** — `backend/tests/test_token_mint_is_session_only.py` (3 tests); both docs now cite it |
| 2 | `ARCHITECTURE.md` | "**Auto-purge:** `purge_old_jobs(days=30)` deletes jobs by liveness … `DELETE FROM jobs WHERE …` (`repositories/database.py:688,723`)" | No `purge_old_jobs` anywhere in `backend/src/`, and no scheduler left to call it. Nothing deletes a `jobs` row on age. | **DELETE** |
| 3 | `ARCHITECTURE.md` | "**Seen-check** — `is_job_seen()` queries by these columns" | No such symbol. `bring.py` looks the key up via `get_job_id_by_key`. | **POINTER + TEST** — cites `test_bring_a_job.py::test_bring_twice_lands_on_same_row` |
| 4 | `.claude/skills/hard-rules/SKILL.md` | Rule 10: "Per-user state lives in `user_feed`, …" · and "**two** of those rules moved up into the index below: … and the digest notification path" | `user_feed` was dropped in `0040_drop_notification_tables.up.sql`. No digest rule is in the 14-rule index. | **DELETE** (rule count untouched — the `hard-rule-count` guard still matches) |
| 5 | `docs/product/product_design_rules.md` | Rules 1–3 restate `scoring_dimensions.py`, `prefilter.py`, `llm_matcher.profile_to_matcher_text`, `embeddings.py`, `services/visa_signal.detect_visa_status()`, `src/services/uk_gate.py`, `scripts/build_uk_gazetteer.py`, `src/data/uk_gazetteer/`, `foreign_admin.txt`, `ambiguous.txt` — plus six raw line citations into files that no longer exist. Rule 4 said the pipeline "**is** hidden behind a flag (off) and **will be** deleted". | Every one of those modules is asserted gone by `tests/test_sourcing_era_deleted.py::test_modules_gone`; slice 5 (#483) shipped 2026-09-05. | **DELETE** — every owner rule, quote and design lesson kept; the implementation prose deleted. −112 lines, the largest single win |
| 6 | `docs/product/DEPLOY.md` | "Five services: `backend`, `frontend`, `worker`, `Postgres`, `Redis`" · "5 services all Online" · "Worker running 10 ARQ functions + 2 crons" · `docker-compose.prod.yml` "(5 services)" · "DB backup script (`backend/scripts/backup_db.py`)" · `/readyz` → `{db:ok, redis:ok}` | Three services since 2026-09-02. `docker-compose.prod.yml` declares 4. No `backend/scripts/backup_db.py` — backups are `.github/workflows/db-backup.yml`. `health.readyz` sets `redis: "skipped"` when `REDIS_URL` is unset, which is prod. | **DELETE / POINTER** |
| 7 | `docs/product/troubleshooting.md` | §4 — 20 lines telling a dev to install Redis (WSL, Docker, Memurai) for the ARQ worker, and "**D. Skip the worker.** The CLI (`python -m src.cli run`) …" · §2 — "`make redis-up` … (`Makefile:238`) … `docker-compose.dev.yml:37` … `:50-54`" · §0 — "archived FROZEN in `docs/_archive/sourcing-era/`" | Worker + Redis deleted 2026-09-02. `src/cli.py`'s docstring: slice 5 deleted `run`. The `Makefile` is **50 lines** and has no redis target. `test_sourcing_era_deleted.py::test_archive_deleted` asserts `docs/_archive/` must not exist. | **DELETE** |
| 8 | `.claude/skills/sync/SKILL.md` | "read it from the `LIVING_DOCS` constant … which is **the only authority** and has grown from 6 files to **15** (it now covers … every file in `docs/product/pillars/`)" · scan `backend/src/services/notifications/` | `LIVING_DOCS` holds **10**; the `<!-- doc: LIVING -->` stamp is the authority (40 docs, via `living_stamped_docs`). `docs/product/pillars/` and `services/notifications/` are both gone. | **DELETE + POINTER** to `doc_sync_check.py::living_stamped_docs` |
| 9 | `docs/harness/maintenance/DOC-MAINTENANCE.md` | `IMPLEMENTATION_LOG.md`, `JOURNAL.md`, `docs/product/plans/batch-2-decisions.md`, `CurrentStatus.md` and "the two `*_progress.md` logs" all cited as live · "the destination `.claude/skills/doc-audit/SKILL.md:89` writes to" | None of those five files exist; ADRs live in `docs/decisions/`. The `DOC-HEALTH.md` write instruction had drifted from line 89 to line 94 — a line citation that had already rotted. | **DELETE / POINTER** |
| 10 | `docs/product/RUNBOOK-backups.md`, `docs/product/VISION.md` | `docs/harness/fable/04-OPS-AND-RELIABILITY.md`; "findings in `docs/operations/`" | Neither path exists (`docs/harness/` holds only `maintenance/`). | **DELETE** |

Nothing was re-worded to be accurate. Where a claim had to survive, it became a pointer by symbol name or a test name — never a line number.

## Checked and found TRUE (recorded so the next run skips them)

- `RUNBOOK-backups.md` §1's backup contract — read against `db-backup.yml`: `pg_dump --no-owner --no-privileges`, gates are exactly `test "$USERS" -ge 1` and `test "$MIG" -ge 20`, `JOBS` echoed but never asserted, `~30` retention via `head -n -30`. Accurate line for line.
- `troubleshooting.md` §9 — the `migrations.runner down 0010` trap (argv[2] is a db_path, so `down` reverts the latest) still reads correctly.
- `product_design_rules.md` Rule 1's open contradiction — `needs_visa: bool = False` still cannot say "unset" (`services/profile/models.py`). Left as-is: it is a live finding, not drift.
- Remaining "dead" paths in LIVING docs are all correct: `backend/data/`, `frontend/.env.local`, `frontend/node_modules/next/dist/docs` (gitignored), `DOC-HEALTH.md` (a pending output), `docs/_archive` / `docs/archive` / `docs/product/pillars` (named expressly as deleted), `docs/sync-auto` (a branch name).

## Proposed follow-ups for the guards (not added here — that script should stop growing)

Both are one-line changes to existing functions, no new parser:

1. **`dead_path_claims()` iterates `LIVING_DOCS` (10 docs), not `living_stamped_docs()` (40).** That is why findings 8, 9 and 10 survived — `docs/product/pillars` sat inside backticks in a skill file the guard never opened. Swapping the loop source catches this whole class. Worth measuring for README-style false alarms first; the existing `factual_docs` README filter may need to widen.
2. **`test_sourcing_era_deleted.py::test_live_docs_clean` hardcodes 8 doc paths.** `docs/product/product_design_rules.md` — 112 lines of deleted-module prose — is not one of them. Same fix: read the stamp.

## Verification

- `python scripts/doc_sync_check.py` → **No drift**, 40 docs / 3,768 lines (`ARCHITECTURE.md`'s `test-files` count bumped 135 → 136 for the new test file — the countable guard catching my own diff)
- `python scripts/doc_sync_mutation_test.py` → **All 10 guards proven able to go RED**
- `cd backend && python -m pytest -q -p no:randomly` → **1746 passed, 1 skipped**
- The new test was mutation-checked: swapping `require_session_user` for `require_verified_user` in `tokens.py` turns 2 of its 3 tests red.
- `python -m ruff check` clean on the new file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019mcERn91W2sj2ex5jZz3rD


---
_Generated by [Claude Code](https://claude.ai/code/session_019mcERn91W2sj2ex5jZz3rD)_