### PR TITLE
fix(harness): review-debt sanitiser cuts at an unclosed container instead of leaking it

### DIFF
--- a/scripts/review_debt.py
+++ b/scripts/review_debt.py
@@ -185,6 +185,17 @@ def sanitize(body: str) -> str:
         if not n:
             break
     text = _FENCE.sub(" ", text)
+    # AN UNCLOSED CONTAINER HIDES EVERYTHING AFTER IT. The three regexes above
+    # only remove a `<details>`, `<!--` or fence that CLOSES; an opener with no
+    # closer survived them, reached the claim, and tripped `assert_no_markup`
+    # on the chain job (2026-09-11, a github-advanced-security thread on PR
+    # #105 whose text has since regenerated). That alarm was correct — the
+    # sanitiser had a hole — and this is the patch for the hole, not for the
+    # alarm: cut the text at the earliest surviving opener. Whatever follows
+    # an unclosed container was never going to render as prose anyway.
+    cut = min((i for i in (text.find(m) for m in FORBIDDEN_MARKERS) if i >= 0), default=-1)
+    if cut >= 0:
+        text = text[:cut]
     # One CodeRabbit comment can carry several findings joined by `---`.
     # The first one is the one anchored at this file:line.
     text = re.split(r"\n-{3,}\n", text)[0]
@@ -771,6 +782,21 @@ def self_drill() -> int:
     clean = _INJECTION not in blob and "Prompt for AI Agents" not in blob and "<details" not in blob
     results.append(("the injection string cannot reach an agent prompt", clean,
                     "" if clean else "IT LEAKED"))
+
+    # 2b. UNCLOSED CONTAINERS. The container regexes need a closer; an opener
+    #     without one reached the claim on the chain job (2026-09-11). Each of
+    #     the three openers, unclosed, with the injection hidden behind it:
+    #     the claim must be marker-free and the injection must not survive.
+    for opener in ("<details>\n<summary>x</summary>\n", "<!-- ", "```\n"):
+        claim = sanitize(f"**A real headline.**\n\n{opener}{_INJECTION}\n")
+        bad = [m for m in FORBIDDEN_MARKERS if m in claim]
+        ok = not bad and _INJECTION not in claim and "real headline" in claim
+        results.append((f"an UNCLOSED {opener.strip()[:9]!r} cannot smuggle the injection",
+                        ok, f"claim={claim!r} markers={bad}"))
+    # Negative control for 2b: a CLOSED container still yields the headline.
+    claim = sanitize(f"**A real headline.**\n\n<details>\n{_INJECTION}\n</details>\n")
+    results.append(("NEGATIVE CONTROL: a closed container still yields the headline",
+                    "real headline" in claim and _INJECTION not in claim, f"claim={claim!r}"))
 
     # 3. An instruction-shaped HEADLINE — the one place a sanitiser cannot
     #    strip, because it is the claim itself. Must be withheld, not relayed.


### PR DESCRIPTION
## Fix: the review-debt sanitiser leaked an unclosed container

Found by the chain job on #546: `review_debt.py --drill` refused with `'<details' survived sanitising` on a github-advanced-security thread from PR #105. The alarm was correct — `sanitize()` only strips `<details>`, `<!--` and fences that **close**, so an opener with no closer reached the claim.

### Fix
After container stripping, cut the text at the earliest surviving forbidden marker. Anything after an unclosed container never rendered as prose.

### Drill
12/12 → **16/16**: each opener unclosed with the injection hidden behind it (claim marker-free, injection absent, headline kept) + a negative control that a closed container still yields the headline. The existing "holed sanitiser" breach case is untouched and still fires.

### Why it appeared now
The drill reads the 25 most recently *updated* PRs live. The branch-reaper's push-to-main runs (slice 2) delete merged branches, which bumps old PRs into that window — so this could hit any PR's chain job at random until fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011wAduRqokWdPEByUkcVbvc
