### PR TITLE
fix(harness): reverse gear brings its own git identity; failed rehearsal routes to needs-your-decision

### DIFF
--- a/.github/workflows/revert-main.yml
+++ b/.github/workflows/revert-main.yml
@@ -142,23 +142,25 @@ jobs:
       # A rehearsal nobody hears about is a rehearsal that did not happen — and a
       # FAILED rehearsal is the single most important thing this workflow can
       # ever say, because it means the revert does not apply.
+      # ROUTED TO needs-your-decision, NOT production-incidents (2026-09-11).
+      # A failed REHEARSAL means the owner must act — there is no tested way
+      # back — but no user is hurt right now, and the routing rule for
+      # production-incidents is "broken for a real user right now". The first
+      # live rehearsal after the squash fix posted a :rotating_light: into the
+      # incident channel for a missing git identity on the runner; that is
+      # exactly the message that teaches an owner to stop reading the channel.
+      # Same voice as every other watcher (the composite action, proven live
+      # by slack-drill.yml), so the wiring checker covers it too.
       - name: Say so if the rehearsal failed
         if: failure()
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: |
-          set -euo pipefail
-          if [ -z "${SLACK_BOT_TOKEN:-}" ]; then
-            echo "::error::no SLACK_BOT_TOKEN — nobody can be told the reverse gear is broken."
-            exit 1
-          fi
-          text=":rotating_light: *The reverse gear could not build a revert of the newest landing on main.*
-          That means there is currently NO tested way back. Railway's dashboard Rollback is
-          the only remaining path until this is fixed. ${RUN_URL}"
-          resp=$(curl -sS -X POST https://slack.com/api/chat.postMessage \
-            -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
-            -H 'Content-Type: application/json; charset=utf-8' \
-            --data "$(jq -nc --arg c production-incidents --arg t "$text" '{channel:$c,text:$t}')")
-          echo "$resp" | jq -e '.ok == true' >/dev/null || {
-            echo "::error::Slack refused: $(echo "$resp" | jq -r '.error')"; exit 1; }
+        uses: ./.github/actions/slack
+        with:
+          channel: needs-your-decision
+          severity: critical
+          title: "reverse gear: the rehearsal could not build a revert of the newest landing on main"
+          body: |
+            That means there is currently NO tested way back. Railway's dashboard Rollback is the
+            only remaining path until this is fixed. Read the run — the gear says why in one line.
+
+            Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/scripts/revert_gear.py
+++ b/scripts/revert_gear.py
@@ -96,6 +96,11 @@ def git(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
 # first-parent line with this marker IS one pull request, landed as one commit.
 _SQUASH_PR_SUBJECT = re.compile(r"\(#\d+\)\s*$")
 
+# The identity the revert commit is written under, passed per-command so it
+# never depends on the runner, the clone or anybody's global config.
+_IDENTITY = ["-c", "user.name=github-actions[bot]",
+             "-c", "user.email=41898282+github-actions[bot]@users.noreply.github.com"]
+
 
 def is_merge_commit(sha: str, cwd: Path) -> tuple[bool, str]:
     """(ok, why) — is `sha` something this gear may revert? Two shapes are:
@@ -154,7 +159,19 @@ def build_revert(sha: str, cwd: Path, branch: str) -> Result:
 
     # `-m 1` is only meaningful (and only accepted by git) for a real merge.
     mainline = ["-m", "1"] if _parent_count(sha, cwd) >= 2 else []
-    rev = git(["revert", *mainline, "--no-edit", sha], cwd)
+    # THE GEAR BRINGS ITS OWN IDENTITY. A fresh CI runner has none, and the
+    # first live rehearsal after the squash fix (run 34573024458, 2026-09-11)
+    # died on "Author identity unknown" — reported as a CONFLICT, because the
+    # only thing this branch knew how to say was "does not apply". The drill
+    # had never caught it: it configured an identity for its own temp repo,
+    # testing something adjacent to the thing that breaks.
+    rev = git([*_IDENTITY, "revert", *mainline, "--no-edit", sha], cwd)
+    if rev.returncode != 0 and "tell me who you are" in (rev.stderr + rev.stdout):
+        git(["revert", "--abort"], cwd)
+        return Result(False, (
+            f"the gear itself is misconfigured: git has no author identity here, so it "
+            f"could not write the revert commit. This is NOT a conflict. "
+            f"git said: {(rev.stderr or rev.stdout).strip()[:200]}"), branch=branch)
     if rev.returncode != 0:
         # THE FAILURE THAT ACTUALLY BITES. Say it plainly: you do not have this
         # revert, and you found out now instead of during an outage.
@@ -199,11 +216,12 @@ def _mk_repo(tmp: Path) -> tuple[Path, str, str, str]:
         return subprocess.run(["git", *a], cwd=str(repo), capture_output=True, text=True,
                               encoding="utf-8", errors="replace", env=env, timeout=60)
     g("init", "-b", "main")
-    # A fresh CI runner has no git identity, so commit/revert failed and this
-    # drill read 7/9 there while passing 9/9 locally. A guard that only fires
-    # where its author sits is not a guard.
-    g("config", "user.email", "drill@example.invalid")
-    g("config", "user.name", "revert-gear drill")
+    # NO IDENTITY IS CONFIGURED IN THIS REPO, ON PURPOSE. The drill's own commits
+    # get theirs from the GIT_AUTHOR_*/GIT_COMMITTER_* env above; the GEAR must
+    # bring its own (`_IDENTITY`). The previous version ran `git config user.*`
+    # here, which is why the drill passed 11/11 on 2026-09-11 while the real
+    # rehearsal on a fresh runner died on "Author identity unknown". A guard
+    # that configures away the condition it should catch is not a guard.
     (repo / "a.txt").write_text("one\n", encoding="utf-8")
     g("add", "-A")
     g("commit", "-m", "base")
@@ -231,6 +249,11 @@ def self_drill() -> int:
     print("DRILL — feeding the reverse gear inputs that would revert the wrong thing.")
     print("=" * 72)
     results: list[tuple[str, bool, str]] = []
+    # Run as a fresh CI runner would: no global or system git config. Whatever
+    # identity the author of this file has on their laptop must not leak into
+    # the gear's calls, or the drill certifies a gear that only works at home.
+    os.environ["GIT_CONFIG_GLOBAL"] = os.devnull
+    os.environ["GIT_CONFIG_SYSTEM"] = os.devnull
 
     def ok(name: str, passed: bool, detail: str = "") -> None:
         results.append((name, passed, "" if passed else detail))


### PR DESCRIPTION
## Follow-up to #541 — the revert rehearsal's second bug

The post-merge proof for #541 ran both live checks. The watchdog one worked end to end (2 red watchers → Slack message → marker issue #542 → #535 auto-closed). The revert rehearsal failed at the same step as last month, for a **different** reason the squash fix uncovered:

```
git said: Author identity unknown  *** Please tell me who you are.
```

A fresh runner has no git identity; `git revert` cannot write the commit; the gear reported it as a conflict (the only failure it knew how to name). The drill never caught it because `_mk_repo` configured an identity for its own temp repo.

### Changes
- `scripts/revert_gear.py`: the revert runs with `-c user.name/user.email` (github-actions[bot]); an identity error is named honestly; the drill runs with `GIT_CONFIG_GLOBAL`/`SYSTEM` = `/dev/null` and **no** local identity, reproducing a bare runner.
- `revert-main.yml`: the failure alert moves from raw curl → `production-incidents` to the composite action → `needs-your-decision`. A failed rehearsal needs your action, but no user is hurt — and that run posted a 🚨 into your incident channel for a missing git identity. **That message was this drill, not an outage.**

### Verified
- Drill 11/11 under no git config. Negative control: with `_IDENTITY` emptied the drill goes RED.
- `check_workflow_slack_wiring` OK · `check_alert_paths` OK · `chain_check` 0 broken · ruff · YAML.

### Proof after merge
Dispatch `revert-main.yml` (dry run) → the rehearsal of the newest landing passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011wAduRqokWdPEByUkcVbvc
