### PR TITLE
fix(oauth): one clock for the OAuth subsystem — housekeeping was deleting just-issued tokens (#530)

### DIFF
--- a/backend/src/services/auth/oauth_clients.py
+++ b/backend/src/services/auth/oauth_clients.py
@@ -22,13 +22,14 @@ import logging
 import secrets
 import unicodedata
 from dataclasses import dataclass
-from datetime import datetime, timedelta, timezone
+from datetime import timedelta
 from typing import Any, Optional
 from urllib.parse import SplitResult, urlsplit, urlunsplit
 
 from src.core import settings
 from src.repositories import pg
 from src.repositories.db_retry import open_db
+from src.services.auth import oauth_clock
 from src.utils.logger import get_audit_logger
 
 logger = logging.getLogger("job360.oauth.clients")
@@ -44,11 +45,6 @@ _LOOPBACK_HOSTS = frozenset({"127.0.0.1", "::1", "localhost"})
 # format incl. bidi overrides (Cf), surrogate (Cs), private-use (Co), and
 # unassigned (Cn) — everything that isn't a printable/spacing character.
 _STRIPPED_CATEGORIES = frozenset({"Cc", "Cf", "Cs", "Co", "Cn"})
-
-
-def _now() -> datetime:
-    """Module-level clock so tests can monkeypatch a single function."""
-    return datetime.now(timezone.utc)
 
 
 class RedirectURIError(ValueError):
@@ -296,7 +292,7 @@ async def register(
     name = sanitize_client_name(client_name)
 
     client_id = CLIENT_ID_PREFIX + secrets.token_urlsafe(24)
-    created_at = _now().isoformat()
+    created_at = oauth_clock.now().isoformat()
 
     async with open_db(db_path) as db:
         await _prune_and_check_ceiling(db)
@@ -348,7 +344,7 @@ async def touch_last_used(db_path: str, client_id: str) -> None:
         async with open_db(db_path) as db:
             await db.execute(
                 "UPDATE oauth_clients SET last_used_at = ? WHERE id = ?",
-                (_now().isoformat(), client_id),
+                (oauth_clock.now().isoformat(), client_id),
             )
             await db.commit()
     except Exception as exc:  # noqa: BLE001 — a display hint, never worth failing a request
@@ -363,7 +359,7 @@ async def prune(db_path: str) -> None:
     are already dead (consumed/expired/revoked) and older than 1 day.
     """
     try:
-        now = _now()
+        now = oauth_clock.now()
         now_iso = now.isoformat()
         client_cutoff = (now - timedelta(days=settings.OAUTH_CLIENT_PRUNE_DAYS)).isoformat()
         row_cutoff = (now - timedelta(days=1)).isoformat()

--- a/backend/src/services/auth/oauth_clock.py
+++ b/backend/src/services/auth/oauth_clock.py
@@ -1,0 +1,23 @@
+"""The ONE clock the whole OAuth subsystem reads.
+
+`oauth_flow` writes `created_at`/`expires_at` on `oauth_grants`,
+`oauth_authorization_codes` and `oauth_tokens`; `oauth_clients.prune`
+DELETES rows from those same tables by comparing those columns against
+"now". Two modules, one set of timestamps — so they must share one time
+frame or housekeeping can delete a row that was written a moment earlier
+(issue #530: the sampled post-token prune wiped a just-issued refresh
+token, and the next refresh answered "refresh token not found or already
+used").
+
+Deliberately a module-level function called as ``oauth_clock.now()``, never
+imported by value: there is exactly one patch target, so a test cannot move
+half the subsystem through time and leave the other half behind.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+
+def now() -> datetime:
+    """Current UTC time for every OAuth read, write and prune."""
+    return datetime.now(timezone.utc)

--- a/backend/src/services/auth/oauth_flow.py
+++ b/backend/src/services/auth/oauth_flow.py
@@ -30,6 +30,7 @@ from urllib.parse import urlencode, urlsplit, urlunsplit
 from src.core import settings
 from src.repositories import pg
 from src.repositories.db_retry import open_db
+from src.services.auth import oauth_clock
 from src.utils.logger import get_audit_logger
 
 ACCESS_TOKEN_PREFIX = "j360a_"  # noqa: S105 — a public display prefix, not a secret
@@ -41,11 +42,6 @@ LAST_USED_WRITE_INTERVAL = timedelta(minutes=5)
 # `\Z`, not `$` — `$` also matches before a trailing newline.
 _CODE_VERIFIER_RE = re.compile(r"^[A-Za-z0-9._~-]{43,128}\Z")
 _CODE_CHALLENGE_RE = re.compile(r"^[A-Za-z0-9_-]{43}\Z")
-
-
-def _now() -> datetime:
-    """Module-level clock so tests can monkeypatch a single function."""
-    return datetime.now(timezone.utc)
 
 
 def _hash(secret: str) -> str:
@@ -167,7 +163,7 @@ async def create_authorization_request(
 ) -> str:
     """Store a pending consent request; returns its `rid` (R3, valid path)."""
     rid = secrets.token_urlsafe(32)
-    now = _now()
+    now = oauth_clock.now()
     expires_at = (now + timedelta(seconds=settings.OAUTH_AUTHORIZE_TTL_SECONDS)).isoformat()
     async with open_db(db_path) as db:
         await db.execute(
@@ -185,7 +181,7 @@ async def create_authorization_request(
 
 async def get_pending_authorization_request(db_path: str, rid: str) -> Optional[AuthorizationRequest]:
     """R4 GET: None when the rid is unknown, consumed, or expired (route -> 404)."""
-    now_iso = _now().isoformat()
+    now_iso = oauth_clock.now().isoformat()
     async with open_db(db_path) as db:
         db.row_factory = pg.Row
         cur = await db.execute(
@@ -221,7 +217,7 @@ async def decide_authorization_request(
         consume_cur = await db.execute(
             "UPDATE oauth_authorization_requests SET consumed_at = ? "
             "WHERE id = ? AND consumed_at IS NULL",
-            (_now().isoformat(), rid),
+            (oauth_clock.now().isoformat(), rid),
         )
         if not consume_cur.rowcount:
             raise AuthorizationRequestGoneError(rid)
@@ -241,7 +237,7 @@ async def decide_authorization_request(
         else:
             ins_cur = await db.execute(
                 "INSERT INTO oauth_grants(user_id, client_id, scope, created_at) VALUES (?, ?, ?, ?)",
-                (user_id, req.client_id, req.scope, _now().isoformat()),
+                (user_id, req.client_id, req.scope, oauth_clock.now().isoformat()),
             )
             grant_id = int(ins_cur.lastrowid)
             get_audit_logger().info(
@@ -253,7 +249,7 @@ async def decide_authorization_request(
             )
 
         code = secrets.token_urlsafe(32)
-        now = _now()
+        now = oauth_clock.now()
         expires_at = (now + timedelta(seconds=settings.OAUTH_CODE_TTL_SECONDS)).isoformat()
         await db.execute(
             "INSERT INTO oauth_authorization_codes(code_hash, grant_id, client_id, redirect_uri, "
@@ -276,12 +272,12 @@ async def _grant_created_at(db: Any, grant_id: int) -> datetime:
     cur = await db.execute("SELECT created_at FROM oauth_grants WHERE id = ?", (grant_id,))
     row = await cur.fetchone()
     ts = _parse_ts(row["created_at"]) if row else None
-    return ts or _now()
+    return ts or oauth_clock.now()
 
 
 async def _issue_token_pair(db: Any, *, grant_id: int, audience: str) -> tuple[str, str, int, int, int]:
     """Insert a fresh access+refresh pair. Returns (access, refresh, expires_in, access_id, refresh_id)."""
-    now = _now()
+    now = oauth_clock.now()
     access = ACCESS_TOKEN_PREFIX + secrets.token_urlsafe(32)
     refresh = REFRESH_TOKEN_PREFIX + secrets.token_urlsafe(32)
     access_expires = (now + timedelta(seconds=settings.OAUTH_ACCESS_TOKEN_TTL_SECONDS)).isoformat()
@@ -307,7 +303,7 @@ async def _issue_token_pair(db: Any, *, grant_id: int, audience: str) -> tuple[s
 async def _revoke_grant(db: Any, grant_id: int, *, reason: str) -> None:
     await db.execute(
         "UPDATE oauth_grants SET revoked_at = ? WHERE id = ? AND revoked_at IS NULL",
-        (_now().isoformat(), grant_id),
+        (oauth_clock.now().isoformat(), grant_id),
     )
     await db.commit()
     get_audit_logger().info(
@@ -361,7 +357,7 @@ async def exchange_authorization_code(
         raise TokenError(400, "invalid_request", "missing required parameter")
 
     code_hash = _hash(code)
-    now = _now()
+    now = oauth_clock.now()
     now_iso = now.isoformat()
     async with open_db(db_path) as db:
         db.row_factory = pg.Row
@@ -451,7 +447,7 @@ async def refresh_access_token(db_path: str, *, refresh_token: str, client_id: s
         raise TokenError(400, "invalid_grant", "not a refresh token")
 
     token_hash = _hash(refresh_token)
-    now = _now()
+    now = oauth_clock.now()
     now_iso = now.isoformat()
     async with open_db(db_path) as db:
         db.row_factory = pg.Row
@@ -553,7 +549,7 @@ async def resolve_access_token(db_path: str, token: str) -> AccessTokenResolutio
     if not token or not token.startswith(ACCESS_TOKEN_PREFIX):
         return AccessTokenResolution(owner=None, hash_known=False)
 
-    now = _now()
+    now = oauth_clock.now()
     now_iso = now.isoformat()
     token_hash = _hash(token)
     async with open_db(db_path) as db:
@@ -638,7 +634,7 @@ async def revoke_token(db_path: str, *, token: str, client_id: Optional[str]) ->
             return
         await db.execute(
             "UPDATE oauth_grants SET revoked_at = ? WHERE id = ? AND revoked_at IS NULL",
-            (_now().isoformat(), grant_id),
+            (oauth_clock.now().isoformat(), grant_id),
         )
         await db.commit()
 
@@ -683,7 +679,7 @@ async def revoke_grant_for_user(db_path: str, *, user_id: str, grant_id: int) ->
     async with open_db(db_path) as db:
         cur = await db.execute(
             "UPDATE oauth_grants SET revoked_at = ? WHERE id = ? AND user_id = ? AND revoked_at IS NULL",
-            (_now().isoformat(), grant_id, user_id),
+            (oauth_clock.now().isoformat(), grant_id, user_id),
         )
         changed = cur.rowcount
         await db.commit()

--- a/backend/tests/test_oauth_server.py
+++ b/backend/tests/test_oauth_server.py
@@ -24,6 +24,7 @@ from httpx import ASGITransport, AsyncClient
 from src.core import settings
 from src.services.auth import magic_link as auth_magic_link
 from src.services.auth import oauth_clients, oauth_flow
+from src.services.auth import oauth_clock as auth_oauth_clock
 
 pytest.importorskip("mcp")
 
@@ -179,7 +180,7 @@ async def _full_code_exchange(
 
 
 class _Clock:
-    """Injectable clock for `oauth_flow._now` — advance instead of sleeping."""
+    """Injectable clock for `oauth_clock.now` — advance instead of sleeping."""
 
     def __init__(self, start: datetime):
         self._now = start
@@ -193,8 +194,16 @@ class _Clock:
 
 @pytest.fixture
 def oauth_clock(monkeypatch):
+    """Move the WHOLE OAuth subsystem through time, never half of it.
+
+    `oauth_clock.now` is the single clock `oauth_flow` (which writes the
+    timestamps) and `oauth_clients.prune` (which deletes rows by comparing
+    them) both read — issue #530 was the prune running on real time while
+    the rows had been written in the fake past, so it deleted a refresh
+    token that had just been issued.
+    """
     clock = _Clock(datetime(2026, 1, 1, tzinfo=timezone.utc))
-    monkeypatch.setattr(oauth_flow, "_now", clock)
+    monkeypatch.setattr(auth_oauth_clock, "now", clock)
     return clock
 
 
@@ -733,6 +742,34 @@ async def test_rotated_refresh_reuse_after_grace_revokes_grant(authenticated_asy
 
     async with _bearer_client(new_access) as agent:
         assert (await agent.get("/api/auth/me")).status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_housekeeping_prune_never_deletes_a_just_issued_token(
+    authenticated_async_context, oauth_clock, monkeypatch
+):
+    """#530: `/api/oauth/token` samples `oauth_clients.prune` into a background
+    task on every SUCCESS (1-in-`OAUTH_PRUNE_SAMPLE`). Prune deletes rows that
+    are dead (`expires_at` in the past) and older than a day — so it has to
+    read the very clock that wrote those rows. Forced to fire on every call
+    here; before the shared `oauth_clock` this failed 100% of the time,
+    because prune ran on real time against rows stamped 2026-01-01.
+    """
+    monkeypatch.setattr(settings, "OAUTH_PRUNE_SAMPLE", 1)
+    result = await _full_code_exchange(authenticated_async_context)
+
+    async with _bearer_client(result["access_token"]) as agent:
+        assert (await agent.get("/api/auth/me")).status_code == 200
+
+    async with _unauth_client() as client:
+        refreshed = await client.post(
+            "/api/oauth/token",
+            data={
+                "grant_type": "refresh_token", "refresh_token": result["refresh_token"],
+                "client_id": result["registered"]["client_id"],
+            },
+        )
+        assert refreshed.status_code == 200, refreshed.text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Root cause

The OAuth subsystem defined "now" **twice**, and the two halves wrote and read the same timestamp columns.

- `oauth_flow._now()` stamped `created_at` / `expires_at` on `oauth_grants`, `oauth_authorization_codes` and `oauth_tokens`.
- `oauth_clients._now()` was the clock `oauth_clients.prune()` used to decide which of **those same rows** are dead (`expires_at` in the past) and old enough (`created_at < now - 1 day`) to `DELETE`.

`POST /api/oauth/token` schedules that prune as a FastAPI background task on **one in every `OAUTH_PRUNE_SAMPLE` (default 20) successful responses** — `backend/src/api/routes/oauth.py:351`. The background task runs before the ASGI call returns, i.e. before the test's next request.

The `oauth_clock` fixture could only patch **half** the subsystem (`oauth_flow._now`). So in every test that used it, the token rows were written at the fake `2026-01-01` while prune ran at the real date. Against real time those brand-new rows looked both expired *and* more than a day old, so prune deleted the access **and** refresh tokens the code exchange had just issued. The next refresh then answered `invalid_grant / "refresh token not found or already used"` — the exact failure in #530, at a 1-in-20 rate, which matches the observed intermittency.

`test_rotated_refresh_reuse_after_grace_revokes_grant` is the only test this can fail: `test_refresh_rotation_issues_a_new_pair` does the same first refresh but without `oauth_clock` (real timestamps, prune is a no-op), and the other two `oauth_clock` tests both *expect* a 400, so a wiped row passes them silently.

Production was never affected — there both `_now`s read the real clock and agree. The defect is that the same concept had two definitions, which is what let a test put half the subsystem in a different time frame.

## The fix

New `backend/src/services/auth/oauth_clock.py` holds the single `now()`; `oauth_flow` and `oauth_clients` both call `oauth_clock.now()` and no longer define their own. One patch target, so no test can move half the subsystem through time again — patching the old `oauth_flow._now` now raises `AttributeError` instead of silently half-working. No retries, no sleeps, no `xfail`, no widened grace window; production timing is byte-for-byte what it was.

## Evidence

Forcing the sample rate turns the flake into a certainty, which is what proves the mechanism:

```
# before the fix
cd backend && OAUTH_PRUNE_SAMPLE=1 python -m pytest \
  tests/test_oauth_server.py::test_rotated_refresh_reuse_after_grace_revokes_grant -q -p no:randomly

E  AssertionError: {"error":"invalid_grant","error_description":"refresh token not found or already used"}
E  assert 400 == 200
1 failed
```

Same command after the fix: `2 passed`.

Pinned by a new test, `test_housekeeping_prune_never_deletes_a_just_issued_token`, which sets `OAUTH_PRUNE_SAMPLE = 1` so prune fires on **every** token success and then asserts the just-issued access token still resolves and the refresh still rotates. It fails 100% of the time without the production change.

## How it was verified

- `tests/test_oauth_server.py` run 5 times back to back: **74 passed** each time (127s / 138s / 131s / 139s / 122s).
- The forced-prune repro above: red before, green after.
- Neighbouring suites that touch OAuth: `test_route_auth_coverage.py`, `test_route_table.py`, `test_migration_0037.py`, `test_migration_0037_prod_shape.py`, `test_application_spine_fixes.py` — 40 passed.
- `python -m ruff check .` — All checks passed.
- `python scripts/mypy_ratchet.py` — 0 errors (baseline 0), no new type errors.
- `bash scripts/agent-gate.sh` — PASS (fast).
- Repo-wide grep confirms no remaining reference to `oauth_flow._now` or `oauth_clients._now` in code or docs.

## Not verified

The two CI run logs (34409125468, 34417295503) are past their retention window — `gh run view --log-failed` returns nothing for both, so the CI-side confirmation rests on the error text quoted in #530 rather than on a re-read of the logs. The local reproduction is exact and deterministic, which is stronger evidence.

Fixes #530

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011wAduRqokWdPEByUkcVbvc
