### PR TITLE
fix(harness): finding-watch never dispatches the fixer at a Dependabot PR (slice 7)

### DIFF
--- a/.github/workflows/finding-watch.yml
+++ b/.github/workflows/finding-watch.yml
@@ -231,7 +231,18 @@ jobs:
               # a bare `dependabot` for some shapes. All three are named because
               # picking one is how chain_check's W12 rule describes a dead wire.
               # (CodeRabbit, PR #380.)
-              Ranjith36963|dependabot|"dependabot[bot]"|app/dependabot) : ;;
+              # DEPENDABOT IS NEVER DISPATCHED (slice 7, 2026-09-11). It was on
+              # this allowlist, so a Dependabot PR going red dispatched the
+              # fixer like any other — and the fixer died at the path cage
+              # every time, because a lockfile is owner-lane and the repair
+              # agent may not touch it (eight Opus runs on #531/#532/#533 in
+              # one afternoon, all refused). A dependency bump has its own
+              # loop: dependabot-auto.yml merges it when fully green and asks
+              # Dependabot itself to rebase on conflict. Nothing here can help
+              # it, so nothing here should spend the owner's subscription on it.
+              dependabot|"dependabot[bot]"|app/dependabot)
+                note "$pr" "is a Dependabot PR — dependabot-auto.yml owns it; the fixer is never dispatched"; exit 0 ;;
+              Ranjith36963) : ;;
               # `exit 0`, NOT `continue` — see the note above the loop. This one
               # survived the sweep that converted the others because it sits in a
               # `case` arm and did not match the shapes I searched for, and it is


### PR DESCRIPTION
## Harness simplification — slice 7 of 8

**The loops on your subscription token stop spending it where they cannot help.**

### What was found
- `triage.yml` and `pr-repair.yml` already run on `CLAUDE_CODE_OAUTH_TOKEN`, event-driven only (issues / dispatch), with turn caps and `timeout-minutes`. No cron starts an LLM anywhere. That part of the slice was already true.
- The real waste: Dependabot was on `finding-watch.yml`'s dispatch allowlist, so a Dependabot PR going red woke the fixer like any other PR — and the fixer died at the path cage every time, because a lockfile is owner-lane. Measured today: **eight Opus runs on #531/#532/#533 in one afternoon, all refused at "Enforce the path cage"**.

### Change (one file)
`finding-watch.yml`: a Dependabot author is noted ("dependabot-auto.yml owns it") and never dispatched. Your own PRs are dispatched exactly as before.

### Model choice — unchanged on purpose
Your word today: "not Sonnet only — any model which can solve the problem." Triage and repair stay on the model their authors chose. (I had downgraded them to Sonnet per the interview note and reverted that before committing.)

### Verified
YAML · chain_check 0 broken · Slack wiring / `bash -n` OK · alert paths OK.

### Proof after merge
The next red Dependabot PR shows a finding-watch note instead of a pr-repair run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011wAduRqokWdPEByUkcVbvc
