### PR TITLE
chore(harness): branch-reaper runs on every merge to main, never weekly (slice 2)

### DIFF
--- a/.github/workflows/branch-reaper.yml
+++ b/.github/workflows/branch-reaper.yml
@@ -19,10 +19,17 @@
 name: branch-reaper
 
 on:
-  schedule:
-    # Weekly. Branch sprawl accrues over weeks, not hours, and a daily job here
-    # would spend its life printing "nothing to do".
-    - cron: "0 4 * * 1"
+  push:
+    # After EVERY merge to main, not weekly (owner decision, harness
+    # simplification slice 2, 2026-09-10): "a branch dies when it merges".
+    # The repo has delete_branch_on_merge on, so GitHub removes the PR's own
+    # branch at merge time; this run is the backstop for the ones that slip
+    # (merged before the setting existed, or re-pushed after the merge). A
+    # merge is the only moment a new merged branch can appear, so this is
+    # the only moment worth looking. Zero grace: a shipped branch has nothing
+    # left to protect, and unshipped work is protected by the open-PR
+    # exclusion in scripts/worktree_reaper.py, not by a waiting period.
+    branches: [main]
   workflow_dispatch:
     inputs:
       dry_run:
@@ -31,7 +38,7 @@ on:
         default: true
       older_than_days:
         description: "Grace period after the merge before a branch may be deleted"
-        default: "14"
+        default: "0"
 
 permissions:
   contents: write        # needed to delete a ref
@@ -62,8 +69,8 @@ jobs:
       - name: Reap merged remote branches
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          APPLY: ${{ (github.event_name == 'schedule' || inputs.dry_run == false) && '--apply' || '' }}
-          DAYS: ${{ inputs.older_than_days || '14' }}
+          APPLY: ${{ (github.event_name == 'push' || inputs.dry_run == false) && '--apply' || '' }}
+          DAYS: ${{ inputs.older_than_days || '0' }}
         run: |
           python scripts/worktree_reaper.py --remote $APPLY \
             --older-than-days "$DAYS" --max 25
@@ -79,9 +86,10 @@ jobs:
       # pull request. GitHub keeps a merged PR and its head commits indefinitely,
       # reachable from the PR page, so `gh pr checkout <n>` restores the work.
       #
-      # Pushing the log anyway would mean a commit to `main` every week, and
-      # `main` auto-deploys to production. A weekly release to write down
-      # something GitHub already stores is a bad trade.
+      # Pushing the log anyway would mean a commit to `main` after every merge,
+      # and `main` auto-deploys to production. A release per merge to write
+      # down something GitHub already stores is a bad trade — and a push to
+      # main from here would re-trigger this very workflow.
       - name: Record what was reaped
         if: always()
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,9 +186,9 @@ jobs:
         run: python scripts/worktree_census.py --drill
 
       # The broom's ENTRANCE. Same reason this step sits next to the one above and
-      # not in branch-reaper.yml alone: that workflow runs weekly, so a break
-      # would sit undetected for up to seven days in the one component whose whole
-      # job is deleting things.
+      # not in branch-reaper.yml alone: that workflow runs only on merges to
+      # main, so a break would surface only AFTER a merge — too late for the one
+      # component whose whole job is deleting things. Here it fires on every PR.
       - name: The reaper still refuses, and still delegates
         run: python scripts/worktree_reaper.py --drill
 

