### PR TITLE
chore(harness): every watchdog reaches Slack; revert drill rehearses what main actually is (slice 4)

### DIFF
--- a/.github/workflows/absence.yml
+++ b/.github/workflows/absence.yml
@@ -50,12 +50,24 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set +e
-          python scripts/watchdog_check.py > watchdog.md 2>&1
+          python scripts/watchdog_check.py --json watchdog.json > watchdog.md 2>&1
           code=$?
           set -e
           cat watchdog.md
           cat watchdog.md >> "$GITHUB_STEP_SUMMARY"
           echo "stopped=$code" >> "$GITHUB_OUTPUT"
+          # THE SECOND QUESTION (slice 4, 2026-09-11): which watchers are
+          # running but RED? Two of the three production watchers were
+          # silent-red for a month with every dashboard green — each opened
+          # its own issue, which went to triage, which emailed, and nothing
+          # reached the channel the owner reads. This roll-up is the one
+          # wire that turns "N watchers are red" into ONE Slack message.
+          # Absent JSON means the checker crashed before writing it, and an
+          # unknown count must never read as zero.
+          if [ -f watchdog.json ]; then
+            echo "red_count=$(jq -r .red_count watchdog.json)" >> "$GITHUB_OUTPUT"
+            echo "red_list=$(jq -r '.red_list | join(", ")' watchdog.json)" >> "$GITHUB_OUTPUT"
+          fi
           [ "$code" -le 1 ] || exit "$code"
 
       - name: Open, update or close the tracking issue
@@ -118,3 +130,93 @@ jobs:
             Run:   ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           resend_api_key: ${{ secrets.RESEND_API_KEY }}
           to_email: ${{ secrets.OWNER_ALERT_EMAIL }}
