### PR TITLE
drill: docs-only PR proves the CI docs lane (close, never merge)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -150,3 +150,5 @@ MCP/route gate parity, timezone-aware quiet-hours dispatch, account-mgmt session
 invalidation, etc.) plus the product path and data-flow.
 
 For docs and plans, start at [`docs/README.md`](docs/README.md).
+
+A docs-only pull request is the live proof of the `docs` lane above (drilled 2026-09-11).


### PR DESCRIPTION
Throwaway drill for the CI scope classifier (harness slice 3, #537).

One sentence in CONTRIBUTING.md. Expected: the `Scope` job says `docs`; every backend, frontend and chain step is skipped; only the doc gates run.

Closed after the proof. Never merge.