--- a/scripts/watchdog_check.py
+++ b/scripts/watchdog_check.py
@@ -46,7 +46,6 @@ EXPECTED: dict[str, tuple[float, str]] = {
     "pr-shepherd.yml": (36, "daily 09:45"),
     "security.yml": (9 * 24, "weekly Mon 04:00"),
     "codeql.yml": (9 * 24, "weekly Mon 05:00"),
-    "branch-reaper.yml": (9 * 24, "weekly Mon 04:00"),
     "revert-main.yml": (32 * 24, "monthly, 1st 06:00"),
     # ci.yml is event-triggered only — silence is normal, so it is
     # deliberately NOT watched here. Watching it would produce a permanent
@@ -60,7 +59,12 @@ EXPECTED: dict[str, tuple[float, str]] = {
 # caused it, not by a nightly bot), so a quiet weekend with no PRs is normal
 # silence, not a stopped watcher. Watching it here would fire "STOPPED" every
 # quiet weekend — a permanent false alarm.
-NOT_SCHEDULED: set[str] = {"ci.yml", "pr-repair.yml", "triage.yml", "doc-sync.yml"}
+# branch-reaper.yml moved here 2026-09-10 (slice 2): it dropped its weekly
+# cron for a push-to-main trigger, so it runs exactly when a merge lands and
+# is silent otherwise. Its drill still fires on every PR via ci.yml.
+NOT_SCHEDULED: set[str] = {
+    "ci.yml", "pr-repair.yml", "triage.yml", "doc-sync.yml", "branch-reaper.yml",
+}
 
 
 def roster_drift(workflow_dir: str = ".github/workflows") -> list[str]:

--- a/scripts/worktree_reaper.py
+++ b/scripts/worktree_reaper.py
@@ -333,13 +333,21 @@ def stale_remote_branches(
     live_refs: set[str],
     now: float,
     older_than_days: float,
+    open_heads: frozenset[str] | set[str] = frozenset(),
 ) -> list[str]:
     """Which remote branches may be deleted. Pure — the drill needs no network.
 
     A branch qualifies only if a pull request for it MERGED, that merge is older
-    than the grace period, and the ref still exists. `gh pr list --state merged`
-    is the oracle because `git branch --merged` reports 1 here where GitHub
-    reports 343: the repo squash-merges, so a shipped tip is never an ancestor.
+    than the grace period, the ref still exists, AND no OPEN pull request uses
+    it. `gh pr list --state merged` is the oracle because `git branch --merged`
+    reports 1 here where GitHub reports 343: the repo squash-merges, so a
+    shipped tip is never an ancestor.
+
+    The open-PR exclusion exists because this runs on EVERY merge with no grace
+    period (2026-09-10): a branch that shipped once and was then re-used for a
+    follow-up PR has a merged PR in its history and an open one in its present.
+    Without the exclusion the reaper would delete unshipped work — the one thing
+    it must never do.
     """
     cutoff = now - older_than_days * 86400
     out: set[str] = set()
@@ -347,6 +355,8 @@ def stale_remote_branches(
         br = pr.get("headRefName") or ""
         if not br or br in PROTECTED_BRANCHES or br not in live_refs:
             continue
+        if br in open_heads:
+            continue  # shipped once, but unshipped work sits on it NOW
         try:
             ts = time.mktime(time.strptime(pr.get("mergedAt") or "", "%Y-%m-%dT%H:%M:%SZ"))
         except ValueError:
@@ -377,10 +387,26 @@ def reap_remote(repo_root: Path, apply: bool, older_than_days: float, cap: int) 
         print("gh returned zero merged PRs — refusing to trust that.")
         return 1
 
+    # The OPEN set is a refusal input: if it cannot be read, nothing is deleted.
+    # A failed query must never read as "no open PRs" — that would turn every
+    # re-used branch into a target.
+    open_out, rc = run(
+        ["gh", "pr", "list", "--state", "open", "--limit", "500", "--json", "headRefName"],
+        cwd=str(repo_root), timeout=60,
+    )
+    if rc != 0:
+        print("gh pr list --state open failed — doing nothing.")
+        return 1
+    try:
+        open_heads = {p.get("headRefName") or "" for p in json.loads(open_out or "[]")}
+    except ValueError:
+        print("could not parse open-PR output — doing nothing.")
+        return 1
+
     refs, _ = run(["git", "ls-remote", "--heads", "origin"], cwd=str(repo_root), timeout=60)
     live = {ln.split("refs/heads/", 1)[1] for ln in refs.splitlines() if "refs/heads/" in ln}
 
-    targets = stale_remote_branches(prs, live, time.time(), older_than_days)[:cap]
+    targets = stale_remote_branches(prs, live, time.time(), older_than_days, open_heads)[:cap]
     if not targets:
         print("No stale merged remote branches.")
         return 0
@@ -570,15 +596,24 @@ def _drill_remote() -> list[tuple[str, bool, str]]:
     now = time.time()
     old = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(now - 30 * 86400))
     fresh = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(now - 3600))
-    live = {"shipped-old", "shipped-fresh", "main", "still-open"}
+    live = {"shipped-old", "shipped-fresh", "main", "still-open", "shipped-then-reused"}
     prs = [
         {"headRefName": "shipped-old", "mergedAt": old},
         {"headRefName": "shipped-fresh", "mergedAt": fresh},
         {"headRefName": "main", "mergedAt": old},
         {"headRefName": "already-gone", "mergedAt": old},
         {"headRefName": "no-date", "mergedAt": None},
+        {"headRefName": "shipped-then-reused", "mergedAt": old},
     ]
-    got = stale_remote_branches(prs, live, now, older_than_days=14)
+    got = stale_remote_branches(prs, live, now, older_than_days=14,
+                                open_heads={"shipped-then-reused"})
+    # Zero grace is what the on-every-merge workflow runs with. It must still
+    # spare the re-used branch — that refusal is the open-PR set, not the clock.
+    got_now = stale_remote_branches(prs, live, now, older_than_days=0,
+                                    open_heads={"shipped-then-reused"})
+    # NEGATIVE CONTROL for the exclusion: drop the open set and the same branch
+    # MUST become a target, or the exclusion is a no-op that happens to pass.
+    got_unguarded = stale_remote_branches(prs, live, now, older_than_days=0)
     return [
         # NEGATIVE CONTROL first: a remote reaper that deletes nothing passes
         # every refusal below and is exactly as useless as no reaper at all.
@@ -587,6 +622,11 @@ def _drill_remote() -> list[tuple[str, bool, str]]:
         ("remote_never_touches_main", "main" not in got, f"got {got}"),
         ("remote_skips_already_deleted", "already-gone" not in got, f"got {got}"),
         ("remote_refuses_unparseable_date", "no-date" not in got, f"got {got}"),
+        ("remote_spares_branch_with_open_pr", "shipped-then-reused" not in got, f"got {got}"),
+        ("remote_zero_grace_still_spares_open_pr",
+         "shipped-then-reused" not in got_now and "shipped-fresh" in got_now, f"got {got_now}"),
+        ("remote_open_pr_guard_is_not_a_noop",
+         "shipped-then-reused" in got_unguarded, f"got {got_unguarded}"),
     ]
 
 


### PR DESCRIPTION
## Harness simplification — slice 2 of 8

**Branch cleanup now runs after every merge to `main`, not once a week.**

### What changed
- `.github/workflows/branch-reaper.yml`: trigger is `push` to `main` (was Monday cron). Grace period 0 days (was 14). `workflow_dispatch` keeps its dry-run default.
- `scripts/worktree_reaper.py`: `stale_remote_branches()` now refuses any branch that has an **open** PR, and `reap_remote()` reads that set from `gh` — refusing to act if the query fails. This is what makes zero grace safe: a branch that shipped once and was re-used for a follow-up PR is never deleted.
- Drill: 3 new cases (spares open-PR branch; still spares it at zero grace; negative control proving the exclusion is not a no-op). 25/25 pass.
- `scripts/watchdog_check.py`: branch-reaper moved to `NOT_SCHEDULED` — silence between merges is correct now. The reaper drill still fires on every PR via `ci.yml`.
- `ci.yml`: comment updated (no longer says "weekly").

### Census (2026-09-10, before this change)
- `delete_branch_on_merge` was already **on**, so GitHub deletes the PR's own branch at merge; this workflow is the backstop.
- 10 stale remote branches with no open PR: 7 never had a PR, 2 had closed-unmerged PRs → all untouched by design ("never touch unmerged"). 1 belongs to merged #498.
- Zero-grace dry run against the real repo: would delete exactly `feat/contacts-stats` (#498). Nothing else.

### Verified locally
- `python scripts/worktree_reaper.py --drill` → 25/25
- `python scripts/worktree_reaper.py --remote --older-than-days 0` (dry run) → 1 branch, the expected one
- ruff clean, both YAML files parse, watchdog roster drift = none, doc-sync = no drift

### Proof after merge
The push to `main` from this merge is itself the first live run. Expect it to delete `feat/contacts-stats` and nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011wAduRqokWdPEByUkcVbvc