+
+      # ── RED WATCHERS REACH SLACK — ANNOUNCE THE TRANSITION, NOT THE STATE ──
+      # scripts/slack_transition.py reads the marker issue `Loop RED:
+      # watchdog-red` and decides: green->red SEND (kind `opened`), red->red
+      # SILENT, red->green SEND (kind `recovered`), green->green SILENT. The
+      # marker is opened and closed HERE, in the same step, so Slack and the
+      # tracker cannot disagree. Measured 2026-08-17: synthetic-live alone was
+      # 29 msg/week of pure repetition under "post every failure"; under
+      # transitions it is one message when it breaks and one when it is fixed.
+      - name: Announce the transition, not the state
+        id: transition
+        if: always() && steps.watch.outputs.red_count != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          RED_COUNT: ${{ steps.watch.outputs.red_count }}
+          RED_LIST: ${{ steps.watch.outputs.red_list }}
+        run: |
+          set -euo pipefail
+          state=ok
+          [ "$RED_COUNT" != "0" ] && state=failing
+          python scripts/slack_transition.py --key watchdog-red --state "$state" \
+            --channel needs-your-decision --severity warn > transition.json
+          send=$(jq -r .send transition.json)
+          kind=$(jq -r .kind transition.json)
+          echo "send=$send" >> "$GITHUB_OUTPUT"
+          echo "kind=$kind" >> "$GITHUB_OUTPUT"
+          title="Loop RED: watchdog-red"
+          num=$(gh issue list --state open --json number,title \
+                  --jq ".[] | select(.title==\"$title\") | .number" | head -1)
+          if [ "$kind" = "opened" ] && [ -z "$num" ]; then
+            {
+              echo "$RED_COUNT watcher(s) are running but RED: $RED_LIST"
+              echo
+              echo "This is the marker issue for the Slack transition rule — it closes itself when all watchers are green again."
+              echo "Details: the watchdog run summary. Each red watcher also has its own \`Loop RED:\` issue."
+              echo
+              echo "- Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            } > marker.md
+            gh issue create --title "$title" --body-file marker.md --label harness
+          elif [ "$kind" = "recovered" ] && [ -n "$num" ]; then
+            gh issue close "$num" --comment "All watchers green again as of run ${{ github.run_id }}. (auto-close)"
+          fi
+
+      - name: Slack — watchers are RED
+        if: always() && steps.transition.outputs.send == 'true' && steps.transition.outputs.kind == 'opened'
+        uses: ./.github/actions/slack
+        with:
+          channel: needs-your-decision
+          severity: warn
+          title: "watchdog: ${{ steps.watch.outputs.red_count }} watcher(s) are red — ${{ steps.watch.outputs.red_list }}"
+          body: |
+            Each has failed at least twice in a row. The run summary shows the streak and the last green day per watcher.
+            A watcher that is red for a missing secret stays red until the secret exists — that is yours to set, not code.
+
+            Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
+
+      # Recovery is NOT an incident — it is news. It goes to the muted log
+      # channel so needs-your-decision only ever contains things still open.
+      - name: Slack — watchers back to green
+        if: always() && steps.transition.outputs.send == 'true' && steps.transition.outputs.kind == 'recovered'
+        uses: ./.github/actions/slack
+        with:
+          channel: log-github-ci
+          severity: info
+          title: "watchdog: every watcher is green again"
+          body: |
+            The red watchers reported in `Loop RED: watchdog-red` are passing again and the marker was auto-closed.
+            Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
+
+      # FALLBACK LAST MILE (scripts/check_alert_paths.py rule B). Every branch
+      # above keys off outputs the transition step only writes if it SUCCEEDS —
+      # a gh 403 or an unreadable marker would skip them all and the red
+      # watchers would go unannounced. If the alarm path itself broke, say THAT.
+      - name: Slack — the watchdog's alarm path itself broke
+        if: always() && (steps.transition.outcome == 'failure' || steps.watch.outcome == 'failure')
+        uses: ./.github/actions/slack
+        with:
+          channel: needs-your-decision
+          severity: warn
+          title: "watchdog: the alarm path itself broke — red watchers may be unannounced"
+          body: |
+            The watchdog ran but could not decide whether to announce (the checker crashed, or the
+            transition marker could not be read). Open the run and look; no message here means
+            the messenger broke, not that every watcher is fine.
+
+            Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/post-merge-watch.yml
+++ b/.github/workflows/post-merge-watch.yml
@@ -407,21 +407,45 @@ jobs:
             echo "issue #$num already open for this trip — commented instead of duplicating" >> "$GITHUB_STEP_SUMMARY"
           fi
 
-      - name: "Step 6 — notify Slack, if configured"
+      # THE SAME VOICE AS EVERY OTHER WATCHER. Until 2026-09-11 this step
+      # posted to an incoming webhook (SLACK_WEBHOOK_URL) and swallowed every
+      # failure with a ::warning:: — the exact RESEND_API_KEY shape: a secret
+      # that may never have been set, and a step that goes green either way.
+      # A production rollback is the one message that must not be lost, so it
+      # now uses the bot-token action that slack-drill.yml proved live on
+      # 2026-09-11, which fails LOUD when it cannot speak.
+      - name: "Step 6 — Slack: production was rolled back"
         if: always() && steps.decide.outputs.tripped == 'true'
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        run: |
-          if [ -z "$SLACK_WEBHOOK_URL" ]; then
-            echo "::warning::SLACK_WEBHOOK_URL is not set — no Slack ping for this trip. The GitHub issue above is the only alarm."
-            exit 0
-          fi
-          prefix=""
-          if [ "${{ steps.mode.outputs.dry_run }}" = "true" ]; then prefix="[DRILL] "; fi
-          text="${prefix}Post-merge watch tripped on ${{ github.sha }}: ${{ steps.decide.outputs.trip_reason }} (services: ${{ steps.decide.outputs.services }})"
-          body=$(python -c 'import json,sys; print(json.dumps({"text": sys.argv[1]}))' "$text")
-          curl -sf -X POST -H 'Content-type: application/json' --data "$body" "$SLACK_WEBHOOK_URL" \
-            || echo "::warning::Slack notification failed to send"
+        uses: ./.github/actions/slack
+        with:
+          channel: production-incidents
+          severity: critical
+          title: "${{ steps.mode.outputs.dry_run == 'true' && '[DRILL] ' || '' }}post-merge watch tripped on ${{ github.sha }} — rolled back"
+          body: |
+            ${{ steps.decide.outputs.trip_reason }} (services: ${{ steps.decide.outputs.services }})
+
+            Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
+
+      # FALLBACK LAST MILE (scripts/check_alert_paths.py rule B). Step 6 keys
+      # off outputs that `mode` and `decide` only write if they REACH that
+      # line. If either dies half way — an unbound variable, a gh 403 — the
+      # trip is never announced and a rolled-back (or NOT rolled-back)
+      # production goes unmentioned. If the alarm path itself broke, say THAT.
+      - name: "Slack — the post-merge watch's alarm path itself broke"
+        if: always() && (steps.mode.outcome == 'failure' || steps.decide.outcome == 'failure')
+        uses: ./.github/actions/slack
+        with:
+          channel: needs-your-decision
+          severity: warn
+          title: "post-merge watch on ${{ github.sha }} could not reach a verdict"
+          body: |
+            The watch ran after a merge to main but the step that decides LIVE vs rehearsal, or the
+            step that decides whether to roll back, failed before writing its verdict. Production may
+            or may not be fine — nobody checked. Open the run and look.
+
+            Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
 
       # ── THE HONESTY RULE — always, win or lose ────────────────────────────
       - name: "HONESTY — what this run watched, what it could NOT, and the verdict"
@@ -460,8 +484,12 @@ jobs:
       # a green checkmark next to a rolled-back prod is exactly the kind of
       # thing that gets missed. Placed LAST so it never blocks the alarm
       # steps above (all of which are `if: always()` or unconditional).
+      # `always()` is load-bearing (scripts/check_alert_paths.py rule A): the
+      # Slack step above fails LOUD when it cannot speak, and without this the
+      # implicit `success()` here would let a Slack outage decide whether the
+      # run reports the trip. The verdict is `decide`'s, never the messenger's.
       - name: Fail the run if the watch tripped
-        if: steps.decide.outputs.tripped == 'true'
+        if: always() && steps.decide.outputs.tripped == 'true'
         run: |
           echo "::error::post-merge-watch TRIPPED — ${{ steps.decide.outputs.trip_reason }}"
           exit 1

--- a/.github/workflows/revert-main.yml
+++ b/.github/workflows/revert-main.yml
@@ -35,7 +35,7 @@ on:
   workflow_dispatch:
     inputs:
       sha:
-        description: "MERGE commit to revert (blank = the newest merge on main)"
+        description: "Commit to revert: a merge commit or a squash-merged PR commit (blank = the newest landing on main)"
         required: false
       dry_run:
         description: "Build it in a throwaway clone and throw it away (no PR)"
@@ -79,7 +79,14 @@ jobs:
       - name: The reverse gear still refuses a bad SHA
         run: python scripts/revert_gear.py --drill
 
-      - name: Which merge
+      # THE NEWEST LANDING ON MAIN, NOT THE NEWEST MERGE COMMIT. This repo
+      # squash-merges, so the newest *merge commit* is whatever last landed
+      # with a merge button months ago (2026-08-16 as of 2026-09-11) and its
+      # revert has not applied since. The drill failed on 2026-09-01 for
+      # exactly that reason and would have failed every month after. The gear
+      # itself decides whether the SHA is revertable (a merge, or a squash-
+      # merged PR commit with GitHub's `(#N)` marker) and refuses anything else.
+      - name: Which landing
         id: pick
         env:
           GIVEN: ${{ inputs.sha }}
@@ -87,10 +94,10 @@ jobs:
           set -euo pipefail
           sha="${GIVEN:-}"
           if [ -z "$sha" ]; then
-            sha=$(git log --merges --first-parent -n 1 --pretty=%H main)
+            sha=$(git log --first-parent -n 1 --pretty=%H main)
           fi
           if [ -z "$sha" ]; then
-            echo "::error::no merge commit found on main — nothing to revert."
+            echo "::error::no commit found on main — nothing to revert."
             exit 1
           fi
           echo "sha=$sha" >> "$GITHUB_OUTPUT"
@@ -107,7 +114,7 @@ jobs:
           {
             echo "### Reverse gear rehearsal"
             echo
-            echo "Newest merge on main: \`${{ steps.pick.outputs.sha }}\`"
+            echo "Newest landing on main: \`${{ steps.pick.outputs.sha }}\`"
             echo "> ${{ steps.pick.outputs.subject }}"
             echo
             echo "The revert was built in a throwaway clone and discarded."
@@ -146,7 +153,7 @@ jobs:
             echo "::error::no SLACK_BOT_TOKEN — nobody can be told the reverse gear is broken."
             exit 1
           fi
-          text=":rotating_light: *The reverse gear could not build a revert of the newest merge on main.*
+          text=":rotating_light: *The reverse gear could not build a revert of the newest landing on main.*
           That means there is currently NO tested way back. Railway's dashboard Rollback is
           the only remaining path until this is fixed. ${RUN_URL}"
           resp=$(curl -sS -X POST https://slack.com/api/chat.postMessage \

--- a/scripts/drill_registry.py
+++ b/scripts/drill_registry.py
@@ -414,10 +414,17 @@ REGISTRY: dict[str, Guard] = {
         since="2026-08-16",
     ),
     "scripts/watchdog_check.py": Guard(
-        status="owed",
-        reason="watches the other loops via the live GitHub API; a drill needs a "
-        "recorded `gh run list` fixture, which does not exist yet",
-        since="2026-08-16",
+        status="drilled",
+        # WAS `owed` since 2026-08-16 ("needs a recorded gh run list fixture").
+        # Slice 4 (2026-09-11) split the file into a gh fetch and a PURE
+        # classifier (`assess`), and the drill feeds the classifier hand-made
+        # run lists: stopped vs fresh, the two-in-a-row RED streak, a single
+        # failure as a flake, in-progress/cancelled runs not breaking the
+        # streak, a success breaking it, and the RED_ONLY (ci.yml on main)
+        # shape. Negative controls first: it must be able to say "fine".
+        # The gh half stays undrilled on purpose — it is the same `gh run
+        # list` every sibling uses, and a recorded fixture would rot.
+        drill=[sys.executable, "scripts/watchdog_check.py", "--drill"],
     ),
     "backend/scripts/mypy_ratchet.py": Guard(
         status="owed",

--- a/scripts/revert_gear.py
+++ b/scripts/revert_gear.py
@@ -55,6 +55,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -91,27 +92,53 @@ def git(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
                           text=True, encoding="utf-8", errors="replace", timeout=180)
 
 
-def is_merge_commit(sha: str, cwd: Path) -> tuple[bool, str]:
-    """Exactly two-or-more parents, and the SHA must exist.
+# GitHub's squash-merge subject convention: `<title> (#123)`. A commit on main's
+# first-parent line with this marker IS one pull request, landed as one commit.
+_SQUASH_PR_SUBJECT = re.compile(r"\(#\d+\)\s*$")
 
-    Kept separate from the revert so the drill can feed it real SHAs from a real
-    repository rather than assert on a mock. `rev-list --parents -n 1` prints the
-    commit and then its parents, so the field count IS the parent count + 1.
+
+def is_merge_commit(sha: str, cwd: Path) -> tuple[bool, str]:
+    """(ok, why) — is `sha` something this gear may revert? Two shapes are:
+
+      * a MERGE commit (two-or-more parents): reverted with `-m 1`;
+      * a SQUASH-MERGED PR commit (one parent, subject ends in `(#N)`): reverted
+        plainly. THIS REPO SQUASH-MERGES, so this is the shape every landing on
+        main has had since August 2026. The first version of this gear accepted
+        only real merge commits, and the monthly drill therefore rehearsed the
+        newest MERGE commit — a month-old one — which no longer applied. It
+        failed 2026-09-01 and would have failed every month after (slice 4,
+        2026-09-11).
+
+    Anything else — an ordinary commit with no PR marker, a SHA that does not
+    exist — is refused loudly: `git revert` would do something plausible and
+    wrong. Kept separate from the revert so the drill can feed it real SHAs
+    from a real repository rather than assert on a mock. `rev-list --parents
+    -n 1` prints the commit and then its parents, so the field count IS the
+    parent count + 1.
     """
     proc = git(["rev-list", "--parents", "-n", "1", sha], cwd)
     if proc.returncode != 0:
         return False, (f"`{sha}` is not a commit in this repository "
-                       f"({proc.stderr.strip()[:160]}). FIX: pass a full merge SHA from "
-                       f"`git log --merges --first-parent main`.")
+                       f"({proc.stderr.strip()[:160]}). FIX: pass a full SHA from "
+                       f"`git log --first-parent main`.")
     fields = proc.stdout.split()
     parents = len(fields) - 1
-    if parents < 2:
-        return False, (
-            f"`{sha[:12]}` has {parents} parent(s), so it is NOT a merge commit. "
-            f"`git revert -m 1` on it would succeed and revert the WRONG THING — quietly, "
-            f"and plausibly. Refusing. "
-            f"FIX: pick a SHA from `git log --merges --first-parent main`.")
-    return True, ""
+    if parents >= 2:
+        return True, ""
+    subject = git(["log", "-1", "--pretty=%s", sha], cwd).stdout.strip()
+    if parents == 1 and _SQUASH_PR_SUBJECT.search(subject):
+        return True, ""
+    return False, (
+        f"`{sha[:12]}` has {parents} parent(s) and its subject carries no `(#N)` PR marker, "
+        f"so it is NOT a merge commit and not a squash-merged pull request either. "
+        f"`git revert` on it would succeed and revert the WRONG THING — quietly, "
+        f"and plausibly. Refusing. "
+        f"FIX: pick a SHA from `git log --first-parent main` whose subject ends in `(#N)`, "
+        f"or a real merge commit from `git log --merges --first-parent main`.")
+
+
+def _parent_count(sha: str, cwd: Path) -> int:
+    return len(git(["rev-list", "--parents", "-n", "1", sha], cwd).stdout.split()) - 1
 
 
 def build_revert(sha: str, cwd: Path, branch: str) -> Result:
@@ -125,7 +152,9 @@ def build_revert(sha: str, cwd: Path, branch: str) -> Result:
         return Result(False, f"could not create the scratch branch `{branch}`: "
                              f"{made.stderr.strip()[:200]}")
 
-    rev = git(["revert", "-m", "1", "--no-edit", sha], cwd)
+    # `-m 1` is only meaningful (and only accepted by git) for a real merge.
+    mainline = ["-m", "1"] if _parent_count(sha, cwd) >= 2 else []
+    rev = git(["revert", *mainline, "--no-edit", sha], cwd)
     if rev.returncode != 0:
         # THE FAILURE THAT ACTUALLY BITES. Say it plainly: you do not have this
         # revert, and you found out now instead of during an outage.
@@ -159,8 +188,9 @@ def run(sha: str, cwd: Path, branch: str) -> int:
 # ─────────────────────────────────────────────────────────────────────────────
 
 
-def _mk_repo(tmp: Path) -> tuple[Path, str, str]:
-    """A repo with one merge commit and one ordinary commit. Returns both SHAs."""
+def _mk_repo(tmp: Path) -> tuple[Path, str, str, str]:
+    """A repo with one merge commit, one ordinary commit and one squash-merged PR
+    commit. Returns (repo, merge_sha, ordinary_sha, squash_sha)."""
     repo = tmp / "repo"
     repo.mkdir()
     env = {**os.environ, "GIT_AUTHOR_NAME": "drill", "GIT_AUTHOR_EMAIL": "d@x",
@@ -188,7 +218,13 @@ def _mk_repo(tmp: Path) -> tuple[Path, str, str]:
     ordinary = g("rev-parse", "HEAD").stdout.strip()
     g("merge", "--no-ff", "feature", "-m", "Merge pull request #999")
     merge = g("rev-parse", "HEAD").stdout.strip()
-    return repo, merge, ordinary
+    # The shape every landing on main has had since August 2026: one parent,
+    # GitHub's `(#N)` marker in the subject.
+    (repo / "d.txt").write_text("squashed pr\n", encoding="utf-8")
+    g("add", "-A")
+    g("commit", "-m", "feat(x): something useful (#1000)")
+    squash = g("rev-parse", "HEAD").stdout.strip()
+    return repo, merge, ordinary, squash
 
 
 def self_drill() -> int:
@@ -201,11 +237,20 @@ def self_drill() -> int:
 
     with tempfile.TemporaryDirectory() as td:
         tmp = Path(td)
-        repo, merge_sha, ordinary_sha = _mk_repo(tmp)
+        repo, merge_sha, ordinary_sha, squash_sha = _mk_repo(tmp)
         main_before = git(["rev-parse", "main"], repo).stdout.strip()
 
         # NEGATIVE CONTROL first, because it is the case that must WORK. A gear
         # that only ever refuses is a gear nobody will reach for at 2 a.m.
+        # The SQUASH case leads: it is what main actually looks like, and it is
+        # the case the gear got wrong for a month.
+        res = build_revert(squash_sha, repo, "revert/drill-0")
+        ok("NEGATIVE CONTROL (a squash-merged PR commit produces a revert that applies)",
+           res.ok, f"the gear refused a squash-merged PR commit: {res.reason}")
+        ok("the file the squashed PR brought in is gone again after the revert",
+           not (repo / "d.txt").exists(), "d.txt survived the revert")
+        git(["checkout", "main"], repo)
+
         res = build_revert(merge_sha, repo, "revert/drill-1")
         ok("NEGATIVE CONTROL (a real merge commit produces a revert that applies)",
            res.ok, f"the gear refused a perfectly good merge SHA: {res.reason}")

--- a/scripts/watchdog_check.py
+++ b/scripts/watchdog_check.py
@@ -13,17 +13,40 @@ signal is the signal.
 Each scheduled workflow declares how long it may go without reporting a run.
 Anything overdue — or that has never run at all — fails this check.
 
+TWO QUESTIONS SINCE 2026-09-11 (harness simplification slice 4), NOT ONE:
+
+  1. STOPPED  — did the watcher stop RUNNING?          (exit 1, the original)
+  2. RED      — is the watcher running but FAILING?    (reported, never exit 1)
+
+The second exists because two of the three production watchers had been
+silent-red for a month (synthetic-live since 2026-08-09, external-health since
+2026-08-06) with every dashboard green: each opened its own issue, the issue
+went to triage, triage emailed, and nothing reached the channel the owner
+actually reads. This file already looks at every scheduled watcher once a day,
+so it is the one place that can say "these N are red, since when, last green
+on" in ONE message — and absence.yml turns that into a Slack transition
+(green->red announces, red->red is silent, red->green announces).
+
+RED is deliberately NOT an exit-1: a watcher that is red because the OWNER has
+not set a secret would otherwise make THIS watcher red every day, and a
+permanently red watchdog is a dead watchdog. The stopped/red split keeps the
+exit code meaning "the harness itself is broken" and nothing else.
+
 No LLM. Read-only (gh run list). Exit 0 = all watchers alive, 1 = one or more
 stopped, 2 = the checker itself broke (fail LOUD).
 
-Run: python scripts/watchdog_check.py     (needs gh authed; GH_TOKEN in CI)
+Run: python scripts/watchdog_check.py            (needs gh authed; GH_TOKEN in CI)
+     python scripts/watchdog_check.py --json out.json   (machine-readable verdict)
+     python scripts/watchdog_check.py --drill     (the pure classifier can go red)
 """
 
 from __future__ import annotations
 
+import argparse
 import json
 import subprocess
 import sys
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 
 if hasattr(sys.stdout, "reconfigure"):
@@ -34,6 +57,8 @@ if hasattr(sys.stdout, "reconfigure"):
 # GitHub's own cron is best-effort and can drift by tens of minutes.
 EXPECTED: dict[str, tuple[float, str]] = {
     "uptime.yml": (3, "every 10 min"),
+    # Gained its cron in #525 (2026-09-08) and drifted out of this roster until
+    # slice 4 (2026-09-11) ran the roster check — the exact blind spot below.
     "auto-merge.yml": (2, "every 20 min"),
     "synthetic-live.yml": (14, "every 6h"),
     "db-backup.yml": (36, "daily 02:17"),
@@ -65,6 +90,62 @@ EXPECTED: dict[str, tuple[float, str]] = {
 NOT_SCHEDULED: set[str] = {
     "ci.yml", "pr-repair.yml", "triage.yml", "doc-sync.yml", "branch-reaper.yml",
 }
+
+# Not scheduled, so never STOPPED — but its conclusion on main IS the health of
+# production's gate, so it joins the RED question. `ci.yml` red on main means
+# the last thing that shipped did not pass its own tests.
+RED_ONLY: dict[str, str] = {"ci.yml": "push to main"}
+
+# How many consecutive failing runs before a watcher counts as RED. One red run
+# is a flake (measured 2026-08-17: Security scanning flapped 1.9 failures/week);
+# two in a row is a condition. The streak is counted over COMPLETED runs only —
+# a cancelled or in-progress run says nothing about the condition.
+RED_STREAK = 2
+RUNS_TO_FETCH = 8
+
+
+@dataclass
+class Verdict:
+    """The pure result for one watcher. Everything absence.yml needs is here."""
+    workflow: str
+    cadence: str
+    last_run_age_h: float | None  # None = never ran
+    stopped: bool
+    red: bool
+    streak: int                    # consecutive failures at the head
+    last_green: str | None         # ISO date of the newest success in the window
+    note: str = ""
+    conclusions: list[str] = field(default_factory=list)
+
+
+def assess(runs: list[dict], now: datetime, max_h: float | None, workflow: str,
+           cadence: str) -> Verdict:
+    """Classify one watcher from its recent runs. PURE — this is what the drill
+    breaks. `runs` is newest-first, each with createdAt/status/conclusion.
+
+    max_h None means the STOPPED question is not asked (RED_ONLY workflows).
+    """
+    if not runs:
+        return Verdict(workflow, cadence, None, stopped=max_h is not None, red=False,
+                       streak=0, last_green=None, note="never ran")
+    newest = datetime.fromisoformat(runs[0]["createdAt"].replace("Z", "+00:00"))
+    age_h = (now - newest).total_seconds() / 3600
+    stopped = max_h is not None and age_h > max_h
+
+    completed = [r for r in runs if r.get("status") == "completed"
+                 and r.get("conclusion") in ("success", "failure")]
+    conclusions = [r["conclusion"] for r in completed]
+    streak = 0
+    for c in conclusions:
+        if c != "failure":
+            break
+        streak += 1
+    last_green = next((r["createdAt"][:10] for r in completed if r["conclusion"] == "success"), None)
+    red = streak >= RED_STREAK
+    note = ""
+    if red and last_green is None:
+        note = f"no green run in the last {len(completed)} completed"
+    return Verdict(workflow, cadence, age_h, stopped, red, streak, last_green, note, conclusions)
 
 
 def roster_drift(workflow_dir: str = ".github/workflows") -> list[str]:
@@ -103,15 +184,18 @@ def roster_drift(workflow_dir: str = ".github/workflows") -> list[str]:
 NOT_DEPLOYED = "not-deployed"
 
 
-def last_run_iso(workflow: str) -> str | None:
-    """Most recent run timestamp, None if never run, NOT_DEPLOYED if absent.
+def recent_runs(workflow: str, branch: str | None = None) -> list[dict] | str:
+    """Newest-first recent runs, [] if never run, NOT_DEPLOYED if absent.
 
     A workflow living only in an open PR would otherwise crash the checker —
     found by running this for the first time against absence.yml (PR #147).
     """
+    cmd = ["gh", "run", "list", "--workflow", workflow, "--limit", str(RUNS_TO_FETCH),
+           "--json", "createdAt,status,conclusion"]
+    if branch:
+        cmd += ["--branch", branch]
     out = subprocess.run(
-        ["gh", "run", "list", "--workflow", workflow, "--limit", "1",
-         "--json", "createdAt"],
+        cmd,
         capture_output=True, text=True, encoding="utf-8", errors="replace",
         # A DETECTOR THAT HANGS REPORTS NOTHING, AND NOTHING READS AS FINE.
         # Both sibling detectors already bound this (checker_scorecard.py uses
@@ -126,39 +210,117 @@ def last_run_iso(workflow: str) -> str | None:
         if "not found" in err.lower() or "HTTP 404" in err:
             return NOT_DEPLOYED
         raise RuntimeError(f"gh failed for {workflow}: {err[:200]}")
-    data = json.loads(out.stdout or "[]")
-    return data[0]["createdAt"] if data else None
+    return json.loads(out.stdout or "[]")
 
 
-def main() -> int:
+def _drill() -> int:
+    """Break the pure classifier on purpose. Needs no gh and no network."""
+    now = datetime(2026, 9, 11, 12, 0, tzinfo=timezone.utc)
+
+    def run(hours_ago: float, conclusion: str | None, status: str = "completed") -> dict:
+        ts = datetime(2026, 9, 11, 12, 0, tzinfo=timezone.utc)
+        from datetime import timedelta
+        return {"createdAt": (ts - timedelta(hours=hours_ago)).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "status": status, "conclusion": conclusion}
+
+    cases: list[tuple[str, bool]] = []
+
+    def check(name: str, got: object, want: object) -> None:
+        ok = got == want
+        cases.append((name, ok))
+        print(f"  {'ok  ' if ok else 'FAIL'} {name}" + ("" if ok else f"   got={got!r} want={want!r}"))
+
+    print("watchdog_check.py --drill")
+    # NEGATIVE CONTROLS FIRST: it must be able to say "fine".
+    v = assess([run(1, "success"), run(7, "success")], now, 14, "x.yml", "6h")
+    check("fresh + green is neither stopped nor red", (v.stopped, v.red), (False, False))
+
+    # STOPPED — the original question.
+    v = assess([run(40, "success")], now, 14, "x.yml", "6h")
+    check("40h since a 6h watcher ran is STOPPED", v.stopped, True)
+    check("...and stopped is not red", v.red, False)
+    v = assess([], now, 14, "x.yml", "6h")
+    check("never ran is STOPPED", v.stopped, True)
+    v = assess([], now, None, "ci.yml", "push")
+    check("a RED_ONLY watcher that never ran is NOT stopped", v.stopped, False)
+
+    # RED — the new question.
+    v = assess([run(1, "failure"), run(7, "failure"), run(13, "success")], now, 14, "x.yml", "6h")
+    check("two failures in a row is RED", v.red, True)
+    check("...with streak 2", v.streak, 2)
+    check("...and it remembers the last green day", v.last_green, "2026-09-10")
+    v = assess([run(1, "failure"), run(7, "success")], now, 14, "x.yml", "6h")
+    check("ONE failure is a flake, not red", v.red, False)
+    v = assess([run(1, "failure"), run(4, None, "in_progress"), run(7, "failure")], now, 14, "x.yml", "6h")
+    check("an in-progress run does not break the streak", v.red, True)
+    v = assess([run(1, "failure"), run(4, "cancelled"), run(7, "failure")], now, 14, "x.yml", "6h")
+    check("a cancelled run does not break the streak", v.red, True)
+    v = assess([run(1, "failure"), run(4, "success"), run(7, "failure")], now, 14, "x.yml", "6h")
+    check("a success in between DOES break the streak", v.red, False)
+    v = assess([run(1, "failure")] * 8, now, 14, "x.yml", "6h")
+    check("all-red window says so in the note", "no green run" in v.note, True)
+    v = assess([run(1, "failure"), run(2, "failure")], now, None, "ci.yml", "push")
+    check("RED_ONLY watcher can be red", v.red, True)
+
+    # Both at once: a watcher can be stopped AND have been red before it stopped.
+    v = assess([run(40, "failure"), run(46, "failure")], now, 14, "x.yml", "6h")
+    check("stopped and red are independent", (v.stopped, v.red), (True, True))
+
+    passed = sum(1 for _, ok in cases if ok)
+    print(f"\n{passed}/{len(cases)}")
+    if passed != len(cases):
+        print("DRILL FAILED — the watchdog classifier no longer behaves as documented.")
+    return 0 if passed == len(cases) else 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Are the watchers still running, and are they green?")
+    ap.add_argument("--json", metavar="FILE", help="write the machine-readable verdict here")
+    ap.add_argument("--drill", action="store_true", help="prove the classifier can go red")
+    args = ap.parse_args(argv)
+    if args.drill:
+        return _drill()
+
     now = datetime.now(timezone.utc)
     stopped: list[str] = []
-    rows: list[tuple[str, str, str]] = []
+    red: list[Verdict] = []
+    rows: list[tuple[str, str, str, str]] = []
 
-    for wf, (max_h, cadence) in sorted(EXPECTED.items()):
-        iso = last_run_iso(wf)
-        if iso == NOT_DEPLOYED:
+    targets: list[tuple[str, float | None, str, str | None]] = [
+        (wf, max_h, cadence, None) for wf, (max_h, cadence) in sorted(EXPECTED.items())
+    ] + [(wf, None, why, "main") for wf, why in sorted(RED_ONLY.items())]
+
+    for wf, max_h, cadence, branch in targets:
+        runs = recent_runs(wf, branch)
+        if runs == NOT_DEPLOYED:
             # Declared here but not yet on the default branch — informational.
-            rows.append((wf, "not on main yet", "—"))
+            rows.append((wf, "not on main yet", "—", "—"))
             continue
-        if iso is None:
-            stopped.append(f"`{wf}` has NEVER run ({cadence})")
-            rows.append((wf, "never", "**STOPPED**"))
-            continue
-        age_h = (now - datetime.fromisoformat(iso.replace("Z", "+00:00"))).total_seconds() / 3600
-        overdue = age_h > max_h
-        rows.append((wf, f"{age_h:.1f}h ago", "**STOPPED**" if overdue else "ok"))
-        if overdue:
-            stopped.append(
-                f"`{wf}` last ran {age_h:.1f}h ago — expected {cadence} "
-                f"(limit {max_h:.0f}h). It is not running."
-            )
+        v = assess(runs, now, max_h, wf, cadence)  # type: ignore[arg-type]
+        if v.last_run_age_h is None:
+            age = "never"
+        else:
+            age = f"{v.last_run_age_h:.1f}h ago"
+        health = "ok"
+        if v.red:
+            health = f"**RED** x{v.streak}" + (f" (last green {v.last_green})" if v.last_green else " (no green in window)")
+            red.append(v)
+        verdict = "**STOPPED**" if v.stopped else ("—" if max_h is None else "ok")
+        rows.append((wf, age, verdict, health))
+        if v.stopped:
+            if v.last_run_age_h is None:
+                stopped.append(f"`{wf}` has NEVER run ({cadence})")
+            else:
+                stopped.append(
+                    f"`{wf}` last ran {v.last_run_age_h:.1f}h ago — expected {cadence} "
+                    f"(limit {max_h:.0f}h). It is not running."
+                )
 
-    print("# Watchdog — are the watchers still running?\n")
-    print("| workflow | last run | verdict |")
-    print("|---|---|---|")
-    for wf, age, verdict in rows:
-        print(f"| `{wf}` | {age} | {verdict} |")
+    print("# Watchdog — are the watchers still running, and are they green?\n")
+    print("| workflow | last run | running? | passing? |")
+    print("|---|---|---|---|")
+    for wf, age, verdict, health in rows:
+        print(f"| `{wf}` | {age} | {verdict} | {health} |")
 
     # The roster itself is a watcher, and nothing was watching IT.
     drift = roster_drift()
@@ -173,6 +335,18 @@ def main() -> int:
         )
         stopped.extend(drift)
 
+    if red:
+        print("\n## Watchers that are running but RED\n")
+        for v in red:
+            since = f"last green {v.last_green}" if v.last_green else v.note
+            print(f"- `{v.workflow}` — {v.streak} failing run(s) in a row, {since}")
+        print(
+            "\nEach of these has its own issue and its own diagnosis; this is the "
+            "roll-up so the owner sees them in ONE place. A watcher that is red "
+            "for a missing secret stays red until the secret exists — that is an "
+            "owner action, not a code fix."
+        )
+
     if stopped:
         print("\n## Watchers have stopped\n")
         for s in stopped:
@@ -182,10 +356,26 @@ def main() -> int:
             "GitHub also auto-disables schedules after ~60 days of repo inactivity. "
             "Re-enable under Actions, or fix the schedule."
         )
-        return 1
 
-    print(f"\nAll {len(rows)} scheduled watchers reported within their window.")
-    return 0
+    if not stopped:
+        print(f"\nAll {len(rows)} watchers reported within their window"
+              + (f"; {len(red)} of them are red." if red else " and are green."))
+
+    if args.json:
+        payload = {
+            "stopped": bool(stopped),
+            "stopped_list": stopped,
+            "red_count": len(red),
+            "red_list": [v.workflow for v in red],
+            "red": [
+                {"workflow": v.workflow, "streak": v.streak, "last_green": v.last_green,
+                 "note": v.note} for v in red
+            ],
+        }
+        with open(args.json, "w", encoding="utf-8") as fh:
+            json.dump(payload, fh, indent=2)
+
+    return 1 if stopped else 0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Harness simplification — slice 4 of 8

**Every watchdog now reaches Slack, the revert drill rehearses what `main` actually is, and the post-merge watch uses the voice that was proven live today.**

### First: is the voice real?
`slack-drill.yml` had **never been run**. I fired it (run 34570686233): transition logic red-on-purpose ✓, empty token exits 1 ✓, bad channel → `channel_not_found` (only a *valid* token produces that) ✓, real message delivered to `log-github-ci` ✓. The bot token works.

### 1. Red watchers reach Slack through ONE wire (`absence.yml` + `watchdog_check.py`)
- Two of three production watchers were silent-red for a month (synthetic-live since 08-09, external-health since 08-06). Each opened an issue → triage → email; nothing reached the channel you read.
- `watchdog_check.py` now asks a second question: **running but RED?** (two failures in a row; cancelled/in-progress runs ignored). Reports streak + last green day. `ci.yml` on `main` joins the RED question without joining STOPPED.
- `absence.yml` posts via the existing transition rule (`slack_transition.py`): green→red → `needs-your-decision`; red→red silent; red→green → `log-github-ci`. Marker issue `Loop RED: watchdog-red` opened/closed in the same step. Rule-B fallback if the alarm path itself breaks.
- The classifier is pure and drilled (15 cases) → guard promoted **owed → drilled** (5 owed left).
- Measured live before merge: `external-health` ×8, `synthetic-live` ×8, everything else green. Both are owner-secret issues, not code (SMOKE creds, SENTRY_API_TOKEN).
- Found on the way: `auto-merge.yml` gained a 20-min cron in #525 and never joined the roster — issue #535 has been ringing since 09-10. Added; the next absence run auto-closes #535.

### 2. Revert drill made to pass (`revert_gear.py` + `revert-main.yml`)
- Root cause: the repo squash-merges. "Newest merge commit on main" was #273 from **2026-08-16**; its revert no longer applies. The drill failed 2026-09-01 and would fail every month.
- The gear now accepts a squash-merged PR commit (one parent, subject ends `(#N)`) and reverts it plainly; merge commits still get `-m 1`; ordinary commits still refused loudly. The workflow picks `git log --first-parent -n 1`.
- Drill 11/11 (two new squash cases). Probed live: `1f807be` (#537) and `6ef90ca` (#273) both accepted.

### 3. Post-merge watch uses the proven voice (`post-merge-watch.yml`)
- Its Slack step posted to `SLACK_WEBHOOK_URL` and swallowed failure with a `::warning::` — the RESEND_API_KEY shape. Now the bot-token action, hard-fail on silence.
- `check_alert_paths.py` then demanded `always()` on the tail gate and a fallback alert for `mode`/`decide` — both added.

### Guards run locally
chain_check 0 broken · check_alert_paths OK (12 alerts / 9 gates) · check_workflow_slack_wiring OK · drill_registry 28 guards, 23 drilled · doc-sync no drift · slack_transition self-check OK · ruff clean · YAML parses.

### Proof after merge
1. Dispatch `absence.yml` → summary shows 2 red, Slack message lands in `needs-your-decision`, marker issue opens, #535 auto-closes.
2. Dispatch `revert-main.yml` (dry run) → rehearsal of the newest landing passes.

### One note on "Slack DM"
Nothing in the repo knows your Slack user ID, so alerts go to the `needs-your-decision` channel the routing table already defines. A true DM needs a `SLACK_OWNER_ID` var — say the word and I'll wire it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011wAduRqokWdPEByUkcVbvc
