### PR TITLE
drill: frontend-only PR proves the CI frontend lane (close, never merge)

### DIFF
--- a/frontend/src/lib/event-labels.test.ts
+++ b/frontend/src/lib/event-labels.test.ts
@@ -93,3 +93,5 @@ describe("whoLabel", () => {
     expect(whoLabel("something-weird")).toEqual({ who: "agent", name: "something-weird" });
   });
 });
+
+// ci_scope drill 2026-09-11: a frontend-only change must take the frontend lane.


### PR DESCRIPTION
Throwaway drill for the CI scope classifier (harness slice 3, #537).

One comment line in a frontend test file. Expected: the `Scope` job says `frontend`; backend, chain and Docker-image-build steps are skipped; tsc, ESLint, vitest, next build and Playwright run.

Closed after the proof. Never merge.
