### PR TITLE
chore(harness): CI runs only the steps a diff needs - docs / frontend / full lanes (slice 3)

### DIFF
--- a/.github/workflows/ci-offline.yml
+++ b/.github/workflows/ci-offline.yml
@@ -33,9 +33,48 @@ permissions:
   contents: read
 
 jobs:
+
+  # ─── Scope: which steps does THIS diff need? ───────────────────────────────
+  # Harness simplification slice 3 (owner decision 2026-09-08). Measured on the
+  # last green run of main: the backend job spends 347s of 414s in pytest, and
+  # ci-offline.yml runs the same suite again. A one-component frontend PR waited
+  # seven minutes for tests it cannot affect.
+  #
+  # scripts/ci_scope.py answers `docs` / `frontend` / `full` from the changed
+  # files, most restrictive wins, unknown is full, empty is full, and anything
+  # that is not a pull_request (push to main, schedule, dispatch) is full
+  # without looking -- main is production.
+  #
+  # JOBS BELOW ARE NEVER SKIPPED, ONLY THEIR STEPS. The ruleset on main and
+  # scripts/merge_cage.py require checks BY NAME; a skipped job never reports
+  # and blocks the merge, a job whose steps were skipped reports success.
+  scope:
+    name: Scope (which checks this diff needs)
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    outputs:
+      scope: ${{ steps.decide.outputs.scope }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0   # the diff needs the base commit
+      # The classifier proves it can still go red BEFORE it is allowed to
+      # decide anything. A broken classifier fails this job, which fails every
+      # job that needs it, which is a red PR -- never a silently fast one.
+      - name: The scope classifier can still fail
+        run: python scripts/ci_scope.py --drill
+      - name: Decide
+        id: decide
+        env:
+          EVENT: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          scope=$(python scripts/ci_scope.py --event "$EVENT" --base "$BASE_SHA" --head HEAD --print-scope --summary)
+          echo "scope=$scope" >> "$GITHUB_OUTPUT"
   offline-suite:
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    needs: [scope]
     # The backend is Postgres-backed now (pg shim); tests need a DB + Redis.
     # Mirrors ci.yml's service setup — without it, tests hit the dev-default
     # :5433 and fail with "connection refused".
@@ -65,15 +104,19 @@ jobs:
       CHANNEL_ENCRYPTION_KEY: ci-test-channel-key-not-used-in-prod
     steps:
       - uses: actions/checkout@v7
+        if: needs.scope.outputs.scope == 'full'
       - uses: actions/setup-python@v7
+        if: needs.scope.outputs.scope == 'full'
         with:
           python-version: "3.12"
       - name: Install backend (with dev extras)
+        if: needs.scope.outputs.scope == 'full'
         working-directory: backend
         run: |
           python -m pip install --upgrade pip
           python -m pip install -e ".[dev]"
       - name: Run offline suite (full backend + automated Loop 2 E2E)
+        if: needs.scope.outputs.scope == 'full'
         working-directory: backend
         run: python -m pytest -q -p no:randomly
 
@@ -84,18 +127,24 @@ jobs:
     # is needed — Playwright's webServer starts `npm run dev` itself.
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    needs: [scope]
     steps:
       - uses: actions/checkout@v7
+        if: needs.scope.outputs.scope != 'docs'
       - uses: actions/setup-node@v7
+        if: needs.scope.outputs.scope != 'docs'
         with:
           node-version: "22"
       - name: Install frontend deps
+        if: needs.scope.outputs.scope != 'docs'
         working-directory: frontend
         run: npm ci
       - name: Install Playwright browser
+        if: needs.scope.outputs.scope != 'docs'
         working-directory: frontend
         run: npx playwright install --with-deps chromium
       - name: Run Playwright UI specs
+        if: needs.scope.outputs.scope != 'docs'
         working-directory: frontend
         # GATING (no continue-on-error): a real regression in the 24 passing specs
         # now fails CI. The 4 pre-existing failures (dashboard-sort x2, landing-cta
@@ -105,7 +154,7 @@ jobs:
         # auth-guard problem). Real browser coverage of prod lives in synthetic-live.yml.
         run: npx playwright test
       - name: Upload Playwright report (on failure)
-        if: failure()
+        if: failure() && needs.scope.outputs.scope != 'docs'
         uses: actions/upload-artifact@v7
         with:
           name: playwright-report
@@ -118,6 +167,7 @@ jobs:
     # scanning the whole suite.
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    needs: [scope]
     # Postgres-backed backend needs a DB + Redis (see offline-suite note above).
     services:
       postgres:
@@ -145,15 +195,19 @@ jobs:
       CHANNEL_ENCRYPTION_KEY: ci-test-channel-key-not-used-in-prod
     steps:
       - uses: actions/checkout@v7
+        if: needs.scope.outputs.scope == 'full'
       - uses: actions/setup-python@v7
+        if: needs.scope.outputs.scope == 'full'
         with:
           python-version: "3.12"
       - name: Install backend (with dev extras)
+        if: needs.scope.outputs.scope == 'full'
         working-directory: backend
         run: |
           python -m pip install --upgrade pip
           python -m pip install -e ".[dev]"
       - name: Automated Loop 2 (E2E lifecycle + log-fill assertions)
+        if: needs.scope.outputs.scope == 'full'
         working-directory: backend
         run: python -m pytest tests/test_e2e_lifecycle.py -v -p no:randomly
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,11 +24,50 @@ permissions:
 
 jobs:
 
+  # ─── Scope: which steps does THIS diff need? ───────────────────────────────
+  # Harness simplification slice 3 (owner decision 2026-09-08). Measured on the
+  # last green run of main: the backend job spends 347s of 414s in pytest, and
+  # ci-offline.yml runs the same suite again. A one-component frontend PR waited
+  # seven minutes for tests it cannot affect.
+  #
+  # scripts/ci_scope.py answers `docs` / `frontend` / `full` from the changed
+  # files, most restrictive wins, unknown is full, empty is full, and anything
+  # that is not a pull_request (push to main, schedule, dispatch) is full
+  # without looking -- main is production.
+  #
+  # JOBS BELOW ARE NEVER SKIPPED, ONLY THEIR STEPS. The ruleset on main and
+  # scripts/merge_cage.py require checks BY NAME; a skipped job never reports
+  # and blocks the merge, a job whose steps were skipped reports success.
+  scope:
+    name: Scope (which checks this diff needs)
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    outputs:
+      scope: ${{ steps.decide.outputs.scope }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0   # the diff needs the base commit
+      # The classifier proves it can still go red BEFORE it is allowed to
+      # decide anything. A broken classifier fails this job, which fails every
+      # job that needs it, which is a red PR -- never a silently fast one.
+      - name: The scope classifier can still fail
+        run: python scripts/ci_scope.py --drill
+      - name: Decide
+        id: decide
+        env:
+          EVENT: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          scope=$(python scripts/ci_scope.py --event "$EVENT" --base "$BASE_SHA" --head HEAD --print-scope --summary)
+          echo "scope=$scope" >> "$GITHUB_OUTPUT"
+
   # ─── Backend ───────────────────────────────────────────────────────────────
   backend:
     name: Backend (Python 3.12)
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    needs: [scope]
 
     services:
       postgres:
@@ -68,20 +107,24 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+        if: needs.scope.outputs.scope == 'full'
 
       - uses: actions/setup-python@v7
+        if: needs.scope.outputs.scope == 'full'
         with:
           python-version: "3.12"
           cache: pip
           cache-dependency-path: backend/pyproject.toml
 
       - name: Install backend (with dev extras)
+        if: needs.scope.outputs.scope == 'full'
         working-directory: backend
         run: |
           python -m pip install --upgrade pip
           python -m pip install -e ".[dev]"
 
       - name: Lint (ruff)
+        if: needs.scope.outputs.scope == 'full'
         # Backlog drained 2026-07-10: 329 findings → 0. The bulk auto-fixed
         # (`ruff check --fix`, ~141 import-sort/style); the rest were real
         # code fixes (dead-var deletes, ambiguous-name renames, a closure
@@ -92,10 +135,12 @@ jobs:
         run: python -m ruff check .
 
       - name: Tests (offline suite)
+        if: needs.scope.outputs.scope == 'full'
         working-directory: backend
         run: python -m pytest -q -p no:randomly
 
       - name: Type-check (mypy ratchet)
+        if: needs.scope.outputs.scope == 'full'
         # BLOCKING (H7). Was `continue-on-error: true` with a comment claiming
         # "existing errors are grandfathered" — but nothing implemented that, so
         # the result was discarded entirely and new code could add type errors
@@ -114,9 +159,12 @@ jobs:
     # Must exceed DRILL_TIMEOUT_S (240s) in scripts/drill_registry.py, or a hung
     # drill is cancelled by the job before it can report DRILL TIMEOUT.
     timeout-minutes: 10
+    needs: [scope]
     steps:
       - uses: actions/checkout@v7
+        if: needs.scope.outputs.scope == 'full'
       - uses: actions/setup-python@v7
+        if: needs.scope.outputs.scope == 'full'
         with:
           python-version: "3.12"
       # aiohttp + aioresponses: scripts/ssrf_drill.py's fetcher-level cases
@@ -126,6 +174,7 @@ jobs:
       # src.core.settings, whose import chain is dotenv -> src.repositories.pg
       # -> psycopg (first PR #496 run: 9/10 cases "No module named 'dotenv'").
       - run: pip install pyyaml aiohttp aioresponses python-dotenv "psycopg[binary]"
+        if: needs.scope.outputs.scope == 'full'
 
       # Every NODE in detect -> triage -> repair -> verify -> PR has always been
       # healthy. The WIRES between them kept breaking silently: two spellings of
@@ -134,6 +183,7 @@ jobs:
       # left the outage unannounced. Nothing watched the wires, because every
       # individual workflow was green. This job watches the wires.
       - name: Every wire connects
+        if: needs.scope.outputs.scope == 'full'
         run: python scripts/chain_check.py --no-map
 
       # And this is the part that matters: a checker nobody has watched fail is
@@ -142,6 +192,7 @@ jobs:
       # name each one — plus a negative control (a comment-only edit) that must
       # stay quiet. If chain_check.py ever silently stops detecting, this fails.
       - name: The checker can still fail
+        if: needs.scope.outputs.scope == 'full'
         run: python scripts/chain_check.py --drill
 
       # The registry is the most dangerous file in the harness: if it stops
@@ -153,6 +204,7 @@ jobs:
       # whether the registry can still detect at all — which is the one answer
       # you need when it is red.
       - name: The registry can still fail
+        if: needs.scope.outputs.scope == 'full'
         run: python scripts/drill_registry.py --drill
 
       # Every guard CI runs must declare how to make itself fail. Ten guards here
@@ -168,9 +220,11 @@ jobs:
       # of the seven log-injection alerts sitting open right now: fixing the
       # instances without adding the guard is how a class grows.
       - name: No text decoded with the machine's locale
+        if: needs.scope.outputs.scope == 'full'
         run: python scripts/encoding_guard.py
 
       - name: That guard can still fail
+        if: needs.scope.outputs.scope == 'full'
         run: python scripts/encoding_guard.py --drill
 
       # The broom that sorts worktrees and local branches into SAFE / KEEP / ASK.
@@ -183,6 +237,7 @@ jobs:
       # checkout would census one clean worktree, report all-green, and become
       # another guard that cannot fire.
       - name: The broom still refuses to sweep up unsaved work
+        if: needs.scope.outputs.scope == 'full'
         run: python scripts/worktree_census.py --drill
 
       # The broom's ENTRANCE. Same reason this step sits next to the one above and
@@ -190,11 +245,14 @@ jobs:
       # main, so a break would surface only AFTER a merge — too late for the one
       # component whose whole job is deleting things. Here it fires on every PR.
       - name: The reaper still refuses, and still delegates
+        if: needs.scope.outputs.scope == 'full'
         run: python scripts/worktree_reaper.py --drill
 
       - name: The ruleset checker can still fail
+        if: needs.scope.outputs.scope == 'full'
         run: python scripts/ruleset_gate.py --drill
       - name: Would the ruleset wedge the repo?
+        if: needs.scope.outputs.scope == 'full'
         run: python scripts/ruleset_gate.py --check --scope ruleset
       # WIRED FOR REAL, NOT IN A COMMENT. Both of these were referenced only
       # from commented-out example lines, so `drill_registry.discover()` counted
@@ -202,21 +260,26 @@ jobs:
       # discover() to ignore comments, which turned them into STALE ENTRY --
       # correctly. The fix is to invoke them, not to un-declare them.
       - name: Every alert path still reaches a human
+        if: needs.scope.outputs.scope == 'full'
         run: python scripts/check_alert_paths.py
 
       - name: Every slack step passes a token, a title and a real channel
+        if: needs.scope.outputs.scope == 'full'
         run: python scripts/check_workflow_slack_wiring.py
 
       - name: The review-debt reader can still fail (and still refuses to gate)
+        if: needs.scope.outputs.scope == 'full'
         run: python scripts/review_debt.py --drill
 
       # The guard on the one route that makes outbound requests to a URL a
       # stranger chose (docs/plans/2026-09-04-url-fetch/spec.md). Ten
       # mutations, each a real SSRF bypass, plus a negative control.
       - name: The SSRF guard can still fail
+        if: needs.scope.outputs.scope == 'full'
         run: python scripts/ssrf_drill.py --drill
 
       - name: Every guard declares its drill
+        if: needs.scope.outputs.scope == 'full'
         run: python scripts/drill_registry.py --run-drills
 
   # ─── Frontend ──────────────────────────────────────────────────────────────
@@ -224,11 +287,14 @@ jobs:
     name: Frontend (Node 20)
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    needs: [scope]
 
     steps:
       - uses: actions/checkout@v7
+        if: needs.scope.outputs.scope != 'docs'
 
       - uses: actions/setup-node@v7
+        if: needs.scope.outputs.scope != 'docs'
         with:
           node-version: "22"
           cache: npm
@@ -239,21 +305,31 @@ jobs:
       # It exists mainly for the local commit gate (scripts/agent-gate.sh), which
       # runs against installed node_modules and cannot see a pruned lock (#503).
       - name: Lockfile sync (scripts/check_lock_sync.py)
+        if: needs.scope.outputs.scope != 'docs'
         run: python scripts/check_lock_sync.py frontend
 
       - name: Install frontend deps
+        if: needs.scope.outputs.scope != 'docs'
         working-directory: frontend
         run: npm ci
 
       - name: Type-check (tsc)
+        if: needs.scope.outputs.scope != 'docs'
         working-directory: frontend
         run: npm run type-check
 
       - name: Lint (ESLint)
+        if: needs.scope.outputs.scope != 'docs'
         working-directory: frontend
         run: npm run lint
 
+      - name: Unit tests (vitest)
+        if: needs.scope.outputs.scope != 'docs'
+        working-directory: frontend
+        run: npx vitest run
+
       - name: Build (next build)
+        if: needs.scope.outputs.scope != 'docs'
         working-directory: frontend
         run: npm run build
 
@@ -262,6 +338,7 @@ jobs:
       # its COPY died, two prod deploys failed) never showed here. No push, no
       # registry: an image that builds is the whole assertion.
       - name: Docker image builds (frontend/Dockerfile)
+        if: needs.scope.outputs.scope == 'full'
         run: docker build --quiet -t job360-frontend-ci frontend
 
   # ── Make this loop LOUD ───────────────────────────────────────────────────

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,6 +96,17 @@ A PR is mergeable only when:
 If the suite was green before your change and is red after, your change is the
 regression — fix it, do not merge around it.
 
+**CI runs only the steps your diff needs** (`scripts/ci_scope.py`, since
+2026-09-10). A `docs`-only PR (markdown anywhere, anything under `docs/`) runs
+just the doc gates; a `frontend`-only PR runs lockfile sync, `tsc`, ESLint,
+vitest, `next build` and the Playwright specs but skips the backend suite and
+the Docker image build; everything else — any backend, schema, workflow or
+script file, any deploy-shaped frontend file (`Dockerfile`, `package.json`, the
+lockfile, `next.config.*`, `.env*`), any path the classifier has no rule for —
+is `full`. One restrictive file makes the whole PR `full`. Pushes to `main`
+are always `full`. Job names never change, so the required checks are always
+present; the scope decision and the files that made it are in the run summary.
+
 ## Local setup
 
 - **Unix / macOS:** `bash setup.sh`

--- a/scripts/ci_scope.py
+++ b/scripts/ci_scope.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""Decide how much of CI a pull request needs: `docs`, `frontend` or `full`.
+
+WHY THIS EXISTS (harness simplification slice 3, owner decision 2026-09-08)
+--------------------------------------------------------------------------
+Measured on the last green run of main (2026-09-10): the backend job spends
+347s of its 414s running the full pytest suite, and ci-offline.yml runs the
+SAME suite again in parallel. A pull request that changes one React component
+therefore waits seven minutes for tests it cannot affect. The owner asked for a
+fast lane: frontend-only or docs-only diffs get lint + type-check + unit tests
+(about two minutes), and anything touching the backend, the schema or the
+harness gets the full gate exactly as before.
+
+WHAT THIS IS NOT
+----------------
+It is NOT the merge lane. `scripts/lane.py` answers "who may merge this and
+what must be true first"; this file answers "which steps are worth running".
+Both are read by CI; neither reads the other. A frontend-only PR still takes
+whatever merge lane its files put it in.
+
+THE ONE RULE: MOST RESTRICTIVE WINS, UNKNOWN IS NOT SAFE
+--------------------------------------------------------
+    full  >  frontend  >  docs
+
+One backend file in a forty-file docs PR makes the whole PR `full`. A path this
+file has no rule for is `full`, and the reason names it. An empty changeset is
+`full`. A push to main is `full` without looking -- main is production. Every
+refusal here costs a few minutes of compute; a wrong `docs` costs a broken
+deploy, and #503 already paid that once.
+
+DEPLOY-SHAPED FRONTEND FILES ARE FULL
+-------------------------------------
+`frontend/**` is the fast lane EXCEPT the files that decide how the app is built
+and shipped: the Dockerfile and .dockerignore (the image Railway builds),
+package.json and the lockfile (what gets installed), next.config.* (output
+mode, the thing the Dockerfile copies), railway.json, and any .env file. Those
+are the files that broke production in #503, and the fast lane skips the exact
+step -- the Docker image build -- that would have caught them.
+
+JOB NAMES NEVER CHANGE
+----------------------
+The ruleset on main requires checks BY NAME (`Backend (Python 3.12)`,
+`Frontend (Node 20)`, `offline-suite`, ...), and so does scripts/merge_cage.py.
+A job that does not run is a missing required check, and a missing check blocks
+the merge. So the fast lane skips STEPS inside those jobs, never the jobs: a
+skipped job never reports, a job whose steps were skipped reports success.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import PurePosixPath
+
+SCOPES: tuple[str, ...] = ("full", "frontend", "docs")  # most restrictive first
+
+# Top-level files under frontend/ that change how the app is BUILT or SHIPPED,
+# not what it does. Any of these -> full, because the fast lane skips the Docker
+# image build and that build is the only step that exercises them.
+_DEPLOY_SHAPED_FRONTEND: frozenset[str] = frozenset({
+    ".dockerignore",
+    "package.json",
+    "package-lock.json",
+    "railway.json",
+})
+_DEPLOY_SHAPED_PREFIXES: tuple[str, ...] = ("Dockerfile", "next.config.")
+
+
+def kind_of(path: str) -> str:
+    """Return `docs`, `frontend` or `full` for ONE path. Pure."""
+    if not path or path.startswith("/") or ".." in PurePosixPath(path).parts:
+        return "full"  # not a repo-relative path -> refuse to guess
+    p = PurePosixPath(path)
+    if p.name.startswith(".env"):
+        return "full"  # an env file anywhere is configuration, never prose
+    if p.suffix == ".md" or path.startswith("docs/"):
+        return "docs"
+    if path.startswith("frontend/"):
+        rel = path[len("frontend/"):]
+        top_level = "/" not in rel
+        if top_level and (rel in _DEPLOY_SHAPED_FRONTEND
+                          or rel.startswith(_DEPLOY_SHAPED_PREFIXES)):
+            return "full"
+        return "frontend"
+    return "full"
+
+
+def classify(files: list[str]) -> dict:
+    """Classify a whole changeset. Always says WHICH files decided it."""
+    if not files:
+        return {"scope": "full", "why": ["no files in the changeset -- refusing to guess"],
+                "by_kind": {}}
+    by_kind: dict[str, list[str]] = {}
+    for f in files:
+        by_kind.setdefault(kind_of(f), []).append(f)
+    for scope in SCOPES:
+        hits = sorted(by_kind.get(scope) or [])
+        if hits:
+            shown = ", ".join(hits[:4]) + (" ..." if len(hits) > 4 else "")
+            return {
+                "scope": scope,
+                "why": [f"scope `{scope}` decided by {len(hits)} file(s): {shown}"],
+                "by_kind": by_kind,
+            }
+    raise AssertionError("unreachable: every file has a kind")
+
+
+def changed_files(base: str, head: str) -> list[str] | None:
+    """`git diff --name-only base...head`, or None if git could not answer."""
+    try:
+        out = subprocess.run(
+            ["git", "diff", "--name-only", f"{base}...{head}"],
+            capture_output=True, text=True, check=True, encoding="utf-8", errors="replace",
+        ).stdout
+    except (subprocess.CalledProcessError, OSError):
+        return None
+    return [ln.strip() for ln in out.splitlines() if ln.strip()]
+
+
+def _emit(verdict: dict, print_scope: bool, summary: bool) -> None:
+    """Report the verdict.
+
+    The JSON goes to STDERR so the run log always shows the reasoning, and with
+    `--print-scope` STDOUT carries the bare scope word and nothing else, so the
+    workflow step can do `scope=$(python ...)` and write `$GITHUB_OUTPUT`
+    itself. The write is deliberately in the workflow's own `run:` line and not
+    in here: scripts/chain_check.py reads workflow text to prove every
+    `steps.X.outputs.Y` a job consumes is actually written by step X, and a
+    write hidden inside a Python file is a wire it cannot see.
+    """
+    print(json.dumps(verdict, indent=2, sort_keys=True), file=sys.stderr)
+    if print_scope:
+        print(verdict["scope"])
+    if summary:
+        path = os.environ.get("GITHUB_STEP_SUMMARY")
+        if path:
+            with open(path, "a", encoding="utf-8") as fh:
+                fh.write(f"### CI scope: `{verdict['scope']}`\n\n")
+                for line in verdict["why"]:
+                    fh.write(f"- {line}\n")
+                fh.write("\n`full` runs everything; `frontend` skips backend tests and the "
+                         "Docker image build; `docs` runs only the doc gates.\n")
+
+
+def _drill() -> int:
+    """Break the classifier on purpose. A guard nobody has watched go red is a claim."""
+    cases: list[tuple[str, bool]] = []
+
+    def check(name: str, got: object, want: object) -> None:
+        ok = got == want
+        cases.append((name, ok))
+        print(f"  {'ok  ' if ok else 'FAIL'} {name}" + ("" if ok else f"   got={got!r} want={want!r}"))
+
+    print("ci_scope.py --drill")
+    # NEGATIVE CONTROLS FIRST. A classifier that answers `full` to everything
+    # passes every refusal below and is exactly as useful as no classifier.
+    check("docs-only diff takes the docs lane", classify(["docs/harness/x.md"])["scope"], "docs")
+    check("frontend-only diff takes the frontend lane",
+          classify(["frontend/src/components/JobCard.tsx"])["scope"], "frontend")
+
+    # PRECEDENCE -- one restrictive file beats any number of safe ones.
+    many_docs = [f"docs/note{i}.md" for i in range(40)]
+    check("40 docs + 1 backend file is FULL",
+          classify([*many_docs, "backend/src/main.py"])["scope"], "full")
+    check("docs + frontend is FRONTEND (the wider of the two)",
+          classify(["README.md", "frontend/src/lib/api.ts"])["scope"], "frontend")
+    check("frontend + one workflow is FULL",
+          classify(["frontend/src/app/page.tsx", ".github/workflows/ci.yml"])["scope"], "full")
+    check("frontend + one script is FULL",
+          classify(["frontend/src/app/page.tsx", "scripts/ci_scope.py"])["scope"], "full")
+
+    # DEPLOY-SHAPED FRONTEND FILES -- the #503 set -- are never fast.
+    for deploy in ("frontend/Dockerfile", "frontend/.dockerignore", "frontend/package.json",
+                   "frontend/package-lock.json", "frontend/next.config.ts",
+                   "frontend/railway.json", "frontend/.env.production"):
+        check(f"deploy-shaped file is FULL: {deploy}", classify([deploy])["scope"], "full")
+    check("a nested .env is FULL even inside src/",
+          classify(["frontend/src/.env.local"])["scope"], "full")
+    check("a NESTED package.json is still frontend (only the top-level one ships)",
+          classify(["frontend/src/fixtures/package.json"])["scope"], "frontend")
+
+    # DOCS SHAPE -- markdown anywhere, anything under docs/.
+    check("root README is docs", classify(["README.md"])["scope"], "docs")
+    check("a non-markdown file under docs/ is docs",
+          classify(["docs/harness/wires.yml"])["scope"], "docs")
+    check("markdown inside frontend/ is docs (cannot affect the build)",
+          classify(["frontend/README.md"])["scope"], "docs")
+    check("backend CLAUDE.md is docs", classify(["backend/CLAUDE.md"])["scope"], "docs")
+
+    # UNKNOWN IS NOT SAFE.
+    check("an unlisted root file is FULL", classify(["foo.txt"])["scope"], "full")
+    check("a brand-new top-level dir is FULL", classify(["newthing/x.ts"])["scope"], "full")
+    check("an empty changeset is FULL", classify([])["scope"], "full")
+    check("a path with .. is FULL", classify(["docs/../backend/x.py"])["scope"], "full")
+    check("an absolute path is FULL", classify(["/etc/passwd"])["scope"], "full")
+
+    # THE VERDICT NAMES ITS EVIDENCE.
+    v = classify(["docs/a.md", "backend/src/x.py"])
+    check("the verdict names the deciding file", "backend/src/x.py" in " ".join(v["why"]), True)
+
+    passed = sum(1 for _, ok in cases if ok)
+    print(f"\n{passed}/{len(cases)}")
+    if passed != len(cases):
+        print("DRILL FAILED -- the scope classifier no longer behaves as documented.")
+    return 0 if passed == len(cases) else 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Decide which CI steps a diff needs.")
+    ap.add_argument("files", nargs="*", help="changed paths (alternative to --base/--head)")
+    ap.add_argument("--event", default="pull_request",
+                    help="GitHub event name; anything but pull_request is full")
+    ap.add_argument("--base", help="base revision (with --head: run git diff)")
+    ap.add_argument("--head", default="HEAD", help="head revision for --base")
+    ap.add_argument("--print-scope", action="store_true",
+                    help="stdout carries only the scope word (JSON verdict goes to stderr)")
+    ap.add_argument("--summary", action="store_true",
+                    help="append a markdown verdict to $GITHUB_STEP_SUMMARY")
+    ap.add_argument("--drill", action="store_true", help="break the classifier on purpose")
+    args = ap.parse_args(argv)
+
+    if args.drill:
+        return _drill()
+
+    if args.event != "pull_request":
+        _emit({"scope": "full",
+               "why": [f"event `{args.event}` is not a pull request -- main is production, "
+                       "so a push, a schedule or a dispatch always runs the full gate"],
+               "by_kind": {}}, args.print_scope, args.summary)
+        return 0
+
+    files: list[str] | None
+    if args.base:
+        files = changed_files(args.base, args.head)
+        if files is None:
+            # FAIL SAFE, LOUDLY. The safe direction is more checks, not fewer --
+            # but a warning in the log so a permanently broken diff does not hide
+            # the fast lane forever.
+            print("::warning::ci_scope: git diff failed -- falling back to the full gate",
+                  file=sys.stderr)
+            _emit({"scope": "full", "why": ["git diff failed -- refusing to guess"],
+                   "by_kind": {}}, args.print_scope, args.summary)
+            return 0
+    else:
+        files = list(args.files)
+
+    _emit(classify(files), args.print_scope, args.summary)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/drill_registry.py
+++ b/scripts/drill_registry.py
@@ -289,6 +289,21 @@ REGISTRY: dict[str, Guard] = {
         # step goes red and the claim is withdrawn.
         drill=[sys.executable, "scripts/check_workflow_slack_wiring.py", "--drill"],
     ),
+    "scripts/ci_scope.py": Guard(
+        status="drilled",
+        # Decides `docs` / `frontend` / `full` for a PR so ci.yml and
+        # ci-offline.yml can skip the seven minutes of backend tests a
+        # one-component frontend change cannot affect (slice 3, 2026-09-10).
+        # Its danger is one-directional: a wrong `full` costs minutes, a wrong
+        # `docs` skips the gate. So the drill's negative controls come first
+        # (it must be ABLE to say docs/frontend), then precedence (one backend
+        # file beats forty docs), the #503 deploy-shaped set (Dockerfile,
+        # lockfile, next.config, .env -> never fast), and unknown-is-full.
+        # The drill also runs inside the `scope` job itself, before the
+        # verdict: a classifier that cannot pass it fails every job that
+        # needs it, so a broken classifier is a red PR, never a fast one.
+        drill=[sys.executable, "scripts/ci_scope.py", "--drill"],
+    ),
     "scripts/slack_transition.py": Guard(
         status="drilled",
         # The volume rule: announce the TRANSITION, not the state. Its drill


### PR DESCRIPTION
## Harness simplification — slice 3 of 8

**CI now runs only the steps a diff needs.** Frontend-only and docs-only PRs stop paying for seven minutes of backend tests they cannot affect.

### Measured before (last green run of main, 2026-09-10)
| job | total | of which |
|---|---|---|
| Backend (Python 3.12) | 414s | 347s pytest |
| offline-suite (ci-offline.yml) | ~7 min | the **same** pytest suite again |
| Frontend (Node 20) | 113s | 53s Docker image build |
| frontend-e2e | 119s | Playwright |

### What changed
- **`scripts/ci_scope.py`** (new, drilled, registered): classifies the changed files into `docs` / `frontend` / `full`. Most restrictive wins; unknown path ⇒ full; empty ⇒ full; anything not a `pull_request` ⇒ full. Deploy-shaped frontend files (the #503 set: `Dockerfile`, `.dockerignore`, `package.json`, lockfile, `next.config.*`, `railway.json`, `.env*`) are always full because the fast lane skips the Docker build that would catch them.
- **`ci.yml` + `ci-offline.yml`**: a `scope` job runs first (drill, then decide). **Jobs are never skipped, only steps** — the ruleset and `merge_cage.py` require checks by name, and a skipped job blocks the merge.
  - `full`: everything, unchanged.
  - `frontend`: lockfile sync, `tsc`, ESLint, **vitest (new step)**, `next build`, Playwright specs. Skips backend, chain drills, Docker image build, offline-suite, loop2.
  - `docs`: only the doc gates (`doc-sync.yml` is a separate PR gate and still runs).
- **`CONTRIBUTING.md`**: documents the lanes.
- The scope verdict and the files that decided it are written to the run summary.

### What the harness's own guards said
- `chain_check.py` caught the first version: the `$GITHUB_OUTPUT` write was inside Python, invisible to the wire parser. Moved into the step's `run:` line. Now 0 broken (the 1 suspect is main's pre-existing dependabot spelling).
- `drill_registry.py`: 28 guards, 22 drilled, 6 owed (unchanged debt).
- `ci_scope.py --drill`: 25/25. Real diff vs `origin/main` classifies this PR as `full` (correct — it touches scripts and workflows).
- doc-sync: no drift. ruleset_gate: OK. check_alert_paths: OK.

### Proof after merge
This PR is `full` by construction. The first frontend-only or docs-only PR after merge is the live proof — its run summary will show the scope and the skipped steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011wAduRqokWdPEByUkcVbvc
