### PR TITLE
fix(harness): reviewer-bugs skips Dependabot PRs (their runs get no secrets)

### DIFF
--- a/.github/workflows/review-bugs.yml
+++ b/.github/workflows/review-bugs.yml
@@ -121,7 +121,15 @@ jobs:
     # names this job's `name:` field by exact string equality — renaming this
     # line silently un-wires the gate.
     name: reviewer-bugs
-    if: github.event.pull_request.draft == false
+    # NOT FOR DEPENDABOT. A Dependabot-triggered run gets no repository
+    # secrets from GitHub, so CLAUDE_CODE_OAUTH_TOKEN is empty and the token
+    # gate fails loud in seconds (measured on #531/#532/#533, 2026-09-11).
+    # That is the right outcome for a missing token and the wrong outcome for
+    # a dependency bump: its diff is a lockfile no reviewer can read, and it
+    # has its own merge loop (dependabot-auto.yml, >= 10 green checks) that
+    # never consults the cage's `bugs` tag. Skipping is honest here; failing
+    # would only teach people to ignore this check.
+    if: github.event.pull_request.draft == false && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:


### PR DESCRIPTION
## reviewer-bugs: skip Dependabot PRs

After the rebases, #531/#532/#533 each failed `reviewer-bugs` in under ten seconds. Cause: GitHub gives Dependabot-triggered runs **no repository secrets**, so `CLAUDE_CODE_OAUTH_TOKEN` is empty and the token gate fails loud (its intended behaviour for a missing token).

For a dependency bump that is the wrong outcome: the diff is a lockfile no reviewer can read, and `dependabot-auto.yml` is its merge loop (≥ 10 green checks) and never consults the cage's `bugs` tag. The job now skips when `github.actor == 'dependabot[bot]'`. One line plus a comment explaining why.

Verified: YAML · chain_check 0 broken · `bash -n` on run blocks (Slack wiring checker).

After merge the three dependabot PRs need a `synchronize`; a `@dependabot rebase` comment does that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011wAduRqokWdPEByUkcVbvc
